### PR TITLE
Faster python driver incremental builds

### DIFF
--- a/backend/app/codegen/scene_nim.py
+++ b/backend/app/codegen/scene_nim.py
@@ -10,7 +10,6 @@ def write_scene_nim(frame: Frame, scene: dict) -> str:
     from app.models.log import new_log as log
     available_apps = get_local_frame_apps()
     scene_id = scene.get('id', 'default')
-    log(frame.id, "stdout", f"- Generating scene: {scene_id}")
     nodes = scene.get('nodes', [])
     nodes_by_id = {n['id']: n for n in nodes}
     node_integer_map: dict[str, int] = {}
@@ -80,16 +79,14 @@ def write_scene_nim(frame: Frame, scene: dict) -> str:
             app_id = f"node{node_integer}"
 
             if name not in available_apps and len(sources) == 0:
-                log(frame.id, "stderr", f"- ERROR: App \"{name}\" for node \"{node_id}\" not found")
+                log(frame.id, "stderr", f"- ERROR: When generating scene {scene_id}. App \"{name}\" for node \"{node_id}\" not found")
                 continue
 
             if len(sources) > 0:
-                log(frame.id, "stdout", f"- Generating source app: {node_id}")
                 node_app_id = "nodeapp_" + node_id.replace('-', '_')
                 app_import = f"import apps/{node_app_id}/app as nodeApp{node_id_to_integer(node_app_id)}"
                 scene_object_fields += [f"{app_id}: nodeApp{node_id_to_integer(node_app_id)}.App"]
             else:
-                log(frame.id, "stdout", f"- Generating app: {node_id} ({name})")
                 app_import = f"import apps/{name}/app as {name}App"
                 scene_object_fields += [f"{app_id}: {name}App.App"]
 
@@ -124,7 +121,7 @@ def write_scene_nim(frame: Frame, scene: dict) -> str:
             for key, value in app_config.items():
                 if key not in config_types:
                     log(frame.id, "stderr",
-                        f"- ERROR: Config key \"{key}\" not found for app \"{name}\", node \"{node_id}\"")
+                        f"- ERROR: When generating scene {scene_id}. Config key \"{key}\" not found for app \"{name}\", node \"{node_id}\"")
                     continue
                 type = config_types[key]
 

--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -113,16 +113,16 @@ def deploy_frame(id: int):
                     # TODO: abstract driver-specific install steps
                     # TODO: abstract vendor logic
                     if inkyPython := drivers.get("inkyPython"):
-                        exec_command(frame, ssh, f"cp -r /srv/frameos/build/build_{build_id}/vendor /srv/frameos/releases/release_{build_id}/vendor")
+                        exec_command(frame, ssh, f"mkdir -p /srv/frameos/vendor && cp -r /srv/frameos/build/build_{build_id}/vendor/inkyPython /srv/frameos/vendor/")
                         install_if_necessary("python3-pip")
                         install_if_necessary("python3-venv")
-                        exec_command(frame, ssh, f"cd /srv/frameos/releases/release_{build_id}/vendor/{inkyPython.vendor_folder} && python3 -m venv env && env/bin/pip3 install -r requirements.txt")
+                        exec_command(frame, ssh, f"cd /srv/frameos/vendor/{inkyPython.vendor_folder} && ([ ! -d env ] && python3 -m venv env || echo 'env exists') && (sha256sum -c requirements.txt.sha256sum 2>/dev/null || (echo '> env/bin/pip3 install -r requirements.txt' && env/bin/pip3 install -r requirements.txt && sha256sum requirements.txt > requirements.txt.sha256sum))")
 
                     if inkyHyperPixel2r := drivers.get("inkyHyperPixel2r"):
-                        exec_command(frame, ssh, f"cp -r /srv/frameos/build/build_{build_id}/vendor /srv/frameos/releases/release_{build_id}/vendor")
+                        exec_command(frame, ssh, f"mkdir -p /srv/frameos/vendor && cp -r /srv/frameos/build/build_{build_id}/vendor/inkyHyperPixel2r /srv/frameos/vendor/")
                         install_if_necessary("python3-pip")
                         install_if_necessary("python3-venv")
-                        exec_command(frame, ssh, f"cd /srv/frameos/releases/release_{build_id}/vendor/{inkyHyperPixel2r.vendor_folder} && python3 -m venv env && env/bin/pip3 install -r requirements.txt")
+                        exec_command(frame, ssh, f"cd /srv/frameos/vendor/{inkyHyperPixel2r.vendor_folder} && ([ ! -d env ] && python3 -m venv env || echo 'env exists') && (sha256sum -c requirements.txt.sha256sum 2>/dev/null || (echo '> env/bin/pip3 install -r requirements.txt' && env/bin/pip3 install -r requirements.txt && sha256sum requirements.txt > requirements.txt.sha256sum))")
 
                     # add frameos.service
                     with open("../frameos/frameos.service", "r") as file:

--- a/frameos/Makefile
+++ b/frameos/Makefile
@@ -3,11 +3,3 @@ run:
 
 test:
 	nimble test
-
-toormoos:
-	nim c --os:linux --cpu:arm64 --compileOnly --genScript --nimcache:tmp/build_1 src/frameos.nim
-	cp /opt/homebrew/Cellar/nim/2.0.0_1/nim/lib/nimbase.h tmp/build_1/nimbase.h
-	awk 'NR==FNR{total=NR; next} {printf "echo Compiling on device: %d/%d\n", NR - total, total; print}' tmp/build_1/compile_frameos.sh tmp/build_1/compile_frameos.sh > tmp/build_1/compile_frameos.sh.awk && mv tmp/build_1/compile_frameos.sh.awk tmp/build_1/compile_frameos.sh
-	(cd tmp && tar -czf ./build_1.tar.gz build_1)
-	scp -r tmp/build_1.tar.gz toormoos:
-	ssh toormoos "rm -rf build_1 && tar -xzf build_1.tar.gz && cd build_1 && sh ./compile_frameos.sh && ./frameos"

--- a/frameos/src/drivers/inkyHyperPixel2r/inkyHyperPixel2r.nim
+++ b/frameos/src/drivers/inkyHyperPixel2r/inkyHyperPixel2r.nim
@@ -12,7 +12,7 @@ proc render*(self: Driver, image: Image) =
   frameBuffer.render(self, image)
 
 proc turnOn*(self: Driver) =
-  discard execCmd("cd ./vendor/inkyHyperPixel2r && ./env/bin/python3 turnOn.py")
+  discard execCmd("cd /srv/frameos/vendor/inkyHyperPixel2r && ./env/bin/python3 turnOn.py")
 
 proc turnOff*(self: Driver) =
-  discard execCmd("cd ./vendor/inkyHyperPixel2r && ./env/bin/python3 turnOff.py")
+  discard execCmd("cd /srv/frameos/vendor/inkyHyperPixel2r && ./env/bin/python3 turnOff.py")

--- a/frameos/src/drivers/inkyPython/inkyPython.nim
+++ b/frameos/src/drivers/inkyPython/inkyPython.nim
@@ -32,7 +32,7 @@ proc init*(frameOS: FrameOS): Driver =
     logger: frameOS.logger
   )
 
-  let process = startProcess(workingDir = "./vendor/inkyPython",
+  let process = startProcess(workingDir = "/srv/frameos/vendor/inkyPython",
       command = "./env/bin/python3", args = ["check.py"], options = {poStdErrToStdOut})
   let pOut = process.outputStream()
   var line = ""
@@ -68,7 +68,7 @@ proc render*(self: Driver, image: Image) =
   self.lastImageData = image.data
   let imageData = image.encodeImage(BmpFormat)
 
-  let process = startProcess(workingDir = "./vendor/inkyPython",
+  let process = startProcess(workingDir = "/srv/frameos/vendor/inkyPython",
       command = "./env/bin/python3", args = ["run.py"], options = {poStdErrToStdOut})
   let pOut = process.outputStream()
   let pIn = process.inputStream()

--- a/frameos/tools/nimc.Makefile
+++ b/frameos/tools/nimc.Makefile
@@ -19,7 +19,7 @@ clean:
 
 pre-build:
 	@mkdir -p ../cache
-	@echo "Compiling on device. This might take a while on the first run."
+	@echo "Compiling on device, largest files first. This might take minutes on the first run."
 
 $(OBJECTS): pre-build
 


### PR DESCRIPTION
It took over a minute to re-install the python inky drivers' requirements. 

After this PR we install "vendor drivers" in a shared `/srv/frameos/vendor/inkyPython` style folders, instead of per-release folders like now. This allows us to easily cache dependencies between steps if nothing changes. Symlinking python venvs wasn't a better option.

As a result, the second install of the inky python drivers now takes less than a second. It used to always add a minute to the deployment time. The python hyperpixel brightness controls are now equally fast to update.

I did some other cleanup in the PR as well.

A full (incremental) redeploy, from SSH connection established to connection closed, including on device compilation and linking, for a Raspberry Pi Zero W2 and an Inky impressions frame now takes 71 seconds... or 60 seconds exactly without the restart in the end.