### PR TITLE
framebuffer: add 24bpp support, use offsets, allow 0 length alpha

### DIFF
--- a/frameos/src/drivers/frameBuffer/frameBuffer.nim
+++ b/frameos/src/drivers/frameBuffer/frameBuffer.nim
@@ -16,9 +16,6 @@ type ScreenInfo* = object
   alphaOffset*: uint32
   alphaLength*: uint32
 
-type ColorBGRA = object
-  b, g, r, a: uint8
-
 type Driver* = ref object of FrameOSDriver
   screenInfo: ScreenInfo
   logger: Logger
@@ -82,35 +79,36 @@ proc init*(frameOS: FrameOS): Driver =
 
 proc render*(self: Driver, image: Image) =
   let imageData = image.data
+  let bitsPerPixel = self.screenInfo.bitsPerPixel
   try:
     var fb = open(DEVICE, fmWrite, (self.screenInfo.width *
-          self.screenInfo.height * self.screenInfo.bitsPerPixel div 8).int)
-    if self.screenInfo.bitsPerPixel == 16:
+          self.screenInfo.height * bitsPerPixel div 8).int)
+    if bitsPerPixel == 16:
       var
         buffer: seq[uint16] = newSeq[uint16](len(imageData))
       for i, color in imageData:
         buffer[i] = ((uint16(color.r) shr 3) shl 11) or ((uint16(
             color.g) shr 2) shl 5) or (uint16(color.b) shr 3)
       discard fb.writeBuffer(addr buffer[0], buffer.len * sizeof(uint16))
-    elif self.screenInfo.bitsPerPixel == 32:
-      if self.screenInfo.blueOffset < self.screenInfo.greenOffset and
-          self.screenInfo.greenOffset < self.screenInfo.redOffset and
-          self.screenInfo.redOffset < self.screenInfo.alphaOffset:
-        var
-          buffer: seq[uint8] = newSeq[uint8](len(imageData) * sizeof(ColorBGRA))
-        for i, color in imageData:
-          let j = i * 4
-          buffer[j] = color.b
-          buffer[j + 1] = color.g
-          buffer[j + 2] = color.r
-          buffer[j + 3] = color.a
-        discard fb.writeBytes(buffer, 0, len(buffer))
-      else:
-        discard fb.writeBuffer(addr imageData[0], sizeof(imageData))
+    elif bitsPerPixel == 24 or bitsPerPixel == 32:
+      var bytesPerPixel = int(bitsPerPixel shr 3) # 24bpp = 3, 32bpp = 4
+      var buffer: seq[uint8] = newSeq[uint8](len(imageData) * bytesPerPixel)
+      for i, color in imageData:
+        let j = i * bytesPerPixel
+        buffer[j + int(self.screenInfo.redOffset) div 8] = color.r
+        buffer[j + int(self.screenInfo.greenOffset) div 8] = color.g
+        buffer[j + int(self.screenInfo.blueOffset) div 8] = color.b
+
+        # Framebuffer could be 32bpp with 0 length alpha (effectively 24bpp)
+        # or 24bpp with 0 length alpha
+        if self.screenInfo.alphaLength > 0:
+          buffer[j + int(self.screenInfo.alphaOffset) div 8] = color.a
+
+      discard fb.writeBytes(buffer, 0, len(buffer))
     else:
       self.logger.log(%*{"event": "driver:frameBuffer",
           "error": "Unsupported bits per pixel",
-          "bpp": self.screenInfo.bitsPerPixel})
+          "bpp": bitsPerPixel})
     fb.close()
   except:
     self.logger.log(%*{"event": "driver:frameBuffer",


### PR DESCRIPTION
I noticed some color banding on an IPS display using the framebuffer driver. After using a reference image to check that it wasn't caused by any image processing I was doing, I confirmed the Raspberry Pi 4 I'm using defaulted to 16 bits per pixel using the `fbset` command.

Changing it to 24bpp threw the error `Unsupported bits per pixel`. Changing it to 32bpp didn't throw an error, but instead resulted in a blank screen.

With these changes, the color banding is gone when setting `video=HDMI-A-1:1920x1200M-24@60` or `video=HDMI-A-1:1920x1200M-32@60` to set 24bpp or 32bpp, respectively, in `/boot/firmware/cmdline.txt`. Changing it back to `video=HDMI-A-1:1920x1200M-16@60` for 16bpp causes the banding to return.

Changes:
* Use the detected color offsets to determine the location of each color in the buffer.
  * This supports any order of RGBA provided by offsets via `FBIOGET_VSCREENINFO`.
* Support 24 bits per pixel.
  * This is identical to supporting 32 bits per pixel, but without an alpha channel.
* Support 32 bits per pixel with an `alpha` length of 0 (effectively 24bpp.)
  * This appears to be common based on my research, and this is the case on my system.

Of course any feedback is welcome, and please let me know if I've missed the intent of the code I've replaced.