### PR TITLE
Fix architecture detection code

### DIFF
--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -56,7 +56,7 @@ def deploy_frame(id: int):
                 elif arch == "i386":
                     cpu = "i386"
                 else:
-                    cpu = "x86_64"
+                    cpu = "amd64"
 
                 drivers = drivers_for_device(frame.device)
 

--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -49,7 +49,7 @@ def deploy_frame(id: int):
                 uname_output = []
                 exec_command(frame, ssh, f"uname -m", uname_output)
                 arch = "".join(uname_output).strip()
-                if arch == "aarch64":
+                if arch == "aarch64" or arch == "armv7l":
                     cpu = "arm64"
                 elif arch == "armv6l":
                     cpu = "arm"


### PR DESCRIPTION
Fix `amd64` and  `armv7l` (RPi 3 / 3+) architectures.  Closes #7
