### PR TITLE
Use prebuilt binaries when installing

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -265,7 +265,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
   push-multiarch:
-    needs: [update-versions, build]
+    needs: [update-versions, build, build-prebuilt-cross]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -113,7 +113,7 @@ jobs:
 
       - id: set-matrix
         run: |
-          MATRIX=$(python3 backend/bin/cross matrix)
+          MATRIX=$(python3 backend/bin/cross matrix --runner-profile depot-8)
           echo "targets=$MATRIX" >> "$GITHUB_OUTPUT"
 
   build-prebuilt-cross:

--- a/backend/app/codegen/drivers_nim.py
+++ b/backend/app/codegen/drivers_nim.py
@@ -6,8 +6,13 @@ from app.drivers.drivers import Driver
 
 DRIVER_BUILD_MODE_STATIC = "static"
 DRIVER_BUILD_MODE_SHARED = "shared"
+DRIVER_BUILD_MODE_PRECOMPILED = "precompiled"
 DEFAULT_DRIVER_BUILD_MODE = DRIVER_BUILD_MODE_STATIC
-VALID_DRIVER_BUILD_MODES = {DRIVER_BUILD_MODE_STATIC, DRIVER_BUILD_MODE_SHARED}
+VALID_DRIVER_BUILD_MODES = {
+    DRIVER_BUILD_MODE_STATIC,
+    DRIVER_BUILD_MODE_SHARED,
+    DRIVER_BUILD_MODE_PRECOMPILED,
+}
 
 
 def normalize_driver_build_mode(value: str | None) -> str:
@@ -20,6 +25,13 @@ def normalize_driver_build_mode(value: str | None) -> str:
 def frame_driver_build_mode(frame) -> str:
     rpios_settings = getattr(frame, "rpios", None) or {}
     return normalize_driver_build_mode(rpios_settings.get("driverBuildMode"))
+
+
+def driver_build_mode_uses_shared_libraries(value: str | None) -> bool:
+    return normalize_driver_build_mode(value) in {
+        DRIVER_BUILD_MODE_SHARED,
+        DRIVER_BUILD_MODE_PRECOMPILED,
+    }
 
 
 def compiled_drivers(drivers: dict[str, Driver]) -> list[Driver]:
@@ -147,7 +159,7 @@ def write_drivers_nim(
     drivers: dict[str, Driver],
     driver_build_mode: str = DEFAULT_DRIVER_BUILD_MODE,
 ) -> str:
-    if normalize_driver_build_mode(driver_build_mode) == DRIVER_BUILD_MODE_SHARED:
+    if driver_build_mode_uses_shared_libraries(driver_build_mode):
         return write_shared_drivers_nim(drivers)
     return write_static_drivers_nim(drivers)
 

--- a/backend/app/tasks/_frame_deployer.py
+++ b/backend/app/tasks/_frame_deployer.py
@@ -28,9 +28,9 @@ from app.drivers.devices import drivers_for_frame
 from app.models import get_apps_from_scenes
 from app.codegen.drivers_nim import (
     DEFAULT_DRIVER_BUILD_MODE,
-    DRIVER_BUILD_MODE_SHARED,
     DRIVER_BUILD_MODE_STATIC,
     compiled_drivers,
+    driver_build_mode_uses_shared_libraries,
     driver_library_filename,
     normalize_driver_build_mode,
     write_driver_library_nim,
@@ -155,7 +155,7 @@ class FrameDeployer:
         drivers: dict[str, Driver],
         driver_build_mode: str,
     ) -> list[str]:
-        if normalize_driver_build_mode(driver_build_mode) != DRIVER_BUILD_MODE_SHARED:
+        if not driver_build_mode_uses_shared_libraries(driver_build_mode):
             return []
         return [
             os.path.join(build_dir, "drivers", driver.name, driver_library_filename(driver))
@@ -167,7 +167,7 @@ class FrameDeployer:
         drivers: dict[str, Driver],
         driver_build_mode: str,
     ) -> list[str]:
-        if normalize_driver_build_mode(driver_build_mode) != DRIVER_BUILD_MODE_SHARED:
+        if not driver_build_mode_uses_shared_libraries(driver_build_mode):
             return []
         return [driver_library_filename(driver) for driver in compiled_drivers(drivers)]
 
@@ -363,7 +363,7 @@ class FrameDeployer:
 
         shared_driver_dir = os.path.join(source_dir, "src", "drivers", "shared")
         shutil.rmtree(shared_driver_dir, ignore_errors=True)
-        if driver_build_mode == DRIVER_BUILD_MODE_SHARED:
+        if driver_build_mode_uses_shared_libraries(driver_build_mode):
             os.makedirs(shared_driver_dir, exist_ok=True)
             for driver in compiled_drivers(drivers):
                 with open(os.path.join(shared_driver_dir, f"{driver.name}.nim"), "w") as sf:
@@ -714,7 +714,7 @@ $(OBJECTS): pre-build
             + main_driver_linker_flags
         )
 
-        if driver_build_mode == DRIVER_BUILD_MODE_SHARED:
+        if driver_build_mode_uses_shared_libraries(driver_build_mode):
             for driver in compiled_drivers(drivers):
                 driver_dir = os.path.join(build_dir, "drivers", driver.name)
                 os.makedirs(driver_dir, exist_ok=True)

--- a/backend/app/tasks/binary_builder.py
+++ b/backend/app/tasks/binary_builder.py
@@ -14,8 +14,14 @@ from app.models.log import new_log as log
 from app.tasks._frame_deployer import FrameDeployer
 from app.drivers.devices import drivers_for_frame
 from app.codegen.drivers_nim import (
+    DRIVER_BUILD_MODE_PRECOMPILED,
     frame_driver_build_mode,
     normalize_driver_build_mode,
+)
+from app.tasks.precompiled_frameos import (
+    download_precompiled_frameos_release,
+    frame_compiled_scene_count,
+    precompiled_frameos_release_url,
 )
 from app.tasks.prebuilt_deps import PrebuiltEntry, fetch_prebuilt_manifest, resolve_prebuilt_target
 from app.utils.build_host import get_build_host_config
@@ -55,6 +61,9 @@ class FrameBinaryPlan:
     will_attempt_cross_compile: bool
     prebuilt_entry: PrebuiltEntry | None
     prebuilt_target: str | None
+    will_attempt_precompiled: bool = False
+    precompiled_release_url: str | None = None
+    precompiled_skip_reason: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -72,6 +81,9 @@ class FrameBinaryPlan:
             "will_attempt_cross_compile": self.will_attempt_cross_compile,
             "prebuilt_target": self.prebuilt_target,
             "has_prebuilt_entry": self.prebuilt_entry is not None,
+            "will_attempt_precompiled": self.will_attempt_precompiled,
+            "precompiled_release_url": self.precompiled_release_url,
+            "precompiled_skip_reason": self.precompiled_skip_reason,
         }
 
 
@@ -90,6 +102,7 @@ class FrameBinaryBuildResult:
     prebuilt_entry: PrebuiltEntry | None
     prebuilt_target: str | None
     log_path: str | None
+    precompiled: bool = False
 
 
 def create_build_folder(temp_dir: str, build_id: str) -> str:
@@ -170,9 +183,30 @@ class FrameBinaryBuilder:
             arch=target.arch,
             logger=self._log,
         )
+        will_attempt_precompiled = False
+        precompiled_url = None
+        precompiled_skip_reason = None
+        if resolved_driver_build_mode == DRIVER_BUILD_MODE_PRECOMPILED:
+            compiled_scene_count = frame_compiled_scene_count(self.frame)
+            precompiled_url = precompiled_frameos_release_url(prebuilt_target or "")
+            if compiled_scene_count > 0:
+                precompiled_skip_reason = (
+                    f"{compiled_scene_count} compiled scene"
+                    + ("s are" if compiled_scene_count != 1 else " is")
+                    + " configured"
+                )
+            elif not prebuilt_target:
+                precompiled_skip_reason = "no matching precompiled target"
+            elif not precompiled_url:
+                precompiled_skip_reason = "no matching precompiled release URL"
+            else:
+                will_attempt_precompiled = True
+
         build_host = get_build_host_config(self.db)
         cross_compile_supported = can_cross_compile_target(target.arch)
-        will_attempt_cross_compile = allow_cross_compile and cross_compile_supported
+        will_attempt_cross_compile = (
+            allow_cross_compile and cross_compile_supported and not will_attempt_precompiled
+        )
 
         return FrameBinaryPlan(
             build_id=self.deployer.build_id,
@@ -185,6 +219,9 @@ class FrameBinaryBuilder:
             will_attempt_cross_compile=will_attempt_cross_compile,
             prebuilt_entry=prebuilt_entry,
             prebuilt_target=prebuilt_target,
+            will_attempt_precompiled=will_attempt_precompiled,
+            precompiled_release_url=precompiled_url,
+            precompiled_skip_reason=precompiled_skip_reason,
         )
 
     async def build(self, plan: FrameBinaryPlan) -> FrameBinaryBuildResult:
@@ -202,6 +239,38 @@ class FrameBinaryBuilder:
             await copy_custom_fonts_to_local_source_folder(self.db, source_dir)
 
         build_dir = create_build_folder(self.temp_dir, self.deployer.build_id)
+        if plan.will_attempt_precompiled:
+            await self._log("stdout", f"{icon} Using precompiled FrameOS release")
+            precompiled_result = await download_precompiled_frameos_release(
+                frame=self.frame,
+                target=plan.prebuilt_target or "",
+                build_dir=build_dir,
+                temp_dir=self.temp_dir,
+                build_id=self.deployer.build_id,
+                logger=self._log,
+            )
+            release_action = "Using cached" if precompiled_result.cache_hit else "Downloaded"
+            await self._log(
+                "stdout",
+                f"{icon} {release_action} precompiled FrameOS release: {precompiled_result.release_url}",
+            )
+            return FrameBinaryBuildResult(
+                build_id=self.deployer.build_id,
+                target=plan.target,
+                driver_build_mode=plan.driver_build_mode,
+                source_dir=source_dir,
+                build_dir=build_dir,
+                archive_path=precompiled_result.archive_path,
+                binary_path=precompiled_result.binary_path,
+                driver_library_paths=precompiled_result.driver_library_paths,
+                driver_library_names=precompiled_result.driver_library_names,
+                cross_compiled=True,
+                prebuilt_entry=plan.prebuilt_entry,
+                prebuilt_target=plan.prebuilt_target,
+                log_path=str(self.log_path) if self.log_path.exists() else None,
+                precompiled=True,
+            )
+
         await self._log("stdout", f"{icon} Creating build archive")
         archive_path = await self.deployer.create_local_build_archive(
             build_dir, source_dir, plan.target.arch, driver_build_mode=plan.driver_build_mode

--- a/backend/app/tasks/frame_deploy_workflow.py
+++ b/backend/app/tasks/frame_deploy_workflow.py
@@ -11,7 +11,7 @@ from arq import ArqRedis as Redis
 from sqlalchemy.orm import Session
 
 from app.drivers.devices import drivers_for_frame
-from app.codegen.drivers_nim import normalize_driver_build_mode
+from app.codegen.drivers_nim import DRIVER_BUILD_MODE_PRECOMPILED, normalize_driver_build_mode
 from app.models.assets import sync_assets
 from app.models.frame import Frame, normalize_https_proxy, update_frame
 from app.models.log import new_log as log
@@ -35,11 +35,11 @@ from app.utils.ssh_authorized_keys import _install_authorized_keys
 from app.utils.ssh_key_utils import normalize_ssh_keys, select_ssh_keys_for_frame
 from app.utils.versions import current_frameos_version
 
-REMOTE_BUILD_APT_PACKAGES = (
-    "build-essential",
+REMOTE_RUNTIME_APT_PACKAGES = (
     "hostapd",
     "imagemagick",
 )
+REMOTE_BUILD_APT_PACKAGES = ("build-essential",)
 
 HELPER_ENSURE_NTP = "ensure_ntp"
 
@@ -336,14 +336,18 @@ class FrameDeployWorkflow:
         ]
         remote_build_fallback_package_plans: list[PackagePlan] = []
 
-        for pkg_name in REMOTE_BUILD_APT_PACKAGES:
-            package_plans.append(await self._plan_package(pkg_name, "base remote deploy/build dependency"))
-        if not binary_plan.will_attempt_cross_compile:
-            package_plans.append(await self._plan_package("libssl-dev", "OpenSSL headers for on-device FrameOS build"))
-        else:
-            remote_build_fallback_package_plans.append(
-                await self._plan_package("libssl-dev", "OpenSSL headers if cross-compilation falls back to an on-device build")
-            )
+        for pkg_name in REMOTE_RUNTIME_APT_PACKAGES:
+            package_plans.append(await self._plan_package(pkg_name, "base remote deploy dependency"))
+
+        if not binary_plan.will_attempt_precompiled:
+            for pkg_name in REMOTE_BUILD_APT_PACKAGES:
+                package_plans.append(await self._plan_package(pkg_name, "base remote build dependency"))
+            if not binary_plan.will_attempt_cross_compile:
+                package_plans.append(await self._plan_package("libssl-dev", "OpenSSL headers for on-device FrameOS build"))
+            else:
+                remote_build_fallback_package_plans.append(
+                    await self._plan_package("libssl-dev", "OpenSSL headers if cross-compilation falls back to an on-device build")
+                )
         package_plans.append(
             await self._plan_package(
                 "caddy",
@@ -403,7 +407,7 @@ class FrameDeployWorkflow:
                 )
             )
 
-        quickjs_required_if_remote_build = not force_cross_compile
+        quickjs_required_if_remote_build = not force_cross_compile and not binary_plan.will_attempt_precompiled
         quickjs_dirname = None
         quickjs_installed = False
         if quickjs_required_if_remote_build:
@@ -431,7 +435,19 @@ class FrameDeployWorkflow:
             f"Cross compilation setting: {cross_compilation_setting}",
             f"Driver build mode: {driver_build_mode}",
         ]
-        if low_memory:
+        if driver_build_mode == DRIVER_BUILD_MODE_PRECOMPILED:
+            if binary_plan.will_attempt_precompiled:
+                notes.append("Precompiled FrameOS release will be used because all scenes are interpreted.")
+            else:
+                notes.append(
+                    "Precompiled FrameOS release will be skipped"
+                    + (
+                        f": {binary_plan.precompiled_skip_reason}."
+                        if binary_plan.precompiled_skip_reason
+                        else "."
+                    )
+                )
+        if low_memory and not binary_plan.will_attempt_precompiled:
             notes.append("Device is low memory; on-device build path will stop FrameOS before compilation.")
         if not selected_public_keys:
             notes.append("No SSH public keys selected for deployment.")
@@ -667,7 +683,8 @@ class FrameDeployWorkflow:
         build_result: FrameBinaryBuildResult,
         release_frameos_path: str,
     ) -> None:
-        await self.deployer.log("stdout", f"{icon} Using cross-compiled binary")
+        message = "Using precompiled FrameOS binary" if build_result.precompiled else "Using cross-compiled binary"
+        await self.deployer.log("stdout", f"{icon} {message}")
         if not build_result.binary_path:
             raise RuntimeError("Cross compilation succeeded but binary path is unknown")
         await upload_binary(self.deployer, build_result.binary_path, release_frameos_path)

--- a/backend/app/tasks/precompiled_frameos.py
+++ b/backend/app/tasks/precompiled_frameos.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urljoin
+
+import httpx
+
+from app.codegen.drivers_nim import DRIVER_BUILD_MODE_SHARED
+from app.drivers.devices import drivers_for_frame
+from app.models.frame import Frame
+from app.tasks._frame_deployer import FrameDeployer
+from app.utils.versions import get_versions
+
+RELEASE_BASE_URL = os.environ.get(
+    "FRAMEOS_PRECOMPILED_RELEASE_BASE_URL",
+    "https://github.com/FrameOS/frameos/releases/download/",
+)
+RELEASE_TIMEOUT = float(os.environ.get("FRAMEOS_PRECOMPILED_TIMEOUT", "60"))
+SAFE_RELEASE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+$")
+SAFE_CACHE_FILENAME = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+@dataclass(slots=True)
+class PrecompiledFrameOSResult:
+    release_url: str
+    binary_path: str
+    driver_library_paths: list[str]
+    driver_library_names: list[str]
+    vendor_folders: list[str]
+    archive_path: str
+    cache_hit: bool = False
+
+
+def frame_compiled_scene_count(frame: Frame) -> int:
+    count = 0
+    for scene in getattr(frame, "scenes", None) or []:
+        if not isinstance(scene, dict):
+            continue
+        execution = scene.get("settings", {}).get("execution", "compiled")
+        if execution != "interpreted":
+            count += 1
+    return count
+
+
+def release_version() -> str | None:
+    versions = get_versions()
+    for key in ("docker", "frameos"):
+        version = versions.get(key)
+        if isinstance(version, str) and version:
+            return version.split("+", 1)[0]
+    return None
+
+
+def precompiled_frameos_release_url(target: str, version: str | None = None) -> str | None:
+    resolved_version = version or release_version()
+    if not resolved_version or not target:
+        return None
+    if not SAFE_RELEASE_SEGMENT.fullmatch(resolved_version) or not SAFE_RELEASE_SEGMENT.fullmatch(target):
+        return None
+    base = RELEASE_BASE_URL if RELEASE_BASE_URL.endswith("/") else f"{RELEASE_BASE_URL}/"
+    return urljoin(base, f"v{resolved_version}/frameos-{resolved_version}-{target}.tar.gz")
+
+
+async def download_precompiled_frameos_release(
+    *,
+    frame: Frame,
+    target: str,
+    build_dir: str,
+    temp_dir: str,
+    build_id: str,
+    logger,
+    timeout: float = RELEASE_TIMEOUT,
+) -> PrecompiledFrameOSResult:
+    url = precompiled_frameos_release_url(target)
+    if not url:
+        raise RuntimeError("Unable to construct precompiled FrameOS release URL")
+
+    release_archive_path, cache_hit = await _cached_release_archive(url, target, timeout, logger)
+    build_path = Path(build_dir)
+    build_path.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="frameos-precompiled-") as extract_tmp:
+        extract_dir = Path(extract_tmp) / "extract"
+        extract_dir.mkdir()
+        with tarfile.open(release_archive_path, "r:gz") as tar:
+            _safe_extract(tar, extract_dir)
+
+        artifact_root = _find_artifact_root(extract_dir, target)
+        if not artifact_root:
+            raise RuntimeError(f"Precompiled FrameOS archive did not contain target {target}")
+
+        required_driver_names = FrameDeployer.driver_library_names(
+            drivers_for_frame(frame),
+            DRIVER_BUILD_MODE_SHARED,
+        )
+        copied_driver_paths = _copy_required_drivers(
+            artifact_root=artifact_root,
+            build_dir=build_path,
+            required_driver_names=required_driver_names,
+        )
+        vendor_folders = _copy_required_vendor_folders(
+            artifact_root=artifact_root,
+            build_dir=build_path,
+            frame=frame,
+        )
+
+        binary_src = artifact_root / "frameos"
+        if not binary_src.is_file():
+            raise RuntimeError("Precompiled FrameOS archive is missing frameos binary")
+        binary_dest = build_path / "frameos"
+        shutil.copy2(binary_src, binary_dest)
+        os.chmod(binary_dest, 0o755)
+
+    result_archive_base = Path(temp_dir) / f"precompiled_{build_id}"
+    result_archive = shutil.make_archive(str(result_archive_base), "gztar", str(build_path))
+    return PrecompiledFrameOSResult(
+        release_url=url,
+        binary_path=str(binary_dest),
+        driver_library_paths=[str(path) for path in copied_driver_paths],
+        driver_library_names=required_driver_names,
+        vendor_folders=vendor_folders,
+        archive_path=result_archive,
+        cache_hit=cache_hit,
+    )
+
+
+def precompiled_frameos_cache_dir() -> Path:
+    configured = os.environ.get("FRAMEOS_PRECOMPILED_CACHE_DIR")
+    if configured:
+        return Path(configured)
+    return Path(tempfile.gettempdir()) / "frameos-precompiled-cache"
+
+
+def precompiled_frameos_cache_path(url: str) -> Path:
+    filename = url.rsplit("/", 1)[-1] or "frameos-precompiled.tar.gz"
+    safe_filename = SAFE_CACHE_FILENAME.sub("_", filename)
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    return precompiled_frameos_cache_dir() / f"{digest}-{safe_filename}"
+
+
+async def _cached_release_archive(url: str, target: str, timeout: float, logger) -> tuple[Path, bool]:
+    cache_path = precompiled_frameos_cache_path(url)
+    if _has_cached_archive(cache_path):
+        await logger("stdout", f"Using cached precompiled FrameOS release for {target}")
+        return cache_path, True
+
+    await logger("stdout", f"Downloading precompiled FrameOS release for {target}")
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    if _has_cached_archive(cache_path):
+        await logger("stdout", f"Using cached precompiled FrameOS release for {target}")
+        return cache_path, True
+
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{cache_path.name}.",
+            suffix=".part",
+            dir=cache_path.parent,
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+        await _download(url, temp_path, timeout)
+        if not _has_cached_archive(temp_path):
+            raise RuntimeError("Downloaded precompiled FrameOS release was empty")
+        os.replace(temp_path, cache_path)
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+    return cache_path, False
+
+
+def _has_cached_archive(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+async def _download(url: str, destination: Path, timeout: float) -> None:
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        async with client.stream("GET", url) as response:
+            response.raise_for_status()
+            with destination.open("wb") as fh:
+                async for chunk in response.aiter_bytes():
+                    fh.write(chunk)
+
+
+def _safe_extract(tar: tarfile.TarFile, path: Path) -> None:
+    root = path.resolve()
+    for member in tar.getmembers():
+        member_path = (path / member.name).resolve()
+        if os.path.commonpath([str(root), str(member_path)]) != str(root):
+            raise RuntimeError("Tar file attempted to escape target directory")
+    tar.extractall(path=path, filter="data")
+
+
+def _find_artifact_root(extract_dir: Path, target: str) -> Path | None:
+    expected = extract_dir / "prebuilt-cross" / target
+    if (expected / "frameos").is_file():
+        return expected
+
+    candidates = []
+    for metadata_path in extract_dir.rglob("metadata.json"):
+        root = metadata_path.parent
+        if not (root / "frameos").is_file():
+            continue
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            metadata = {}
+        if metadata.get("slug") == target:
+            return root
+        candidates.append(root)
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _copy_required_drivers(
+    *,
+    artifact_root: Path,
+    build_dir: Path,
+    required_driver_names: list[str],
+) -> list[Path]:
+    if not required_driver_names:
+        return []
+    source_dir = artifact_root / "drivers"
+    destination_dir = build_dir / "drivers"
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    copied_paths: list[Path] = []
+    missing = []
+    for driver_name in required_driver_names:
+        source = source_dir / driver_name
+        if not source.is_file():
+            missing.append(driver_name)
+            continue
+        destination = destination_dir / driver_name
+        shutil.copy2(source, destination)
+        copied_paths.append(destination)
+    if missing:
+        raise RuntimeError(
+            "Precompiled FrameOS archive is missing required driver libraries: "
+            + ", ".join(sorted(missing))
+        )
+    return copied_paths
+
+
+def _copy_required_vendor_folders(
+    *,
+    artifact_root: Path,
+    build_dir: Path,
+    frame: Frame,
+) -> list[str]:
+    required = sorted(
+        {
+            driver.vendor_folder
+            for driver in drivers_for_frame(frame).values()
+            if getattr(driver, "vendor_folder", None)
+        }
+    )
+    if not required:
+        return []
+    source_root = artifact_root / "vendor"
+    destination_root = build_dir / "vendor"
+    destination_root.mkdir(parents=True, exist_ok=True)
+    missing = []
+    copied: list[str] = []
+    for folder in required:
+        source = source_root / folder
+        if not source.is_dir():
+            missing.append(folder)
+            continue
+        shutil.copytree(source, destination_root / folder, dirs_exist_ok=True)
+        copied.append(folder)
+    if missing:
+        raise RuntimeError(
+            "Precompiled FrameOS archive is missing required vendor folders: "
+            + ", ".join(sorted(missing))
+        )
+    return copied

--- a/backend/app/tasks/tests/test_binary_builder.py
+++ b/backend/app/tasks/tests/test_binary_builder.py
@@ -4,8 +4,9 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.codegen.drivers_nim import DRIVER_BUILD_MODE_SHARED, DRIVER_BUILD_MODE_STATIC
+from app.codegen.drivers_nim import DRIVER_BUILD_MODE_PRECOMPILED, DRIVER_BUILD_MODE_SHARED, DRIVER_BUILD_MODE_STATIC
 from app.tasks.binary_builder import FrameBinaryBuilder, FrameBinaryPlan
+from app.tasks.precompiled_frameos import PrecompiledFrameOSResult, release_version
 from app.utils.cross_compile import TargetMetadata
 
 
@@ -66,6 +67,72 @@ async def test_plan_build_defaults_to_static_driver_mode(monkeypatch: pytest.Mon
 
 
 @pytest.mark.asyncio
+async def test_plan_build_attempts_precompiled_when_all_scenes_are_interpreted(monkeypatch: pytest.MonkeyPatch):
+    async def fake_resolve_prebuilt_entry(**_kwargs):
+        return None, "debian-trixie-arm64"
+
+    monkeypatch.setattr("app.tasks.binary_builder.get_build_host_config", lambda _db: None)
+    monkeypatch.setattr("app.tasks.binary_builder.resolve_prebuilt_entry", fake_resolve_prebuilt_entry)
+
+    builder = FrameBinaryBuilder(
+        db=None,
+        redis=None,
+        frame=SimpleNamespace(
+            device="framebuffer",
+            gpio_buttons=[],
+            rpios={"driverBuildMode": "precompiled"},
+            scenes=[{"settings": {"execution": "interpreted"}}],
+        ),
+        deployer=FakeDeployer(),
+        temp_dir="/tmp",
+    )
+
+    plan = await builder.plan_build(
+        target_override=TargetMetadata(arch="aarch64", distro="debian", version="trixie")
+    )
+
+    assert plan.driver_build_mode == DRIVER_BUILD_MODE_PRECOMPILED
+    assert plan.will_attempt_precompiled is True
+    assert plan.will_attempt_cross_compile is False
+    assert plan.precompiled_release_url is not None
+    assert plan.precompiled_release_url.endswith(
+        f"/frameos-{release_version()}-debian-trixie-arm64.tar.gz"
+    )
+    assert plan.precompiled_skip_reason is None
+
+
+@pytest.mark.asyncio
+async def test_plan_build_skips_precompiled_when_compiled_scenes_exist(monkeypatch: pytest.MonkeyPatch):
+    async def fake_resolve_prebuilt_entry(**_kwargs):
+        return None, "debian-trixie-arm64"
+
+    monkeypatch.setattr("app.tasks.binary_builder.get_build_host_config", lambda _db: None)
+    monkeypatch.setattr("app.tasks.binary_builder.resolve_prebuilt_entry", fake_resolve_prebuilt_entry)
+
+    builder = FrameBinaryBuilder(
+        db=None,
+        redis=None,
+        frame=SimpleNamespace(
+            device="framebuffer",
+            gpio_buttons=[],
+            rpios={"driverBuildMode": "precompiled"},
+            scenes=[{"settings": {"execution": "compiled"}}],
+        ),
+        deployer=FakeDeployer(),
+        temp_dir="/tmp",
+    )
+
+    plan = await builder.plan_build(
+        target_override=TargetMetadata(arch="aarch64", distro="debian", version="trixie")
+    )
+
+    assert plan.driver_build_mode == DRIVER_BUILD_MODE_PRECOMPILED
+    assert plan.will_attempt_precompiled is False
+    assert plan.will_attempt_cross_compile is True
+    assert plan.precompiled_skip_reason == "1 compiled scene is configured"
+
+
+@pytest.mark.asyncio
 async def test_build_passes_plan_fields_to_cross_compile(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 
@@ -103,3 +170,64 @@ async def test_build_passes_plan_fields_to_cross_compile(monkeypatch: pytest.Mon
     assert captured["target_override"] == plan.target
     assert captured["prebuilt_entry"] is plan.prebuilt_entry
     assert captured["prebuilt_target"] == plan.prebuilt_target
+
+
+@pytest.mark.asyncio
+async def test_build_uses_precompiled_release_when_planned(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    async def fake_download_precompiled_frameos_release(**kwargs):
+        build_dir = kwargs["build_dir"]
+        binary_path = f"{build_dir}/frameos"
+        driver_path = f"{build_dir}/drivers/frameBuffer.so"
+        archive_path = f"{build_dir}.tar.gz"
+        import os
+
+        os.makedirs(f"{build_dir}/drivers", exist_ok=True)
+        with open(binary_path, "wb") as fh:
+            fh.write(b"frameos")
+        with open(driver_path, "wb") as fh:
+            fh.write(b"driver")
+        with open(archive_path, "wb") as fh:
+            fh.write(b"archive")
+        return PrecompiledFrameOSResult(
+            release_url="https://example.test/frameos.tar.gz",
+            binary_path=binary_path,
+            driver_library_paths=[driver_path],
+            driver_library_names=["frameBuffer.so"],
+            vendor_folders=[],
+            archive_path=archive_path,
+        )
+
+    monkeypatch.setattr("app.tasks.binary_builder.get_build_host_config", lambda _db: None)
+    monkeypatch.setattr(
+        "app.tasks.binary_builder.download_precompiled_frameos_release",
+        fake_download_precompiled_frameos_release,
+    )
+
+    builder = FrameBinaryBuilder(
+        db=None,
+        redis=None,
+        frame=SimpleNamespace(device="framebuffer", gpio_buttons=[], scenes=[]),
+        deployer=FakeDeployer(),
+        temp_dir=str(tmp_path),
+    )
+    plan = FrameBinaryPlan(
+        build_id="build12345678",
+        target=TargetMetadata(arch="aarch64", distro="debian", version="trixie"),
+        driver_build_mode="precompiled",
+        allow_cross_compile=True,
+        force_cross_compile=False,
+        cross_compile_supported=True,
+        build_host_configured=False,
+        will_attempt_cross_compile=False,
+        prebuilt_entry=None,
+        prebuilt_target="debian-trixie-arm64",
+        will_attempt_precompiled=True,
+        precompiled_release_url="https://example.test/frameos.tar.gz",
+    )
+
+    result = await builder.build(plan)
+
+    assert result.precompiled is True
+    assert result.cross_compiled is True
+    assert result.binary_path and result.binary_path.endswith("/frameos")
+    assert result.driver_library_names == ["frameBuffer.so"]

--- a/backend/app/tasks/tests/test_driver_build_mode.py
+++ b/backend/app/tasks/tests/test_driver_build_mode.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from app.codegen.drivers_nim import (
+    DRIVER_BUILD_MODE_PRECOMPILED,
     DRIVER_BUILD_MODE_SHARED,
     DRIVER_BUILD_MODE_STATIC,
+    driver_build_mode_uses_shared_libraries,
     driver_library_filename,
     frame_driver_build_mode,
     normalize_driver_build_mode,
@@ -29,6 +31,14 @@ def test_driver_build_mode_shared_requires_explicit_setting():
 def test_driver_build_mode_static_is_valid():
     assert normalize_driver_build_mode("static") == DRIVER_BUILD_MODE_STATIC
     assert frame_driver_build_mode(SimpleNamespace(rpios={"driverBuildMode": "static"})) == DRIVER_BUILD_MODE_STATIC
+
+
+def test_driver_build_mode_precompiled_uses_shared_libraries():
+    assert normalize_driver_build_mode("precompiled") == DRIVER_BUILD_MODE_PRECOMPILED
+    assert frame_driver_build_mode(SimpleNamespace(rpios={"driverBuildMode": "precompiled"})) == DRIVER_BUILD_MODE_PRECOMPILED
+    assert driver_build_mode_uses_shared_libraries("precompiled") is True
+    assert driver_build_mode_uses_shared_libraries("shared") is True
+    assert driver_build_mode_uses_shared_libraries("static") is False
 
 
 def test_waveshare_driver_library_filename_includes_variant():

--- a/backend/app/tasks/tests/test_frame_deploy_workflow.py
+++ b/backend/app/tasks/tests/test_frame_deploy_workflow.py
@@ -95,6 +95,24 @@ class FakeBinaryBuilder:
         )
 
 
+class FakePrecompiledBinaryBuilder:
+    async def plan_build(self, **_kwargs) -> FrameBinaryPlan:
+        return FrameBinaryPlan(
+            build_id="build12345678",
+            target=TargetMetadata(arch="arm64", distro="raspios", version="bookworm"),
+            driver_build_mode="precompiled",
+            allow_cross_compile=True,
+            force_cross_compile=False,
+            cross_compile_supported=True,
+            build_host_configured=False,
+            will_attempt_cross_compile=False,
+            prebuilt_entry=None,
+            prebuilt_target="debian-bookworm-arm64",
+            will_attempt_precompiled=True,
+            precompiled_release_url="https://example.test/frameos.tar.gz",
+        )
+
+
 @pytest.mark.asyncio
 async def test_full_plan_defaults_to_single_executable(monkeypatch: pytest.MonkeyPatch):
     captured_modes: list[str] = []
@@ -300,6 +318,52 @@ async def test_full_plan_reports_installed_state_and_remote_build_dependencies(m
     assert plan.full_deploy.post_deploy["disable_caddy_service"] is True
     assert plan.full_deploy.post_deploy["bootconfig_changes"] == []
     assert plan.full_deploy.post_deploy["final_action"] == "restart_frameos"
+
+
+@pytest.mark.asyncio
+async def test_full_plan_skips_remote_build_dependencies_for_precompiled(monkeypatch: pytest.MonkeyPatch):
+    frame = SimpleNamespace(
+        id=17,
+        name="PrecompiledFrame",
+        ssh_keys=[],
+        rpios={"crossCompilation": "auto", "driverBuildMode": "precompiled"},
+        reboot=None,
+        last_successful_deploy={"frameos_version": "9.9.9"},
+        last_successful_deploy_at="2026-01-01T00:00:00+00:00",
+        to_dict=lambda: {"id": 17, "name": "PrecompiledFrame"},
+    )
+    deployer = FakeDeployer()
+
+    monkeypatch.setattr("app.tasks.frame_deploy_workflow.drivers_for_frame", lambda _frame: {})
+    monkeypatch.setattr("app.tasks.frame_deploy_workflow.get_settings_dict", lambda _db: {})
+    monkeypatch.setattr("app.tasks.frame_deploy_workflow.select_ssh_keys_for_frame", lambda _frame, _settings: [])
+    monkeypatch.setattr("app.tasks.frame_deploy_workflow.normalize_ssh_keys", lambda _settings: [])
+
+    workflow = FrameDeployWorkflow(
+        db=None,
+        redis=None,
+        frame=frame,
+        deployer=deployer,
+        temp_dir="",
+        binary_builder=FakePrecompiledBinaryBuilder(),
+    )
+
+    plan = await workflow.plan("full")
+
+    assert plan.full_deploy is not None
+    assert plan.full_deploy.binary_plan.will_attempt_precompiled is True
+    assert plan.full_deploy.quickjs_required_if_remote_build is False
+    assert plan.full_deploy.remote_build_fallback_package_plans == []
+    package_names = {pkg.name for pkg in plan.full_deploy.package_plans}
+    assert "build-essential" not in package_names
+    assert "libssl-dev" not in package_names
+    assert "libunistring-dev" not in package_names
+    assert "libtool" not in package_names
+    assert "cmake" not in package_names
+    assert "pkg-config" not in package_names
+    assert "libatomic-ops-dev" not in package_names
+    assert "libicu-dev" not in package_names
+    assert "zlib1g-dev" not in package_names
 
 
 def test_python_vendor_setup_command_reinstalls_only_when_env_or_requirements_change():

--- a/backend/app/tasks/tests/test_precompiled_frameos.py
+++ b/backend/app/tasks/tests/test_precompiled_frameos.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import shutil
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.tasks.precompiled_frameos import download_precompiled_frameos_release, frame_compiled_scene_count
+
+
+def test_frame_compiled_scene_count_treats_missing_execution_as_compiled():
+    frame = SimpleNamespace(
+        scenes=[
+            {"settings": {"execution": "interpreted"}},
+            {"settings": {"execution": "compiled"}},
+            {"settings": {}},
+        ]
+    )
+
+    assert frame_compiled_scene_count(frame) == 2
+
+
+@pytest.mark.asyncio
+async def test_download_precompiled_frameos_release_extracts_required_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_root = tmp_path / "source" / "prebuilt-cross" / "debian-trixie-arm64"
+    (source_root / "drivers").mkdir(parents=True)
+    (source_root / "frameos").write_bytes(b"frameos")
+    (source_root / "drivers" / "frameBuffer.so").write_bytes(b"driver")
+    (source_root / "drivers" / "evdev.so").write_bytes(b"evdev")
+    (source_root / "metadata.json").write_text(
+        '{"slug":"debian-trixie-arm64","driver_libraries":["evdev.so","frameBuffer.so"]}\n',
+        encoding="utf-8",
+    )
+    archive = tmp_path / "release.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(tmp_path / "source" / "prebuilt-cross", arcname="prebuilt-cross")
+
+    async def fake_download(_url: str, destination: Path, _timeout: float) -> None:
+        shutil.copy2(archive, destination)
+
+    logs: list[tuple[str, str]] = []
+
+    async def logger(level: str, message: str) -> None:
+        logs.append((level, message))
+
+    monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr("app.tasks.precompiled_frameos._download", fake_download)
+
+    build_dir = tmp_path / "build"
+    result = await download_precompiled_frameos_release(
+        frame=SimpleNamespace(device="framebuffer", gpio_buttons=[]),
+        target="debian-trixie-arm64",
+        build_dir=str(build_dir),
+        temp_dir=str(tmp_path),
+        build_id="build12345678",
+        logger=logger,
+    )
+
+    assert Path(result.binary_path).read_bytes() == b"frameos"
+    assert result.driver_library_names == ["frameBuffer.so", "evdev.so"]
+    assert [Path(path).read_bytes() for path in result.driver_library_paths] == [b"driver", b"evdev"]
+    assert Path(result.archive_path).is_file()
+    assert result.cache_hit is False
+    assert any("Downloading precompiled FrameOS release" in message for _level, message in logs)
+
+
+@pytest.mark.asyncio
+async def test_download_precompiled_frameos_release_reuses_cached_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_root = tmp_path / "source" / "prebuilt-cross" / "debian-trixie-arm64"
+    (source_root / "drivers").mkdir(parents=True)
+    (source_root / "frameos").write_bytes(b"frameos")
+    (source_root / "drivers" / "frameBuffer.so").write_bytes(b"driver")
+    (source_root / "drivers" / "evdev.so").write_bytes(b"evdev")
+    (source_root / "metadata.json").write_text(
+        '{"slug":"debian-trixie-arm64","driver_libraries":["evdev.so","frameBuffer.so"]}\n',
+        encoding="utf-8",
+    )
+    archive = tmp_path / "release.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(tmp_path / "source" / "prebuilt-cross", arcname="prebuilt-cross")
+
+    download_count = 0
+
+    async def fake_download(_url: str, destination: Path, _timeout: float) -> None:
+        nonlocal download_count
+        download_count += 1
+        shutil.copy2(archive, destination)
+
+    logs: list[tuple[str, str]] = []
+
+    async def logger(level: str, message: str) -> None:
+        logs.append((level, message))
+
+    monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr("app.tasks.precompiled_frameos._download", fake_download)
+
+    first = await download_precompiled_frameos_release(
+        frame=SimpleNamespace(device="framebuffer", gpio_buttons=[]),
+        target="debian-trixie-arm64",
+        build_dir=str(tmp_path / "build-first"),
+        temp_dir=str(tmp_path),
+        build_id="first1234567",
+        logger=logger,
+    )
+    second = await download_precompiled_frameos_release(
+        frame=SimpleNamespace(device="framebuffer", gpio_buttons=[]),
+        target="debian-trixie-arm64",
+        build_dir=str(tmp_path / "build-second"),
+        temp_dir=str(tmp_path),
+        build_id="second123456",
+        logger=logger,
+    )
+
+    assert download_count == 1
+    assert first.cache_hit is False
+    assert second.cache_hit is True
+    assert Path(second.binary_path).read_bytes() == b"frameos"
+    assert any("Using cached precompiled FrameOS release" in message for _level, message in logs)

--- a/backend/bin/cross
+++ b/backend/bin/cross
@@ -660,9 +660,9 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     build.add_argument("--artifacts-dir", default="build/cross", help="Directory for compiled binaries")
     build.add_argument(
         "--driver-build-mode",
-        choices=("static", "shared"),
+        choices=("static", "shared", "precompiled"),
         default=None,
-        help="Override driver build mode (static single executable or shared driver libraries)",
+        help="Override driver build mode (static, shared, or precompiled release when eligible)",
     )
 
     release = subparsers.add_parser(

--- a/backend/bin/cross
+++ b/backend/bin/cross
@@ -15,6 +15,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
+DEFAULT_RUNNER_PROFILE = "default"
+DEPOT_8_CPU_RUNNER_PROFILE = "depot-8"
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKEND_ROOT = REPO_ROOT / "backend"
 if str(REPO_ROOT) not in sys.path:
@@ -36,7 +39,7 @@ class TargetDefinition:
     def slug(self) -> str:
         return f"{self.distro}-{self.version}-{self.arch}"
 
-    def to_matrix_entry(self) -> dict[str, str]:
+    def to_matrix_entry(self, runner: str | None = None) -> dict[str, str]:
         return {
             "slug": self.slug,
             "distro": self.distro,
@@ -44,7 +47,7 @@ class TargetDefinition:
             "arch": self.arch,
             "platform": self.platform,
             "image": self.image,
-            "runner": self.runner,
+            "runner": runner or self.runner,
         }
 
 
@@ -63,6 +66,14 @@ TARGETS: tuple[TargetDefinition, ...] = (
 )
 
 TARGET_MAP = {target.slug: target for target in TARGETS}
+
+
+def runner_for_profile(target: TargetDefinition, runner_profile: str) -> str:
+    if runner_profile == DEFAULT_RUNNER_PROFILE:
+        return target.runner
+    if runner_profile == DEPOT_8_CPU_RUNNER_PROFILE:
+        return f"depot-{target.runner}-8"
+    raise ValueError(f"Unknown runner profile: {runner_profile}")
 
 RELEASE_CACHE_VERSION = "2"
 RELEASE_BUILD_MAKEFILE_VERSION = "3"
@@ -130,8 +141,13 @@ def load_frame_stub(frameos_root: Path) -> FrameStub:
     )
 
 
-def targets_matrix_json() -> str:
-    matrix = {"include": [target.to_matrix_entry() for target in TARGETS]}
+def targets_matrix_json(runner_profile: str = DEFAULT_RUNNER_PROFILE) -> str:
+    matrix = {
+        "include": [
+            target.to_matrix_entry(runner=runner_for_profile(target, runner_profile))
+            for target in TARGETS
+        ]
+    }
     return json.dumps(matrix, separators=(",", ":"))
 
 
@@ -630,7 +646,13 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     subparsers.add_parser("list", help="List available cross compilation targets")
-    subparsers.add_parser("matrix", help="Emit the GitHub Actions matrix JSON")
+    matrix = subparsers.add_parser("matrix", help="Emit the GitHub Actions matrix JSON")
+    matrix.add_argument(
+        "--runner-profile",
+        choices=(DEFAULT_RUNNER_PROFILE, DEPOT_8_CPU_RUNNER_PROFILE),
+        default=DEFAULT_RUNNER_PROFILE,
+        help="Runner label profile for matrix entries",
+    )
 
     build = subparsers.add_parser("build", help="Build a specific cross compilation target")
     build.add_argument("--target", required=True, help="Target slug (distro-version-arch)")
@@ -684,7 +706,7 @@ def main(argv: list[str]) -> int:
         print(list_targets())
         return 0
     if args.command == "matrix":
-        print(targets_matrix_json())
+        print(targets_matrix_json(args.runner_profile))
         return 0
     if args.command == "build":
         frameos_root = Path(args.frameos_root)

--- a/frameos/src/frameos/metrics.nim
+++ b/frameos/src/frameos/metrics.nim
@@ -158,7 +158,6 @@ proc runMetricsLoop(self: MetricsLoggerThread, maxIterations = -1) {.gcsafe.} =
   if ms == 0:
     log(%*{"event": "metrics", "state": "disabled"})
   else:
-    log(%*{"event": "metrics", "state": "enabled", "intervalMs": ms})
     var iterations = 0
     while true:
       if maxIterations >= 0 and iterations >= maxIterations:

--- a/frameos/src/frameos/tests/test_metrics.nim
+++ b/frameos/src/frameos/tests/test_metrics.nim
@@ -29,7 +29,7 @@ suite "metrics loop":
     let (hasNext, _) = logChannel.tryRecv()
     check not hasNext
 
-  test "enabled interval logs one metrics sample with hook values":
+  test "enabled interval logs one metrics sample with hook values and no startup placeholder":
     setMetricsHooksForTest(
       readFileHook = proc(path: string): string {.gcsafe, nimcall.} =
         if path == "/proc/loadavg":
@@ -47,13 +47,11 @@ suite "metrics loop":
 
     runMetricsLoopForTest(FrameConfig(metricsInterval: 1), iterations = 1)
 
-    let (_, enabledPayload) = logChannel.tryRecv()
-    check enabledPayload[1]["state"].getStr() == "enabled"
-    check enabledPayload[1]["intervalMs"].getInt() == 1000
-
     let (okSample, samplePayload) = logChannel.tryRecv()
     check okSample
     check samplePayload[1]["event"].getStr() == "metrics"
+    check not samplePayload[1].hasKey("state")
+    check not samplePayload[1].hasKey("intervalMs")
     check samplePayload[1]["load"].len == 3
     check abs(samplePayload[1]["cpuTemperature"].getFloat() - 42.0) < 0.0001
     check samplePayload[1]["memoryUsage"]["total"].getInt() == 1234
@@ -79,7 +77,6 @@ suite "metrics loop":
 
     runMetricsLoopForTest(FrameConfig(metricsInterval: 1), iterations = 1)
 
-    discard logChannel.tryRecv() # enabled message
     let (okError, errorPayload) = logChannel.tryRecv()
     check okError
     check errorPayload[1]["event"].getStr() == "metrics"

--- a/frameos/tools/build_driver_libraries.py
+++ b/frameos/tools/build_driver_libraries.py
@@ -23,6 +23,7 @@ if str(BACKEND_ROOT) not in sys.path:
 from app.codegen.drivers_nim import (  # noqa: E402
     DRIVER_BUILD_MODE_SHARED,
     compiled_drivers,
+    driver_build_mode_uses_shared_libraries,
     driver_library_filename,
     frame_driver_build_mode,
     normalize_driver_build_mode,
@@ -71,7 +72,7 @@ async def build_driver_libraries(
 ) -> list[Path]:
     frame = load_frame_stub(config_path)
     mode = normalize_driver_build_mode(driver_build_mode or frame_driver_build_mode(frame))
-    if only_if_shared and mode != DRIVER_BUILD_MODE_SHARED:
+    if only_if_shared and not driver_build_mode_uses_shared_libraries(mode):
         print(f"Driver build mode is {mode}; skipping shared driver libraries")
         return []
 
@@ -130,11 +131,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--only-if-shared",
         action="store_true",
-        help="Skip unless the effective driver build mode is shared",
+        help="Skip unless the effective driver build mode uses shared libraries",
     )
     parser.add_argument(
         "--driver-build-mode",
-        choices=("static", "shared"),
+        choices=("static", "shared", "precompiled"),
         default=None,
         help="Override frame.json rpios.driverBuildMode when deciding whether to skip",
     )

--- a/frameos/tools/generate_driver_sources.py
+++ b/frameos/tools/generate_driver_sources.py
@@ -20,8 +20,8 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.codegen.drivers_nim import (  # noqa: E402
-    DRIVER_BUILD_MODE_SHARED,
     compiled_drivers,
+    driver_build_mode_uses_shared_libraries,
     frame_driver_build_mode,
     normalize_driver_build_mode,
     write_driver_library_nim,
@@ -86,7 +86,7 @@ def generate_driver_sources(
 
     shared_dir = drivers_dir / "shared"
     shutil.rmtree(shared_dir, ignore_errors=True)
-    if mode == DRIVER_BUILD_MODE_SHARED:
+    if driver_build_mode_uses_shared_libraries(mode):
         shared_dir.mkdir(parents=True, exist_ok=True)
         for driver in compiled_drivers(drivers):
             (shared_dir / f"{driver.name}.nim").write_text(
@@ -103,7 +103,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--config", default=str(FRAMEOS_ROOT / "frame.json"), help="Frame config JSON")
     parser.add_argument(
         "--driver-build-mode",
-        choices=("static", "shared"),
+        choices=("static", "shared", "precompiled"),
         default=None,
         help="Override frame.json rpios.driverBuildMode",
     )

--- a/frontend/src/scenes/frame/frameDeployUtils.ts
+++ b/frontend/src/scenes/frame/frameDeployUtils.ts
@@ -27,12 +27,15 @@ export interface FullDeployPlanResponse {
   low_memory: boolean
   drivers: string[]
   binary: {
-    driver_build_mode?: 'static' | 'shared'
+    driver_build_mode?: 'static' | 'shared' | 'precompiled'
     will_attempt_cross_compile?: boolean
+    will_attempt_precompiled?: boolean
     cross_compile_supported?: boolean
     build_host_configured?: boolean
     prebuilt_target?: string | null
     has_prebuilt_entry?: boolean
+    precompiled_release_url?: string | null
+    precompiled_skip_reason?: string | null
   }
   packages: {
     name: string
@@ -145,7 +148,9 @@ export function buildFullDeployPlanSummary(
     },
     {
       label: 'Build strategy',
-      value: fullPlan.binary.will_attempt_cross_compile
+      value: fullPlan.binary.will_attempt_precompiled
+        ? 'Download the precompiled FrameOS release'
+        : fullPlan.binary.will_attempt_cross_compile
         ? fullPlan.binary.build_host_configured
           ? 'Cross-compile on the configured build host'
           : 'Cross-compile locally on this server'
@@ -161,10 +166,25 @@ export function buildFullDeployPlanSummary(
   if (fullPlan.binary.driver_build_mode === 'shared') {
     items.push({ label: 'Driver delivery', value: 'Shared libraries deployed next to the FrameOS binary' })
   }
+  if (fullPlan.binary.driver_build_mode === 'precompiled') {
+    items.push({
+      label: 'Driver delivery',
+      value: fullPlan.binary.will_attempt_precompiled
+        ? 'Precompiled FrameOS binary and shared driver libraries'
+        : `Shared driver libraries; precompiled release skipped${
+            fullPlan.binary.precompiled_skip_reason ? ` (${fullPlan.binary.precompiled_skip_reason})` : ''
+          }`,
+    })
+  }
   if (packagesToInstall.length > 0) {
     items.push({ label: 'Packages to install', value: stringifyList(packagesToInstall) })
   }
-  if (!fullPlan.binary.will_attempt_cross_compile && fullPlan.quickjs.required_if_remote_build && !fullPlan.quickjs.installed) {
+  if (
+    !fullPlan.binary.will_attempt_precompiled &&
+    !fullPlan.binary.will_attempt_cross_compile &&
+    fullPlan.quickjs.required_if_remote_build &&
+    !fullPlan.quickjs.installed
+  ) {
     items.push({
       label: 'QuickJS',
       value: `${fullPlan.quickjs.dirname || 'Required'} will be prepared for the on-device build`,
@@ -202,7 +222,11 @@ export function buildFullDeployPlanSummary(
   if (fullPlan.post_deploy?.reboot_schedule?.needs_remove) {
     items.push({ label: 'Reboot schedule', value: 'Old scheduled reboot config will be removed' })
   }
-  if (fullPlan.low_memory && !fullPlan.binary.will_attempt_cross_compile) {
+  if (
+    fullPlan.low_memory &&
+    !fullPlan.binary.will_attempt_precompiled &&
+    !fullPlan.binary.will_attempt_cross_compile
+  ) {
     items.push({ label: 'Low memory', value: 'FrameOS will be stopped before the on-device build' })
   }
   if (fullPlan.post_deploy?.final_action === 'reboot') {

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -546,6 +546,10 @@ export function FrameSettings({ className, hideDropdown, hideDeploymentMode }: F
                       Choose whether display/input drivers are built as separate shared libraries deployed next to
                       FrameOS, or linked into the FrameOS executable.
                     </p>
+                    <p>
+                      Precompiled only downloads a published FrameOS release when all scenes are interpreted; otherwise
+                      it falls back to shared driver libraries.
+                    </p>
                   </div>
                 }
               >
@@ -554,6 +558,7 @@ export function FrameSettings({ className, hideDropdown, hideDeploymentMode }: F
                   options={[
                     { value: '', label: 'Default (single executable)' },
                     { value: 'shared', label: 'Shared driver libraries' },
+                    { value: 'precompiled', label: 'Precompiled only / experimental' },
                     { value: 'static', label: 'Single executable' },
                   ]}
                 />

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -661,5 +661,5 @@ export interface FrameBuildrootConfig {
 export interface FrameRpiOSConfig {
   platform?: string
   crossCompilation?: '' | 'auto' | 'always' | 'never'
-  driverBuildMode?: '' | 'static' | 'shared'
+  driverBuildMode?: '' | 'static' | 'shared' | 'precompiled'
 }


### PR DESCRIPTION
Adds an experimental mode which uses prebuilt frameos binaries. Opt-in for now, but probably soon the default:

<img width="1090" height="482" alt="image" src="https://github.com/user-attachments/assets/6ede7030-5428-4c11-8e95-4c920444c2c5" />


A full deploy took 6 seconds on a pi 5, and 10-15 on a zero w2.
