### PR TITLE
Fix SQLite lock starvation in log ingestion, stop forced agent version bumps

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           NEXT_VERSION: ${{ inputs.next_version }}
         run: |
-          args=(--force-project docker --force-project agent)
+          args=(--force-project docker)
           if [ -n "$NEXT_VERSION" ]; then
             args+=(--force-project frameos --next-version "$NEXT_VERSION")
           fi

--- a/backend/app/api/log.py
+++ b/backend/app/api/log.py
@@ -4,7 +4,7 @@ from arq import ArqRedis as Redis
 
 from app.database import get_db
 from app.models.frame import Frame
-from app.models.log import maybe_prune_logs, process_log
+from app.models.log import process_log
 from app.schemas.log import LogRequest, LogResponse
 from app.utils.request_ip import extract_client_ip
 from app.redis import get_redis
@@ -40,11 +40,11 @@ async def post_api_log(
         await process_log(db, redis, frame, data.log, ip=client_ip)
 
     if data.logs:
-        # Devices ship logs in batches of up to 1000; commit and prune once
-        # per request instead of once per line.
+        # Commit per line, not per batch: a batch-wide transaction stayed open
+        # across awaited Redis publishes, holding the SQLite write lock while
+        # other requests blocked the event loop waiting for it. WAL mode with
+        # synchronous=NORMAL makes per-line commits cheap.
         for log in data.logs:
-            await process_log(db, redis, frame, log, ip=client_ip, commit=False)
-        maybe_prune_logs(db, frame.project_id, frame.id, inserts=len(data.logs))
-        db.commit()
+            await process_log(db, redis, frame, log, ip=client_ip)
 
     return LogResponse(message="OK")

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -24,6 +24,18 @@ if is_sqlite:
         cursor.execute("PRAGMA synchronous=NORMAL")
         cursor.execute("PRAGMA busy_timeout=30000")
         cursor.close()
+
+    # WAL silently falls back to another journal mode on filesystems that
+    # don't support it; surface that in the logs instead of guessing later.
+    try:
+        with engine.connect() as _conn:
+            _journal_mode = _conn.exec_driver_sql("PRAGMA journal_mode").scalar()
+        if _journal_mode != "wal":
+            print(f"🔴 SQLite journal_mode is {_journal_mode!r} (expected 'wal'); "
+                  "concurrent writes may fail with 'database is locked'")
+    except Exception as e:
+        print(f"🔴 Could not verify SQLite journal mode: {e}")
+
 SessionLocal = sessionmaker(
     autocommit=False,
     autoflush=False,

--- a/backend/app/models/log.py
+++ b/backend/app/models/log.py
@@ -8,7 +8,7 @@ from .frame import Frame, update_frame
 from .metrics import new_metrics
 from app.database import Base
 from app.utils.timezone import stored_timezone
-from sqlalchemy import Index, Integer, String, DateTime, ForeignKey, Text, event, func
+from sqlalchemy import Index, Integer, String, DateTime, ForeignKey, Text, delete, event, func, select
 from sqlalchemy.orm import relationship, backref, Session, mapped_column
 from app.websockets import publish_message
 
@@ -74,14 +74,16 @@ def maybe_prune_logs(db: Session, project_id: int, frame_id: int, inserts: int =
 
     frame_logs_count = db.query(Log).filter_by(project_id=project_id, frame_id=frame_id).count()
     if frame_logs_count > LOG_LIMIT_PER_FRAME + 100:
-        oldest_logs = (db.query(Log)
-                       .filter_by(frame_id=frame_id)
-                       .filter(Log.project_id == project_id)
-                       .order_by(Log.timestamp)
-                       .limit(frame_logs_count - LOG_LIMIT_PER_FRAME)
-                       .all())
-        for old_log in oldest_logs:
-            db.delete(old_log)
+        # One bulk DELETE: loading the excess rows as ORM objects and deleting
+        # them one by one held the write transaction open for the whole sweep,
+        # locking out every other writer.
+        oldest_ids = (
+            select(Log.id)
+            .where(Log.project_id == project_id, Log.frame_id == frame_id)
+            .order_by(Log.timestamp)
+            .limit(frame_logs_count - LOG_LIMIT_PER_FRAME)
+        )
+        db.execute(delete(Log).where(Log.id.in_(oldest_ids)))
 
 
 async def new_log(
@@ -92,7 +94,6 @@ async def new_log(
     line: str,
     timestamp: Optional[datetime] = None,
     ip: Optional[str] = None,
-    commit: bool = True,
 ) -> Log:
     timestamp = timestamp or datetime.utcnow()
     frame = db.get(Frame, frame_id)
@@ -110,13 +111,16 @@ async def new_log(
     db.add(log)
     if is_frame_activity_log(type, line) and (frame.last_log_at is None or timestamp > frame.last_log_at):
         frame.last_log_at = timestamp
-    # Make the pending row visible to the prune count and assign its id
-    # without paying a commit per call (autoflush is off).
+    # Make the pending row visible to the prune count and assign its id.
     db.flush()
     payload = {**log.to_dict(), "timestamp": log.timestamp.replace(tzinfo=timezone.utc).isoformat()}
-    if commit:
-        maybe_prune_logs(db, frame.project_id, frame_id)
-        db.commit()
+    maybe_prune_logs(db, frame.project_id, frame_id)
+    # Commit before any await. Sessions here run sync SQLAlchemy on the event
+    # loop: awaiting while the flush's write transaction is open suspends this
+    # task with the SQLite write lock held, and any other request that then
+    # blocks on that lock freezes the loop, so the holder never resumes to
+    # commit ("database is locked" storms).
+    db.commit()
 
     await publish_message(redis, "new_log", payload)
     return log
@@ -128,7 +132,6 @@ async def process_log(
     frame: Frame,
     log: dict | list,
     ip: Optional[str] = None,
-    commit: bool = True,
 ):
     if isinstance(log, list):
         timestamp = datetime.utcfromtimestamp(log[0])
@@ -136,7 +139,7 @@ async def process_log(
     else:
         timestamp = datetime.utcnow()
 
-    await new_log(db, redis, int(frame.id), "webhook", json.dumps(log), timestamp, ip=ip, commit=commit)
+    await new_log(db, redis, int(frame.id), "webhook", json.dumps(log), timestamp, ip=ip)
 
     assert isinstance(log, dict), f"Log must be a dict, got {type(log)}"
 

--- a/backend/app/models/metrics.py
+++ b/backend/app/models/metrics.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import timezone
 from sqlalchemy.dialects.sqlite import JSON
-from sqlalchemy import Index, Integer, String, ForeignKey, DateTime, event, func
+from sqlalchemy import Index, Integer, String, ForeignKey, DateTime, delete, event, func, select
 from arq import ArqRedis as Redis
 from app.database import Base
 from app.models.frame import Frame
@@ -62,14 +62,15 @@ async def new_metrics(db: Session, redis: Redis, frame_id: int, metrics: dict) -
     payload = metric.to_dict()
     if metrics_count > METRICS_RETAINED_PER_FRAME:
         trim_count = metrics_count - METRICS_RETAINED_PER_FRAME
-        oldest_metrics = (db.query(Metrics)
-                          .filter_by(frame_id=frame_id)
-                          .filter(Metrics.project_id == frame.project_id)
-                          .order_by(Metrics.timestamp)
-                          .limit(trim_count)
-                          .all())
-        for old_metric in oldest_metrics:
-            db.delete(old_metric)
+        # One bulk DELETE instead of loading the excess rows as ORM objects;
+        # see maybe_prune_logs for why the long write transaction hurt.
+        oldest_ids = (
+            select(Metrics.id)
+            .where(Metrics.project_id == frame.project_id, Metrics.frame_id == frame_id)
+            .order_by(Metrics.timestamp)
+            .limit(trim_count)
+        )
+        db.execute(delete(Metrics).where(Metrics.id.in_(oldest_ids)))
     db.commit()
 
     await publish_message(redis, "new_metrics", payload)

--- a/backend/app/models/tests/test_log.py
+++ b/backend/app/models/tests/test_log.py
@@ -216,3 +216,24 @@ async def test_new_log_trimming(mock_pub, db, redis):
     # Pruning trims back down to exactly the limit; the new log survives.
     assert count == LOG_LIMIT_PER_FRAME
     assert db.query(Log).filter_by(frame_id=frame.id).order_by(Log.id.desc()).first().line == "Trigger trim"
+
+
+@pytest.mark.asyncio
+async def test_new_log_commits_before_publishing(db, redis):
+    """new_log must not await while a write transaction is open: the session is
+    sync SQLAlchemy on the event loop, so a task suspended mid-publish would
+    hold the SQLite write lock while other requests block the loop waiting for
+    it ("database is locked" storms in production)."""
+    with patch("app.models.log.publish_message", new_callable=AsyncMock):
+        frame = await new_frame(db, redis, "PublishFrame", "localhost", "server_host")
+
+    tx_open_during_publish = None
+
+    async def record_tx_state(_redis, _event, _payload):
+        nonlocal tx_open_during_publish
+        tx_open_during_publish = db.in_transaction()
+
+    with patch("app.models.log.publish_message", record_tx_state):
+        await new_log(db, redis, frame.id, "webhook", '{"event":"test"}')
+
+    assert tx_open_during_publish is False

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -70,7 +70,9 @@ const settingsNavSections: readonly SettingsNavSection[] = [
 
 const settingsNavItems = settingsNavSections.flatMap((section) => section.items)
 
-const frameosVersion = typeof versions.frameos === 'string' ? versions.frameos.split('+')[0] : null
+// The docker version is the release version: it bumps on every release, while
+// the frameos/agent components only bump when their own sources change.
+const frameosVersion = typeof versions.docker === 'string' ? versions.docker.split('+')[0] : null
 const frameosVersionLabel = frameosVersion ? `FrameOS ${frameosVersion}` : 'FrameOS'
 
 function settingsHeaderOffset(): number {


### PR DESCRIPTION
## The bug

Production (Home Assistant addon) kept hitting `sqlite3.OperationalError: database is locked` on `UPDATE frame SET last_log_at` during log ingestion — even after WAL mode and a 30s busy timeout were enabled in #231 (`05e82361`).

Root cause: the backend runs **sync** SQLAlchemy inside `async` endpoints on a single event loop. In the batch log path (`commit=False`), `new_log` flushed — opening a SQLite write transaction — then **awaited** a Redis publish per log line with that transaction still open. The suspended task held the SQLite write lock; the next request on the same loop blocked the loop *synchronously* waiting for that lock, so the holder could never resume to commit. Coroutine self-deadlock — no busy timeout can help.

## Fixes

- **Never await with a transaction open**: `new_log` always commits before publishing to Redis; the `commit=False` batch mode is removed. Per-line commits are cheap under WAL + `synchronous=NORMAL` (no fsync per commit). Regression test asserts no transaction is open during the awaited publish.
- **Pruning is one bulk `DELETE`** (logs and metrics) instead of loading thousands of ORM rows and deleting them one by one inside a single long write transaction — the other way to hold the write lock past the busy timeout.
- **Startup warning** if `journal_mode` is not actually `wal` (SQLite silently falls back on unsupported filesystems), so the HA log shows it.

## Version cleanups

- The release workflow no longer passes `--force-project agent`, so the agent version only bumps when agent sources actually change (it was force-bumped every release since #209 despite an unchanged hash). Artifact downloads are unaffected: `release_version()` resolves release URLs from the docker version.
- The Settings page now shows the **docker** (release) version instead of the `frameos` component version, which legitimately stays behind when device sources don't change (e.g. UI said 2026.6.15 while running the 2026.6.16 container). Device-update comparisons (`CURRENT_FRAMEOS_VERSION`) still use the `frameos` component.

## Testing

- Full backend suite: 538 passed, 3 skipped
- New regression test `test_new_log_commits_before_publishing`
- Existing trim/prune tests cover the bulk DELETE paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)