### PR TITLE
Two more WaveShare Spectra 6 color displays

### DIFF
--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -290,8 +290,8 @@ async def deploy_frame_task(ctx: dict[str, Any], id: int):
         else:
             await exec_command(db, redis, frame, ssh, "sudo rm -f /etc/cron.d/frameos-reboot")
 
+        must_reboot = False
         if drivers.get("bootconfig"):
-            must_reboot = False
             for line in drivers["bootconfig"].lines:
                 if await exec_command(db, redis, frame, ssh,
                                       f'grep -q "^{line}" ' + boot_config, raise_on_error=False) != 0:

--- a/frameos/src/frameos/utils/dither.nim
+++ b/frameos/src/frameos/utils/dither.nim
@@ -16,8 +16,19 @@ const saturated4ColorPalette* = @[
   (156, 72, 75),
 ]
 
-# 6-color Spectra e-ink displays, as measured on a real display
+# 6-color Spectra e-ink displays, measured on display and modulated
 const spectra6ColorPalette* = @[
+  (13, 0, 19),     # 0x0 - black
+  (220, 220, 215), # 0x1 - white
+  (242, 220, 0),   # 0x2 - yellow
+  (130, 0, 0),     # 0x3 - red
+  (999, 999, 999), # skips an index!
+  (19, 60, 160),   # 0x5 - blue
+  (51, 83, 38),    # 0x6 - green
+]
+
+# 6-color Spectra e-ink displays, as measured on a real display (Attempt 1)
+const spectra6ColorPaletteTry1* = @[
   (50, 44, 52),    # 0x0 - black
   (255, 255, 255), # 0x1 - white
   (255, 248, 0),   # 0x2 - yellow
@@ -28,7 +39,7 @@ const spectra6ColorPalette* = @[
 ]
 
 # 6-color Spectra e-ink displays, as presented by the manufacturer. These are not used.
-const spectra6ColorPaletteOriginal* = @[
+const spectra6ColorPaletteOrig* = @[
   (0, 0, 0),       # 0x0 - black
   (255, 255, 255), # 0x1 - white
   (255, 255, 0),   # 0x2 - yellow

--- a/frontend/src/devices.ts
+++ b/frontend/src/devices.ts
@@ -53,7 +53,7 @@ export const devices: Option[] = [
   { value: 'waveshare.EPD_3in52', label: 'Waveshare 3.52" 360x240 Black/White' },
   { value: 'waveshare.EPD_3in52b', label: 'Waveshare 3.52" (B) 360x240 Black/White/Red' },
   { value: 'waveshare.EPD_3in7', label: 'Waveshare 3.7" 480x280 4 Grayscale' },
-  // { value: 'waveshare.EPD_4in0e', label: 'Waveshare 4.0" (E) 600x400 Spectra 6 Color' },
+  { value: 'waveshare.EPD_4in0e', label: 'Waveshare 4.0" (E) 600x400 Spectra 6 Color' },
   { value: 'waveshare.EPD_4in01f', label: 'Waveshare 4.01" (F) 640x400 7 Color' },
   { value: 'waveshare.EPD_4in2', label: 'Waveshare 4.2" 400x300 4 Grayscale' },
   { value: 'waveshare.EPD_4in2_V2', label: 'Waveshare 4.2" (V2) 400x300 4 Grayscale' },

--- a/frontend/src/devices.ts
+++ b/frontend/src/devices.ts
@@ -76,7 +76,7 @@ export const devices: Option[] = [
   { value: 'waveshare.EPD_5in83_V2', label: 'Waveshare 5.83" (V2) 648x480 Black/White' },
   { value: 'waveshare.EPD_5in83b_V2', label: 'Waveshare 5.83" (B V2) 648x480 Black/White/Red' },
   { value: 'waveshare.EPD_5in84', label: 'Waveshare 5.84" 768x256 Black/White' },
-  // { value: 'waveshare.EPD_7in3e', label: 'Waveshare 7.3" (E) 800x480 Spectra 6 Color' },
+  { value: 'waveshare.EPD_7in3e', label: 'Waveshare 7.3" (E) 800x480 Spectra 6 Color' },
   { value: 'waveshare.EPD_7in3f', label: 'Waveshare 7.3" (F) 800x480 7 Color' },
   { value: 'waveshare.EPD_7in3g', label: 'Waveshare 7.3" (G) 800x480 Black/White/Yellow/Red' },
   { value: 'waveshare.EPD_7in5', label: 'Waveshare 7.5" 640x384 Black/White' },

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -11,6 +11,8 @@ import { Field } from '../../../../components/Field'
 import { devices } from '../../../../devices'
 import { secureToken } from '../../../../utils/secureToken'
 import { appsLogic } from '../Apps/appsLogic'
+import { frameSettingsLogic } from './frameSettingsLogic'
+import { Spinner } from '../../../../components/Spinner'
 
 export interface FrameSettingsProps {
   className?: string
@@ -21,6 +23,8 @@ export function FrameSettings({ className }: FrameSettingsProps) {
   const { touchFrameFormField, setFrameFormValues } = useActions(frameLogic)
   const { deleteFrame } = useActions(framesModel)
   const { appsWithSaveAssets } = useValues(appsLogic)
+  const { clearBuildCache } = useActions(frameSettingsLogic({ frameId }))
+  const { buildCacheLoading } = useValues(frameSettingsLogic({ frameId }))
 
   return (
     <div className={clsx('space-y-4', className)}>
@@ -30,6 +34,16 @@ export function FrameSettings({ className }: FrameSettingsProps) {
         <>
           <div className="flex space-x-2">
             <div className="flex-1"></div>
+            <Button
+              type="button"
+              size="small"
+              color="secondary"
+              className="flex gap-2 items-center"
+              onClick={() => clearBuildCache()}
+            >
+              {buildCacheLoading ? <Spinner color="white" className="w-4 h-4" /> : null}
+              Clear build cache
+            </Button>
             <Button
               type="button"
               size="small"

--- a/frontend/src/scenes/frame/panels/FrameSettings/frameSettingsLogic.ts
+++ b/frontend/src/scenes/frame/panels/FrameSettings/frameSettingsLogic.ts
@@ -1,0 +1,28 @@
+import { kea, key, path, props } from 'kea'
+
+import type { frameSettingsLogicType } from './frameSettingsLogicType'
+import { loaders } from 'kea-loaders'
+import { apiFetch } from '../../../../utils/apiFetch'
+
+export const frameSettingsLogic = kea<frameSettingsLogicType>([
+  path(['src', 'scenes', 'frame', 'panels', 'FrameSettings', 'frameSettingsLogic']),
+  props({} as { frameId: number }),
+  key((props) => props.frameId),
+  loaders(({ props }) => ({
+    buildCache: [
+      false,
+      {
+        clearBuildCache: async () => {
+          if (confirm('Are you sure you want to clear the build cache?')) {
+            try {
+              await apiFetch(`/api/frames/${props.frameId}/clear_build_cache`, { method: 'POST' })
+            } catch (error) {
+              console.error(error)
+            }
+          }
+          return false
+        },
+      },
+    ],
+  })),
+])


### PR DESCRIPTION
- Adds support for the 4.0" and 7.3" spectra displays
![image](https://github.com/user-attachments/assets/401d0e74-4323-4b2b-8444-ad3789032a10)
![image](https://github.com/user-attachments/assets/6848598b-e429-456c-b9e9-c7deec7ea7b7)

- Adds a new button "clear build cache" under frame settings, which may come in useful sometimes
![image](https://github.com/user-attachments/assets/3156775f-e968-4923-8191-d40183dd5505)

- Change the dithering algorithm somewhat
- Fix a bug with deploying and restarting introduced in the previous build
