### PR TITLE
Add PhotoPainter frame profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ files/
 nimcache/
 e2e/scenes/*.so
 *.rdb
+tmp/
+release-assets/

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -151,6 +151,7 @@ from app.tasks.buildroot_image import (
     validate_buildroot_wifi_credentials,
 )
 from app.codegen.drivers_nim import frame_compilation_mode
+from app.drivers.devices import apply_device_config_defaults, apply_device_gpio_button_defaults
 from app.api.project_scope import project_get_or_404
 from app.utils.local_exec import exec_local_command
 from app.utils.jwt_tokens import validate_scoped_token
@@ -454,10 +455,14 @@ def _apply_frame_preview_update(frame: Frame, data: FrameUpdateRequest) -> Any:
         ensure_embedded_frame_defaults(preview, (preview.embedded or {}).get("platform"))
     elif data.mode == "rpios" and old_mode == "buildroot" and preview.ssh_user == "root":
         preview.ssh_user = "pi"
+    apply_device_config_defaults(preview, frame.device)
+    apply_device_gpio_button_defaults(preview, frame.device)
 
     def _preview_to_dict():
         result = {**frame.to_dict(), **preview_data}
         result["mode"] = preview.mode
+        result["device_config"] = preview.device_config
+        result["gpio_buttons"] = preview.gpio_buttons
         result["https_proxy"] = normalize_https_proxy(preview.https_proxy)
         result["error_behavior"] = normalize_error_behavior(preview.error_behavior)
         result["ssh_user"] = preview.ssh_user
@@ -3093,6 +3098,7 @@ async def api_frame_update_endpoint(
             raise HTTPException(status_code=400, detail="Invalid input for scenes (must be JSON)")
 
     old_mode = frame.mode
+    old_device = frame.device
     for field, value in update_data.items():
         setattr(frame, field, value)
 
@@ -3119,6 +3125,8 @@ async def api_frame_update_endpoint(
             _bad_request(str(exc))
     elif data.mode == "rpios" and old_mode == "buildroot" and frame.ssh_user == "root":
         frame.ssh_user = "pi"
+    apply_device_config_defaults(frame, old_device)
+    apply_device_gpio_button_defaults(frame, old_device)
 
     if (
         (frame.mode or "rpios") == "buildroot"
@@ -3207,6 +3215,8 @@ async def api_frame_new(
             frame.embedded = dict(data.embedded)
         if data.gpio_buttons is not None:
             frame.gpio_buttons = list(data.gpio_buttons)
+        apply_device_config_defaults(frame)
+        apply_device_gpio_button_defaults(frame)
 
         if data.ssh_keys is not None:
             frame.ssh_keys = list(dict.fromkeys([key for key in data.ssh_keys if key]))

--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -616,39 +616,39 @@ def test_embedded_hardware_preset_for_waveshare_13in3e6():
     assert embedded_module_psram_bytes(frame) == 16 * 1024 * 1024
     assert frame.device_config["psramMB"] == 16
     assert embedded_pins_for_frame(frame) == {
-        "rst": 10,
-        "dc": 7,
-        "cs": 1,
-        "cs2": 4,
-        "busy": 8,
-        "sck": 6,
-        "mosi": 5,
-        "pwr": 16,
+        "rst": 2,
+        "dc": 11,
+        "cs": 10,
+        "cs2": 3,
+        "busy": 12,
+        "sck": 9,
+        "mosi": 46,
+        "pwr": 1,
     }
     assert embedded_sd_card_assets_for_frame(frame) == {
         "enabled": True,
         "preset": "waveshare_esp32_s3_epaper_13_3e6",
         "mountPath": "/srv/assets",
-        "pins": {"cs": 3, "sck": 44, "miso": 43, "mosi": 2},
+        "pins": {"cs": 15, "sck": 6, "miso": 5, "mosi": 7},
         "maxFrequencyKHz": 20_000,
     }
     check_embedded_panel_fits_memory(frame)
 
     header = _generated_config_header(frame)
     assert '#define FRAMEOS_DEFAULT_PANEL "EPD_13in3e"' in header
-    assert "#define FRAMEOS_DEFAULT_PIN_RST 10" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_DC 7" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_CS 1" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_CS2 4" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_BUSY 8" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_SCK 6" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_MOSI 5" in header
-    assert "#define FRAMEOS_DEFAULT_PIN_PWR 16" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_RST 2" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_DC 11" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_CS 10" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_CS2 3" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_BUSY 12" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_SCK 9" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_MOSI 46" in header
+    assert "#define FRAMEOS_DEFAULT_PIN_PWR 1" in header
     assert "#define FRAMEOS_DEFAULT_ASSETS_SD_ENABLE 1" in header
-    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_CS 3" in header
-    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_SCK 44" in header
-    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_MISO 43" in header
-    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_MOSI 2" in header
+    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_CS 15" in header
+    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_SCK 6" in header
+    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_MISO 5" in header
+    assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_MOSI 7" in header
 
 
 def test_embedded_hardware_preset_for_waveshare_photopainter():

--- a/backend/app/api/tests/test_frames.py
+++ b/backend/app/api/tests/test_frames.py
@@ -2050,20 +2050,20 @@ async def test_api_frame_new_embedded_waveshare_13in3e6_preset(async_client):
     assert frame['device_config']['hardwarePreset'] == 'waveshare_esp32_s3_epaper_13_3e6'
     assert frame['device_config']['psramMB'] == 16
     assert frame['device_config']['pins'] == {
-        'rst': 10,
-        'dc': 7,
-        'cs': 1,
-        'cs2': 4,
-        'busy': 8,
-        'sck': 6,
-        'mosi': 5,
-        'pwr': 16,
+        'rst': 2,
+        'dc': 11,
+        'cs': 10,
+        'cs2': 3,
+        'busy': 12,
+        'sck': 9,
+        'mosi': 46,
+        'pwr': 1,
     }
     assert frame['device_config']['sdCardAssets'] == {
         'enabled': True,
         'preset': 'waveshare_esp32_s3_epaper_13_3e6',
         'mountPath': '/srv/assets',
-        'pins': {'cs': 3, 'sck': 44, 'miso': 43, 'mosi': 2},
+        'pins': {'cs': 15, 'sck': 6, 'miso': 5, 'mosi': 7},
         'maxFrequencyKHz': 20000,
     }
 

--- a/backend/app/api/tests/test_frames.py
+++ b/backend/app/api/tests/test_frames.py
@@ -23,6 +23,10 @@ from app.models.user import User
 from app.tenancy import ensure_default_project_for_user
 from app.tasks.buildroot_image import BUILDROOT_SD_IMAGE_CUSTOMIZATION_VERSION, buildroot_sd_image_config_fingerprint
 from app.codegen.drivers_nim import frame_compilation_mode
+from app.drivers.devices import (
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS,
+)
 
 
 def set_buildroot_sd_image_config_fingerprint(frame: Frame) -> None:
@@ -2108,6 +2112,28 @@ async def test_api_frame_new_embedded_waveshare_photopainter_preset(async_client
         'pins': {'cs': 38, 'sck': 39, 'miso': 40, 'mosi': 41},
         'maxFrequencyKHz': 20000,
     }
+
+
+@pytest.mark.asyncio
+async def test_api_frame_new_rpios_waveshare_photopainter_profile(async_client):
+    payload = {
+        "mode": "rpios",
+        "name": "RPi PhotoPainter",
+        "frame_host": "pi@photopainter.local",
+        "server_host": "backend.local",
+        "device": WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+    }
+
+    response = await async_client.post('/api/frames/new', json=payload)
+
+    assert response.status_code == 200
+    frame = response.json()['frame']
+    assert frame['mode'] == 'rpios'
+    assert frame['device'] == WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE
+    assert frame['width'] == 800
+    assert frame['height'] == 480
+    assert frame['device_config']['pins'] == WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS
+    assert frame['gpio_buttons'] is None
 
 
 @pytest.mark.asyncio

--- a/backend/app/codegen/drivers_nim.py
+++ b/backend/app/codegen/drivers_nim.py
@@ -85,6 +85,7 @@ proc buildDriverContext(frameOS: FrameOS): driverContext.DriverContext =
     partialMaxRefreshesBeforeFull: 0,
     httpUploadUrl: "",
     httpUploadHeaders: @[],
+    pins: driverContext.PinOverrides(rst: -1, dc: -1, cs: -1, busy: -1, sclk: -1, mosi: -1, pwr: -1),
   )
   if not sourceDeviceConfig.isNil:
     deviceConfig.vcom = sourceDeviceConfig.vcom
@@ -92,6 +93,16 @@ proc buildDriverContext(frameOS: FrameOS): driverContext.DriverContext =
     deviceConfig.partialMaxAreaPercent = sourceDeviceConfig.partialMaxAreaPercent
     deviceConfig.partialMaxRefreshesBeforeFull = sourceDeviceConfig.partialMaxRefreshesBeforeFull
     deviceConfig.httpUploadUrl = sourceDeviceConfig.httpUploadUrl
+    if not sourceDeviceConfig.pins.isNil:
+      deviceConfig.pins = driverContext.PinOverrides(
+        rst: sourceDeviceConfig.pins.rst,
+        dc: sourceDeviceConfig.pins.dc,
+        cs: sourceDeviceConfig.pins.cs,
+        busy: sourceDeviceConfig.pins.busy,
+        sclk: sourceDeviceConfig.pins.sclk,
+        mosi: sourceDeviceConfig.pins.mosi,
+        pwr: sourceDeviceConfig.pins.pwr,
+      )
     for header in sourceDeviceConfig.httpUploadHeaders:
       deviceConfig.httpUploadHeaders.add(driverContext.HttpHeaderPair(
         name: header.name,
@@ -217,6 +228,7 @@ proc cloneDriverContext(source: DriverContext): DriverContext =
     partialMaxRefreshesBeforeFull: 0,
     httpUploadUrl: "",
     httpUploadHeaders: @[],
+    pins: PinOverrides(rst: -1, dc: -1, cs: -1, busy: -1, sclk: -1, mosi: -1, pwr: -1),
   )
   var palette = PaletteConfig(colors: @[])
   var config = DriverFrameConfig(
@@ -248,6 +260,16 @@ proc cloneDriverContext(source: DriverContext): DriverContext =
         deviceConfig.partialMaxAreaPercent = sourceConfig.deviceConfig.partialMaxAreaPercent
         deviceConfig.partialMaxRefreshesBeforeFull = sourceConfig.deviceConfig.partialMaxRefreshesBeforeFull
         deviceConfig.httpUploadUrl = sourceConfig.deviceConfig.httpUploadUrl
+        if not sourceConfig.deviceConfig.pins.isNil:
+          deviceConfig.pins = PinOverrides(
+            rst: sourceConfig.deviceConfig.pins.rst,
+            dc: sourceConfig.deviceConfig.pins.dc,
+            cs: sourceConfig.deviceConfig.pins.cs,
+            busy: sourceConfig.deviceConfig.pins.busy,
+            sclk: sourceConfig.deviceConfig.pins.sclk,
+            mosi: sourceConfig.deviceConfig.pins.mosi,
+            pwr: sourceConfig.deviceConfig.pins.pwr,
+          )
         for header in sourceConfig.deviceConfig.httpUploadHeaders:
           deviceConfig.httpUploadHeaders.add(HttpHeaderPair(name: header.name, value: header.value))
       if not sourceConfig.palette.isNil:

--- a/backend/app/codegen/release_drivers_nim.py
+++ b/backend/app/codegen/release_drivers_nim.py
@@ -13,6 +13,7 @@ from app.codegen.drivers_nim import (
     write_driver_library_nim,
 )
 from app.drivers.drivers import DRIVERS, Driver
+from app.drivers.devices import WAVESHARE_DEVICE_VARIANTS
 from app.drivers.waveshare import get_variant_keys, write_waveshare_driver_nim
 
 
@@ -98,6 +99,10 @@ def write_release_shared_drivers_nim(drivers: dict[str, Driver]) -> str:
         if driver.import_path or driver.setup_import_path or driver.lines
     ]
     available_driver_names_source = nim_string_seq_literal(available_driver_names)
+    custom_waveshare_variant_lines = "\n".join(
+        f'  if device == "{device}":\n    return "{variant}"'
+        for device, variant in sorted(WAVESHARE_DEVICE_VARIANTS.items())
+    )
 
     return f"""
 import std/[dynlib, json, options, os, strutils]
@@ -209,6 +214,7 @@ proc evdevEnabledDevice(device: string): bool =
 
 proc normalizedWaveshareVariant(device: string): string =
   const prefix = "waveshare."
+{custom_waveshare_variant_lines}
   if not device.startsWith(prefix) or device.len <= prefix.len:
     return ""
   result = device[prefix.len .. ^1]

--- a/backend/app/drivers/devices.py
+++ b/backend/app/drivers/devices.py
@@ -87,13 +87,32 @@ WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS = {
     "mosi": 10,
     "pwr": 27,
 }
-
+INKY_GPIO_BUTTONS = [
+    {"pin": 5, "label": "A"},
+    {"pin": 6, "label": "B"},
+    {"pin": 16, "label": "C"},
+    {"pin": 24, "label": "D"},
+]
+INKY_13_GPIO_BUTTONS = [
+    {"pin": 5, "label": "A"},
+    {"pin": 6, "label": "B"},
+    {"pin": 25, "label": "C"},
+    {"pin": 24, "label": "D"},
+]
 WAVESHARE_DEVICE_VARIANTS = {
     WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE: WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_VARIANT,
 }
 
 WAVESHARE_DEVICE_PIN_DEFAULTS = {
     WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE: WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS,
+}
+DEVICE_GPIO_BUTTON_DEFAULTS = {
+    **{
+        device: INKY_13_GPIO_BUTTONS
+        if device in {"pimoroni.inky_impression_13", "pimoroni.inky_impression_13_2025"}
+        else INKY_GPIO_BUTTONS
+        for device in INKY_BUTTON_DEVICES
+    },
 }
 
 NATIVE_DEVICE_DIMENSIONS = {
@@ -196,8 +215,39 @@ def device_config_with_defaults(
     return config
 
 
+def device_gpio_button_defaults(device: str | None) -> list[dict] | None:
+    defaults = DEVICE_GPIO_BUTTON_DEFAULTS.get(device or "")
+    return [dict(button) for button in defaults] if defaults is not None else None
+
+
+def _normalized_gpio_buttons(buttons: list[dict] | None) -> list[dict]:
+    normalized: list[dict] = []
+    for button in buttons or []:
+        if not isinstance(button, dict):
+            continue
+        try:
+            pin = int(button.get("pin"))
+        except (TypeError, ValueError):
+            continue
+        normalized.append({"pin": pin, "label": str(button.get("label") or f"Pin {pin}")})
+    return normalized
+
+
+def apply_device_gpio_button_defaults(frame: Frame, previous_device: str | None = None) -> None:
+    defaults = device_gpio_button_defaults(frame.device)
+    if defaults is not None:
+        frame.gpio_buttons = defaults
+        return
+
+    previous_defaults = device_gpio_button_defaults(previous_device)
+    if previous_defaults is not None and _normalized_gpio_buttons(frame.gpio_buttons) == previous_defaults:
+        frame.gpio_buttons = None
+
+
 def apply_device_config_defaults(frame: Frame, previous_device: str | None = None) -> None:
-    frame.device_config = device_config_with_defaults(frame.device, frame.device_config, previous_device)
+    config = device_config_with_defaults(frame.device, frame.device_config, previous_device)
+    if config or isinstance(frame.device_config, dict):
+        frame.device_config = config
 
 
 def device_dimensions(device: str | None) -> tuple[int, int] | None:
@@ -265,24 +315,11 @@ def drivers_for_frame(frame: Frame) -> dict[str, Driver]:
     if device not in INKY_BUTTON_DEVICES and not device.startswith("waveshare.") and device not in VIRTUAL_OUTPUT_DEVICES:
         device_drivers["evdev"] = DRIVERS["evdev"]
 
+    default_gpio_buttons = device_gpio_button_defaults(frame.device)
+    if default_gpio_buttons is not None:
+        frame.gpio_buttons = default_gpio_buttons
+
     if frame.device in INKY_BUTTON_DEVICES:
-        if frame.device in {
-            "pimoroni.inky_impression_13",
-            "pimoroni.inky_impression_13_2025",
-        }:
-            frame.gpio_buttons = [
-                {"pin": 5, "label": "A"},
-                {"pin": 6, "label": "B"},
-                {"pin": 25, "label": "C"},
-                {"pin": 24, "label": "D"},
-            ]
-        else:
-            frame.gpio_buttons = [
-                {"pin": 5, "label": "A"},
-                {"pin": 6, "label": "B"},
-                {"pin": 16, "label": "C"},
-                {"pin": 24, "label": "D"},
-            ]
         if "bootconfig" not in device_drivers:
             device_drivers["bootconfig"] = replace(DRIVERS["bootConfig"], lines=["dtoverlay=spi0-0cs"])
 

--- a/backend/app/drivers/devices.py
+++ b/backend/app/drivers/devices.py
@@ -76,6 +76,26 @@ VIRTUAL_OUTPUT_DEVICES = {
     "web_only",
 }
 
+WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE = "waveshare.rpi_zero_photopainter_7in3e"
+WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_VARIANT = "EPD_7in3e"
+WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS = {
+    "rst": 17,
+    "dc": 25,
+    "cs": 8,
+    "busy": 24,
+    "sclk": 11,
+    "mosi": 10,
+    "pwr": 27,
+}
+
+WAVESHARE_DEVICE_VARIANTS = {
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE: WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_VARIANT,
+}
+
+WAVESHARE_DEVICE_PIN_DEFAULTS = {
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE: WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS,
+}
+
 NATIVE_DEVICE_DIMENSIONS = {
     "pimoroni.inky_impression_7_3": (800, 480),
     "pimoroni.inky_impression_7_color": (800, 480),
@@ -117,17 +137,76 @@ NATIVE_DEVICE_DIMENSIONS = {
 }
 
 
+def waveshare_variant_for_device(device: str | None) -> str | None:
+    if not device:
+        return None
+    if device in WAVESHARE_DEVICE_VARIANTS:
+        return WAVESHARE_DEVICE_VARIANTS[device]
+    if not device.startswith("waveshare."):
+        return None
+    variant = device.split(".", 1)[1]
+    if variant == "epd7in5_V2":
+        return "EPD_7in5_V2"
+    if variant == "epd2in13_V3":
+        return "EPD_2in13_V3"
+    return variant
+
+
+def _merged_pin_defaults(pins: dict | None, defaults: dict[str, int]) -> dict[str, int]:
+    merged = dict(defaults)
+    if isinstance(pins, dict):
+        for key in defaults:
+            if pins.get(key) is not None:
+                merged[key] = pins[key]
+        if pins.get("sck") is not None and pins.get("sclk") is None and "sclk" in defaults:
+            merged["sclk"] = pins["sck"]
+    return merged
+
+
+def _remove_matching_pin_defaults(pins: dict | None, defaults: dict[str, int]) -> dict | None:
+    if not isinstance(pins, dict):
+        return pins
+    remaining = dict(pins)
+    for key, value in defaults.items():
+        if remaining.get(key) == value:
+            remaining.pop(key, None)
+    if remaining.get("sck") == defaults.get("sclk"):
+        remaining.pop("sck", None)
+    return remaining or None
+
+
+def device_config_with_defaults(
+    device: str | None,
+    device_config: dict | None,
+    previous_device: str | None = None,
+) -> dict:
+    config = dict(device_config or {})
+    pin_defaults = WAVESHARE_DEVICE_PIN_DEFAULTS.get(device or "")
+    if pin_defaults is not None:
+        config["pins"] = _merged_pin_defaults(config.get("pins"), pin_defaults)
+        return config
+
+    previous_pin_defaults = WAVESHARE_DEVICE_PIN_DEFAULTS.get(previous_device or "")
+    if previous_pin_defaults is not None:
+        remaining_pins = _remove_matching_pin_defaults(config.get("pins"), previous_pin_defaults)
+        if remaining_pins:
+            config["pins"] = remaining_pins
+        else:
+            config.pop("pins", None)
+    return config
+
+
+def apply_device_config_defaults(frame: Frame, previous_device: str | None = None) -> None:
+    frame.device_config = device_config_with_defaults(frame.device, frame.device_config, previous_device)
+
+
 def device_dimensions(device: str | None) -> tuple[int, int] | None:
     if not device:
         return None
     if device in NATIVE_DEVICE_DIMENSIONS:
         return NATIVE_DEVICE_DIMENSIONS[device]
-    if device.startswith("waveshare."):
-        variant = device.split(".", 1)[1]
-        if variant == "epd7in5_V2":
-            variant = "EPD_7in5_V2"
-        elif variant == "epd2in13_V3":
-            variant = "EPD_2in13_V3"
+    variant = waveshare_variant_for_device(device)
+    if variant:
         try:
             source = convert_waveshare_source(variant)
         except Exception:
@@ -165,13 +244,9 @@ def drivers_for_frame(frame: Frame) -> dict[str, Driver]:
     elif device == "http.upload":
         device_drivers = {"httpUpload": DRIVERS["httpUpload"]}
     elif device.startswith("waveshare."):
-        waveshare = DRIVERS["waveshare"]
-        waveshare.variant = device.split(".")[1]
-        # backwards compatibility
-        if waveshare.variant == "epd7in5_V2":
-            waveshare.variant = "EPD_7in5_V2"
-        if waveshare.variant == "epd2in13_V3":
-            waveshare.variant = "EPD_2in13_V3"
+        apply_device_config_defaults(frame)
+        waveshare = replace(DRIVERS["waveshare"])
+        waveshare.variant = waveshare_variant_for_device(device)
         if waveshare.variant not in get_variant_keys():
             raise Exception(f"Unknown waveshare driver variant {waveshare.variant}")
 
@@ -184,8 +259,7 @@ def drivers_for_frame(frame: Frame) -> dict[str, Driver]:
 
         boot_config_lines = BOOT_CONFIG_LINES_BY_VARIANT.get(waveshare.variant)
         if boot_config_lines:
-            device_drivers["bootconfig"] = DRIVERS["bootConfig"]
-            device_drivers["bootconfig"].lines = list(boot_config_lines)
+            device_drivers["bootconfig"] = replace(DRIVERS["bootConfig"], lines=list(boot_config_lines))
 
     # Enable evdev for devices that can have local input attached.
     if device not in INKY_BUTTON_DEVICES and not device.startswith("waveshare.") and device not in VIRTUAL_OUTPUT_DEVICES:

--- a/backend/app/drivers/tests/test_devices.py
+++ b/backend/app/drivers/tests/test_devices.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from app.drivers.devices import drivers_for_frame
+from app.drivers.devices import (
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS,
+    device_config_with_defaults,
+    device_dimensions,
+    drivers_for_frame,
+)
 from app.drivers.waveshare import (
     BOOT_CONFIG_LINES_BY_VARIANT,
     BOOT_CONFIG_SPI_VARIANTS,
@@ -10,8 +16,12 @@ from app.drivers.waveshare import (
 )
 
 
-def frame(device: str, gpio_buttons: list[dict] | None = None) -> SimpleNamespace:
-    return SimpleNamespace(device=device, gpio_buttons=gpio_buttons or [])
+def frame(
+    device: str,
+    gpio_buttons: list[dict] | None = None,
+    device_config: dict | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(device=device, gpio_buttons=gpio_buttons or [], device_config=device_config)
 
 
 def test_web_only_frame_has_no_native_drivers():
@@ -52,6 +62,43 @@ def test_waveshare_epd10in3_uses_boot_config_without_generic_spi_setup():
     assert "spi" not in drivers
     assert "noSpi" not in drivers
     assert drivers["bootconfig"].lines == ["dtoverlay=spi0-0cs", "#dtparam=spi=on"]
+
+
+def test_waveshare_rpi_zero_photopainter_uses_7in3e_driver_and_pin_defaults():
+    test_frame = frame(WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE)
+
+    drivers = drivers_for_frame(test_frame)
+
+    assert device_dimensions(WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE) == (800, 480)
+    assert "waveshare" in drivers
+    assert "spi" in drivers
+    assert "evdev" not in drivers
+    assert "gpioButton" not in drivers
+    assert drivers["waveshare"].variant == "EPD_7in3e"
+    assert test_frame.device_config == {"pins": WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS}
+
+
+def test_waveshare_rpi_zero_photopainter_preserves_explicit_pin_overrides():
+    test_frame = frame(
+        WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+        device_config={"pins": {"pwr": 18, "sck": 9}},
+    )
+
+    drivers_for_frame(test_frame)
+
+    assert test_frame.device_config["pins"] == {
+        **WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS,
+        "pwr": 18,
+        "sclk": 9,
+    }
+
+
+def test_waveshare_rpi_zero_photopainter_defaults_are_removed_when_switching_away():
+    assert device_config_with_defaults(
+        "waveshare.EPD_7in3e",
+        {"pins": dict(WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS)},
+        previous_device=WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+    ) == {}
 
 
 def test_native_inky_2025_frame_uses_nim_driver_and_gpio_buttons():

--- a/backend/app/models/frame.py
+++ b/backend/app/models/frame.py
@@ -9,7 +9,13 @@ from sqlalchemy import ForeignKey, Integer, String, Double, DateTime, Boolean
 from sqlalchemy.orm import Session, mapped_column
 from app.database import Base
 
-from app.drivers.devices import device_dimensions
+from app.drivers.devices import (
+    apply_device_config_defaults,
+    apply_device_gpio_button_defaults,
+    device_config_with_defaults,
+    device_dimensions,
+    device_gpio_button_defaults,
+)
 from app.models.apps import get_app_configs
 from app.models.settings import get_settings_dict
 from app.utils.timezone import frame_timezone, stored_timezone
@@ -49,11 +55,24 @@ def _optional_config_int(cfg: dict, key: str) -> dict:
 
 def serialize_device_config(cfg: Optional[dict]) -> dict:
     cfg = dict(cfg or {}) if isinstance(cfg, dict) else {}
+    pins = cfg.get("pins") if isinstance(cfg.get("pins"), dict) else {}
+    serialized_pins = {}
+    for key in ("rst", "dc", "cs", "busy", "sclk", "mosi", "pwr"):
+        value = pins.get(key)
+        if key == "sclk" and value is None:
+            value = pins.get("sck")
+        if value in (None, ""):
+            continue
+        try:
+            serialized_pins[key] = int(value)
+        except (TypeError, ValueError):
+            continue
     return {
         **({"vcom": float(cfg.get('vcom', '0'))} if cfg.get('vcom') not in (None, "") else {}),
         "partial": _config_bool(cfg.get('partial', False)),
         **_optional_config_float(cfg, "partialMaxAreaPercent"),
         **_optional_config_int(cfg, "partialMaxRefreshesBeforeFull"),
+        **({"pins": serialized_pins} if serialized_pins else {}),
         **({"uploadUrl": str(cfg.get('uploadUrl'))} if cfg.get('uploadUrl') else {}),
         **({"uploadHeaders": [
             {"name": str(h.get('name')).strip(), "value": str(h.get('value', ''))}
@@ -387,7 +406,7 @@ class Frame(Base):
             'reboot': normalize_reboot_config(self.reboot),
             'control_code': self.control_code,
             'schedule': self.schedule,
-            'gpio_buttons': self.gpio_buttons,
+            'gpio_buttons': device_gpio_button_defaults(self.device) or self.gpio_buttons,
             'network': self.network,
             'agent': self.agent,
             'mountpoints': normalize_mountpoints(self.mountpoints),
@@ -504,6 +523,8 @@ async def new_frame(
         schedule={"events": []},
         reboot={"enabled": "true", "crontab": "0 4 * * *"}
     )
+    apply_device_config_defaults(frame)
+    apply_device_gpio_button_defaults(frame)
     db.add(frame)
     db.commit()
     await publish_message(redis, "new_frame", frame.to_dict())
@@ -572,6 +593,8 @@ def get_frame_json(db: Session, frame: Frame) -> dict:
     explicit_timezone = stored_timezone(frame.timezone)
     timezone_updater = resolve_timezone_updater(frame.timezone_updater)
     fallback_dimensions = device_dimensions(frame.device)
+    device_config = device_config_with_defaults(frame.device, frame.device_config)
+    gpio_buttons = device_gpio_button_defaults(frame.device) or frame.gpio_buttons or []
     frame_json: dict = {
         **({"frameosVersion": frameos_version} if isinstance(frameos_version, str) and frameos_version else {}),
         "name": frame.name,
@@ -594,7 +617,7 @@ def get_frame_json(db: Session, frame: Frame) -> dict:
         "width": frame.width or (fallback_dimensions[0] if fallback_dimensions else 0),
         "height": frame.height or (fallback_dimensions[1] if fallback_dimensions else 0),
         "device": frame.device or "web_only",
-        "deviceConfig": serialize_device_config(frame.device_config),
+        "deviceConfig": serialize_device_config(device_config),
         "interval": frame.interval or 300.0,
         "metricsInterval": frame.metrics_interval or 60.0,
         "maxHttpResponseBytes": frame.max_http_response_bytes or DEFAULT_MAX_HTTP_RESPONSE_BYTES,
@@ -612,7 +635,7 @@ def get_frame_json(db: Session, frame: Frame) -> dict:
                 "pin": int(button.get("pin", 0)),
                 "label": str(button.get("label", "Pin " + str(button.get("pin"))))
             }
-            for button in (frame.gpio_buttons or [])
+            for button in gpio_buttons
             if int(button.get("pin", 0)) > 0
         ],
         "palette": frame.palette or {},

--- a/backend/app/models/tests/test_frame.py
+++ b/backend/app/models/tests/test_frame.py
@@ -12,6 +12,10 @@ from app.models.frame import (
     normalize_reboot_crontab,
     update_frame,
 )
+from app.drivers.devices import (
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+    WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS,
+)
 from app.database import SessionLocal
 from app.models.settings import Settings
 from app.schemas.frames import FrameErrorBehavior
@@ -281,6 +285,27 @@ async def test_get_frame_json_includes_partial_device_config(_mock_publish, db, 
     device_config = get_frame_json(db, frame)["deviceConfig"]
     assert "partialMaxAreaPercent" not in device_config
     assert "partialMaxRefreshesBeforeFull" not in device_config
+
+
+@pytest.mark.asyncio
+@patch("app.models.frame.publish_message", new_callable=AsyncMock)
+async def test_get_frame_json_includes_waveshare_photopainter_pin_defaults(_mock_publish, db, redis):
+    frame = await new_frame(
+        db,
+        redis,
+        "PhotoPainter",
+        "host",
+        "server_host.com",
+        WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+    )
+
+    data = get_frame_json(db, frame)
+
+    assert data["device"] == WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE
+    assert data["width"] == 800
+    assert data["height"] == 480
+    assert data["deviceConfig"]["pins"] == WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_PINS
+    assert data["gpioButtons"] == []
 
 
 @pytest.mark.asyncio

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -52,7 +52,7 @@ EMBEDDED_PLATFORM_ALIASES = {"", "esp32s3", "esp32-s3-devkitc-1"}
 EMBEDDED_PROJECT_DIR = REPO_ROOT / "embedded" / "esp32"
 EMBEDDED_IDF_TARGET = "esp32s3"
 # Bump when the firmware project changes so existing "ready" images rebuild on next request
-EMBEDDED_FIRMWARE_VERSION = 28  # PhotoPainter default GPIO buttons
+EMBEDDED_FIRMWARE_VERSION = 29  # Waveshare ESP32-S3 ePaper 13.3E6 GPIO defaults
 EMBEDDED_DEFAULT_PANEL = "EPD_7in5_V2"
 EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES = 4 * 1024 * 1024
 EMBEDDED_PIN_KEYS = ("rst", "dc", "cs", "cs2", "busy", "sck", "mosi", "pwr")
@@ -87,18 +87,18 @@ EMBEDDED_WAVESHARE_PHOTOPAINTER_GPIO_BUTTONS = [
     {"pin": 0, "label": "BOOT"},
     {"pin": 4, "label": "KEY1"},
 ]
-# Waveshare ESP32-S3 ePaper 13.3E6 schematic pinout:
-# CSB_M=GPIO1, CSB_S=GPIO4, SDA=GPIO5, SCL=GPIO6, D/C=GPIO7,
-# BUSY_N=GPIO8, RST_N=GPIO10, EPD_PWR=GPIO16.
+# Waveshare ESP32-S3 ePaper 13.3E6 GPIO table / vendor example pinout:
+# EPD_PWR=GPIO1, RST_N=GPIO2, CSB_S=GPIO3, SCL=GPIO9,
+# CSB_M=GPIO10, D/C=GPIO11, BUSY_N=GPIO12, SDA=GPIO46.
 EMBEDDED_WAVESHARE_13IN3E6_PINS = {
-    "rst": 10,
-    "dc": 7,
-    "cs": 1,
-    "cs2": 4,
-    "busy": 8,
-    "sck": 6,
-    "mosi": 5,
-    "pwr": 16,
+    "rst": 2,
+    "dc": 11,
+    "cs": 10,
+    "cs2": 3,
+    "busy": 12,
+    "sck": 9,
+    "mosi": 46,
+    "pwr": 1,
 }
 EMBEDDED_SD_CARD_ASSETS_PIN_KEYS = ("cs", "sck", "miso", "mosi")
 EMBEDDED_SD_CARD_ASSETS_DEFAULT_PINS = {
@@ -110,8 +110,9 @@ EMBEDDED_SD_CARD_ASSETS_DEFAULT_PINS = {
 # Waveshare ESP32-S3 PhotoPainter TF socket, from the vendor schematic:
 # TF pin 2 (DAT3/CS)=GPIO38, pin 5 (CLK)=GPIO39, pin 7 (DAT0/MISO)=GPIO40,
 # pin 3 (CMD/MOSI)=GPIO41.
-# Waveshare ESP32-S3 ePaper 13.3E6 TF socket: SD_CS=GPIO3,
-# SD_CLK=GPIO44, SD_MISO=GPIO43, SD_MOSI=GPIO2.
+# Waveshare ESP32-S3 ePaper 13.3E6 TF socket: SD_D1=GPIO4,
+# SD_MISO=GPIO5, SD_CLK=GPIO6, SD_MOSI=GPIO7, SD_CS=GPIO15,
+# SD_D2=GPIO16. FrameOS uses SPI mode.
 EMBEDDED_SD_CARD_ASSETS_PRESET_PINS = {
     "waveshare_esp32_s3_photopainter": {
         "cs": 38,
@@ -120,10 +121,10 @@ EMBEDDED_SD_CARD_ASSETS_PRESET_PINS = {
         "mosi": 41,
     },
     "waveshare_esp32_s3_epaper_13_3e6": {
-        "cs": 3,
-        "sck": 44,
-        "miso": 43,
-        "mosi": 2,
+        "cs": 15,
+        "sck": 6,
+        "miso": 5,
+        "mosi": 7,
     },
 }
 EMBEDDED_SD_CARD_ASSETS_DEFAULT_MAX_FREQUENCY_KHZ = 20_000

--- a/backend/app/tasks/tests/test_compilation_mode.py
+++ b/backend/app/tasks/tests/test_compilation_mode.py
@@ -80,6 +80,18 @@ def test_shared_driver_registry_types_empty_sequence():
     assert "proc availableDriverNames*(): seq[string]" in source
 
 
+def test_generated_driver_context_copies_pin_overrides():
+    source = write_static_drivers_nim({})
+
+    assert "pins: driverContext.PinOverrides(rst: -1, dc: -1, cs: -1, busy: -1, sclk: -1, mosi: -1, pwr: -1)" in source
+    assert "deviceConfig.pins = driverContext.PinOverrides(" in source
+    assert "sclk: sourceDeviceConfig.pins.sclk" in source
+
+    library_source = write_driver_library_nim(Driver(name="frameBuffer", import_path="frameBuffer/frameBuffer"))
+    assert "pins: PinOverrides(rst: -1, dc: -1, cs: -1, busy: -1, sclk: -1, mosi: -1, pwr: -1)" in library_source
+    assert "deviceConfig.pins = PinOverrides(" in library_source
+
+
 def test_shared_drivers_run_compiled_driver_setup_from_library():
     source = write_shared_drivers_nim(
         {

--- a/backend/app/tasks/tests/test_release_drivers_nim.py
+++ b/backend/app/tasks/tests/test_release_drivers_nim.py
@@ -44,6 +44,7 @@ def test_release_shared_registry_filters_drivers_at_runtime():
     assert '"frameBuffer"' in source
     assert '"waveshare_EPD_7in3e"' in source
     assert 'return spec.name == ("waveshare_" & normalizedWaveshareVariant(device))' in source
+    assert 'if device == "waveshare.rpi_zero_photopainter_7in3e":\n    return "EPD_7in3e"' in source
     assert 'device == "framebuffer"' in source
     assert 'frameOS.frameConfig.gpioButtons.len > 0' in source
     assert "proc isNativeInkyDevice(device: string): bool" in source

--- a/backend/list_devices.py
+++ b/backend/list_devices.py
@@ -1,4 +1,5 @@
 import json
+from app.drivers.devices import WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE
 from app.drivers.waveshare import get_variant_keys, convert_waveshare_source
 
 
@@ -74,6 +75,11 @@ if __name__ == '__main__':
             "label": f'Waveshare {v.size}"{code} {dim} {color}',
         }
         waveshare_devices.append(output)
+        if v.key == "EPD_7in3e":
+            waveshare_devices.append({
+                "value": WAVESHARE_RPI_ZERO_PHOTOPAINTER_7IN3E_DEVICE,
+                "label": 'Waveshare 7.3" RPi Zero PhotoPainter -800x480 Spectra 6 Color',
+            })
 
     print_group("Waveshare", waveshare_devices)
 

--- a/frameos/src/frameos/config.nim
+++ b/frameos/src/frameos/config.nim
@@ -111,7 +111,7 @@ proc loadDeviceConfig*(data: JsonNode): DeviceConfig =
       result.dc = data{"dc"}.getInt(-1)
       result.cs = data{"cs"}.getInt(-1)
       result.busy = data{"busy"}.getInt(-1)
-      result.sclk = data{"sclk"}.getInt(-1)
+      result.sclk = data{"sclk"}.getInt(data{"sck"}.getInt(-1))
       result.mosi = data{"mosi"}.getInt(-1)
       result.pwr = data{"pwr"}.getInt(-1)
 

--- a/frameos/src/frameos/portal.nim
+++ b/frameos/src/frameos/portal.nim
@@ -197,6 +197,8 @@ proc frameHostFromHostname(hostname: string): string =
 
 proc normalizedWaveshareVariant(device: string): string =
   const prefix = "waveshare."
+  if device == "waveshare.rpi_zero_photopainter_7in3e":
+    return "EPD_7in3e"
   if not device.startsWith(prefix) or device.len <= prefix.len:
     return ""
   result = device[prefix.len .. ^1]
@@ -390,6 +392,8 @@ proc nativeDeviceDimensions(device: string): tuple[width: int, height: int] =
     (width: 400, height: 300)
   of "pimoroni.hyperpixel2r", "pimoroni.hyperpixel2r_native":
     (width: 480, height: 480)
+  of "waveshare.rpi_zero_photopainter_7in3e":
+    (width: 800, height: 480)
   else:
     (width: 0, height: 0)
 
@@ -407,6 +411,8 @@ proc labelForDevice(device: string): string =
     "Pimoroni HyperPixel 2.1 Round"
   of "pimoroni.hyperpixel2r_native":
     "Pimoroni HyperPixel 2.1 Round (native)"
+  of "waveshare.rpi_zero_photopainter_7in3e":
+    "Waveshare RPi Zero PhotoPainter - 7.3\""
   else:
     if device.startsWith("waveshare."):
       "Waveshare " & normalizedWaveshareVariant(device).replace("_", " ")
@@ -502,6 +508,8 @@ proc setupDisplayOptions*(frameOS: FrameOS): seq[SetupDisplayOption] =
     if driver.startsWith("waveshare_") and driver.len > "waveshare_".len:
       let variant = driver["waveshare_".len .. ^1]
       result.addDisplayOption(makeDisplayOption("waveshare." & variant, driver))
+      if variant == "EPD_7in3e":
+        result.addDisplayOption(makeDisplayOption("waveshare.rpi_zero_photopainter_7in3e", driver))
 
   if result.len == 0 and frameOS.frameConfig.device.len > 0:
     result.addDisplayOption(makeDisplayOption(frameOS.frameConfig.device, currentDriver))
@@ -543,18 +551,53 @@ proc ensureDeviceConfig(frameConfig: FrameConfig): DeviceConfig =
   if result.pins.isNil:
     result.pins = PinOverrides(rst: -1, dc: -1, cs: -1, busy: -1, sclk: -1, mosi: -1, pwr: -1)
 
+proc applyDeviceConfigDefaults(device: string, deviceConfig: JsonNode, runtimeDeviceConfig: DeviceConfig = nil) =
+  if device != "waveshare.rpi_zero_photopainter_7in3e" or deviceConfig == nil or deviceConfig.kind != JObject:
+    return
+
+  var pins = deviceConfig{"pins"}
+  if pins == nil or pins.kind != JObject:
+    pins = newJObject()
+
+  proc pinValue(key: string, fallback: int): int =
+    if pins{key} == nil:
+      pins[key] = %fallback
+      return fallback
+    pins{key}.getInt(fallback)
+
+  let rst = pinValue("rst", 17)
+  let dc = pinValue("dc", 25)
+  let cs = pinValue("cs", 8)
+  let busy = pinValue("busy", 24)
+  let sclk = pinValue("sclk", 11)
+  let mosi = pinValue("mosi", 10)
+  let pwr = pinValue("pwr", 27)
+  deviceConfig["pins"] = pins
+
+  if not runtimeDeviceConfig.isNil:
+    if runtimeDeviceConfig.pins.isNil:
+      runtimeDeviceConfig.pins = PinOverrides(rst: -1, dc: -1, cs: -1, busy: -1, sclk: -1, mosi: -1, pwr: -1)
+    runtimeDeviceConfig.pins.rst = rst
+    runtimeDeviceConfig.pins.dc = dc
+    runtimeDeviceConfig.pins.cs = cs
+    runtimeDeviceConfig.pins.busy = busy
+    runtimeDeviceConfig.pins.sclk = sclk
+    runtimeDeviceConfig.pins.mosi = mosi
+    runtimeDeviceConfig.pins.pwr = pwr
+
 proc gpioButtonsForDeviceJson(device: string): JsonNode =
   result = newJArray()
-  if not isInkyButtonDevice(device):
-    return
-  let cPin = if device in ["pimoroni.inky_impression_13", "pimoroni.inky_impression_13_2025"]: 25 else: 16
-  for pair in [(5, "A"), (6, "B"), (cPin, "C"), (24, "D")]:
+  var pairs: seq[tuple[pin: int, label: string]] = @[]
+  if isInkyButtonDevice(device):
+    let cPin = if device in ["pimoroni.inky_impression_13", "pimoroni.inky_impression_13_2025"]: 25 else: 16
+    pairs = @[(5, "A"), (6, "B"), (cPin, "C"), (24, "D")]
+  for pair in pairs:
     result.add(%*{"pin": pair[0], "label": pair[1]})
 
 proc applyGpioButtonsForDevice(frameConfig: FrameConfig, data: JsonNode, device: string) =
-  if not isInkyButtonDevice(device):
-    return
   let buttons = gpioButtonsForDeviceJson(device)
+  if buttons.len == 0:
+    return
   data["gpioButtons"] = buttons
   frameConfig.gpioButtons = @[]
   for item in buttons.items:
@@ -695,9 +738,10 @@ proc persistPortalSetup*(frameOS: FrameOS, options: PortalSetupOptions): bool =
     deviceConfig["partialMaxAreaPercent"] = %options.partialMaxAreaPercent
     deviceConfig["partialMaxRefreshesBeforeFull"] = %options.partialMaxRefreshesBeforeFull
     deviceConfig["uploadUrl"] = %options.httpUploadUrl.strip()
-    data["deviceConfig"] = deviceConfig
 
     let runtimeDeviceConfig = ensureDeviceConfig(frameConfig)
+    applyDeviceConfigDefaults(device, deviceConfig, runtimeDeviceConfig)
+    data["deviceConfig"] = deviceConfig
     runtimeDeviceConfig.vcom = options.vcom
     runtimeDeviceConfig.partial = options.partial
     runtimeDeviceConfig.partialMaxAreaPercent = options.partialMaxAreaPercent

--- a/frontend/src/devices.ts
+++ b/frontend/src/devices.ts
@@ -121,6 +121,10 @@ export const devices: OptionGroup<Option>[] = [
       { value: 'waveshare.EPD_5in83b_V2', label: 'Waveshare 5.83" (B V2) 648x480 Black/White/Red' },
       { value: 'waveshare.EPD_5in84', label: 'Waveshare 5.84" 768x256 Black/White' },
       { value: 'waveshare.EPD_7in3e', label: 'Waveshare 7.3" (E) 800x480 Spectra 6 Color' },
+      {
+        value: 'waveshare.rpi_zero_photopainter_7in3e',
+        label: 'Waveshare 7.3" RPi Zero PhotoPainter - 800x480 Spectra 6 Color',
+      },
       { value: 'waveshare.EPD_7in3f', label: 'Waveshare 7.3" (F) 800x480 7 Color' },
       { value: 'waveshare.EPD_7in3g', label: 'Waveshare 7.3" (G) 800x480 Black/White/Yellow/Red' },
       { value: 'waveshare.EPD_7in5', label: 'Waveshare 7.5" 640x384 Black/White' },
@@ -218,6 +222,7 @@ export const spectraPalettes: Palette[] = [
 export const withCustomPalette: Record<string, Palette> = {
   'waveshare.EPD_13in3e': spectraPalettes[0],
   'waveshare.EPD_7in3e': spectraPalettes[0],
+  'waveshare.rpi_zero_photopainter_7in3e': spectraPalettes[0],
   'waveshare.EPD_4in0e': spectraPalettes[0],
   'pimoroni.inky_impression_4': spectraPalettes[0],
   'pimoroni.inky_impression_4_2025': spectraPalettes[0],

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -47,6 +47,7 @@ import {
   FrameErrorBehaviorMode,
   FrameMountpointConfig,
   FrameType,
+  GPIOButton,
   Palette,
 } from '../../../../types'
 import { A } from 'kea-router'
@@ -432,6 +433,47 @@ const ESP32_WAVESHARE_13IN3E6_DEVICE = 'waveshare.EPD_13in3e'
 const ESP32_WAVESHARE_PHOTOPAINTER_HARDWARE_PRESET: FrameEmbeddedHardwarePreset =
   'waveshare_esp32_s3_photopainter'
 const ESP32_WAVESHARE_PHOTOPAINTER_DEVICE = 'waveshare.EPD_7in3e'
+const INKY_GPIO_BUTTONS: GPIOButton[] = [
+  { pin: 5, label: 'A' },
+  { pin: 6, label: 'B' },
+  { pin: 16, label: 'C' },
+  { pin: 24, label: 'D' },
+]
+const INKY_13_GPIO_BUTTONS: GPIOButton[] = [
+  { pin: 5, label: 'A' },
+  { pin: 6, label: 'B' },
+  { pin: 25, label: 'C' },
+  { pin: 24, label: 'D' },
+]
+const INKY_AUTO_BUTTON_DEVICES = new Set([
+  'pimoroni.inky_impression',
+  'pimoroni.inky_impression_7_3',
+  'pimoroni.inky_impression_7_color',
+  'pimoroni.inky_impression_5_7',
+  'pimoroni.inky_impression_5_7_color',
+  'pimoroni.inky_impression_4_7_color',
+  'pimoroni.inky_impression_4',
+  'pimoroni.inky_impression_4_2025',
+  'pimoroni.inky_impression_4_spectra6',
+  'pimoroni.inky_impression_7',
+  'pimoroni.inky_impression_7_2025',
+  'pimoroni.inky_impression_13',
+  'pimoroni.inky_impression_13_2025',
+])
+const INKY_13_AUTO_BUTTON_DEVICES = new Set(['pimoroni.inky_impression_13', 'pimoroni.inky_impression_13_2025'])
+
+function configuredGpioButtonsForDevice(device?: string | null): GPIOButton[] | null {
+  if (!device) {
+    return null
+  }
+  if (INKY_13_AUTO_BUTTON_DEVICES.has(device)) {
+    return INKY_13_GPIO_BUTTONS
+  }
+  if (INKY_AUTO_BUTTON_DEVICES.has(device)) {
+    return INKY_GPIO_BUTTONS
+  }
+  return null
+}
 
 const ESP32_XIAO_PIN_LAYOUT: Esp32PinLayout = {
   rst: 5,
@@ -817,24 +859,6 @@ export function FrameSettings({
   }
 
   const palette = withCustomPalette[frame.device || '']
-  const inkyAutoButtonDevice = [
-    'pimoroni.inky_impression',
-    'pimoroni.inky_impression_7_3',
-    'pimoroni.inky_impression_7_color',
-    'pimoroni.inky_impression_5_7',
-    'pimoroni.inky_impression_5_7_color',
-    'pimoroni.inky_impression_4_7_color',
-    'pimoroni.inky_impression_4',
-    'pimoroni.inky_impression_4_2025',
-    'pimoroni.inky_impression_4_spectra6',
-    'pimoroni.inky_impression_7',
-    'pimoroni.inky_impression_7_2025',
-    'pimoroni.inky_impression_13',
-    'pimoroni.inky_impression_13_2025',
-  ].includes(frameForm.device || '')
-  const inkyThirteenDevice = ['pimoroni.inky_impression_13', 'pimoroni.inky_impression_13_2025'].includes(
-    frameForm.device || ''
-  )
   const sshKeyOptions = normalizeSshKeys(savedSettings?.ssh_keys).keys
   const normalizeKeyIds = (keys: string[]) => Array.from(new Set(keys)).sort()
   const deployedSshKeyIds = normalizeKeyIds(
@@ -848,6 +872,7 @@ export function FrameSettings({
   const errorBehavior = normalizeFrameErrorBehavior(frameForm.error_behavior ?? frame.error_behavior)
   const isBuildrootMode = mode === 'buildroot'
   const isEmbeddedMode = mode === 'embedded'
+  const configuredGpioButtons = !isEmbeddedMode ? configuredGpioButtonsForDevice(frameForm.device) : null
   const showWifiCredentials = isBuildrootMode || isEmbeddedMode
   const maxHttpResponsePlaceholder = String(
     isEmbeddedMode ? EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES : DEFAULT_MAX_HTTP_RESPONSE_BYTES
@@ -2944,7 +2969,9 @@ export function FrameSettings({
         ) : null}
         <H6 id="frame-settings-gpio" className="flex items-center gap-2">
           GPIO buttons
-          {!(!isEmbeddedMode && inkyAutoButtonDevice) ? (
+          {configuredGpioButtons ? (
+            <Tag color="gray">Configured</Tag>
+          ) : (
             <Button
               size="small"
               color="secondary"
@@ -2954,13 +2981,23 @@ export function FrameSettings({
               <PlusIcon className="w-4 h-4" />
               Add button
             </Button>
-          ) : null}
+          )}
         </H6>
         <div className="pl-2 @md:pl-8 space-y-2">
-          {!isEmbeddedMode && inkyAutoButtonDevice ? (
-            <div>
-              Inky Impression boards automatically configure pins 5, 6, {inkyThirteenDevice ? '25' : '16'} and 24 as
-              buttons A, B, C and D
+          {configuredGpioButtons ? (
+            <div className="space-y-2">
+              {configuredGpioButtons.map((button) => (
+                <div key={`${button.pin}-${button.label}`} className="grid grid-cols-1 gap-2 @md:grid-cols-2">
+                  <div className="space-y-1 @md:flex @md:gap-2">
+                    <Label className="@md:w-1/3">Pin</Label>
+                    <TextInput value={String(button.pin)} readOnly className="cursor-default opacity-70" />
+                  </div>
+                  <div className="space-y-1 @md:flex @md:gap-2">
+                    <Label className="@md:w-1/3">Label</Label>
+                    <TextInput value={button.label} readOnly className="cursor-default opacity-70" />
+                  </div>
+                </div>
+              ))}
             </div>
           ) : (
             frameForm.gpio_buttons?.map((_, index) => (

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -461,14 +461,14 @@ const ESP32_WAVESHARE_PHOTOPAINTER_PIN_LAYOUT: Esp32PinLayout = {
 }
 
 const ESP32_WAVESHARE_13IN3E6_PIN_LAYOUT: Esp32PinLayout = {
-  rst: 10,
-  dc: 7,
-  cs: 1,
-  cs2: 4,
-  busy: 8,
-  sck: 6,
-  mosi: 5,
-  pwr: 16,
+  rst: 2,
+  dc: 11,
+  cs: 10,
+  cs2: 3,
+  busy: 12,
+  sck: 9,
+  mosi: 46,
+  pwr: 1,
 }
 
 const ESP32_SD_CARD_PIN_FIELDS: { key: Esp32SdCardPinKey; label: string }[] = [
@@ -493,10 +493,10 @@ const ESP32_PHOTOPAINTER_SD_CARD_PIN_LAYOUT: Esp32SdCardPinLayout = {
 }
 
 const ESP32_WAVESHARE_13IN3E6_SD_CARD_PIN_LAYOUT: Esp32SdCardPinLayout = {
-  cs: 3,
-  sck: 44,
-  miso: 43,
-  mosi: 2,
+  cs: 15,
+  sck: 6,
+  miso: 5,
+  mosi: 7,
 }
 
 const ESP32_HARDWARE_PRESET_OPTIONS: Option[] = [

--- a/frontend/src/scenes/frames/NewFrame.tsx
+++ b/frontend/src/scenes/frames/NewFrame.tsx
@@ -184,14 +184,14 @@ const WAVESHARE_PHOTOPAINTER_GPIO_BUTTONS: GPIOButton[] = [
   { pin: 4, label: 'KEY1' },
 ]
 const WAVESHARE_13IN3E6_PINS: NonNullable<NonNullable<NewFrameFormType['device_config']>['pins']> = {
-  rst: 10,
-  dc: 7,
-  cs: 1,
-  cs2: 4,
-  busy: 8,
-  sck: 6,
-  mosi: 5,
-  pwr: 16,
+  rst: 2,
+  dc: 11,
+  cs: 10,
+  cs2: 3,
+  busy: 12,
+  sck: 9,
+  mosi: 46,
+  pwr: 1,
 }
 const WAVESHARE_PHOTOPAINTER_SD_CARD_ASSETS: NonNullable<
   NonNullable<NewFrameFormType['device_config']>['sdCardAssets']
@@ -208,7 +208,7 @@ const WAVESHARE_13IN3E6_SD_CARD_ASSETS: NonNullable<
   enabled: true,
   preset: WAVESHARE_13IN3E6_HARDWARE_PRESET,
   mountPath: '/srv/assets',
-  pins: { cs: 3, sck: 44, miso: 43, mosi: 2 },
+  pins: { cs: 15, sck: 6, miso: 5, mosi: 7 },
   maxFrequencyKHz: 20000,
 }
 

--- a/scripts/frameos-setup.sh
+++ b/scripts/frameos-setup.sh
@@ -481,6 +481,7 @@ waveshare.EPD_5in83bc:600x448
 waveshare.EPD_5in83c:600x448
 waveshare.EPD_5in84:768x256
 waveshare.EPD_7in3e:800x480
+waveshare.rpi_zero_photopainter_7in3e:800x480
 waveshare.EPD_7in3f:800x480
 waveshare.EPD_7in3g:800x480
 waveshare.EPD_7in5:640x384
@@ -554,6 +555,7 @@ print_waveshare_devices() {
   waveshare.EPD_5in83
   waveshare.EPD_5in83_V2
   waveshare.EPD_7in3e
+  waveshare.rpi_zero_photopainter_7in3e
   waveshare.EPD_7in3f
   waveshare.EPD_7in3g
   waveshare.EPD_7in5
@@ -580,6 +582,7 @@ choose_device() {
     prompt_line "  6) waveshare.EPD_7in3e"
     prompt_line "  7) waveshare.EPD_13in3e"
     prompt_line "  8) waveshare.EPD_7in5_V2"
+    prompt_line "  9) waveshare.rpi_zero_photopainter_7in3e"
     prompt_line "  p) list Pimoroni devices"
     prompt_line "  w) list Waveshare examples"
     prompt_line "  c) custom device key"
@@ -593,6 +596,7 @@ choose_device() {
       6) echo "waveshare.EPD_7in3e"; return ;;
       7) echo "waveshare.EPD_13in3e"; return ;;
       8) echo "waveshare.EPD_7in5_V2"; return ;;
+      9) echo "waveshare.rpi_zero_photopainter_7in3e"; return ;;
       p|P)
         print_pimoroni_devices >&2
         ;;
@@ -678,6 +682,13 @@ else:
     data = {}
 
 device_config = dict(data.get("deviceConfig") or {})
+photopainter_device = "waveshare.rpi_zero_photopainter_7in3e"
+photopainter_pins = {"rst": 17, "dc": 25, "cs": 8, "busy": 24, "sclk": 11, "mosi": 10, "pwr": 27}
+if env("FRAMEOS_DEVICE") == photopainter_device:
+    pins = dict(device_config.get("pins") or {})
+    for key, value in photopainter_pins.items():
+        pins.setdefault(key, value)
+    device_config["pins"] = pins
 if env("FRAMEOS_DEVICE") == "http.upload":
     device_config["uploadUrl"] = env("FRAMEOS_HTTP_UPLOAD_URL")
 else:

--- a/scripts/tests/test_frameos_setup.py
+++ b/scripts/tests/test_frameos_setup.py
@@ -140,6 +140,36 @@ class FrameOSSetupScriptTest(unittest.TestCase):
         self.assertNotIn("TTYVHangup=yes", service)
         self.assertNotIn("TTYVTDisallocate=yes", service)
 
+    def test_photopainter_install_writes_waveshare_pin_overrides(self) -> None:
+        self._run_setup(
+            {
+                "FRAMEOS_NAME": "PhotoPainter Frame",
+                "FRAMEOS_DEVICE": "waveshare.rpi_zero_photopainter_7in3e",
+                "FRAMEOS_WIDTH": "800",
+                "FRAMEOS_HEIGHT": "480",
+                "FRAMEOS_FRAME_PORT": "8787",
+                "FRAMEOS_BACKEND_ENABLED": "false",
+                "FRAMEOS_FRAME_ACCESS_KEY": "local-access-key",
+                "FRAMEOS_NETWORK_CHECK": "false",
+                "FRAMEOS_WIFI_HOTSPOT": "disabled",
+            }
+        )
+
+        frame_json = self._installed_frame_json()
+        self.assertEqual(frame_json["device"], "waveshare.rpi_zero_photopainter_7in3e")
+        self.assertEqual(frame_json["width"], 800)
+        self.assertEqual(frame_json["height"], 480)
+        self.assertEqual(frame_json["deviceConfig"]["pins"], {
+            "rst": 17,
+            "dc": 25,
+            "cs": 8,
+            "busy": 24,
+            "sclk": 11,
+            "mosi": 10,
+            "pwr": 27,
+        })
+        self.assertEqual(frame_json["gpioButtons"], [])
+
     def test_existing_frame_json_defaults_enable_backend_agent(self) -> None:
         existing_dir = self.out_dir / "srv" / "frameos" / "current"
         existing_dir.mkdir(parents=True)
@@ -243,6 +273,7 @@ class FrameOSSetupScriptTest(unittest.TestCase):
         self.assertIn("6) waveshare.EPD_7in3e", menu.stderr)
         self.assertIn("7) waveshare.EPD_13in3e", menu.stderr)
         self.assertIn("8) waveshare.EPD_7in5_V2", menu.stderr)
+        self.assertIn("9) waveshare.rpi_zero_photopainter_7in3e", menu.stderr)
         self.assertNotIn("\\nDevice choices", menu.stderr)
         self.assertNotIn("custom device key\\nDevice", menu.stderr)
 


### PR DESCRIPTION
## Summary

- Add PhotoPainter-oriented frame profile support across backend device defaults, generated driver mappings, setup script, and portal setup.
- Add the RPi Zero PhotoPainter 7.3" profile as an `EPD_7in3e` alias with explicit display pin defaults, including the PhotoPainter power pin override.
- Keep configured GPIO buttons read-only for board profiles that actually provide them, while leaving the RPi PhotoPainter profile without GPIO button defaults.
- Cover the new profile/default behavior with backend, setup-script, codegen, and portal tests.

## Why

PhotoPainter hardware needs a named profile so users can select the correct display setup without manually entering panel and pin details. During review, the RPi PhotoPainter GPIO button mapping was removed because those button pins were inferred rather than hardware-backed.

## Validation

- `pytest -q backend/app/api/tests/test_embedded_firmware.py`
- `pytest -q backend/app/tasks/tests/test_compilation_mode.py backend/app/tasks/tests/test_release_drivers_nim.py`
- `pytest -q backend/app/drivers/tests/test_devices.py backend/app/api/tests/test_frames.py::test_api_frame_new_rpios_waveshare_photopainter_profile backend/app/models/tests/test_frame.py::test_get_frame_json_includes_waveshare_photopainter_pin_defaults`
- `python3 -m unittest scripts.tests.test_frameos_setup.FrameOSSetupScriptTest.test_photopainter_install_writes_waveshare_pin_overrides`
- `pnpm --dir frontend exec tsc --noEmit`
- `nim c -r src/frameos/tests/test_portal.nim`
- `git diff --check`