### PR TITLE
Simplify shell commands

### DIFF
--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -120,9 +120,8 @@ def deploy_frame(id: int):
 
                 # restart
                 exec_command(frame, ssh, "sudo systemctl daemon-reload")
-                exec_command(frame, ssh, "sudo systemctl stop frameos.service || true")
                 exec_command(frame, ssh, "sudo systemctl enable frameos.service")
-                exec_command(frame, ssh, "sudo systemctl start frameos.service")
+                exec_command(frame, ssh, "sudo systemctl restart frameos.service")
                 exec_command(frame, ssh, "sudo systemctl status frameos.service")
 
             if drivers.get("i2c"):


### PR DESCRIPTION
Use `systemctl restart` instead of `stop && start`.
(Note: `systemctl enable --now` would be useful if the service did not need to be stopped first)

Use a helper function to install packages, and switch to `apt-get` instead of `apt` (the latter is intended for interactive use)
My goal here is to move towards abstracting away the install process to work on other distros / package managers.
