### PR TITLE
Logging via websockets

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -11,6 +11,7 @@ from flask import Flask
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from flask_sock import Sock
 from flask_socketio import SocketIO
 from config import Config, get_config
 from urllib.parse import urlparse
@@ -22,6 +23,7 @@ login_manager = LoginManager()
 login_manager.login_view = 'api.login'
 migrate = Migrate()
 socketio = SocketIO(async_mode='gevent')
+sock = Sock()
 
 DEFAULT_REDIS_URL = 'redis://localhost:6379/0'
 
@@ -52,7 +54,6 @@ def create_app(config: Optional[Config] = None):
     config = config or get_config()
     app = Flask(__name__, static_folder='../../frontend/dist', static_url_path='/', template_folder='../templates')
     app.config.from_object(config)
-
     db.init_app(app)
     with app.app_context():
         os.makedirs('../db', exist_ok=True)
@@ -60,6 +61,7 @@ def create_app(config: Optional[Config] = None):
         db.create_all()
     login_manager.init_app(app)
     migrate.init_app(app, db)
+    sock.init_app(app)
     socketio.init_app(app, cors_allowed_origins="*", message_queue=os.environ.get('REDIS_URL', DEFAULT_REDIS_URL))
     initialize_sentry(app)
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -10,3 +10,4 @@ from .repositories import *
 from .settings import *
 from .templates import *
 from .misc import *
+from .sock import *

--- a/backend/app/api/sock.py
+++ b/backend/app/api/sock.py
@@ -1,0 +1,7 @@
+from app import sock
+
+@sock.route('/echo')
+def echo(ws):
+    while True:
+        data = ws.receive()
+        ws.send(data)

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -24,3 +24,4 @@ pip-tools
 pre-commit
 ruff
 imagehash
+flask-sock

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,6 +61,7 @@ flask==2.3.2
     #   -r requirements.in
     #   flask-login
     #   flask-migrate
+    #   flask-sock
     #   flask-socketio
     #   flask-sqlalchemy
     #   flask-wtf
@@ -68,6 +69,8 @@ flask==2.3.2
 flask-login==0.6.3
     # via -r requirements.in
 flask-migrate==4.0.4
+    # via -r requirements.in
+flask-sock==0.7.0
     # via -r requirements.in
 flask-socketio==5.3.5
     # via -r requirements.in
@@ -85,6 +88,8 @@ gevent-websocket==0.10.1
     # via -r requirements.in
 greenlet==2.0.2
     # via gevent
+h11==0.14.0
+    # via wsproto
 honcho==1.1.0
     # via -r requirements.in
 huey==2.4.5
@@ -191,6 +196,8 @@ scp==0.14.5
     # via -r requirements.in
 sentry-sdk[flask]==1.35.0
     # via -r requirements.in
+simple-websocket==1.0.0
+    # via flask-sock
 six==1.16.0
     # via asttokens
 sqlalchemy==2.0.19
@@ -222,6 +229,8 @@ werkzeug==2.3.6
     #   flask-login
 wheel==0.41.3
     # via pip-tools
+wsproto==1.2.0
+    # via simple-websocket
 wtforms==3.0.1
     # via
     #   -r requirements.in


### PR DESCRIPTION
Work in progress.

This switches logging to the backend to use websockets instead of separate HTTP requests.

TODO:
- Investigate a non-async webserver like [mummy](https://github.com/guzba/mummy/) or [GuildenStern](https://github.com/olliNiinivaara/GuildenStern)
- Investigate alternative websocket client libraries
- Multiple logging targets