### PR TITLE
Support 7-color waveshare displays

### DIFF
--- a/frameos/src/frameos/runner.nim
+++ b/frameos/src/frameos/runner.nim
@@ -26,14 +26,18 @@ var
   thread: Thread[(FrameConfig, Logger)]
   pngLock: Lock
   pngImage = newImage(1, 1)
+  hasPngImage = false
 
 proc setLastImage(image: Image) =
   withLock pngLock:
     if pngImage.width != image.width or pngImage.height != image.height:
       pngImage = newImage(image.width, image.height)
     pngImage.draw(image)
+    hasPngImage = true
 
 proc getLastPng*(): string =
+  if not hasPngImage:
+    raise newException(Exception, "No image rendered yet")
   var copy: seq[ColorRGBX]
   withLock pngLock:
     copy = pngImage.data

--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -112,7 +112,7 @@ export const framesModel = kea<framesModelType>([
     [socketLogic.actionTypes.newLog]: ({ log }) => {
       if (log.type === 'webhook') {
         const parsed = JSON.parse(log.line)
-        if (parsed.event == 'render:done' || parsed.event == 'http:start') {
+        if (parsed.event == 'render:dither' || parsed.event == 'render:done' || parsed.event == 'http:start') {
           actions.updateFrameImage(log.frame_id)
         }
       }


### PR DESCRIPTION
Follow-up to https://github.com/FrameOS/frameos/pull/47

- This enables support for 7-color waveshare displays. Tested with the [4.01" 7-color display](https://www.waveshare.com/wiki/4.01inch_e-Paper_HAT_(F)_Manual#Working_With_Raspberry_Pi). 
- It'll probably also works with the 4-color displays, though I haven't tested any.
- 3-color displays (e.g. black, white, red) are supported, but their rendered image won't show up in the UI yet. This will be fixed later this week.

![image](https://github.com/FrameOS/frameos/assets/53387/62c4eac6-fedd-4ef7-8b3e-bee22b364b80)
