### PR TITLE
fix: prevent NameError in image endpoint when scene_id is None

### DIFF
--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -1247,17 +1247,18 @@ async def api_frame_get_image(
                         db.add(img_row)
                     db.commit()
 
-                await publish_message(
-                    redis,
-                    "new_scene_image",
-                    {
-                        "frameId": id,
-                        "sceneId": scene_id,
-                        "timestamp": now.isoformat(),
-                        "width": width,
-                        "height": height,
-                    },
-                )
+                if scene_id:
+                    await publish_message(
+                        redis,
+                        "new_scene_image",
+                        {
+                            "frameId": id,
+                            "sceneId": scene_id,
+                            "timestamp": now.isoformat(),
+                            "width": width,
+                            "height": height,
+                        },
+                    )
 
                 return Response(content=body, media_type="image/png")
             else:

--- a/backend/app/api/tests/test_frames.py
+++ b/backend/app/api/tests/test_frames.py
@@ -288,6 +288,25 @@ async def test_api_frame_get_image_with_cookie_no_token(no_auth_client, db, redi
 
 
 @pytest.mark.asyncio
+async def test_api_frame_get_image_no_scene_id(async_client, db, redis):
+    """When the frame returns a 200 image but no x-scene-id header and no
+    cached active scene, the endpoint should still return the image without
+    crashing (no NameError on `now`/`width`/`height`)."""
+    frame = await new_frame(db, redis, 'NoSceneFrame', 'example.com', 'localhost')
+
+    fake_png = b'\x89PNG\r\n\x1a\n' + b'\x00' * 100
+
+    async def mock_fetch(frame_obj, redis_obj, *, path, method="GET"):
+        # Return 200 with image bytes but NO x-scene-id header
+        return 200, fake_png, {}
+
+    with patch('app.api.frames._fetch_frame_http_bytes', side_effect=mock_fetch):
+        response = await async_client.get(f'/api/frames/{frame.id}/image')
+    assert response.status_code == 200
+    assert response.content == fake_png
+
+
+@pytest.mark.asyncio
 async def test_api_frame_generate_tls_material_includes_validity_dates(async_client, db, redis):
     frame = await new_frame(db, redis, 'TlsFrame', 'localhost', 'localhost')
 


### PR DESCRIPTION
## Summary
- Guard `publish_message` call behind `if scene_id:` check to prevent `NameError` when the frame returns a 200 image but no `x-scene-id` header
- Add test `test_api_frame_get_image_no_scene_id` to verify the endpoint returns the image without crashing when no scene ID is present

## Test plan
- New test covers the missing-scene-id code path
- Existing image endpoint tests continue to pass