### PR TITLE
Add inky_impression_13 driver

### DIFF
--- a/backend/app/drivers/devices.py
+++ b/backend/app/drivers/devices.py
@@ -5,13 +5,13 @@ from app.drivers.waveshare import get_variant_keys
 def drivers_for_frame(frame: Frame) -> dict[str, Driver]:
     device = frame.device
     device_drivers: dict[str, Driver] = {}
-    if device == "pimoroni.inky_impression" or device == "pimoroni.inky_python":
+    if device == "pimoroni.inky_impression" or device == "pimoroni.inky_impression_13" or device == "pimoroni.inky_python":
         device_drivers = {
             "inkyPython": DRIVERS["inkyPython"],
             "spi": DRIVERS["spi"],
             "i2c": DRIVERS["i2c"],
         }
-        if device == "pimoroni.inky_impression":
+        if device == "pimoroni.inky_impression" or device == "pimoroni.inky_impression_13":
             device_drivers["gpioButton"] = DRIVERS["gpioButton"]
     elif device == "pimoroni.hyperpixel2r":
         device_drivers = {"inkyHyperPixel2r": DRIVERS["inkyHyperPixel2r"]}
@@ -41,16 +41,24 @@ def drivers_for_frame(frame: Frame) -> dict[str, Driver]:
             ]
 
     # Always enable evdev if not eink
-    if device != "pimoroni.inky_impression" and not device.startswith("waveshare."):
+    if device != "pimoroni.inky_impression" and device != "pimoroni.inky_impression_13" and not device.startswith("waveshare."):
         device_drivers['evdev'] = DRIVERS['evdev']
 
-    if frame.device == "pimoroni.inky_impression":
-        frame.gpio_buttons = [
-            {"pin": 5, "label": "A"},
-            {"pin": 6, "label": "B"},
-            {"pin": 16, "label": "C"},
-            {"pin": 24, "label": "D"},
-        ]
+    if frame.device == "pimoroni.inky_impression" or frame.device == "pimoroni.inky_impression_13":
+        if frame.device == "pimoroni.inky_impression_13":
+            frame.gpio_buttons = [
+                {"pin": 5, "label": "A"},
+                {"pin": 6, "label": "B"},
+                {"pin": 25, "label": "C"},
+                {"pin": 24, "label": "D"},
+            ]
+        else:
+            frame.gpio_buttons = [
+                {"pin": 5, "label": "A"},
+                {"pin": 6, "label": "B"},
+                {"pin": 16, "label": "C"},
+                {"pin": 24, "label": "D"},
+            ]
         device_drivers["bootconfig"] = DRIVERS["bootConfig"]
         device_drivers["bootconfig"].lines = [
             "dtoverlay=spi0-0cs",

--- a/backend/list_devices.py
+++ b/backend/list_devices.py
@@ -8,7 +8,8 @@ if __name__ == '__main__':
     list = [
         {"value": 'web_only', "label": 'Web only'},
         {"value": 'framebuffer', "label": 'HDMI / Framebuffer'},
-        {"value": 'pimoroni.inky_impression', "label": 'Pimoroni Inky Impression (Python driver + Buttons)'},
+        {"value": 'pimoroni.inky_impression_13', "label": 'Pimoroni Inky Impression - 13.3" Spectra'},
+        {"value": 'pimoroni.inky_impression', "label": 'Pimoroni Inky Impression - all others'},
         {"value": 'pimoroni.inky_python', "label": 'Pimoroni Inky other (Python driver)'},
         {"value": 'pimoroni.hyperpixel2r', "label": 'Pimoroni HyperPixel 2.1" Round'},
     ]

--- a/frameos/src/frameos/utils/dither.nim
+++ b/frameos/src/frameos/utils/dither.nim
@@ -27,28 +27,6 @@ const spectra6ColorPalette* = @[
   (67, 138, 28),   # 0x6 - green
 ]
 
-# 6-color Spectra e-ink displays, as measured on a real display (Attempt 1)
-const spectra6ColorPaletteTry1* = @[
-  (50, 44, 52),    # 0x0 - black
-  (255, 255, 255), # 0x1 - white
-  (255, 248, 0),   # 0x2 - yellow
-  (223, 38, 27),   # 0x3 - red
-  (999, 999, 999), # skips an index!
-  (41, 112, 238),  # 0x5 - blue
-  (87, 161, 126),  # 0x6 - green
-]
-
-# 6-color Spectra e-ink displays, measured on display and modulated
-const spectra6ColorPaletteTry2* = @[
-  (13, 0, 19),     # 0x0 - black
-  (220, 220, 215), # 0x1 - white
-  (242, 220, 0),   # 0x2 - yellow
-  (130, 0, 0),     # 0x3 - red
-  (999, 999, 999), # skips an index!
-  (19, 60, 160),   # 0x5 - blue
-  (51, 83, 38),    # 0x6 - green
-]
-
 # 6-color Spectra e-ink displays, as presented by the manufacturer. These are not used.
 const spectra6ColorPaletteOrig* = @[
   (0, 0, 0),       # 0x0 - black

--- a/frameos/vendor/inkyPython/check.py
+++ b/frameos/vendor/inkyPython/check.py
@@ -18,5 +18,13 @@ def init():
 
 if __name__ == "__main__":
     inky = init()
-    log({ "inky": True, "width": inky.resolution[0], "height": inky.resolution[1], "color": inky.colour })
+    log({
+        "inky": True,
+        "width": inky.resolution[0],
+        "height": inky.resolution[1],
+        "color": inky.colour,
+        "model": inky.eeprom.get_variant(),
+        "variant": inky.eeprom.display_variant,
+        "pcb": inky.eeprom.pcb_variant,
+    })
     sys.exit(0)

--- a/frontend/src/devices.ts
+++ b/frontend/src/devices.ts
@@ -6,6 +6,7 @@ import { Option } from './components/Select'
 export const devices: Option[] = [
   { value: 'web_only', label: 'Web only' },
   { value: 'framebuffer', label: 'HDMI / Framebuffer' },
+  { value: 'pimoroni.inky_impression_13', label: 'Pimoroni Inky Impression 13.3" Spectra' },
   { value: 'pimoroni.inky_impression', label: 'Pimoroni Inky Impression (Python driver + Buttons)' },
   { value: 'pimoroni.inky_python', label: 'Pimoroni Inky other (Python driver)' },
   { value: 'pimoroni.hyperpixel2r', label: 'Pimoroni HyperPixel 2.1" Round' },

--- a/frontend/src/devices.ts
+++ b/frontend/src/devices.ts
@@ -6,8 +6,8 @@ import { Option } from './components/Select'
 export const devices: Option[] = [
   { value: 'web_only', label: 'Web only' },
   { value: 'framebuffer', label: 'HDMI / Framebuffer' },
-  { value: 'pimoroni.inky_impression_13', label: 'Pimoroni Inky Impression 13.3" Spectra' },
-  { value: 'pimoroni.inky_impression', label: 'Pimoroni Inky Impression (Python driver + Buttons)' },
+  { value: 'pimoroni.inky_impression_13', label: 'Pimoroni Inky Impression - 13.3" Spectra' },
+  { value: 'pimoroni.inky_impression', label: 'Pimoroni Inky Impression - all others' },
   { value: 'pimoroni.inky_python', label: 'Pimoroni Inky other (Python driver)' },
   { value: 'pimoroni.hyperpixel2r', label: 'Pimoroni HyperPixel 2.1" Round' },
   { value: 'waveshare.EPD_1in02d', label: 'Waveshare 1.02" (D) 128x80 Black/White' },

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -478,7 +478,7 @@ export function FrameSettings({ className }: FrameSettingsProps) {
             </div>
             <H6 className="flex items-center gap-2">
               GPIO buttons
-              {frameForm.device !== 'pimoroni.inky_impression' ? (
+              {frameForm.device !== 'pimoroni.inky_impression' && frameForm.device !== 'pimoroni.inky_impression_13' ? (
                 <Button
                   size="small"
                   color="secondary"
@@ -491,8 +491,11 @@ export function FrameSettings({ className }: FrameSettingsProps) {
               ) : null}
             </H6>
             <div className="pl-2 @md:pl-8 space-y-2">
-              {frameForm.device === 'pimoroni.inky_impression' ? (
-                <div>Inky Impression boards automatically configure pins 5, 6, 16 and 24 as buttons A, B, C and D</div>
+              {frameForm.device === 'pimoroni.inky_impression' || frameForm.device === 'pimoroni.inky_impression_13' ? (
+                <div>
+                  Inky Impression boards automatically configure pins 5, 6,{' '}
+                  {frameForm.device === 'pimoroni.inky_impression_13' ? '25' : '16'} and 24 as buttons A, B, C and D
+                </div>
               ) : (
                 frameForm.gpio_buttons?.map((_, index) => (
                   <Group key={index} name={`gpio_buttons.${index}`}>


### PR DESCRIPTION
Adding a separate driver for the Pimoroni 13.3" panel as the GPIO buttons changed.

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/6dacfcc4-27aa-4aae-9fb8-070f63522f52" />
