### PR TITLE
Fix deleting frames

### DIFF
--- a/backend/app/models/frame.py
+++ b/backend/app/models/frame.py
@@ -126,8 +126,12 @@ def update_frame(frame: Frame):
 def delete_frame(frame_id: int):
     frame = Frame.query.get(frame_id)
     if frame:
+        # delete corresonding log and metric entries first
         from .log import Log
         Log.query.filter_by(frame_id=frame_id).delete()
+        from .metrics import Metrics
+        Metrics.query.filter_by(frame_id=frame_id).delete()
+
         db.session.delete(frame)
         db.session.commit()
         socketio.emit('delete_frame', {'id': frame_id})

--- a/backend/app/models/frame.py
+++ b/backend/app/models/frame.py
@@ -124,8 +124,7 @@ def update_frame(frame: Frame):
 
 
 def delete_frame(frame_id: int):
-    frame = Frame.query.get(frame_id)
-    if frame:
+    if frame := Frame.query.get(frame_id):
         # delete corresonding log and metric entries first
         from .log import Log
         Log.query.filter_by(frame_id=frame_id).delete()


### PR DESCRIPTION
Closes #22

There is a non-nullable key in `Metrics` that is violated if a frame is deleted, so delete the `Metric` first. 
