### PR TITLE
fast deploy

### DIFF
--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -473,6 +473,16 @@ async def api_frame_deploy_event(id: int, redis: Redis = Depends(get_redis)):
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e))
 
 
+@api_with_auth.post("/frames/{id:int}/fast_deploy")
+async def api_frame_fast_deploy_event(id: int, redis: Redis = Depends(get_redis)):
+    try:
+        from app.tasks import fast_deploy_frame
+        await fast_deploy_frame(id, redis)
+        return "Success"
+    except Exception as e:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e))
+
+
 @api_with_auth.post("/frames/{id:int}")
 async def api_frame_update_endpoint(
     id: int,

--- a/backend/app/models/frame.py
+++ b/backend/app/models/frame.py
@@ -95,6 +95,8 @@ class Frame(Base):
             'reboot': self.reboot,
             'control_code': self.control_code,
             'schedule': self.schedule,
+            'last_successful_deploy': self.last_successful_deploy,
+            'last_successful_deploy_at': self.last_successful_deploy_at.replace(tzinfo=timezone.utc).isoformat() if self.last_successful_deploy_at else None,
         }
 
 async def new_frame(db: Session, redis: Redis, name: str, frame_host: str, server_host: str, device: Optional[str] = None, interval: Optional[float] = None) -> Frame:

--- a/backend/app/schemas/frames.py
+++ b/backend/app/schemas/frames.py
@@ -38,6 +38,8 @@ class FrameBase(BaseModel):
     control_code: Any
     scenes: Optional[List[Dict[str, Any]]]
     schedule: Optional[Dict[str, Any]]
+    last_successful_deploy: Optional[Dict[str, Any]]
+    last_successful_deploy_at: Optional[datetime]
 
 class FrameResponse(BaseModel):
     frame: FrameBase

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,3 +1,4 @@
+from .fast_deploy_frame import fast_deploy_frame # noqa
 from .deploy_frame import deploy_frame # noqa
 from .reset_frame import reset_frame # noqa
 from .restart_frame import restart_frame # noqa

--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -49,6 +49,10 @@ async def deploy_frame_task(ctx: dict[str, Any], id: int):
             raise Exception("Already deploying. Request again to force redeploy.")
 
         frame_dict = frame.to_dict() # persisted as frame.last_successful_deploy if successful
+        if "last_successful_deploy" in frame_dict:
+            del frame_dict["last_successful_deploy"]
+        if "last_successful_deploy_at" in frame_dict:
+            del frame_dict["last_successful_deploy_at"]
 
         frame.status = 'deploying'
         await update_frame(db, redis, frame)

--- a/backend/app/tasks/fast_deploy_frame.py
+++ b/backend/app/tasks/fast_deploy_frame.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timezone
+import json
+import os
+import tempfile
+from typing import Any
+import asyncssh
+from sqlalchemy.orm import Session
+from arq import ArqRedis as Redis
+
+from app.models.log import new_log as log
+from app.models.frame import Frame, update_frame, get_frame_json
+from app.utils.ssh_utils import get_ssh_connection, exec_command, remove_ssh_connection
+
+async def fast_deploy_frame(id: int, redis: Redis):
+    await redis.enqueue_job("fast_deploy_frame", id=id)
+
+async def fast_deploy_frame_task(ctx: dict[str, Any], id: int):
+    db: Session = ctx['db']
+    redis: Redis = ctx['redis']
+
+    ssh = None
+    frame = None
+    try:
+        frame = db.get(Frame, id)
+        if not frame:
+            await log(db, redis, id, "stderr", "Frame not found")
+            return
+
+        ssh = await get_ssh_connection(db, redis, frame)
+
+        frame.status = 'restarting'
+        await update_frame(db, redis, frame)
+
+        await exec_command(db, redis, frame, ssh, "sudo systemctl stop frameos.service || true")
+
+        frame_dict = frame.to_dict() # persisted as frame.last_successful_deploy if successful
+        if "last_successful_deploy" in frame_dict:
+            del frame_dict["last_successful_deploy"]
+        if "last_successful_deploy_at" in frame_dict:
+            del frame_dict["last_successful_deploy_at"]
+
+        # Upload new frame.json
+        frame_json_data = (json.dumps(get_frame_json(db, frame), indent=4) + "\n").encode('utf-8')
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmpf:
+            local_json_path = tmpf.name
+            tmpf.write(frame_json_data)
+        await asyncssh.scp(
+            local_json_path, (ssh, "/srv/frameos/current/frame.json"),
+            recurse=False
+        )
+        os.remove(local_json_path)  # remove local temp file
+        await log(db, redis, id, "stdout", "> updated /srv/frameos/current/frame.json")
+
+        await exec_command(db, redis, frame, ssh, "sudo systemctl enable frameos.service")
+        await exec_command(db, redis, frame, ssh, "sudo systemctl start frameos.service")
+        await exec_command(db, redis, frame, ssh, "sudo systemctl status frameos.service")
+
+        frame.status = 'starting'
+        frame.last_successful_deploy = frame_dict
+        frame.last_successful_deploy_at = datetime.now(timezone.utc)
+        await update_frame(db, redis, frame)
+
+    except Exception as e:
+        await log(db, redis, id, "stderr", str(e))
+        if frame:
+            frame.status = 'uninitialized'
+            await update_frame(db, redis, frame)
+    finally:
+        if ssh is not None:
+            await remove_ssh_connection(db, redis, ssh, frame)

--- a/backend/app/tasks/worker.py
+++ b/backend/app/tasks/worker.py
@@ -10,6 +10,7 @@ from arq.connections import RedisSettings
 from arq.worker import func
 
 from app.tasks.deploy_frame import deploy_frame_task
+from app.tasks.fast_deploy_frame import fast_deploy_frame_task
 from app.tasks.reset_frame import reset_frame_task
 from app.tasks.restart_frame import restart_frame_task
 from app.tasks.stop_frame import stop_frame_task
@@ -44,10 +45,11 @@ class WorkerSettings:
     You run it with: `arq app.tasks.worker.WorkerSettings`.
     """
     functions = [
-        func(deploy_frame_task,  name="deploy_frame"),
-        func(reset_frame_task,   name="reset_frame"),
-        func(restart_frame_task, name="restart_frame"),
-        func(stop_frame_task,    name="stop_frame"),
+        func(deploy_frame_task,      name="deploy_frame"),
+        func(fast_deploy_frame_task, name="fast_deploy_frame"),
+        func(reset_frame_task,       name="reset_frame"),
+        func(restart_frame_task,     name="restart_frame"),
+        func(stop_frame_task,        name="stop_frame"),
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/frontend/src/components/DropdownMenu.tsx
+++ b/frontend/src/components/DropdownMenu.tsx
@@ -68,9 +68,11 @@ export function DropdownMenu({ items, className, horizontal, buttonColor: _butto
                       {({ active }) => (
                         <a
                           href="#"
-                          className={`${
-                            active && !!item.onClick ? 'bg-[#4a4b8c] text-white' : 'text-white'
-                          } px-4 py-2 text-sm flex gap-2`}
+                          className={clsx(
+                            `${
+                              active && !!item.onClick ? 'bg-[#4a4b8c] text-white' : 'text-white'
+                            } px-4 py-2 text-sm flex gap-2`
+                          )}
                           title={item.title}
                           onClick={
                             item.onClick

--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -20,7 +20,7 @@ export const framesModel = kea<framesModelType>([
   actions({
     addFrame: (frame: FrameType) => ({ frame }),
     loadFrame: (id: number) => ({ id }),
-    deployFrame: (id: number) => ({ id }),
+    deployFrame: (id: number, fastDeploy?: boolean) => ({ id, fastDeploy: fastDeploy || false }),
     stopFrame: (id: number) => ({ id }),
     restartFrame: (id: number) => ({ id }),
     renderFrame: (id: number) => ({ id }),
@@ -105,8 +105,12 @@ export const framesModel = kea<framesModelType>([
     renderFrame: async ({ id }) => {
       await apiFetch(`/api/frames/${id}/event/render`, { method: 'POST' })
     },
-    deployFrame: async ({ id }) => {
-      await apiFetch(`/api/frames/${id}/deploy`, { method: 'POST' })
+    deployFrame: async ({ id, fastDeploy }) => {
+      if (fastDeploy) {
+        await apiFetch(`/api/frames/${id}/fast_deploy`, { method: 'POST' })
+      } else {
+        await apiFetch(`/api/frames/${id}/deploy`, { method: 'POST' })
+      }
     },
     stopFrame: async ({ id }) => {
       await apiFetch(`/api/frames/${id}/stop`, { method: 'POST' })

--- a/frontend/src/scenes/frame/Frame.tsx
+++ b/frontend/src/scenes/frame/Frame.tsx
@@ -15,7 +15,7 @@ interface FrameSceneProps {
 export function Frame(props: FrameSceneProps) {
   const frameId = parseInt(props.id)
   const frameLogicProps = { frameId }
-  const { frame, frameChanged } = useValues(frameLogic(frameLogicProps))
+  const { frame, unsavedChanges, undeployedChanges, requiresRecompilation } = useValues(frameLogic(frameLogicProps))
   const { saveFrame, renderFrame, restartFrame, stopFrame, deployFrame } = useActions(frameLogic(frameLogicProps))
   const { openLogs } = useActions(panelsLogic(frameLogicProps))
 
@@ -34,21 +34,33 @@ export function Frame(props: FrameSceneProps) {
                     { label: 'Re-Render', onClick: () => renderFrame() },
                     { label: 'Restart', onClick: () => restartFrame() },
                     { label: 'Stop', onClick: () => stopFrame() },
+                    ...(!requiresRecompilation
+                      ? [
+                          {
+                            label: 'Full deploy',
+                            onClick: () => {
+                              deployFrame()
+                              openLogs()
+                            },
+                          },
+                        ]
+                      : []),
                   ]}
                 />
                 <div className="flex pl-2 space-x-2">
-                  <Button color={frameChanged ? 'primary' : 'secondary'} type="button" onClick={() => saveFrame()}>
+                  <Button color={unsavedChanges ? 'primary' : 'secondary'} type="button" onClick={() => saveFrame()}>
                     Save
                   </Button>
                   <Button
-                    color={'secondary'}
+                    color={undeployedChanges ? 'primary' : 'secondary'}
                     type="button"
                     onClick={() => {
                       deployFrame()
                       openLogs()
                     }}
                   >
-                    Redeploy
+                    {requiresRecompilation ? 'Full ' : 'Fast '}
+                    deploy
                   </Button>
                 </div>
               </div>

--- a/frontend/src/scenes/frame/panels/Assets/Assets.tsx
+++ b/frontend/src/scenes/frame/panels/Assets/Assets.tsx
@@ -140,7 +140,7 @@ export function Assets(): JSX.Element {
       <div className="float-right mt-[-8px]">
         <DropdownMenu
           className="w-fit"
-          buttonColor="none"
+          buttonColor="secondary"
           items={[
             {
               label: 'Sync fonts',

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -14,6 +14,9 @@ import { appsLogic } from '../Apps/appsLogic'
 import { frameSettingsLogic } from './frameSettingsLogic'
 import { Spinner } from '../../../../components/Spinner'
 import { H6 } from '../../../../components/H6'
+import { DropdownMenu } from '../../../../components/DropdownMenu'
+import { ArrowDownTrayIcon, ArrowPathIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline'
+import { TrashIcon } from '@heroicons/react/24/solid'
 
 export interface FrameSettingsProps {
   className?: string
@@ -28,92 +31,84 @@ export function FrameSettings({ className }: FrameSettingsProps) {
   const { buildCacheLoading } = useValues(frameSettingsLogic({ frameId }))
 
   return (
-    <div className={clsx('space-y-4', className)}>
+    <div className={className}>
       {!frame ? (
         `Loading frame ${frameId}...`
       ) : (
         <>
-          <div className="flex space-x-2">
-            <div className="flex-1"></div>
-            <Button
-              type="button"
-              size="small"
-              color="secondary"
-              className="flex gap-2 items-center"
-              onClick={() => clearBuildCache()}
-            >
-              {buildCacheLoading ? <Spinner color="white" className="w-4 h-4" /> : null}
-              Clear build cache
-            </Button>
-            <Button
-              type="button"
-              size="small"
-              color="secondary"
-              className="flex-0"
-              onClick={() => {
-                function handleFileSelect(event: Event): void {
-                  const inputElement = event.target as HTMLInputElement
-                  const file = inputElement.files?.[0]
+          <div className="float-right">
+            <DropdownMenu
+              className="w-fit"
+              buttonColor="secondary"
+              items={[
+                {
+                  label: 'Clear build cache',
+                  onClick: () => clearBuildCache(),
+                  icon: buildCacheLoading ? (
+                    <Spinner color="white" className="w-4 h-4" />
+                  ) : (
+                    <ArrowPathIcon className="w-5 h-5" />
+                  ),
+                },
+                {
+                  label: 'Import .json',
+                  onClick: () => {
+                    function handleFileSelect(event: Event): void {
+                      const inputElement = event.target as HTMLInputElement
+                      const file = inputElement.files?.[0]
 
-                  if (!file) {
-                    console.error('No file selected')
-                    return
-                  }
+                      if (!file) {
+                        console.error('No file selected')
+                        return
+                      }
 
-                  const reader = new FileReader()
+                      const reader = new FileReader()
 
-                  reader.onload = (loadEvent: ProgressEvent<FileReader>) => {
-                    try {
-                      const jsonData = JSON.parse(loadEvent.target?.result as string)
-                      const { id, ...rest } = jsonData
-                      setFrameFormValues(rest)
-                      console.log('Imported frame:', jsonData)
-                      console.log('Press SAVE now to save the imported frame')
-                    } catch (error) {
-                      console.error('Error parsing JSON:', error)
+                      reader.onload = (loadEvent: ProgressEvent<FileReader>) => {
+                        try {
+                          const jsonData = JSON.parse(loadEvent.target?.result as string)
+                          const { id, ...rest } = jsonData
+                          setFrameFormValues(rest)
+                          console.log('Imported frame:', jsonData)
+                          console.log('Press SAVE now to save the imported frame')
+                        } catch (error) {
+                          console.error('Error parsing JSON:', error)
+                        }
+                      }
+
+                      reader.onerror = () => {
+                        console.error('Error reading file:', reader.error)
+                      }
+
+                      reader.readAsText(file)
                     }
-                  }
 
-                  reader.onerror = () => {
-                    console.error('Error reading file:', reader.error)
-                  }
-
-                  reader.readAsText(file)
-                }
-
-                const fileInput = document.createElement('input')
-                fileInput.type = 'file'
-                fileInput.accept = '.json'
-                fileInput.addEventListener('change', handleFileSelect)
-                fileInput.click()
-              }}
-            >
-              Import .json
-            </Button>
-            <Button
-              type="button"
-              size="small"
-              color="secondary"
-              className="flex-0"
-              onClick={() => {
-                downloadJson(frame, `${frame.name || `frame-${frame.id}`}.json`)
-              }}
-            >
-              Export .json
-            </Button>
-            <Button
-              type="button"
-              size="small"
-              color="secondary"
-              className="flex-0"
-              onClick={() => {
-                if (confirm('Are you sure you want to DELETE this frame?')) {
-                  deleteFrame(frame.id)
-                }
-              }}
-            >
-              <span className="text-red-300">Delete frame</span>
-            </Button>
+                    const fileInput = document.createElement('input')
+                    fileInput.type = 'file'
+                    fileInput.accept = '.json'
+                    fileInput.addEventListener('change', handleFileSelect)
+                    fileInput.click()
+                  },
+                  icon: <ArrowDownTrayIcon className="w-5 h-5" />,
+                },
+                {
+                  label: 'Export .json',
+                  onClick: () => {
+                    downloadJson(frame, `${frame.name || `frame-${frame.id}`}.json`)
+                  },
+                  icon: <ArrowUpTrayIcon className="w-5 h-5" />,
+                },
+                {
+                  label: 'Delete frame',
+                  onClick: () => {
+                    if (confirm('Are you sure you want to DELETE this frame?')) {
+                      deleteFrame(frame.id)
+                    }
+                  },
+                  icon: <TrashIcon className="w-5 h-5" />,
+                },
+              ]}
+            />
           </div>
           <Form
             formKey="frameForm"
@@ -122,7 +117,7 @@ export function FrameSettings({ className }: FrameSettingsProps) {
             className="space-y-4 @container"
             enableFormOnSubmit
           >
-            <H6>Frame Settings</H6>
+            <H6 className="mt-2">Frame Settings</H6>
             <div className="pl-2 @md:pl-8 space-y-2">
               <Field name="name" label="Name">
                 <TextInput name="name" placeholder="Hallway frame" required />

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -126,15 +126,19 @@ export function FrameSettings({ className }: FrameSettingsProps) {
                 <Select name="device" options={devices} />
               </Field>
               <Field name="rotate" label="Rotation">
-                <Select
-                  name="rotate"
-                  options={[
-                    { value: '0', label: '0 degrees' },
-                    { value: '90', label: '90 degrees' },
-                    { value: '180', label: '180 degrees' },
-                    { value: '270', label: '270 degrees' },
-                  ]}
-                />
+                {({ value, onChange }) => (
+                  <Select
+                    value={value || '0'}
+                    onChange={(v) => onChange(parseInt(v))}
+                    name="rotate"
+                    options={[
+                      { value: '0', label: '0 degrees' },
+                      { value: '90', label: '90 degrees' },
+                      { value: '180', label: '180 degrees' },
+                      { value: '270', label: '270 degrees' },
+                    ]}
+                  />
+                )}
               </Field>
             </div>
             <H6>Connection</H6>

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -132,10 +132,10 @@ export function FrameSettings({ className }: FrameSettingsProps) {
                     onChange={(v) => onChange(parseInt(v))}
                     name="rotate"
                     options={[
-                      { value: '0', label: '0 degrees' },
-                      { value: '90', label: '90 degrees' },
-                      { value: '180', label: '180 degrees' },
-                      { value: '270', label: '270 degrees' },
+                      { value: 0, label: '0 degrees' },
+                      { value: 90, label: '90 degrees' },
+                      { value: 180, label: '180 degrees' },
+                      { value: 270, label: '270 degrees' },
                     ]}
                   />
                 )}

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -31,6 +31,8 @@ export interface FrameType {
   assets_path?: string
   save_assets?: boolean | Record<string, boolean>
   upload_fonts?: string
+  last_successful_deploy?: Record<string, any>
+  last_successful_deploy_at?: string
   reboot?: {
     enabled?: 'true' | 'false'
     crontab?: string


### PR DESCRIPTION
If possible, opt for a fast deploy, which just updates `frame.json` and reloads without compilation.

This makes it possible to update the schedule without a full recompile.

<img width="549" alt="image" src="https://github.com/user-attachments/assets/1c7c04fb-d5ad-42ba-bb27-9e00cbf59965" />
<img width="677" alt="image" src="https://github.com/user-attachments/assets/3f763e80-e891-4a8e-b39f-ebfa9fee4a82" />
