### PR TITLE
Build frontend in PR CI

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -76,3 +81,9 @@ jobs:
       - name: Fail if changes detected
         if: env.changes_detected == 'true'
         run: exit 1
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm install
+          npm run build

--- a/frontend/src/scenes/frame/panels/Diagram/CustomEdge.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/CustomEdge.tsx
@@ -48,7 +48,7 @@ export default function CustomEdge({
           isNodeConnection
             ? selected
               ? { strokeWidth: 10, stroke: '#ffffff' }
-              : { strokeWidth: 8, stroke: 'hsl(202 80% 60% / 1)' }
+              : { strokeWidth: 8, stroke: 'hsl(56 60% 70% / 1)' }
             : selected
             ? { strokeWidth: 4, stroke: '#ffffff' }
             : { strokeWidth: 2, stroke: '#c5c5c5' }

--- a/frontend/src/scenes/frame/panels/Diagram/diagramLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/diagramLogic.tsx
@@ -129,7 +129,7 @@ export const diagramLogic = kea<diagramLogicType>([
     selectedNodeId: [(s) => [s.selectedNode], (node) => node?.id ?? null],
     edges: [
       (s) => [s.rawEdges],
-      (rawEdges) => rawEdges.map((edge) => (edge.type !== 'edge' ? { ...edge, type: 'edge' } : edge)),
+      (rawEdges): Edge[] => rawEdges.map((edge) => (edge.type !== 'edge' ? { ...edge, type: 'edge' } : edge)),
     ],
     selectedEdge: [(s) => [s.edges], (edges): Edge | null => edges.find((edge) => edge.selected) ?? null],
     selectedEdgeId: [(s) => [s.selectedEdge], (edge) => edge?.id ?? null],


### PR DESCRIPTION
The PR CI scripts didn't test if the frontend builds, hence causing the merged PR's docker build step to fail.

This adds frontend build to the list of checks CI does on a PR, and fixes what caused the regression.