### PR TITLE
Use render event as destination

### DIFF
--- a/frontend/src/scenes/frame/panels/Events/Events.tsx
+++ b/frontend/src/scenes/frame/panels/Events/Events.tsx
@@ -9,7 +9,7 @@ const events = {
   mouseMove: 'When a mouse moves {x: int, y: int}',
   mouseDown: 'When a mouse button is pressed {button: int}',
   mouseUp: 'When a mouse button is released {button: int}',
-  button: 'When a GPIO button is triggered {pin: int, label: str, line: int}',
+  button: 'When a GPIO button is triggered {pin: int, label: string, line: int}',
 }
 
 export function Events() {


### PR DESCRIPTION
Now that Inky Impression GPIO buttons work, I realised using the render event as a destination didn't work anymore, as it did before the nim rewrite. Now it does. 

<img width="1630" alt="image" src="https://github.com/FrameOS/frameos/assets/53387/c72525a0-7fbe-4c31-b157-ad1c5caf9bb8">

<img width="1631" alt="image" src="https://github.com/FrameOS/frameos/assets/53387/d9995ef1-ecc4-40c7-924c-7ec411983f28">

You can now build many interactive demos with these frames and a bit of code. The "break if rendering" app helps with trigger happy fingers if your render takes 40 seconds.