### PR TITLE
Convert `node_id` to `distinct integer` (might be breaking for some users)

### DIFF
--- a/backend/app/codegen/scene_nim.py
+++ b/backend/app/codegen/scene_nim.py
@@ -4,7 +4,8 @@ from typing import Dict
 
 from app.models.frame import Frame
 from app.models.apps import get_local_frame_apps, local_apps_path
-from app.codegen.utils import sanitize_nim_string
+from app.codegen.utils import sanitize_nim_string, natural_keys
+
 
 def write_scene_nim(frame: Frame, scene: Dict) -> str:
     from app.models.log import new_log as log
@@ -13,16 +14,23 @@ def write_scene_nim(frame: Frame, scene: Dict) -> str:
     log(frame.id, "stdout", f"- Generating scene: {scene_id}")
     nodes = scene.get('nodes', [])
     nodes_by_id = {n['id']: n for n in nodes}
+    node_integer_map: Dict[str, int] = {}
     imports = []
     scene_object_fields = []
     init_apps = []
-    render_nodes = []
-    event_lines = []
+    run_node_lines = []
+    run_event_lines = []
     edges = scene.get('edges', [])
     event_nodes = {}
     next_nodes = {}
     field_inputs: Dict[str, Dict[str, str]] = {}
     node_fields: Dict[str, Dict[str, str]] = {}
+    
+    def node_id_to_integer(node_id: str) -> int:
+        if node_id not in node_integer_map:
+            node_integer_map[node_id] = len(node_integer_map) + 1
+        return node_integer_map[node_id]
+    
     for edge in edges:
         source = edge.get('source', None)
         target = edge.get('target', None)
@@ -55,103 +63,109 @@ def write_scene_nim(frame: Frame, scene: Dict) -> str:
         elif node.get('type') == 'app':
             sources = node.get('data', {}).get('sources', {})
             name = node.get('data', {}).get('keyword', f"app_{node_id}")
-            app_id = "app_" + node_id.replace('-', '_')
+            node_integer = node_id_to_integer(node_id)
+            app_id = f"node{node_integer}"
 
-            if name in available_apps or len(sources) > 0:
-                if len(sources) > 0:
-                    log(frame.id, "stdout", f"- Generating source app: {node_id}")
-                    node_app_id = "nodeapp_" + node_id.replace('-', '_')
-                    app_import = f"import apps/{node_app_id}/app as {node_app_id}App"
-                    scene_object_fields += [f"{app_id}: {node_app_id}App.App"]
+            if name not in available_apps and len(sources) == 0:
+                log(frame.id, "stderr", f"- ERROR: App \"{name}\" for node \"{node_id}\" not found")
+                continue
+
+            if len(sources) > 0:
+                log(frame.id, "stdout", f"- Generating source app: {node_id}")
+                node_app_id = "nodeapp_" + node_id.replace('-', '_')
+                app_import = f"import apps/{node_app_id}/app as nodeApp{node_id_to_integer(node_app_id)}"
+                scene_object_fields += [f"{app_id}: nodeApp{node_id_to_integer(node_app_id)}.App"]
+            else:
+                log(frame.id, "stdout", f"- Generating app: {node_id} ({name})")
+                app_import = f"import apps/{name}/app as {name}App"
+                scene_object_fields += [f"{app_id}: {name}App.App"]
+
+            if app_import not in imports:
+                imports += [app_import]
+
+            app_config = node.get('data', {}).get('config', {}).copy()
+            if len(sources) > 0 and sources.get('config.json', None):
+                config = json.loads(sources.get('config.json'))
+            else:
+                config_path = os.path.join(local_apps_path, name, "config.json")
+                if os.path.exists(config_path):
+                    with open(config_path, 'r') as file:
+                        config = json.load(file)
                 else:
-                    log(frame.id, "stdout", f"- Generating app: {node_id} ({name})")
-                    app_import = f"import apps/{name}/app as {name}App"
-                    scene_object_fields += [f"{app_id}: {name}App.App"]
+                    config = {}
 
-                if app_import not in imports:
-                    imports += [app_import]
+            config_types: Dict[str, str] = {}
+            for field in config.get('fields'):
+                key = field.get('name', None)
+                value = field.get('value', None)
+                field_type = field.get('type', 'string')
+                config_types[key] = field_type
+                if (key not in app_config or app_config.get(key) is None) and (
+                        value is not None or field_type == 'node'):
+                    app_config[key] = value
 
-                app_config = node.get('data', {}).get('config', {}).copy()
-                if len(sources) > 0 and sources.get('config.json', None):
-                    config = json.loads(sources.get('config.json'))
+            field_inputs_for_node = field_inputs.get(node_id, {})
+            node_fields_for_node = node_fields.get(node_id, {})
+
+            app_config_pairs = []
+            for key, value in app_config.items():
+                if key not in config_types:
+                    log(frame.id, "stderr",
+                        f"- ERROR: Config key \"{key}\" not found for app \"{name}\", node \"{node_id}\"")
+                    continue
+                type = config_types[key]
+
+                if key in field_inputs_for_node:
+                    app_config_pairs += [f"{key}: {field_inputs_for_node[key]}"]
+                elif type == "node" and key in node_fields_for_node:
+                    node_id = node_fields_for_node[key]
+                    app_config_pairs += [f"{key}: {node_id_to_integer(node_id)}.NodeId"]
+                elif type == "node" and key not in node_fields_for_node:
+                    app_config_pairs += [f"{key}: 0.NodeId"]
+                elif type == "integer":
+                    app_config_pairs += [f"{key}: {int(value)}"]
+                elif type == "float":
+                    app_config_pairs += [f"{key}: {float(value)}"]
+                elif type == "boolean":
+                    app_config_pairs += [f"{key}: {'true' if value == 'true' else 'false'}"]
+                elif type == "color":
+                    app_config_pairs += [f"{key}: parseHtmlColor(\"{sanitize_nim_string(str(value))}\")"]
+                elif type == "node":
+                    app_config_pairs += [f"{key}: -1.NodeId"]
                 else:
-                    config_path = os.path.join(local_apps_path, name, "config.json")
-                    if os.path.exists(config_path):
-                        with open(config_path, 'r') as file:
-                            config = json.load(file)
-                    else:
-                        config = {}
+                    app_config_pairs += [f"{key}: \"{sanitize_nim_string(str(value))}\""]
 
-                config_types: Dict[str, str] = {}
-                for field in config.get('fields'):
-                    key = field.get('name', None)
-                    value = field.get('value', None)
-                    field_type = field.get('type', 'string')
-                    config_types[key] = field_type
-                    if (key not in app_config or app_config.get(key) is None) and (
-                            value is not None or field_type == 'node'):
-                        app_config[key] = value
-
-                field_inputs_for_node = field_inputs.get(node_id, {})
-                node_fields_for_node = node_fields.get(node_id, {})
-
-                app_config_pairs = []
-                for key, value in app_config.items():
-                    if key not in config_types:
-                        log(frame.id, "stderr",
-                            f"- ERROR: Config key \"{key}\" not found for app \"{name}\", node \"{node_id}\"")
-                        continue
-                    type = config_types[key]
-
-                    if key in field_inputs_for_node:
-                        app_config_pairs += [f"{key}: {field_inputs_for_node[key]}"]
-                    elif type == "node" and key in node_fields_for_node:
-                        app_config_pairs += [f"{key}: \"{sanitize_nim_string(node_fields_for_node[key])}\".NodeId"]
-                    elif type == "node" and key not in node_fields_for_node:
-                        app_config_pairs += [f"{key}: \"\".NodeId"]
-                    elif type == "integer":
-                        app_config_pairs += [f"{key}: {int(value)}"]
-                    elif type == "float":
-                        app_config_pairs += [f"{key}: {float(value)}"]
-                    elif type == "boolean":
-                        app_config_pairs += [f"{key}: {'true' if value == 'true' else 'false'}"]
-                    elif type == "color":
-                        app_config_pairs += [f"{key}: parseHtmlColor(\"{sanitize_nim_string(str(value))}\")"]
-                    elif type == "node":
-                        app_config_pairs += [f"{key}: \"-1\""]
-                    else:
-                        app_config_pairs += [f"{key}: \"{sanitize_nim_string(str(value))}\""]
-
-                if len(sources) > 0:
-                    node_app_id = "nodeapp_" + node_id.replace('-', '_')
-                    init_apps += [
-                        f"scene.{app_id} = {node_app_id}App.init(\"{node_id}\".NodeId, scene, {node_app_id}App.AppConfig({', '.join(app_config_pairs)}))"
-                    ]
-                else:
-                    init_apps += [
-                        f"scene.{app_id} = {name}App.init(\"{node_id}\".NodeId, scene, {name}App.AppConfig({', '.join(app_config_pairs)}))"
-                    ]
-
-                render_nodes += [
-                    f"of \"{node_id}\".NodeId:",
-                ]
-                for key, code in field_inputs_for_node.items():
-                    render_nodes += [f"  self.{app_id}.appConfig.{key} = {code}"]
-
-                render_nodes += [
-                    f"  self.{app_id}.run(context)",
-                    f"  nextNode = \"{next_nodes.get(node_id, '-1')}\".NodeId"
+            if len(sources) > 0:
+                node_app_id = "nodeapp_" + node_id.replace('-', '_')
+                init_apps += [
+                    f"scene.{app_id} = nodeApp{node_id_to_integer(node_app_id)}.init({node_integer}.NodeId, scene, nodeApp{node_id_to_integer(node_app_id)}.AppConfig({', '.join(app_config_pairs)}))"
                 ]
             else:
-                log(frame.id, "stderr", f"- ERROR: App not found: {name}")
+                init_apps += [
+                    f"scene.{app_id} = {name}App.init({node_integer}.NodeId, scene, {name}App.AppConfig({', '.join(app_config_pairs)}))"
+                ]
+
+            run_node_lines += [
+                f"of {node_integer}.NodeId: # {name}",
+            ]
+            for key, code in field_inputs_for_node.items():
+                run_node_lines += [f"  self.{app_id}.appConfig.{key} = {code}"]
+
+            next_node_id = next_nodes.get(node_id, None)
+            run_node_lines += [
+                f"  self.{app_id}.run(context)",
+                f"  nextNode = {-1 if next_node_id is None else node_id_to_integer(next_node_id)}.NodeId"
+            ]
+    
+    scene_object_fields.sort(key=natural_keys)
+
     for event, nodes in event_nodes.items():
-        event_lines += [f"of \"{event}\":", ]
+        run_event_lines += [f"of \"{event}\":", ]
         for node in nodes:
             next_node = next_nodes.get(node['id'], '-1')
-            event_lines += [f"  try: self.runNode(\"{next_node}\".NodeId, context)"]
-            event_lines += [f"  except Exception as e: self.logger.log(%*{{\"event\": \"event:error\","]
-            event_lines += [f"      \"node\": \"{next_node}\","]
-            event_lines += [f"      \"error\": $e.msg, \"stacktrace\": e.getStackTrace()}})"]
+            run_event_lines += [f"  try: self.runNode({node_id_to_integer(next_node)}.NodeId, context)"]
+            run_event_lines += [f"  except Exception as e: self.logger.log(%*{{\"event\": \"{sanitize_nim_string(event)}:error\","]
+            run_event_lines += [f"      \"node\": {node_id_to_integer(next_node)}, \"error\": $e.msg, \"stacktrace\": e.getStackTrace()}})"]
     newline = "\n"
     scene_source = f"""
 import pixie, json, times, strformat
@@ -176,19 +190,19 @@ proc runNode*(self: Scene, nodeId: NodeId,
   var nextNode = nodeId
   var currentNode = nodeId
   var timer = epochTime()
-  while nextNode != "-1".NodeId:
+  while nextNode != -1.NodeId:
     currentNode = nextNode
     timer = epochTime()
     case nextNode:
-    {(newline + "    ").join(render_nodes)}
+    {(newline + "    ").join(run_node_lines)}
     else:
-      nextNode = "-1".NodeId
+      nextNode = -1.NodeId
     if DEBUG:
-      self.logger.log(%*{{"event": "runApp", "node": currentNode.string, "ms": (-timer + epochTime()) * 1000}})
+      self.logger.log(%*{{"event": "runApp", "node": currentNode, "ms": (-timer + epochTime()) * 1000}})
 
 proc runEvent*(self: Scene, context: var ExecutionContext) =
   case context.event:
-  {(newline + "  ").join(event_lines)}
+  {(newline + "  ").join(run_event_lines)}
   else: discard
 
 proc init*(frameConfig: FrameConfig, logger: Logger, dispatchEvent: proc(

--- a/backend/app/codegen/utils.py
+++ b/backend/app/codegen/utils.py
@@ -1,3 +1,10 @@
+import re
 
 def sanitize_nim_string(string: str) -> str:
-    return string.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
+    return string.replace('"', '\\"').replace('\n', '\\n')
+
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+def natural_keys(text):
+    return [ atoi(c) for c in re.split(r'(\d+)', text) ]

--- a/backend/migrations/versions/f4fafd71db11_migrate_node_id.py
+++ b/backend/migrations/versions/f4fafd71db11_migrate_node_id.py
@@ -1,0 +1,60 @@
+"""migrate node_id
+
+Revision ID: f4fafd71db11
+Revises: fa715fc28251
+Create Date: 2024-01-18 23:47:48.016511
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import attributes
+
+
+# revision identifiers, used by Alembic.
+revision = 'f4fafd71db11'
+down_revision = 'fa715fc28251'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    from app.models import Frame
+    from app import db
+    frames = Frame.query.all()
+    for frame in frames:
+        frame.scenes = list(frame.scenes)
+        changed = False
+        for scene in frame.scenes:
+            for node in scene.get('nodes', []):
+                if node.get('type', None) == 'app' and 'data' in node:
+                    sources = node['data'].get('sources', {})
+                    if 'app.nim' in sources:
+                        source = sources['app.nim']
+                        node['data']['sources']['app.nim'] = source.replace('nodeId*: string', 'nodeId*: NodeId').replace('nodeId: string', 'nodeId: NodeId')
+                        changed = True
+        if changed:
+            attributes.flag_modified(frame, "scenes")
+            db.session.add(frame)
+            db.session.commit()
+    db.session.flush()
+
+def downgrade():
+    from app.models import Frame
+    from app import db
+    frames = Frame.query.all()
+    for frame in frames:
+        frame.scenes = list(frame.scenes)
+        changed = False
+        for scene in frame.scenes:
+            for node in scene.get('nodes', []):
+                if node.get('type', None) == 'app' and 'data' in node:
+                    sources = node['data'].get('sources', {})
+                    if 'app.nim' in sources:
+                        source = sources['app.nim']
+                        node['data']['sources']['app.nim'] = source.replace('nodeId*: NodeId', 'nodeId*: string').replace('nodeId: NodeId', 'nodeId: string')
+                        changed = True
+        if changed:
+            attributes.flag_modified(frame, "scenes")
+            db.session.add(frame)
+            db.session.commit()
+    db.session.flush()

--- a/frameos/src/apps/breakIfRendering/app.nim
+++ b/frameos/src/apps/breakIfRendering/app.nim
@@ -7,12 +7,12 @@ type
     discard
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     frameConfig*: FrameConfig
     appConfig*: AppConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/clock/app.nim
+++ b/frameos/src/apps/clock/app.nim
@@ -33,14 +33,14 @@ type
     borderTypeset*: Option[Arrangement]
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
     typeface*: Typeface
     cachedRender*: Option[CachedRender]
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   let typeface = getDefaultTypeface()
   result = App(
     nodeId: nodeId,

--- a/frameos/src/apps/code/app.nim
+++ b/frameos/src/apps/code/app.nim
@@ -7,12 +7,12 @@ type
     keyword*: string
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     frameConfig*: FrameConfig
     appConfig*: AppConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/color/app.nim
+++ b/frameos/src/apps/color/app.nim
@@ -6,12 +6,12 @@ type
     color*: Color
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/downloadImage/app.nim
+++ b/frameos/src/apps/downloadImage/app.nim
@@ -11,7 +11,7 @@ type
     cacheSeconds*: float
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
@@ -20,7 +20,7 @@ type
     cachedImage: Option[Image]
     cachedUrl: string
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/frameOSGallery/app.nim
+++ b/frameos/src/apps/frameOSGallery/app.nim
@@ -11,7 +11,7 @@ type
     cacheSeconds*: float
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
@@ -20,7 +20,7 @@ type
     cachedImage: Option[Image]
     cachedUrl: string
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/gradient/app.nim
+++ b/frameos/src/apps/gradient/app.nim
@@ -8,12 +8,12 @@ type
     angle*: float
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/haSensor/app.nim
+++ b/frameos/src/apps/haSensor/app.nim
@@ -9,14 +9,14 @@ type
     debug*: bool
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
     lastFetchAt*: float
     json: Option[JsonNode]
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/ifElse/app.nim
+++ b/frameos/src/apps/ifElse/app.nim
@@ -3,16 +3,16 @@ import frameos/types
 type
   AppConfig* = object
     condition*: bool
-    thenNode*: string
-    elseNode*: string
+    thenNode*: NodeId
+    elseNode*: NodeId
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/ifElse/app.nim
+++ b/frameos/src/apps/ifElse/app.nim
@@ -22,8 +22,8 @@ proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
 
 proc run*(self: App, context: var ExecutionContext) =
   if self.appConfig.condition:
-    if self.appConfig.thenNode != "":
+    if self.appConfig.thenNode != 0:
       self.scene.execNode(self.appConfig.thenNode, context)
   else:
-    if self.appConfig.elseNode != "":
+    if self.appConfig.elseNode != 0:
       self.scene.execNode(self.appConfig.elseNode, context)

--- a/frameos/src/apps/openai/app.nim
+++ b/frameos/src/apps/openai/app.nim
@@ -15,7 +15,7 @@ type
     cacheSeconds*: float
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
@@ -24,7 +24,7 @@ type
     cachedImage: Option[Image]
     cachedPrompt: string
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/resize/app.nim
+++ b/frameos/src/apps/resize/app.nim
@@ -9,12 +9,12 @@ type
     height*: int
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     frameConfig*: FrameConfig
     scene*: FrameScene
     appConfig*: AppConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/rotate/app.nim
+++ b/frameos/src/apps/rotate/app.nim
@@ -10,12 +10,12 @@ type
     scalingMode*: string
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     frameConfig*: FrameConfig
     appConfig*: AppConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/split/app.nim
+++ b/frameos/src/apps/split/app.nim
@@ -131,7 +131,7 @@ proc run*(self: App, context: var ExecutionContext) =
     for column in 0..<columns:
       let (cellWidth, cellHeight) = cellDims[row * columns + column]
       let image = context.image.subImage(cellX.toInt, cellY.toInt, cellWidth, cellHeight)
-      if renderFunction != "":
+      if renderFunction != 0:
         var cellContext = ExecutionContext(
             scene: context.scene,
             image: image,

--- a/frameos/src/apps/split/app.nim
+++ b/frameos/src/apps/split/app.nim
@@ -6,19 +6,19 @@ type
   AppConfig* = object
     rows*: int
     columns*: int
-    renderFunction*: string
+    renderFunction*: NodeId
     gap*: string
     margin*: string
     widthRatios*: string
     heightRatios*: string
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/apps/text/app.nim
+++ b/frameos/src/apps/text/app.nim
@@ -32,14 +32,14 @@ type
     borderTypeset*: Option[Arrangement]
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
     typeface*: Typeface
     cachedRender*: Option[CachedRender]
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   let typeface = getDefaultTypeface()
   result = App(
     nodeId: nodeId,

--- a/frameos/src/apps/unsplash/app.nim
+++ b/frameos/src/apps/unsplash/app.nim
@@ -12,7 +12,7 @@ type
     cacheSeconds*: float
 
   App* = ref object
-    nodeId*: string
+    nodeId*: NodeId
     scene*: FrameScene
     appConfig*: AppConfig
     frameConfig*: FrameConfig
@@ -21,7 +21,7 @@ type
     cachedImage: Option[Image]
     cachedUrl: string
 
-proc init*(nodeId: string, scene: FrameScene, appConfig: AppConfig): App =
+proc init*(nodeId: NodeId, scene: FrameScene, appConfig: AppConfig): App =
   result = App(
     nodeId: nodeId,
     scene: scene,

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -32,12 +32,14 @@ type
     frameConfig*: FrameConfig
     logger*: Logger
 
+  NodeId* = distinct string
+
   FrameScene* = ref object of RootObj
     isRendering*: bool
     frameConfig*: FrameConfig
     logger*: Logger
     state*: JsonNode
-    execNode*: proc(nodeId: string, context: var ExecutionContext)
+    execNode*: proc(nodeId: NodeId, context: var ExecutionContext)
     dispatchEvent*: proc(event: string, payload: JsonNode)
 
   ExecutionContext* = ref object
@@ -70,3 +72,8 @@ type
     metricsLogger*: MetricsLogger
     server*: Server
     runner*: RunnerControl
+
+
+proc `==`*(x, y: NodeId): bool = x.string == y.string
+proc `==`*(x: string, y: NodeId): bool = x == y.string
+proc `==`*(x: NodeId, y: string): bool = x.string == y

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -32,7 +32,7 @@ type
     frameConfig*: FrameConfig
     logger*: Logger
 
-  NodeId* = distinct string
+  NodeId* = distinct int
 
   FrameScene* = ref object of RootObj
     isRendering*: bool
@@ -74,6 +74,8 @@ type
     runner*: RunnerControl
 
 
-proc `==`*(x, y: NodeId): bool = x.string == y.string
-proc `==`*(x: string, y: NodeId): bool = x == y.string
-proc `==`*(x: NodeId, y: string): bool = x.string == y
+proc `==`*(x, y: NodeId): bool = x.int == y.int
+proc `==`*(x: int, y: NodeId): bool = x == y.int
+proc `==`*(x: NodeId, y: int): bool = x.int == y
+proc `$`*(x: NodeId): string = $(x.int)
+proc `%`*(x: NodeId): JsonNode = %(x.int)

--- a/frameos/src/scenes/default.nim
+++ b/frameos/src/scenes/default.nim
@@ -14,15 +14,15 @@ import apps/gradient/app as gradientApp
 const DEBUG = false
 
 type Scene* = ref object of FrameScene
-  app_cbef1661_d2f5_4ef8_b0cf_458c3ae11200: unsplashApp.App
-  app_b94c5793_aeb1_4f3a_b273_c2305c12096e: textApp.App
-  app_1c9414bd_8bc4_4249_8ffb_1b3094715a06: clockApp.App
-  app_ddbd3753_ea6a_4a80_98b4_455fb623ef6b: downloadImageApp.App
-  app_caa0e562_49c7_47ba_9bfb_c6d1a837e414: splitApp.App
-  app_af43bfef_9f59_4a37_912b_8138c07ff9d3: unsplashApp.App
-  app_bbe82c34_84f6_4afe_beb3_87baa54f02e7: ifElseApp.App
-  app_b5f06d55_8889_4869_b12e_f5207211fa05: gradientApp.App
-  app_f4071b08_9afa_47c1_b890_0ca025849914: unsplashApp.App
+  node1: unsplashApp.App
+  node2: textApp.App
+  node3: clockApp.App
+  node4: downloadImageApp.App
+  node5: splitApp.App
+  node6: ifElseApp.App
+  node7: unsplashApp.App
+  node8: gradientApp.App
+  node9: unsplashApp.App
 
 {.push hint[XDeclaredButNotUsed]: off.}
 # This makes strformat available within the scene's inline code and avoids the "unused import" error
@@ -36,51 +36,51 @@ proc runNode*(self: Scene, nodeId: NodeId,
   var nextNode = nodeId
   var currentNode = nodeId
   var timer = epochTime()
-  while nextNode != "-1".NodeId:
+  while nextNode != -1.NodeId:
     currentNode = nextNode
     timer = epochTime()
     case nextNode:
-    of "cbef1661-d2f5-4ef8-b0cf-458c3ae11200".NodeId:
-      self.app_cbef1661_d2f5_4ef8_b0cf_458c3ae11200.run(context)
-      nextNode = "-1".NodeId
-    of "b94c5793-aeb1-4f3a-b273-c2305c12096e".NodeId:
-      self.app_b94c5793_aeb1_4f3a_b273_c2305c12096e.appConfig.text = &"Welcome to FrameOS!\nResolution: {context.image.width} x {context.image.height} .. " &
+    of 1.NodeId: # unsplash
+      self.node1.run(context)
+      nextNode = -1.NodeId
+    of 2.NodeId: # text
+      self.node2.appConfig.text = &"Welcome to FrameOS!\nResolution: {context.image.width} x {context.image.height} .. " &
           scene.state{"magic"}.getStr()
-      self.app_b94c5793_aeb1_4f3a_b273_c2305c12096e.appConfig.position = "top-left"
-      self.app_b94c5793_aeb1_4f3a_b273_c2305c12096e.run(context)
-      nextNode = "1c9414bd-8bc4-4249-8ffb-1b3094715a06".NodeId
-    of "1c9414bd-8bc4-4249-8ffb-1b3094715a06".NodeId:
-      self.app_1c9414bd_8bc4_4249_8ffb_1b3094715a06.run(context)
-      nextNode = "-1".NodeId
-    of "ddbd3753-ea6a-4a80-98b4-455fb623ef6b".NodeId:
-      self.app_ddbd3753_ea6a_4a80_98b4_455fb623ef6b.run(context)
-      nextNode = "-1".NodeId
-    of "caa0e562-49c7-47ba-9bfb-c6d1a837e414".NodeId:
-      self.app_caa0e562_49c7_47ba_9bfb_c6d1a837e414.run(context)
-      nextNode = "-1".NodeId
-    of "af43bfef-9f59-4a37-912b-8138c07ff9d3".NodeId:
-      self.app_af43bfef_9f59_4a37_912b_8138c07ff9d3.run(context)
-      nextNode = "-1".NodeId
-    of "bbe82c34-84f6-4afe-beb3-87baa54f02e7".NodeId:
-      self.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7.appConfig.condition = context.loopIndex mod 2 == 0
-      self.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7.run(context)
-      nextNode = "-1".NodeId
-    of "b5f06d55-8889-4869-b12e-f5207211fa05".NodeId:
-      self.app_b5f06d55_8889_4869_b12e_f5207211fa05.run(context)
-      nextNode = "-1".NodeId
-    of "f4071b08-9afa-47c1-b890-0ca025849914".NodeId:
-      self.app_f4071b08_9afa_47c1_b890_0ca025849914.run(context)
-      nextNode = "b94c5793-aeb1-4f3a-b273-c2305c12096e".NodeId
+      self.node2.appConfig.position = "top-left"
+      self.node2.run(context)
+      nextNode = 3.NodeId
+    of 3.NodeId: # clock
+      self.node3.run(context)
+      nextNode = -1.NodeId
+    of 4.NodeId: # downloadImage
+      self.node4.run(context)
+      nextNode = -1.NodeId
+    of 5.NodeId: # split
+      self.node5.run(context)
+      nextNode = -1.NodeId
+    of 7.NodeId: # unsplash
+      self.node7.run(context)
+      nextNode = -1.NodeId
+    of 6.NodeId: # ifElse
+      self.node6.appConfig.condition = context.loopIndex mod 2 == 0
+      self.node6.run(context)
+      nextNode = -1.NodeId
+    of 8.NodeId: # gradient
+      self.node8.run(context)
+      nextNode = -1.NodeId
+    of 9.NodeId: # unsplash
+      self.node9.run(context)
+      nextNode = 2.NodeId
     else:
-      nextNode = "-1".NodeId
+      nextNode = -1.NodeId
     if DEBUG:
-      self.logger.log(%*{"event": "runApp", "node": currentNode.string, "ms": (-timer + epochTime()) * 1000})
+      self.logger.log(%*{"event": "runApp", "node": currentNode, "ms": (-timer + epochTime()) * 1000})
 
 proc runEvent*(self: Scene, context: var ExecutionContext) =
   case context.event:
   of "render":
-    try: self.runNode("f4071b08-9afa-47c1-b890-0ca025849914".NodeId, context)
-    except Exception as e: self.logger.log(%*{"event": "event:error",
+    try: self.runNode(9.NodeId, context)
+    except Exception as e: self.logger.log(%*{"event": "event:render:error",
         "node": "f4071b08-9afa-47c1-b890-0ca025849914",
         "error": $e.msg, "stacktrace": e.getStackTrace()})
   else: discard
@@ -95,30 +95,24 @@ proc init*(frameConfig: FrameConfig, logger: Logger, dispatchEvent: proc(
     }, image: newImage(1, 1), loopIndex: 0, loopKey: ".")
   result = scene
   scene.execNode = (proc(nodeId: NodeId, context: var ExecutionContext) = self.runNode(nodeId, context))
-  scene.app_cbef1661_d2f5_4ef8_b0cf_458c3ae11200 = unsplashApp.init("cbef1661-d2f5-4ef8-b0cf-458c3ae11200".NodeId,
-      scene, unsplashApp.AppConfig(cacheSeconds: 60.0, keyword: "birds"))
-  scene.app_b94c5793_aeb1_4f3a_b273_c2305c12096e = textApp.init("b94c5793-aeb1-4f3a-b273-c2305c12096e".NodeId, scene,
-      textApp.AppConfig(borderWidth: 2, fontColor: parseHtmlColor("#ffffff"), fontSize: 64.0,
-      text: &"Welcome to FrameOS!\nResolution: {context.image.width} x {context.image.height} .. " & scene.state{
-      "magic"}.getStr(), position: "top-left", offsetX: 0.0, offsetY: 0.0, padding: 10.0, borderColor: parseHtmlColor("#000000")))
-  scene.app_1c9414bd_8bc4_4249_8ffb_1b3094715a06 = clockApp.init("1c9414bd-8bc4-4249-8ffb-1b3094715a06".NodeId, scene,
-      clockApp.AppConfig(position: "bottom-center", format: "HH:mm:ss", formatCustom: "", offsetX: 0.0, offsetY: 0.0,
-      padding: 10.0, fontColor: parseHtmlColor("#ffffff"), fontSize: 32.0, borderColor: parseHtmlColor("#000000"),
-      borderWidth: 1))
-  scene.app_ddbd3753_ea6a_4a80_98b4_455fb623ef6b = downloadImageApp.init("ddbd3753-ea6a-4a80-98b4-455fb623ef6b".NodeId,
-      scene, downloadImageApp.AppConfig(url: "http://10.4.0.11:4999/", scalingMode: "cover", cacheSeconds: 60.0))
-  scene.app_caa0e562_49c7_47ba_9bfb_c6d1a837e414 = splitApp.init("caa0e562-49c7-47ba-9bfb-c6d1a837e414".NodeId, scene,
-      splitApp.AppConfig(columns: 3, gap: "10", margin: "5", rows: 2,
-      render_function: "bbe82c34-84f6-4afe-beb3-87baa54f02e7".NodeId))
-  scene.app_af43bfef_9f59_4a37_912b_8138c07ff9d3 = unsplashApp.init("af43bfef-9f59-4a37-912b-8138c07ff9d3".NodeId,
-      scene, unsplashApp.AppConfig(keyword: "nature", cacheSeconds: 60.0))
-  scene.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7 = ifElseApp.init("bbe82c34-84f6-4afe-beb3-87baa54f02e7".NodeId, scene,
-      ifElseApp.AppConfig(condition: context.loopIndex mod 2 == 0,
-      thenNode: "af43bfef-9f59-4a37-912b-8138c07ff9d3".NodeId, elseNode: "b5f06d55-8889-4869-b12e-f5207211fa05".NodeId))
-  scene.app_b5f06d55_8889_4869_b12e_f5207211fa05 = gradientApp.init("b5f06d55-8889-4869-b12e-f5207211fa05".NodeId,
-      scene, gradientApp.AppConfig(startColor: parseHtmlColor("#800080"), endColor: parseHtmlColor("#ffc0cb"), angle: 45.0))
-  scene.app_f4071b08_9afa_47c1_b890_0ca025849914 = unsplashApp.init("f4071b08-9afa-47c1-b890-0ca025849914".NodeId,
-      scene, unsplashApp.AppConfig(cacheSeconds: 600.0, keyword: "nature"))
+  scene.node1 = unsplashApp.init(1.NodeId, scene, unsplashApp.AppConfig(cacheSeconds: 60.0, keyword: "birds"))
+  scene.node2 = textApp.init(2.NodeId, scene, textApp.AppConfig(borderWidth: 2, fontColor: parseHtmlColor("#ffffff"),
+      fontSize: 64.0, text: &"Welcome to FrameOS!\nResolution: {context.image.width} x {context.image.height} .. " &
+      scene.state{"magic"}.getStr(), position: "top-left", offsetX: 0.0, offsetY: 0.0, padding: 10.0,
+      borderColor: parseHtmlColor("#000000")))
+  scene.node3 = clockApp.init(3.NodeId, scene, clockApp.AppConfig(position: "bottom-center", format: "HH:mm:ss",
+      formatCustom: "", offsetX: 0.0, offsetY: 0.0, padding: 10.0, fontColor: parseHtmlColor("#ffffff"), fontSize: 32.0,
+      borderColor: parseHtmlColor("#000000"), borderWidth: 1))
+  scene.node4 = downloadImageApp.init(4.NodeId, scene, downloadImageApp.AppConfig(url: "http://10.4.0.11:4999/",
+      scalingMode: "cover", cacheSeconds: 60.0))
+  scene.node5 = splitApp.init(5.NodeId, scene, splitApp.AppConfig(columns: 3, gap: "10", margin: "5", rows: 2,
+      render_function: 6.NodeId))
+  scene.node7 = unsplashApp.init(7.NodeId, scene, unsplashApp.AppConfig(keyword: "nature", cacheSeconds: 60.0))
+  scene.node6 = ifElseApp.init(6.NodeId, scene, ifElseApp.AppConfig(condition: context.loopIndex mod 2 == 0,
+      thenNode: 7.NodeId, elseNode: 8.NodeId))
+  scene.node8 = gradientApp.init(8.NodeId, scene, gradientApp.AppConfig(startColor: parseHtmlColor("#800080"),
+      endColor: parseHtmlColor("#ffc0cb"), angle: 45.0))
+  scene.node9 = unsplashApp.init(9.NodeId, scene, unsplashApp.AppConfig(cacheSeconds: 600.0, keyword: "nature"))
   runEvent(scene, context)
 
 proc render*(self: Scene): Image =

--- a/frameos/src/scenes/default.nim
+++ b/frameos/src/scenes/default.nim
@@ -28,7 +28,7 @@ type Scene* = ref object of FrameScene
 # This makes strformat available within the scene's inline code and avoids the "unused import" error
 discard &""
 
-proc runNode*(self: Scene, nodeId: string,
+proc runNode*(self: Scene, nodeId: NodeId,
     context: var ExecutionContext) =
   let scene = self
   let frameConfig = scene.frameConfig
@@ -36,50 +36,50 @@ proc runNode*(self: Scene, nodeId: string,
   var nextNode = nodeId
   var currentNode = nodeId
   var timer = epochTime()
-  while nextNode != "-1":
+  while nextNode != "-1".NodeId:
     currentNode = nextNode
     timer = epochTime()
     case nextNode:
-    of "cbef1661-d2f5-4ef8-b0cf-458c3ae11200":
+    of "cbef1661-d2f5-4ef8-b0cf-458c3ae11200".NodeId:
       self.app_cbef1661_d2f5_4ef8_b0cf_458c3ae11200.run(context)
-      nextNode = "-1"
-    of "b94c5793-aeb1-4f3a-b273-c2305c12096e":
+      nextNode = "-1".NodeId
+    of "b94c5793-aeb1-4f3a-b273-c2305c12096e".NodeId:
       self.app_b94c5793_aeb1_4f3a_b273_c2305c12096e.appConfig.text = &"Welcome to FrameOS!\nResolution: {context.image.width} x {context.image.height} .. " &
           scene.state{"magic"}.getStr()
       self.app_b94c5793_aeb1_4f3a_b273_c2305c12096e.appConfig.position = "top-left"
       self.app_b94c5793_aeb1_4f3a_b273_c2305c12096e.run(context)
-      nextNode = "1c9414bd-8bc4-4249-8ffb-1b3094715a06"
-    of "1c9414bd-8bc4-4249-8ffb-1b3094715a06":
+      nextNode = "1c9414bd-8bc4-4249-8ffb-1b3094715a06".NodeId
+    of "1c9414bd-8bc4-4249-8ffb-1b3094715a06".NodeId:
       self.app_1c9414bd_8bc4_4249_8ffb_1b3094715a06.run(context)
-      nextNode = "-1"
-    of "ddbd3753-ea6a-4a80-98b4-455fb623ef6b":
+      nextNode = "-1".NodeId
+    of "ddbd3753-ea6a-4a80-98b4-455fb623ef6b".NodeId:
       self.app_ddbd3753_ea6a_4a80_98b4_455fb623ef6b.run(context)
-      nextNode = "-1"
-    of "caa0e562-49c7-47ba-9bfb-c6d1a837e414":
+      nextNode = "-1".NodeId
+    of "caa0e562-49c7-47ba-9bfb-c6d1a837e414".NodeId:
       self.app_caa0e562_49c7_47ba_9bfb_c6d1a837e414.run(context)
-      nextNode = "-1"
-    of "af43bfef-9f59-4a37-912b-8138c07ff9d3":
+      nextNode = "-1".NodeId
+    of "af43bfef-9f59-4a37-912b-8138c07ff9d3".NodeId:
       self.app_af43bfef_9f59_4a37_912b_8138c07ff9d3.run(context)
-      nextNode = "-1"
-    of "bbe82c34-84f6-4afe-beb3-87baa54f02e7":
+      nextNode = "-1".NodeId
+    of "bbe82c34-84f6-4afe-beb3-87baa54f02e7".NodeId:
       self.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7.appConfig.condition = context.loopIndex mod 2 == 0
       self.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7.run(context)
-      nextNode = "-1"
-    of "b5f06d55-8889-4869-b12e-f5207211fa05":
+      nextNode = "-1".NodeId
+    of "b5f06d55-8889-4869-b12e-f5207211fa05".NodeId:
       self.app_b5f06d55_8889_4869_b12e_f5207211fa05.run(context)
-      nextNode = "-1"
-    of "f4071b08-9afa-47c1-b890-0ca025849914":
+      nextNode = "-1".NodeId
+    of "f4071b08-9afa-47c1-b890-0ca025849914".NodeId:
       self.app_f4071b08_9afa_47c1_b890_0ca025849914.run(context)
-      nextNode = "b94c5793-aeb1-4f3a-b273-c2305c12096e"
+      nextNode = "b94c5793-aeb1-4f3a-b273-c2305c12096e".NodeId
     else:
-      nextNode = "-1"
+      nextNode = "-1".NodeId
     if DEBUG:
-      self.logger.log(%*{"event": "runApp", "node": currentNode, "ms": (-timer + epochTime()) * 1000})
+      self.logger.log(%*{"event": "runApp", "node": currentNode.string, "ms": (-timer + epochTime()) * 1000})
 
 proc runEvent*(self: Scene, context: var ExecutionContext) =
   case context.event:
   of "render":
-    try: self.runNode("f4071b08-9afa-47c1-b890-0ca025849914", context)
+    try: self.runNode("f4071b08-9afa-47c1-b890-0ca025849914".NodeId, context)
     except Exception as e: self.logger.log(%*{"event": "event:error",
         "node": "f4071b08-9afa-47c1-b890-0ca025849914",
         "error": $e.msg, "stacktrace": e.getStackTrace()})
@@ -94,31 +94,31 @@ proc init*(frameConfig: FrameConfig, logger: Logger, dispatchEvent: proc(
   var context = ExecutionContext(scene: scene, event: "init", payload: %*{
     }, image: newImage(1, 1), loopIndex: 0, loopKey: ".")
   result = scene
-  scene.execNode = (proc(nodeId: string, context: var ExecutionContext) = self.runNode(nodeId, context))
-  scene.app_cbef1661_d2f5_4ef8_b0cf_458c3ae11200 = unsplashApp.init("cbef1661-d2f5-4ef8-b0cf-458c3ae11200", scene,
-      unsplashApp.AppConfig(cacheSeconds: 60.0, keyword: "birds"))
-  scene.app_b94c5793_aeb1_4f3a_b273_c2305c12096e = textApp.init("b94c5793-aeb1-4f3a-b273-c2305c12096e", scene,
+  scene.execNode = (proc(nodeId: NodeId, context: var ExecutionContext) = self.runNode(nodeId, context))
+  scene.app_cbef1661_d2f5_4ef8_b0cf_458c3ae11200 = unsplashApp.init("cbef1661-d2f5-4ef8-b0cf-458c3ae11200".NodeId,
+      scene, unsplashApp.AppConfig(cacheSeconds: 60.0, keyword: "birds"))
+  scene.app_b94c5793_aeb1_4f3a_b273_c2305c12096e = textApp.init("b94c5793-aeb1-4f3a-b273-c2305c12096e".NodeId, scene,
       textApp.AppConfig(borderWidth: 2, fontColor: parseHtmlColor("#ffffff"), fontSize: 64.0,
       text: &"Welcome to FrameOS!\nResolution: {context.image.width} x {context.image.height} .. " & scene.state{
       "magic"}.getStr(), position: "top-left", offsetX: 0.0, offsetY: 0.0, padding: 10.0, borderColor: parseHtmlColor("#000000")))
-  scene.app_1c9414bd_8bc4_4249_8ffb_1b3094715a06 = clockApp.init("1c9414bd-8bc4-4249-8ffb-1b3094715a06", scene,
+  scene.app_1c9414bd_8bc4_4249_8ffb_1b3094715a06 = clockApp.init("1c9414bd-8bc4-4249-8ffb-1b3094715a06".NodeId, scene,
       clockApp.AppConfig(position: "bottom-center", format: "HH:mm:ss", formatCustom: "", offsetX: 0.0, offsetY: 0.0,
       padding: 10.0, fontColor: parseHtmlColor("#ffffff"), fontSize: 32.0, borderColor: parseHtmlColor("#000000"),
       borderWidth: 1))
-  scene.app_ddbd3753_ea6a_4a80_98b4_455fb623ef6b = downloadImageApp.init("ddbd3753-ea6a-4a80-98b4-455fb623ef6b", scene,
-      downloadImageApp.AppConfig(url: "http://10.4.0.11:4999/", scalingMode: "cover", cacheSeconds: 60.0))
-  scene.app_caa0e562_49c7_47ba_9bfb_c6d1a837e414 = splitApp.init("caa0e562-49c7-47ba-9bfb-c6d1a837e414", scene,
+  scene.app_ddbd3753_ea6a_4a80_98b4_455fb623ef6b = downloadImageApp.init("ddbd3753-ea6a-4a80-98b4-455fb623ef6b".NodeId,
+      scene, downloadImageApp.AppConfig(url: "http://10.4.0.11:4999/", scalingMode: "cover", cacheSeconds: 60.0))
+  scene.app_caa0e562_49c7_47ba_9bfb_c6d1a837e414 = splitApp.init("caa0e562-49c7-47ba-9bfb-c6d1a837e414".NodeId, scene,
       splitApp.AppConfig(columns: 3, gap: "10", margin: "5", rows: 2,
-      render_function: "bbe82c34-84f6-4afe-beb3-87baa54f02e7"))
-  scene.app_af43bfef_9f59_4a37_912b_8138c07ff9d3 = unsplashApp.init("af43bfef-9f59-4a37-912b-8138c07ff9d3", scene,
-      unsplashApp.AppConfig(keyword: "nature", cacheSeconds: 60.0))
-  scene.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7 = ifElseApp.init("bbe82c34-84f6-4afe-beb3-87baa54f02e7", scene,
-      ifElseApp.AppConfig(condition: context.loopIndex mod 2 == 0, thenNode: "af43bfef-9f59-4a37-912b-8138c07ff9d3",
-      elseNode: "b5f06d55-8889-4869-b12e-f5207211fa05"))
-  scene.app_b5f06d55_8889_4869_b12e_f5207211fa05 = gradientApp.init("b5f06d55-8889-4869-b12e-f5207211fa05", scene,
-      gradientApp.AppConfig(startColor: parseHtmlColor("#800080"), endColor: parseHtmlColor("#ffc0cb"), angle: 45.0))
-  scene.app_f4071b08_9afa_47c1_b890_0ca025849914 = unsplashApp.init("f4071b08-9afa-47c1-b890-0ca025849914", scene,
-      unsplashApp.AppConfig(cacheSeconds: 600.0, keyword: "nature"))
+      render_function: "bbe82c34-84f6-4afe-beb3-87baa54f02e7".NodeId))
+  scene.app_af43bfef_9f59_4a37_912b_8138c07ff9d3 = unsplashApp.init("af43bfef-9f59-4a37-912b-8138c07ff9d3".NodeId,
+      scene, unsplashApp.AppConfig(keyword: "nature", cacheSeconds: 60.0))
+  scene.app_bbe82c34_84f6_4afe_beb3_87baa54f02e7 = ifElseApp.init("bbe82c34-84f6-4afe-beb3-87baa54f02e7".NodeId, scene,
+      ifElseApp.AppConfig(condition: context.loopIndex mod 2 == 0,
+      thenNode: "af43bfef-9f59-4a37-912b-8138c07ff9d3".NodeId, elseNode: "b5f06d55-8889-4869-b12e-f5207211fa05".NodeId))
+  scene.app_b5f06d55_8889_4869_b12e_f5207211fa05 = gradientApp.init("b5f06d55-8889-4869-b12e-f5207211fa05".NodeId,
+      scene, gradientApp.AppConfig(startColor: parseHtmlColor("#800080"), endColor: parseHtmlColor("#ffc0cb"), angle: 45.0))
+  scene.app_f4071b08_9afa_47c1_b890_0ca025849914 = unsplashApp.init("f4071b08-9afa-47c1-b890-0ca025849914".NodeId,
+      scene, unsplashApp.AppConfig(cacheSeconds: 600.0, keyword: "nature"))
   runEvent(scene, context)
 
 proc render*(self: Scene): Image =

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -38,7 +38,7 @@ export const frameLogic = kea<frameLogicType>([
   connect({ values: [framesModel, ['frames']] }),
   actions({
     updateScene: (sceneId: string, scene: Partial<FrameScene>) => ({ sceneId, scene }),
-    updateNodeData: (sceneId: string, nodeId: string, nodeData: Record<string, any>) => ({ sceneId, nodeId, nodeData }),
+    updateNodeData: (sceneId: string, nodeId: NodeId, nodeData: Record<string, any>) => ({ sceneId, nodeId, nodeData }),
     saveFrame: true,
     renderFrame: true,
     restartFrame: true,

--- a/frontend/src/scenes/frame/panels/Diagram/appNodeLogic.ts
+++ b/frontend/src/scenes/frame/panels/Diagram/appNodeLogic.ts
@@ -8,7 +8,7 @@ import { App, ConfigField, MarkdownField } from '../../../../types'
 import type { Edge } from '@reactflow/core/dist/esm/types/edges'
 
 export interface AppNodeLogicProps extends DiagramLogicProps {
-  nodeId: string
+  nodeId: NodeId
 }
 
 export const appNodeLogic = kea<appNodeLogicType>([
@@ -20,7 +20,7 @@ export const appNodeLogic = kea<appNodeLogicType>([
   })),
   selectors({
     nodeId: [() => [(_, props) => props.nodeId], (nodeId): string => nodeId],
-    node: [(s) => [s.nodes, s.nodeId], (nodes: Node[], nodeId: string) => nodes?.find((n) => n.id === nodeId) ?? null],
+    node: [(s) => [s.nodes, s.nodeId], (nodes: Node[], nodeId: NodeId) => nodes?.find((n) => n.id === nodeId) ?? null],
     nodeEdges: [
       (s) => [s.edges, s.nodeId],
       (edges: Edge[], nodeId): Edge[] => edges?.filter((e) => e.source === nodeId || e.target === nodeId) ?? [],

--- a/frontend/src/scenes/frame/panels/Diagram/diagramLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/diagramLogic.tsx
@@ -42,7 +42,7 @@ export const diagramLogic = kea<diagramLogicType>([
     keywordDropped: (keyword: string, type: string, position: XYPosition) => ({ keyword, type, position }),
     updateNodeData: (id: string, data: Record<string, any>) => ({ id, data }),
     updateNodeConfig: (id: string, field: string, value: any) => ({ id, field, value }),
-    copyAppJSON: (nodeId: string) => ({ nodeId }),
+    copyAppJSON: (nodeId: NodeId) => ({ nodeId }),
     deleteApp: (id: string) => ({ id }),
   }),
   reducers({

--- a/frontend/src/scenes/frame/panels/EditApp/EditApp.tsx
+++ b/frontend/src/scenes/frame/panels/EditApp/EditApp.tsx
@@ -18,7 +18,7 @@ import { Markdown } from '../../../../components/Markdown'
 interface EditAppProps {
   panel: PanelWithMetadata
   sceneId: string
-  nodeId: string
+  nodeId: NodeId
   nodeData: AppNodeData
 }
 

--- a/frontend/src/scenes/frame/panels/EditApp/editAppLogic.tsx
+++ b/frontend/src/scenes/frame/panels/EditApp/editAppLogic.tsx
@@ -10,7 +10,7 @@ export interface ModelMarker extends editor.IMarkerData {}
 export interface EditAppLogicProps {
   frameId: number
   sceneId: string
-  nodeId: string
+  nodeId: NodeId
   keyword: string
   sources?: Record<string, string>
 }

--- a/frontend/src/scenes/frame/panels/panelsLogic.ts
+++ b/frontend/src/scenes/frame/panels/panelsLogic.ts
@@ -42,7 +42,7 @@ export const panelsLogic = kea<panelsLogicType>([
     setPanel: (area: Area, panel: PanelWithMetadata) => ({ area, panel }),
     closePanel: (panel: PanelWithMetadata) => ({ panel }),
     toggleFullScreenPanel: (panel: PanelWithMetadata) => ({ panel }),
-    editApp: (sceneId: string, nodeId: string, nodeData: AppNodeData) => ({ sceneId, nodeId, nodeData }),
+    editApp: (sceneId: string, nodeId: NodeId, nodeData: AppNodeData) => ({ sceneId, nodeId, nodeData }),
     persistUntilClosed: (panel: PanelWithMetadata, logic: AnyBuiltLogic) => ({ panel, logic }),
   }),
   reducers({

--- a/frontend/src/utils/arrangeNodes.ts
+++ b/frontend/src/utils/arrangeNodes.ts
@@ -7,7 +7,7 @@ const SPACE_BETWEEN_CHAINS = 50
 export function arrangeNodes(nodes: Node[], edges: Edge[]): Node[] {
   let visited = new Set<string>()
 
-  function dfs(currentNodeId: string, chain: Node[]): Node[] {
+  function dfs(currentnodeId: NodeId, chain: Node[]): Node[] {
     visited.add(currentNodeId)
 
     // Add the current node to the chain


### PR DESCRIPTION
This PR converts the `nodeId` variable used in scene apps from a `string` to a `type NodeId* = distinct int`. Comparing and passing integers around should be simpler and faster than strings. We also reduce the app's memory footprint (more efficiency), making it more possible to run on ESP-style devices.

Sadly this requires changing every app, including those created in the interface. 

Happily, I have added a migration that does most changes automatically. Yet there may be some custom apps created by users that use this `nodeId` in different ways than I had in mind. For this latter group, I apologise for the disruption this brings. I'm going to try really hard not to have breaking changes in FrameOS, but a change like this seems necessary and will be worse later though, so... 🙃. 

If you upgrade via docker, everything should be fine. If you're running FrameOS manually, run `flask db upgrade` after merging in the new changes.

Scene source before:

<img width="1080" alt="image" src="https://github.com/FrameOS/frameos/assets/53387/f9e7e292-e63e-4e54-a08b-153941324bfb">

Scene source after:

<img width="1075" alt="image" src="https://github.com/FrameOS/frameos/assets/53387/9828aebe-4247-41d8-b718-ba155814b09c">
