### PR TITLE
ESP32 and embedded runtime hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,22 @@
 - Build pipeline orchestrated by `build.mjs` using esbuild, with Tailwind/PostCSS for styling and optional bundle analysis via `vite-bundle-visualizer`.
 - Development: `pnpm install` followed by `pnpm --dir frontend run dev` (spawns kea typegen watch and esbuild dev build concurrently).
 - Repo-level local development runner: `pnpm dev` starts `mprocs` with panes for backend API, ARQ worker, the main frontend dev server, and the frame-local frontend watcher. `redis`, `frameos`, and `backend-docker` panes are available but do not autostart. The `backend-docker` pane runs `scripts/backend-docker.sh`, which persists a generated Docker `SECRET_KEY` in the gitignored `.env.docker.local`. `mprocs.yaml` defines the process list.
-- Production build: `pnpm --dir frontend run build` which chains kea codegen, schema generation (`ts-json-schema-generator`), TypeScript type-checking, and final bundling to `dist/`. 【F:frontend/package.json†L6-L66】
-- Output folder is consumed by the backend’s static file mounts; ensure `frontend/dist` exists (e.g., via `pnpm --dir frontend run build`) before running the Python app outside of test mode. 【F:backend/app/fastapi.py†L38-L86】
+- Production build: `pnpm --dir frontend run build` which chains kea codegen, schema generation (`ts-json-schema-generator`), TypeScript type-checking, and final bundling to `dist/`. 【F:frontend/package.json†L6-L66】- Output folder is consumed by the backend’s static file mounts; ensure `frontend/dist` exists (e.g., via `pnpm --dir frontend run build`) before running the Python app outside of test mode. 【F:backend/app/fastapi.py†L38-L86】
 - ALWAYS prefer writing frontend business logic in kea logic files over using effects like `useState` or `useEffect`.
 - This includes small functions and callbacks inside components. Prefer to keep as much code as possible in logic files, treating React as a templating layer.
 - When adding a frame model key that is tracked for deploy changes in `frontend/src/scenes/frame/frameLogic.ts`, also add a marker to `FRAME_KEY_INTRODUCED_FRAMEOS_VERSION`. For unreleased work, use the next patch after the current `versions.json` FrameOS base version.
 
 ## Device runtime (Nim) notes
+- **HARD RULE — no image proxies for frames, EVER.** Frames download and render
+  images directly from their sources; never route a frame's image fetches
+  through the backend (or any other middleman) to resize or fetch on its
+  behalf, and don't paper over device limits with host-side resize params
+  either. When a source serves images too large for a device, THE fix is
+  better on-device streaming decode (incremental inflate, row-by-row
+  unfilter/scale into the target — a multi-MB PNG should need its compressed
+  body plus a few rows, not a full-resolution RGBA buffer). Proxies are fine
+  for in-browser previews only. Proxying has been implemented and reverted
+  before — do not implement it again.
 - `frameos/frameos` houses the on-device runtime written in Nim with asyncdispatch.
 - Entry point `src/frameos.nim` waits on `startFrameOS()` defined under `src/frameos/frameos`. Drivers, system integrations, and Nim app implementations live in nested directories (`src/apps`, `src/drivers`, `src/system`); JavaScript example app sources/configs live under `repo/apps/<folder>/<app>`. 【F:frameos/src/frameos.nim†L1-L6】
 - JavaScript repo apps under `repo/apps/code` are catalog templates for custom code apps. Do not generate or commit Nim wrappers inside `repo/apps`; compiled scenes that use them copy their sources into generated `src/apps/sceneapp_*` folders during build/deploy.

--- a/backend/app/api/embedded_device.py
+++ b/backend/app/api/embedded_device.py
@@ -293,6 +293,13 @@ async def api_embedded_device_settings(
     return embedded_settings_payload(db, frame)
 
 
+# NOTE: Do NOT add a backend image proxy for device rendering here. Frames
+# must fetch and render images independently of the backend. Oversized
+# sources are fixed with better on-device streaming decode (see the rule in
+# AGENTS.md and frameos/src/frameos/utils/image.nim). Proxies are acceptable
+# for in-browser previews only, never for frames.
+
+
 @api_public.get("/frames/{id:int}/embedded/ota/manifest")
 async def api_embedded_device_ota_manifest(
     id: int,
@@ -326,5 +333,9 @@ async def api_embedded_device_ota_download(
     if (firmware.get("status") != "ready" or not isinstance(ota_path, str)
             or not os.path.isfile(ota_path)):
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="No OTA image available")
-    return FileResponse(ota_path, media_type="application/octet-stream",
-                        filename=os.path.basename(ota_path))
+    return FileResponse(
+        ota_path,
+        media_type="application/octet-stream",
+        filename=os.path.basename(ota_path),
+        headers={"Cache-Control": "no-store"},
+    )

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -2941,7 +2941,12 @@ async def api_frame_embedded_firmware_download(id: int, db: Session = Depends(ge
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Generated firmware file not found")
 
     filename = str(firmware.get("filename") or f"frameos-esp32-{id}.bin")
-    return FileResponse(path, media_type="application/octet-stream", filename=filename)
+    return FileResponse(
+        path,
+        media_type="application/octet-stream",
+        filename=filename,
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @api_project.post("/frames/{id:int}/embedded/firmware/ota")

--- a/backend/app/api/tests/test_embedded_device.py
+++ b/backend/app/api/tests/test_embedded_device.py
@@ -224,6 +224,7 @@ async def test_ota_manifest_serves_ready_artifact(async_client, no_auth_client, 
         f'/api/frames/{frame.id}/embedded/ota/download', headers=auth(frame))
     assert response.status_code == 200
     assert response.content == b'\xe9firmware-bytes'
+    assert response.headers['cache-control'] == 'no-store'
 
     response = await no_auth_client.head(
         f'/api/frames/{frame.id}/embedded/ota/download', headers=auth(frame))

--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from app.models.frame import Frame
+from app.tasks import embedded_firmware as embedded_firmware_module
 from app.tasks.embedded_firmware import (
     EMBEDDED_DEFAULT_FLASH_SIZE,
     EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES,
@@ -18,6 +19,7 @@ from app.tasks.embedded_firmware import (
     embedded_default_pins_for_frame,
     embedded_flash_size_for_frame,
     embedded_firmware_config_hash,
+    embedded_firmware_source_fingerprint,
     embedded_gpio_buttons_for_frame,
     embedded_hardware_preset_for_frame,
     embedded_hostname_for_frame,
@@ -334,6 +336,7 @@ async def test_firmware_download(async_client, db, tmp_path):
             'firmwareVersion': EMBEDDED_FIRMWARE_VERSION,
             'filename': 'frameos-esp32-s3.bin',
             'path': str(artifact),
+            'sha256': 'ef' * 32,
             'panel': 'EPD_7in5_V2',
             'configHash': embedded_firmware_config_hash(stored),
             'otaPath': str(artifact),
@@ -345,10 +348,17 @@ async def test_firmware_download(async_client, db, tmp_path):
     db.add(stored)
     db.commit()
 
-    response = await async_client.get(f"/api/frames/{frame['id']}/embedded/firmware/download")
+    status_response = await async_client.get(f"/api/frames/{frame['id']}/embedded/firmware")
+    download_url = status_response.json()['firmware']['downloadUrl']
+    assert download_url == (
+        f"/api/frames/{frame['id']}/embedded/firmware/download?sha256={'ef' * 32}"
+    )
+
+    response = await async_client.get(download_url)
     assert response.status_code == 200
     assert response.content == b'firmware-bytes'
     assert 'frameos-esp32-s3.bin' in response.headers.get('content-disposition', '')
+    assert response.headers['cache-control'] == 'no-store'
 
 
 @pytest.mark.asyncio
@@ -1077,3 +1087,40 @@ def test_embedded_pixie_path_resolves_override(tmp_path, monkeypatch):
     (pixie / "src" / "pixie").mkdir(parents=True)
     monkeypatch.setenv("FRAMEOS_PIXIE_PATH", str(pixie))
     assert embedded_pixie_path() == pixie.resolve()
+
+
+def test_embedded_source_fingerprint_uses_contents_without_git(tmp_path, monkeypatch):
+    source = tmp_path / "frameos" / "src" / "embedded" / "embedded_main.nim"
+    source.parent.mkdir(parents=True)
+    source.write_text("const firmwareSource = 1\n", encoding="utf-8")
+    lock = tmp_path / "frameos" / "nimble.lock"
+    lock.write_text('{"packages":{"pixie":{"vcsRevision":"pixie-one"}}}\n', encoding="utf-8")
+    codegen = tmp_path / "backend" / "app" / "codegen" / "apps_nim.py"
+    codegen.parent.mkdir(parents=True)
+    codegen.write_text("CODEGEN_VERSION = 1\n", encoding="utf-8")
+    generated = tmp_path / "embedded" / "esp32" / "build" / "firmware.bin"
+    generated.parent.mkdir(parents=True)
+    generated.write_bytes(b"generated-one")
+
+    monkeypatch.setattr(embedded_firmware_module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(embedded_firmware_module, "embedded_pixie_path", lambda: None)
+    monkeypatch.setattr(embedded_firmware_module, "_source_fingerprint_cache", None)
+
+    first = embedded_firmware_source_fingerprint()
+    assert first.startswith("sha256:")
+    assert "unknown" not in first
+
+    # Build output is intentionally ignored and cannot make a ready artifact
+    # immediately stale after its own build.
+    generated.write_bytes(b"generated-two")
+    monkeypatch.setattr(embedded_firmware_module, "_source_fingerprint_cache", None)
+    assert embedded_firmware_source_fingerprint() == first
+
+    source.write_text("const firmwareSource = 2\n", encoding="utf-8")
+    monkeypatch.setattr(embedded_firmware_module, "_source_fingerprint_cache", None)
+    second = embedded_firmware_source_fingerprint()
+    assert second != first
+
+    lock.write_text('{"packages":{"pixie":{"vcsRevision":"pixie-two"}}}\n', encoding="utf-8")
+    monkeypatch.setattr(embedded_firmware_module, "_source_fingerprint_cache", None)
+    assert embedded_firmware_source_fingerprint() != second

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -25,6 +25,7 @@ import os
 import re
 import shlex
 import shutil
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -52,7 +53,7 @@ EMBEDDED_PLATFORM_ALIASES = {"", "esp32s3", "esp32-s3-devkitc-1"}
 EMBEDDED_PROJECT_DIR = REPO_ROOT / "embedded" / "esp32"
 EMBEDDED_IDF_TARGET = "esp32s3"
 # Bump when the firmware project changes so existing "ready" images rebuild on next request
-EMBEDDED_FIRMWARE_VERSION = 42  # ESP32 preserves Wikimedia image aspect before render placement
+EMBEDDED_FIRMWARE_VERSION = 44  # Acknowledge OTA requests before the scheduled reboot
 EMBEDDED_DEFAULT_PANEL = "EPD_7in5_V2"
 EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES = 4 * 1024 * 1024
 EMBEDDED_PIN_KEYS = ("rst", "dc", "cs", "cs2", "busy", "sck", "mosi", "pwr")
@@ -383,6 +384,133 @@ def embedded_pixie_path() -> Path | None:
     if (candidate / "src" / "pixie").is_dir():
         return candidate.resolve()
     return None
+
+
+_FIRMWARE_SOURCE_PATHS = (
+    Path("Dockerfile"),
+    Path("backend/app/codegen"),
+    Path("backend/app/drivers/waveshare.py"),
+    Path("backend/app/tasks/embedded_firmware.py"),
+    Path("embedded/esp32"),
+    Path("frameos/config.nims"),
+    Path("frameos/frameos.nimble"),
+    Path("frameos/nim.cfg"),
+    Path("frameos/nimble.lock"),
+    Path("frameos/src"),
+    Path("frameos/tools/makeapploaders.py"),
+    Path("repo/apps"),
+    Path("repo/scenes"),
+)
+_FIRMWARE_SOURCE_EXCLUDED_NAMES = {
+    ".cache",
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "build",
+    "managed_components",
+    "nimcache",
+    "node_modules",
+    "testresults",
+    "tests",
+    "tmp",
+}
+_FIRMWARE_SOURCE_EXCLUDED_PATHS = {
+    Path("embedded/esp32/dependencies.lock"),
+    Path("embedded/esp32/main/generated_config.h"),
+    Path("embedded/esp32/sdkconfig"),
+    Path("embedded/esp32/sdkconfig.old"),
+    Path("frameos/src/codegen"),
+}
+_source_fingerprint_cache: tuple[float, tuple[tuple[str, int, int], ...], str] | None = None
+
+
+def _firmware_source_files() -> tuple[list[tuple[str, Path | None]], tuple[tuple[str, int, int], ...]]:
+    """Collect immutable firmware inputs without relying on a Git checkout.
+
+    The production image deliberately has no ``.git`` directory. Build output,
+    per-frame generated config, caches, and tests are excluded because they do
+    not define the firmware source and may change while a build is running.
+    """
+    entries: list[tuple[str, Path | None]] = []
+    signature: list[tuple[str, int, int]] = []
+
+    def excluded(relative: Path) -> bool:
+        if relative in _FIRMWARE_SOURCE_EXCLUDED_PATHS:
+            return True
+        return any(
+            part in _FIRMWARE_SOURCE_EXCLUDED_NAMES or part.startswith("build-")
+            for part in relative.parts
+        )
+
+    def collect(label: str, path: Path, relative: Path) -> None:
+        if excluded(relative):
+            return
+        if path.is_symlink():
+            target = os.readlink(path)
+            entries.append((f"symlink:{label}\0{target}", None))
+            signature.append((f"{label}\0{target}", -2, path.lstat().st_mtime_ns))
+            return
+        if path.is_dir():
+            for child in sorted(path.iterdir(), key=lambda item: item.name):
+                collect(f"{label}/{child.name}", child, relative / child.name)
+            return
+        if path.is_file():
+            stat = path.stat()
+            entries.append((f"file:{label}", path))
+            signature.append((label, stat.st_size, stat.st_mtime_ns))
+            return
+        entries.append((f"missing:{label}", None))
+        signature.append((label, -1, -1))
+
+    for relative in _FIRMWARE_SOURCE_PATHS:
+        collect(f"repo/{relative.as_posix()}", REPO_ROOT / relative, relative)
+
+    pixie_path = embedded_pixie_path()
+    if pixie_path is None:
+        # nimble.lock is one of the repo inputs above and pins the exact Pixie
+        # revision used in production. This marker distinguishes that path from
+        # an explicit source override.
+        entries.append(("pixie/nimble-lock", None))
+        signature.append(("pixie/nimble-lock", -3, -3))
+    else:
+        for relative in (Path("pixie.nimble"), Path("src")):
+            collect(f"pixie/{relative.as_posix()}", pixie_path / relative, relative)
+
+    return entries, tuple(signature)
+
+
+def embedded_firmware_source_fingerprint() -> str:
+    """Fingerprint of the source trees a firmware image is built from, so
+    cached builds go stale when the code changes — not only when the frame's
+    settings or the manually-bumped EMBEDDED_FIRMWARE_VERSION do. Covers this
+    repo (the inputs baked into the image) and either the local Pixie checkout
+    or its production lock. The digest is based on file content, so it works in
+    Docker where Git metadata and a neighboring Pixie checkout are absent."""
+    global _source_fingerprint_cache
+    now = time.monotonic()
+    if _source_fingerprint_cache is not None and now - _source_fingerprint_cache[0] < 5.0:
+        return _source_fingerprint_cache[2]
+
+    entries, signature = _firmware_source_files()
+    if _source_fingerprint_cache is not None and signature == _source_fingerprint_cache[1]:
+        fingerprint = _source_fingerprint_cache[2]
+        _source_fingerprint_cache = (now, signature, fingerprint)
+        return fingerprint
+
+    digest = hashlib.sha256()
+    for label, path in entries:
+        digest.update(label.encode("utf-8"))
+        digest.update(b"\0")
+        if path is not None:
+            with path.open("rb") as source:
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        digest.update(b"\0")
+    fingerprint = f"sha256:{digest.hexdigest()}"
+    _source_fingerprint_cache = (now, signature, fingerprint)
+    return fingerprint
 
 
 def embedded_panel_for_frame(frame: Frame) -> str:
@@ -1006,6 +1134,20 @@ def clear_embedded_firmware(frame: Frame | Any) -> None:
     frame.embedded = embedded
 
 
+def embedded_firmware_download_url(frame_id: int, sha256: object = None) -> str:
+    """Return a content-addressed browser download URL when a hash is known.
+
+    Firmware artifacts are replaced in place for each frame. Keeping the URL
+    stable lets a browser reuse an older merged image after a rebuild, so put
+    the image hash in the query string to give every build a distinct cache
+    key. The download response is also marked no-store as a second safeguard.
+    """
+    base_url = f"/api/frames/{frame_id}/embedded/firmware/download"
+    if isinstance(sha256, str) and re.fullmatch(r"[0-9a-fA-F]{64}", sha256):
+        return f"{base_url}?sha256={sha256.lower()}"
+    return base_url
+
+
 def latest_embedded_firmware(frame: Frame) -> dict[str, Any] | None:
     embedded = frame.embedded if isinstance(frame.embedded, dict) else {}
     firmware = embedded.get("firmware")
@@ -1017,6 +1159,15 @@ def latest_embedded_firmware(frame: Frame) -> dict[str, Any] | None:
             "status": "stale",
             "error": "The generated firmware was built from an older firmware project version",
         })
+    if firmware.get("status") == "ready":
+        source_fingerprint = firmware.get("sourceFingerprint")
+        if isinstance(source_fingerprint, str) and \
+                source_fingerprint != embedded_firmware_source_fingerprint():
+            return with_embedded_firmware_layout(frame, {
+                **firmware,
+                "status": "stale",
+                "error": "The generated firmware was built from older FrameOS sources",
+            })
     if firmware.get("status") == "ready":
         try:
             firmware_flash_size = normalize_embedded_flash_size(firmware.get("flashSize") or EMBEDDED_DEFAULT_FLASH_SIZE)
@@ -1058,6 +1209,10 @@ def latest_embedded_firmware(frame: Frame) -> dict[str, Any] | None:
                     frame,
                     {**firmware, "status": "missing", "error": "The generated OTA firmware file is missing"},
                 )
+        firmware = {
+            **firmware,
+            "downloadUrl": embedded_firmware_download_url(int(frame.id), firmware.get("sha256")),
+        }
     return with_embedded_firmware_layout(frame, firmware)
 
 
@@ -1451,6 +1606,7 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
 
     frame = get_fresh_frame(db, int(frame.id)) or frame
     current = latest_embedded_firmware(frame) or {}
+    merged_sha256 = _sha256(artifact_path)
     ready_status = {
         **_preserved_queue_metadata(current),
         "status": "ready",
@@ -1464,17 +1620,18 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
         "filename": filename,
         "path": str(artifact_path),
         "size": artifact_path.stat().st_size,
-        "sha256": _sha256(artifact_path),
+        "sha256": merged_sha256,
         "flashOffset": EMBEDDED_FLASH_OFFSET,
         "panel": selected_panel,
         "configHash": generated_config_hash,
+        "sourceFingerprint": embedded_firmware_source_fingerprint(),
         "appSize": ota_bin.stat().st_size,
         "bootloaderSize": (build_dir / "bootloader" / "bootloader.bin").stat().st_size,
         "partitionTableSize": (build_dir / "partition_table" / "partition-table.bin").stat().st_size,
         "otaElfSha256": _sha256(ota_elf),
         "startedAt": current.get("startedAt") or started_at,
         "completedAt": _utc_now(),
-        "downloadUrl": f"/api/frames/{frame.id}/embedded/firmware/download",
+        "downloadUrl": embedded_firmware_download_url(int(frame.id), merged_sha256),
     }
     if flash_profile["otaSupported"]:
         ready_status = {

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -149,6 +149,18 @@ thin-client mode. Backend local-render builds run the same check
 default 8MB) and fail early with an actionable error; backend-rendered
 thin-client builds are allowed for panels that exceed local PSRAM.
 
+**No image proxies, ever:** when a remote image source serves files too large
+to decode on-device (e.g. multi-MB PNGs), the fix is a streaming decoder —
+incremental inflate with row-by-row unfilter/scale into the render target, so
+a decode needs the compressed body plus a few rows instead of a full-size
+RGBA buffer. Never route the frame's downloads through the backend, and don't
+lean on host-side resize params. Proxying has been built and reverted before;
+do not build it again.
+
+TODO: streaming PNG decode into target (`decodePngScaledInto` currently does a
+full `decodePng` first — that is what OOMs on multi-MB PNGs under PSRAM
+fragmentation; the gallery scenes hit this on the 13.3" Spectra-6 frame).
+
 Default pins target the XIAO ESP32-S3: CS=GPIO3 (D2), DC=GPIO4 (D3), RST=GPIO5 (D4),
 BUSY=GPIO6 (D5), SCK=GPIO7 (D8), MOSI=GPIO9 (D10). Remap at runtime with `set pins`,
 in the portal, or per-frame via `deviceConfig.pins` in the backend. The 13.3-inch

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -18,8 +18,10 @@
 #include "esp_heap_caps.h"
 #include "esp_http_client.h"
 #include "esp_log.h"
+#include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "freertos/task.h"
 
 /* Nim's os module calls lstat()/readlink(); newlib/VFS has no symlinks, so
  * stat() is exact and every path is a non-symlink (EINVAL per POSIX). */
@@ -190,6 +192,35 @@ void fos_nim_fatal_oom(size_t size)
     /* No guard armed: fall through to Nim's raiseOutOfMem (log + reboot). */
 }
 
+/* A longjmp abort skips every Nim destructor on the abandoned stack, so the
+ * aborted call's allocations (render canvas, decode buffers, HTTP chunks)
+ * leak with their refcounts stuck — no GC pass can ever reclaim them. One
+ * abort is survivable; once the leaks eat the contiguous PSRAM a render
+ * canvas needs, every future render is doomed and only a reboot recovers
+ * the heap. A device that stays "alive" but can never render again is worse
+ * than one clean restart. */
+#define FOS_NIM_OOM_ABORT_RESTART_STREAK 4
+
+static int s_frame_width = 0;
+static int s_frame_height = 0;
+static unsigned s_nim_oom_abort_streak = 0;
+
+static void nim_oom_abort_note(const char *what)
+{
+    s_nim_oom_abort_streak++;
+    size_t canvas_bytes = (size_t)s_frame_width * (size_t)s_frame_height * 4u;
+    size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    bool canvas_impossible = canvas_bytes > 0 && largest < canvas_bytes;
+    ESP_LOGE("fos_nim", "%s aborted: out of memory (abort streak %u, largest PSRAM block %u, canvas needs %u)",
+             what, s_nim_oom_abort_streak, (unsigned)largest, (unsigned)canvas_bytes);
+    if ((s_nim_oom_abort_streak >= 2 && canvas_impossible) ||
+        s_nim_oom_abort_streak >= FOS_NIM_OOM_ABORT_RESTART_STREAK) {
+        ESP_LOGE("fos_nim", "OOM aborts have leaked the Nim heap beyond recovery; restarting");
+        vTaskDelay(pdMS_TO_TICKS(250)); /* let the log lines drain */
+        esp_restart();
+    }
+}
+
 bool frameos_nim_available(void) { return true; }
 
 static void configure_backend_auth(const char *backend_url, uint32_t frame_id, const char *api_key)
@@ -241,6 +272,8 @@ bool frameos_nim_init(int width, int height, const char *frame_name,
                       uint32_t frame_id, const char *api_key,
                       bool server_send_logs)
 {
+    s_frame_width = width;
+    s_frame_height = height;
     configure_backend_auth(backend_url, frame_id, api_key);
     s_log_upload_configured = server_send_logs;
     s_log_upload_enabled = false;
@@ -270,8 +303,9 @@ int frameos_nim_render(uint8_t *buf, size_t len, int pixel_format)
     if (setjmp(s_nim_oom_jmp) == 0) {
         s_nim_oom_jmp_armed = true;
         result = fos_nim_render_impl(buf, len, pixel_format);
+        if (result == 0) s_nim_oom_abort_streak = 0;
     } else {
-        ESP_LOGE("fos_nim", "render aborted: out of memory");
+        nim_oom_abort_note("render");
         result = -1;
     }
     s_nim_oom_jmp_armed = false;
@@ -288,8 +322,9 @@ int frameos_nim_render_alloc(uint8_t **buf, size_t *len, int pixel_format)
     if (setjmp(s_nim_oom_jmp) == 0) {
         s_nim_oom_jmp_armed = true;
         result = fos_nim_render_alloc_impl(buf, len, pixel_format);
+        if (result == 0) s_nim_oom_abort_streak = 0;
     } else {
-        ESP_LOGE("fos_nim", "render aborted: out of memory");
+        nim_oom_abort_note("render");
         if (s_pending_render_buffer != NULL) {
             free(s_pending_render_buffer);
         }
@@ -345,7 +380,7 @@ bool frameos_nim_set_scene(const char *scene_id)
         s_nim_oom_jmp_armed = true;
         ok = fos_nim_set_scene_impl(scene_id);
     } else {
-        ESP_LOGE("fos_nim", "scene switch aborted: out of memory");
+        nim_oom_abort_note("scene switch");
         ok = false;
     }
     s_nim_oom_jmp_armed = false;
@@ -362,7 +397,7 @@ int frameos_nim_load_scenes(const char *json)
         s_nim_oom_jmp_armed = true;
         count = fos_nim_load_scenes_impl(json);
     } else {
-        ESP_LOGE("fos_nim", "scene load aborted: out of memory");
+        nim_oom_abort_note("scene load");
         count = 0;
     }
     s_nim_oom_jmp_armed = false;
@@ -397,7 +432,7 @@ bool frameos_nim_send_event(const char *event, const char *payload_json)
         s_nim_oom_jmp_armed = true;
         ok = fos_nim_send_event_impl(event, payload_json ? payload_json : "{}");
     } else {
-        ESP_LOGE("fos_nim", "event dispatch aborted: out of memory");
+        nim_oom_abort_note("event dispatch");
         ok = false;
     }
     s_nim_oom_jmp_armed = false;
@@ -732,16 +767,31 @@ void frameos_nim_flush_logs(void)
 /* ------------------------------------------------------- outbound HTTP */
 
 static const char *TAG = "fos_nim_http";
-/* Never clamp below this, so small fetches keep working under pressure. */
-#define FOS_NIM_HTTP_NIM_COPY_LIMIT_MIN (512u * 1024u)
+/* HTTP bodies are buffered in fixed-size PSRAM chunks so that no download
+ * ever needs one large contiguous allocation — a fragmented heap next to a
+ * full-size render canvas can still take multi-MB images. The decoders
+ * consume the chunks as segments (streamed PNG/JPEG). */
+#define FOS_NIM_HTTP_CHUNK_BYTES (512u * 1024u)
+#define FOS_NIM_HTTP_CHUNK_MIN_BYTES (64u * 1024u)
+/* Keep this much PSRAM free while buffering, for decode rows and friends.
+ * Streamed decodes need well under 200KB of working memory; a bigger
+ * reserve starves legitimate downloads when a render is already live. */
+#define FOS_NIM_HTTP_PSRAM_RESERVE (768u * 1024u)
 
-static uint8_t *http_error_response(int *out_status, size_t *out_len, const char *fmt, ...)
+void fos_nim_http_free_chunks(fos_nim_http_chunk *chunks, size_t count)
+{
+    if (chunks == NULL) return;
+    for (size_t i = 0; i < count; i++) {
+        free(chunks[i].data);
+    }
+    free(chunks);
+}
+
+static uint8_t *http_error_response_v(int *out_status, size_t *out_len,
+                                      const char *fmt, va_list args)
 {
     char message[256];
-    va_list args;
-    va_start(args, fmt);
     vsnprintf(message, sizeof(message), fmt, args);
-    va_end(args);
 
     size_t len = strlen(message);
     uint8_t *buf = heap_caps_malloc(len + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
@@ -755,6 +805,36 @@ static uint8_t *http_error_response(int *out_status, size_t *out_len, const char
     *out_status = 599;
     *out_len = len;
     return buf;
+}
+
+static uint8_t *http_error_response(int *out_status, size_t *out_len, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    uint8_t *buf = http_error_response_v(out_status, out_len, fmt, args);
+    va_end(args);
+    return buf;
+}
+
+static fos_nim_http_chunk *chunked_error(int *out_status, size_t *out_count,
+                                         const char *fmt, ...)
+{
+    *out_count = 0;
+    va_list args;
+    va_start(args, fmt);
+    size_t len = 0;
+    uint8_t *msg = http_error_response_v(out_status, &len, fmt, args);
+    va_end(args);
+    if (msg == NULL) return NULL;
+    fos_nim_http_chunk *chunks = malloc(sizeof(*chunks));
+    if (chunks == NULL) {
+        free(msg);
+        return NULL;
+    }
+    chunks[0].data = msg;
+    chunks[0].len = len;
+    *out_count = 1;
+    return chunks;
 }
 
 static bool should_authorize_backend_url(const char *url)
@@ -815,14 +895,15 @@ static bool set_extra_headers(esp_http_client_handle_t client, const char *heade
     return has_content_type;
 }
 
-uint8_t *fos_nim_http_request(const char *method, const char *url,
+fos_nim_http_chunk *fos_nim_http_request_chunked(
+                              const char *method, const char *url,
                               const void *body, size_t body_len,
                               const char *headers, size_t headers_len,
                               int timeout_ms, size_t max_bytes,
-                              int *out_status, size_t *out_len)
+                              int *out_status, size_t *out_count)
 {
     *out_status = 0;
-    *out_len = 0;
+    *out_count = 0;
 
     esp_http_client_method_t http_method = HTTP_METHOD_GET;
     if (method != NULL) {
@@ -860,13 +941,13 @@ uint8_t *fos_nim_http_request(const char *method, const char *url,
         ESP_LOGW(TAG, "%s %s: connect failed: %s", method ? method : "GET", url,
                  esp_err_to_name(err));
         esp_http_client_cleanup(client);
-        return http_error_response(out_status, out_len, "connect failed: %s", esp_err_to_name(err));
+        return chunked_error(out_status, out_count, "connect failed: %s", esp_err_to_name(err));
     }
     if (body != NULL && body_len > 0) {
         if (esp_http_client_write(client, body, body_len) < 0) {
             ESP_LOGW(TAG, "%s %s: body write failed", method, url);
             esp_http_client_cleanup(client);
-            return http_error_response(out_status, out_len, "request body write failed");
+            return chunked_error(out_status, out_count, "request body write failed");
         }
     }
 
@@ -889,14 +970,14 @@ uint8_t *fos_nim_http_request(const char *method, const char *url,
             ESP_LOGW(TAG, "%s %s: redirect connect failed: %s", method ? method : "GET", url,
                      esp_err_to_name(err));
             esp_http_client_cleanup(client);
-            return http_error_response(out_status, out_len, "redirect connect failed: %s",
-                                       esp_err_to_name(err));
+            return chunked_error(out_status, out_count, "redirect connect failed: %s",
+                                 esp_err_to_name(err));
         }
         if (body != NULL && body_len > 0) {
             if (esp_http_client_write(client, body, body_len) < 0) {
                 ESP_LOGW(TAG, "%s %s: redirect body write failed", method ? method : "GET", url);
                 esp_http_client_cleanup(client);
-                return http_error_response(out_status, out_len, "request body write failed");
+                return chunked_error(out_status, out_count, "request body write failed");
             }
         }
         content_length = esp_http_client_fetch_headers(client);
@@ -904,106 +985,172 @@ uint8_t *fos_nim_http_request(const char *method, const char *url,
         redirects++;
     }
 
-    if (max_bytes == 0) max_bytes = 10 * 1024 * 1024;
-    size_t nim_copy_limit = max_bytes;
-    /* Clamp to live PSRAM instead of a fixed constant: half the largest free
-     * block still has to hold the decode target and intermediates. The old
-     * fixed 4MB cap silently rejected 4-6MB images the Nim side allowed. */
-    size_t largest_spiram = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    size_t dynamic_limit = largest_spiram / 2;
-    if (dynamic_limit < FOS_NIM_HTTP_NIM_COPY_LIMIT_MIN) {
-        dynamic_limit = FOS_NIM_HTTP_NIM_COPY_LIMIT_MIN;
-    }
-    if (nim_copy_limit > dynamic_limit) {
-        nim_copy_limit = dynamic_limit;
-    }
-    if (content_length > 0 && (size_t)content_length > nim_copy_limit) {
+    size_t limit = max_bytes ? max_bytes : 10u * 1024u * 1024u;
+    if (content_length > 0 && (size_t)content_length > limit) {
         ESP_LOGW(TAG, "%s: response too large (%lld > %u)", url,
-                 content_length, (unsigned)nim_copy_limit);
+                 content_length, (unsigned)limit);
         esp_http_client_close(client);
         esp_http_client_cleanup(client);
-        return http_error_response(out_status, out_len, "response too large: %lld > %u bytes",
-                                   content_length, (unsigned)nim_copy_limit);
+        return chunked_error(out_status, out_count, "response too large: %lld > %u bytes",
+                             content_length, (unsigned)limit);
     }
 
-    /* Grow in PSRAM; bodies can be multi-MB images. Large image responses can
-     * arrive with an under-reported Content-Length, so reserve the expected
-     * image budget up front instead of needing two large buffers during growth. */
-    size_t cap = (content_length > 0) ? (size_t)content_length : 16384;
-    if (nim_copy_limit > (2u * 1024u * 1024u) &&
-        content_length > (1024u * 1024u) &&
-        cap < (3u * 1024u * 1024u)) {
-        cap = 3u * 1024u * 1024u;
-    }
-    if (cap > nim_copy_limit) cap = nim_copy_limit;
-    if (cap < 1024) cap = 1024;
-    uint8_t *buf = heap_caps_malloc(cap + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    if (buf == NULL) buf = malloc(cap + 1);
-    if (buf == NULL) {
-        ESP_LOGW(TAG, "%s: out of memory allocating HTTP response buffer: cap=%u internal=%u psram=%u largest_psram=%u",
-                 url, (unsigned)cap,
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-        esp_http_client_close(client);
-        esp_http_client_cleanup(client);
-        *out_status = 0;
-        return NULL;
-    }
-
+    /* Accumulate the body in fixed-size PSRAM chunks: no download needs one
+     * contiguous allocation, no matter how fragmented PSRAM is. Only the
+     * Nim-side max_bytes and a live free-PSRAM reserve bound the size. */
+    fos_nim_http_chunk *chunks = NULL;
+    size_t chunk_count = 0, chunk_capacity = 0;
     size_t total = 0;
+    size_t cur_cap = 0, cur_len = 0;
+    uint8_t *cur = NULL;
+    enum { BODY_OK, BODY_OOM, BODY_TOO_BIG, BODY_READ_FAILED } body_status = BODY_OK;
+
     while (true) {
-        if (total == cap) {
-            if (cap >= nim_copy_limit) {
-                ESP_LOGW(TAG, "%s: response exceeded %u bytes", url, (unsigned)nim_copy_limit);
-                fos_nim_http_free(buf);
-                esp_http_client_close(client);
-                esp_http_client_cleanup(client);
-                return http_error_response(out_status, out_len, "response exceeded %u bytes",
-                                           (unsigned)nim_copy_limit);
+        if (cur == NULL || cur_len == cur_cap) {
+            if (cur != NULL) {
+                chunks[chunk_count - 1].len = cur_len;
+                cur = NULL;
             }
-            size_t new_cap = (cap >= (1024u * 1024u)) ? (cap + 512u * 1024u) : (cap * 2u);
-            if (new_cap > nim_copy_limit) new_cap = nim_copy_limit;
-            uint8_t *new_buf = heap_caps_malloc(new_cap + 1,
-                                                MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-            if (new_buf == NULL) new_buf = malloc(new_cap + 1);
-            if (new_buf == NULL) {
-                ESP_LOGW(TAG, "%s: out of memory growing HTTP response buffer: total=%u cap=%u new_cap=%u internal=%u psram=%u largest_psram=%u",
-                         url, (unsigned)total, (unsigned)cap, (unsigned)new_cap,
-                         (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
-                         (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
-                         (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-                fos_nim_http_free(buf);
-                esp_http_client_close(client);
-                esp_http_client_cleanup(client);
-                return http_error_response(out_status, out_len,
-                                           "out of memory growing HTTP response buffer: total=%u cap=%u new=%u largest_psram=%u",
-                                           (unsigned)total, (unsigned)cap, (unsigned)new_cap,
-                                           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+            if (total >= limit) {
+                body_status = BODY_TOO_BIG;
+                break;
             }
-            if (total > 0) memcpy(new_buf, buf, total);
-            fos_nim_http_free(buf);
-            buf = new_buf;
-            cap = new_cap;
+            if (chunk_count == chunk_capacity) {
+                size_t new_capacity = chunk_capacity ? chunk_capacity * 2u : 8u;
+                fos_nim_http_chunk *new_chunks =
+                    realloc(chunks, new_capacity * sizeof(*new_chunks));
+                if (new_chunks == NULL) {
+                    body_status = BODY_OOM;
+                    break;
+                }
+                chunks = new_chunks;
+                chunk_capacity = new_capacity;
+            }
+            size_t want = FOS_NIM_HTTP_CHUNK_BYTES;
+            if (want > limit - total) want = limit - total;
+            if (want < 1) want = 1;
+            uint8_t *buf = NULL;
+            while (true) {
+                size_t free_spiram =
+                    heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                if (free_spiram >= want + 1 + FOS_NIM_HTTP_PSRAM_RESERVE) {
+                    buf = heap_caps_malloc(want + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                }
+                if (buf != NULL) break;
+                if (want <= FOS_NIM_HTTP_CHUNK_MIN_BYTES) break;
+                want /= 2;
+            }
+            if (buf == NULL) {
+                body_status = BODY_OOM;
+                break;
+            }
+            chunks[chunk_count].data = buf;
+            chunks[chunk_count].len = 0;
+            chunk_count++;
+            cur = buf;
+            cur_cap = want;
+            cur_len = 0;
         }
-        int r = esp_http_client_read(client, (char *)buf + total, cap - total);
+        int r = esp_http_client_read(client, (char *)cur + cur_len, cur_cap - cur_len);
         if (r < 0) {
             ESP_LOGW(TAG, "%s %s: response read failed, internal=%u psram=%u",
                      method ? method : "GET", url,
                      (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
                      (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
-            fos_nim_http_free(buf);
-            esp_http_client_close(client);
-            esp_http_client_cleanup(client);
-            return http_error_response(out_status, out_len, "response read failed");
+            body_status = BODY_READ_FAILED;
+            break;
         }
         if (r == 0) break;
-        total += r;
+        cur_len += (size_t)r;
+        total += (size_t)r;
+    }
+
+    if (cur != NULL) {
+        chunks[chunk_count - 1].len = cur_len;
     }
 
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
+
+    if (body_status != BODY_OK) {
+        fos_nim_http_free_chunks(chunks, chunk_count);
+        switch (body_status) {
+        case BODY_TOO_BIG:
+            ESP_LOGW(TAG, "%s: response exceeded %u bytes", url, (unsigned)limit);
+            return chunked_error(out_status, out_count, "response exceeded %u bytes",
+                                 (unsigned)limit);
+        case BODY_READ_FAILED:
+            return chunked_error(out_status, out_count, "response read failed");
+        default:
+            ESP_LOGW(TAG, "%s: out of memory buffering HTTP response: total=%u internal=%u psram=%u largest_psram=%u",
+                     url, (unsigned)total,
+                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
+                     (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+            return chunked_error(out_status, out_count,
+                                 "out of memory buffering HTTP response: total=%u psram_free=%u",
+                                 (unsigned)total,
+                                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+        }
+    }
+
+    if (chunk_count == 0) {
+        /* Empty body: hand back one empty chunk so callers always get a buffer */
+        chunks = malloc(sizeof(*chunks));
+        if (chunks == NULL) {
+            return chunked_error(out_status, out_count, "out of memory");
+        }
+        chunks[0].data = malloc(1);
+        if (chunks[0].data == NULL) {
+            free(chunks);
+            return chunked_error(out_status, out_count, "out of memory");
+        }
+        chunks[0].len = 0;
+        chunk_count = 1;
+    }
+    /* NUL-terminate the final chunk (its allocation reserved the byte) for
+     * cstring-leaning consumers of coalesced single-chunk bodies. */
+    chunks[chunk_count - 1].data[chunks[chunk_count - 1].len] = 0;
+
+    *out_count = chunk_count;
+    return chunks;
+}
+
+uint8_t *fos_nim_http_request(const char *method, const char *url,
+                              const void *body, size_t body_len,
+                              const char *headers, size_t headers_len,
+                              int timeout_ms, size_t max_bytes,
+                              int *out_status, size_t *out_len)
+{
+    *out_len = 0;
+    size_t count = 0;
+    fos_nim_http_chunk *chunks = fos_nim_http_request_chunked(
+        method, url, body, body_len, headers, headers_len,
+        timeout_ms, max_bytes, out_status, &count);
+    if (chunks == NULL) return NULL;
+    if (count == 1) {
+        uint8_t *buf = chunks[0].data;
+        *out_len = chunks[0].len;
+        free(chunks);
+        return buf;
+    }
+    size_t total = 0;
+    for (size_t i = 0; i < count; i++) total += chunks[i].len;
+    uint8_t *buf = heap_caps_malloc(total + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (buf == NULL) buf = malloc(total + 1);
+    if (buf == NULL) {
+        fos_nim_http_free_chunks(chunks, count);
+        return http_error_response(out_status, out_len,
+                                   "out of memory coalescing %u byte HTTP response",
+                                   (unsigned)total);
+    }
+    size_t pos = 0;
+    for (size_t i = 0; i < count; i++) {
+        memcpy(buf + pos, chunks[i].data, chunks[i].len);
+        pos += chunks[i].len;
+    }
     buf[total] = 0;
+    fos_nim_http_free_chunks(chunks, count);
     *out_len = total;
     return buf;
 }

--- a/embedded/esp32/components/frameos_nim/include/frameos_nim.h
+++ b/embedded/esp32/components/frameos_nim/include/frameos_nim.h
@@ -74,6 +74,24 @@ uint8_t *fos_nim_http_request(const char *method, const char *url,
                               int *out_status, size_t *out_len);
 void fos_nim_http_free(void *ptr);
 
+/* Chunked variant: the body is returned as a malloc'd array of fixed-size
+ * PSRAM chunks, so no download ever needs one large contiguous allocation.
+ * Image decoders consume the chunks as segments. Free the array and its
+ * buffers with fos_nim_http_free_chunks. Error semantics match
+ * fos_nim_http_request (single status-599 chunk with a diagnostic body). */
+typedef struct {
+    uint8_t *data;
+    size_t len;
+} fos_nim_http_chunk;
+
+fos_nim_http_chunk *fos_nim_http_request_chunked(
+                              const char *method, const char *url,
+                              const void *body, size_t body_len,
+                              const char *headers, size_t headers_len,
+                              int timeout_ms, size_t max_bytes,
+                              int *out_status, size_t *out_chunk_count);
+void fos_nim_http_free_chunks(fos_nim_http_chunk *chunks, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -344,6 +344,25 @@ static void log_render_event(const char *event, const char *scene_id,
              (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT),
              (int)esp_err, err_name_esc);
     frameos_nim_log_hook(log_line);
+
+    /* The structured line above only reaches the serial console at INFO,
+     * which the firmware log level (WARN) filters out — anyone watching the
+     * USB stream during a deploy sees nothing for the minutes a render
+     * takes. Print the key lifecycle moments directly. */
+    if (strcmp(event, "render:scene") == 0) {
+        printf("render #%lu started: scene \"%s\"\n", (unsigned long)count,
+               scene_name && scene_name[0] ? scene_name : scene_id);
+    } else if (strcmp(event, "render:device") == 0 &&
+               strcmp(status, "refreshing") == 0) {
+        printf("render #%lu refreshing display (%lld ms so far)\n",
+               (unsigned long)count, ms);
+    } else if (strcmp(event, "render:done") == 0) {
+        printf("render #%lu done in %lld ms\n", (unsigned long)count, ms);
+    } else if (strcmp(event, "render:error") == 0) {
+        printf("render #%lu failed at %s: %s\n", (unsigned long)count,
+               stage && stage[0] ? stage : "?",
+               reason && reason[0] ? reason : esp_err_to_name(esp_err));
+    }
 }
 
 static void store_snapshot(const uint8_t *buf, size_t len, int width, int height,

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -413,7 +413,8 @@ static bool usb_api_read_exact(uint8_t *buf, size_t len, TickType_t timeout_tick
         if ((xTaskGetTickCount() - start) >= timeout_ticks) {
             return false;
         }
-        vTaskDelay(pdMS_TO_TICKS(1));
+        /* At least one full tick: pdMS_TO_TICKS(1) is 0 ticks at 100Hz. */
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
     return true;
 }
@@ -701,7 +702,10 @@ static void fos_console_usb_task(void *arg)
     while (true) {
         int ch = fgetc(stdin);
         if (ch == EOF) {
-            vTaskDelay(pdMS_TO_TICKS(1));
+            /* stdin is non-blocking; sleep at least one full tick. At
+             * CONFIG_FREERTOS_HZ=100, pdMS_TO_TICKS(1) rounds to 0 ticks and
+             * this loop busy-spins, starving IDLE0 (task_wdt warnings). */
+            vTaskDelay(pdMS_TO_TICKS(10));
             continue;
         }
 

--- a/embedded/esp32/main/fos_ota.c
+++ b/embedded/esp32/main/fos_ota.c
@@ -30,13 +30,17 @@ static const char *TAG = "fos_ota";
 #define FOS_OTA_RETRY_DELAY_MS 1000
 #define FOS_OTA_WIFI_SETTLE_MS 3000
 #define FOS_OTA_BOOT_REQUEST_KEY "ota_req"
+#define FOS_OTA_REBOOT_DELAY_MS 1000
+#define FOS_OTA_REBOOT_TASK_STACK_SIZE 2048
 
 static char s_auth_header[FOS_STR_LEN + 16];
 static StaticSemaphore_t s_ota_lock_storage;
 static SemaphoreHandle_t s_ota_lock = NULL;
 static portMUX_TYPE s_ota_lock_mux = portMUX_INITIALIZER_UNLOCKED;
+static portMUX_TYPE s_ota_request_mux = portMUX_INITIALIZER_UNLOCKED;
 static TaskHandle_t s_ota_task_handle = NULL;
 static volatile bool s_ota_busy = false;
+static volatile bool s_ota_reboot_scheduled = false;
 
 typedef struct {
     char sha[80];
@@ -496,6 +500,13 @@ void fos_ota_start_periodic_task(uint32_t interval_hours)
     }
 }
 
+static void ota_reboot_task(void *arg)
+{
+    (void)arg;
+    vTaskDelay(pdMS_TO_TICKS(FOS_OTA_REBOOT_DELAY_MS));
+    esp_restart();
+}
+
 esp_err_t fos_ota_request_check(void)
 {
     if (!ota_supported()) return ESP_ERR_NOT_SUPPORTED;
@@ -504,8 +515,27 @@ esp_err_t fos_ota_request_check(void)
         ESP_LOGW(TAG, "failed to store OTA request: %s", esp_err_to_name(err));
         return err;
     }
-    ESP_LOGW(TAG, "OTA requested; rebooting into early updater");
-    vTaskDelay(pdMS_TO_TICKS(500));
-    esp_restart();
+
+    taskENTER_CRITICAL(&s_ota_request_mux);
+    bool already_scheduled = s_ota_reboot_scheduled;
+    s_ota_reboot_scheduled = true;
+    taskEXIT_CRITICAL(&s_ota_request_mux);
+    if (already_scheduled) return ESP_OK;
+
+    BaseType_t created = xTaskCreate(ota_reboot_task, "fos_ota_reboot",
+                                     FOS_OTA_REBOOT_TASK_STACK_SIZE, NULL, 5, NULL);
+    if (created != pdPASS) {
+        taskENTER_CRITICAL(&s_ota_request_mux);
+        s_ota_reboot_scheduled = false;
+        taskEXIT_CRITICAL(&s_ota_request_mux);
+        ESP_LOGW(TAG, "failed to schedule OTA reboot: internal=%u",
+                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+        return ESP_ERR_NO_MEM;
+    }
+
+    /* Reboot from a separate task so HTTP and USB callers can flush their
+     * success response before the connection disappears. */
+    ESP_LOGW(TAG, "OTA requested; rebooting into early updater in %d ms",
+             FOS_OTA_REBOOT_DELAY_MS);
     return ESP_OK;
 }

--- a/embedded/esp32/main/fos_ota.h
+++ b/embedded/esp32/main/fos_ota.h
@@ -22,5 +22,6 @@ bool fos_ota_boot_request_pending(void);
 esp_err_t fos_ota_run_boot_request(void);
 /* Background task that checks every interval_hours. */
 void fos_ota_start_periodic_task(uint32_t interval_hours);
-/* Request an early-boot OTA check and reboot into it. */
+/* Request an early-boot OTA check and schedule a reboot into it. The delay
+ * lets HTTP and USB callers flush their acknowledgement first. */
 esp_err_t fos_ota_request_check(void);

--- a/embedded/esp32/main/fos_scenes.c
+++ b/embedded/esp32/main/fos_scenes.c
@@ -12,6 +12,7 @@
 #include "esp_log.h"
 #include "esp_spiffs.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 #include "fos_config.h"
 #include "fos_wifi.h"
@@ -36,6 +37,12 @@ static char s_etag[ETAG_LEN] = "";
 static char s_pending_scene_id[SCENE_ID_LEN] = "";
 static char s_last_error[SCENE_ERROR_LEN] = "";
 static portMUX_TYPE s_scene_select_lock = portMUX_INITIALIZER_UNLOCKED;
+/* Serializes writers of /state/scenes.json: the USB upload (console task)
+ * and the backend sync (fos_client task) share one tmp path, and two
+ * concurrent write+rename dances delete each other's tmp file (rename then
+ * fails ENOENT on a freshly written file). Created in fos_scenes_init(),
+ * which runs before either task starts. */
+static SemaphoreHandle_t s_scene_file_lock = NULL;
 
 static void json_escape_value(const char *src, char *out, size_t out_len)
 {
@@ -258,8 +265,8 @@ static esp_err_t write_file_atomic(const char *path, const char *tmp_path,
     return ESP_OK;
 }
 
-static esp_err_t write_file_replace(const char *path, const char *tmp_path,
-                                    const char *data, size_t len)
+static esp_err_t write_file_replace_locked(const char *path, const char *tmp_path,
+                                           const char *data, size_t len)
 {
     esp_err_t err = write_file_atomic(path, tmp_path, data, len);
     if (err == ESP_OK) return ESP_OK;
@@ -415,15 +422,36 @@ bool fos_scenes_apply_pending_selection(void)
         return false;
     }
     ESP_LOGI(TAG, "scene selected: %s", scene_id);
+    printf("scene changed: %s\n", scene_id); /* visible on the USB serial stream */
     log_scene_event("event:setCurrentScene", "ok", "queued", scene_id,
+                    "selected", 0, 0, 0, ESP_OK);
+    /* Pi parity: the UI's scene-activation and preview tasks complete on
+     * render:sceneChange (see longRunningTasksModel). */
+    log_scene_event("render:sceneChange", "ok", "queued", scene_id,
                     "selected", 0, 0, 0, ESP_OK);
     return true;
 }
 
 /* ---------------------------------------------------------------- init */
 
+static esp_err_t write_file_replace(const char *path, const char *tmp_path,
+                                    const char *data, size_t len)
+{
+    if (s_scene_file_lock != NULL) {
+        xSemaphoreTake(s_scene_file_lock, portMAX_DELAY);
+    }
+    esp_err_t err = write_file_replace_locked(path, tmp_path, data, len);
+    if (s_scene_file_lock != NULL) {
+        xSemaphoreGive(s_scene_file_lock);
+    }
+    return err;
+}
+
 esp_err_t fos_scenes_init(void)
 {
+    if (s_scene_file_lock == NULL) {
+        s_scene_file_lock = xSemaphoreCreateMutex();
+    }
     esp_err_t err = mount_state();
     if (err != ESP_OK) return err;
     load_etag();

--- a/frameos/frameos.nimble
+++ b/frameos/frameos.nimble
@@ -16,7 +16,7 @@ bin           = @["frameos"]
 requires "chrono >= 0.3.1"
 requires "checksums >= 0.2.1"
 requires "nim >= 2.2.4"
-requires "https://github.com/FrameOS/pixie#075da8d7293a842364ad7f829feeba2eddca2e47"
+requires "https://github.com/FrameOS/pixie#8b6b6e72c854c3334be3f8efc99cea1cf604500a"
 requires "mummy >= 0.4.7"
 requires "linuxfb >= 0.1.0"
 requires "QRgen >= 3.1.0"

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -151,7 +151,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "075da8d7293a842364ad7f829feeba2eddca2e47",
+      "vcsRevision": "8b6b6e72c854c3334be3f8efc99cea1cf604500a",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -164,7 +164,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "0dcf6b90c6b7c75c73c9e79394b7d803464b1d18"
+        "sha1": "da311f03c2e2127ccced332a0955b23a6f71ceac"
       }
     }
   },

--- a/frameos/src/apps/data/downloadImage/app.nim
+++ b/frameos/src/apps/data/downloadImage/app.nim
@@ -40,5 +40,5 @@ proc get*(self: App, context: ExecutionContext): Image =
   except CatchableError as e:
     let detail = if e.msg.len > 0: e.msg else: "unknown error"
     self.logError "An error occurred while downloading the image: " & detail
-    return renderError(self.contextImageWidth(context), self.contextImageHeight(context),
+    return self.renderErrorForContext(context,
         "An error occurred while downloading the image.\n" & detail)

--- a/frameos/src/apps/data/frameOSGallery/app.nim
+++ b/frameos/src/apps/data/frameOSGallery/app.nim
@@ -2,6 +2,7 @@ import pixie, strformat, json
 import frameos/apps
 import frameos/types
 import frameos/utils/app_images
+import frameos/utils/image
 
 const BASE_URL = "https://gallery.frameos.net/image"
 
@@ -34,5 +35,11 @@ proc get*(self: App, context: ExecutionContext): Image =
   self.log(%*{"category": category})
   let url = galleryUrl(category)
   let target = context.contextImage()
-  result = galleryDownloadHook(url, self.maxImageResponseBytes(), target,
-      scaledDecodeFitForFrame(self.frameConfig))
+  try:
+    result = galleryDownloadHook(url, self.maxImageResponseBytes(), target,
+        scaledDecodeFitForFrame(self.frameConfig))
+  except CatchableError as e:
+    let detail = if e.msg.len > 0: e.msg else: "unknown error"
+    self.logError "An error occurred while downloading the gallery image: " & detail
+    result = self.renderErrorForContext(context,
+        "An error occurred while downloading the gallery image.\n" & detail)

--- a/frameos/src/apps/data/googlePhotos/app.nim
+++ b/frameos/src/apps/data/googlePhotos/app.nim
@@ -9,7 +9,6 @@ import frameos/apps
 import frameos/types
 import frameos/utils/app_images
 import frameos/utils/http_client
-import frameos/utils/image
 import frameos/hal/entropy
 
 const
@@ -87,7 +86,7 @@ proc init*(self: App) =
 
 proc error*(self: App, context: ExecutionContext, message: string): Image =
   self.logError(message)
-  result = renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
+  result = self.renderErrorForContext(context, message)
 
 proc albumStale(self: App): bool =
   self.photoUrls.len == 0 or

--- a/frameos/src/apps/data/immich/app.nim
+++ b/frameos/src/apps/data/immich/app.nim
@@ -10,7 +10,6 @@ import frameos/types
 import frameos/hal/entropy
 import frameos/utils/app_images
 import frameos/utils/http_client
-import frameos/utils/image
 
 const RequestTimeoutMs = 30000
 
@@ -38,7 +37,7 @@ proc init*(self: App) =
 
 proc error*(self: App, context: ExecutionContext, message: string): Image =
   self.logError(message)
-  result = renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
+  result = self.renderErrorForContext(context, message)
 
 proc normalizeServerUrl*(url: string): string =
   result = url.strip()

--- a/frameos/src/apps/data/openaiImage/app.nim
+++ b/frameos/src/apps/data/openaiImage/app.nim
@@ -29,7 +29,7 @@ type
 
 proc error*(self: App, context: ExecutionContext, message: string): Image =
   self.logError(message)
-  result = renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
+  result = self.renderErrorForContext(context, message)
 
 when defined(frameosEmbedded):
   proc bestEmbeddedGptImage2Size(width, height: int): string =

--- a/frameos/src/apps/data/unsplash/app.nim
+++ b/frameos/src/apps/data/unsplash/app.nim
@@ -7,7 +7,6 @@ import frameos/apps
 import frameos/types
 import frameos/utils/app_images
 import frameos/utils/http_client
-import frameos/utils/image
 
 type
   AppConfig* = object
@@ -25,7 +24,7 @@ proc init*(self: App) =
 
 proc error*(self: App, context: ExecutionContext, message: string): Image =
   self.logError(message)
-  result = renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
+  result = self.renderErrorForContext(context, message)
 
 proc get*(self: App, context: ExecutionContext): Image =
   self.ensureEmbeddedServiceSettings()

--- a/frameos/src/apps/data/wikicommons/app.nim
+++ b/frameos/src/apps/data/wikicommons/app.nim
@@ -55,7 +55,7 @@ proc init*(self: App) =
 
 proc error*(self: App, context: ExecutionContext, message: string): Image =
   self.logError(message)
-  result = renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
+  result = self.renderErrorForContext(context, message)
 
 proc commonsHeaders(): seq[SimpleHttpHeader] =
   @[

--- a/frameos/src/apps/render/svg/app.nim
+++ b/frameos/src/apps/render/svg/app.nim
@@ -72,8 +72,11 @@ proc render*(self: App, context: ExecutionContext, image: Image) =
   except Exception as e:
     let message = &"Error rendering SVG: {e.msg}"
     self.logError(message)
-    let errorImage = renderError(image.width, image.height, message)
-    scaleAndDrawImage(image, errorImage, self.appConfig.placement)
+    when defined(frameosEmbedded):
+      renderErrorInto(image, image.width, image.height, message)
+    else:
+      let errorImage = renderError(image.width, image.height, message)
+      scaleAndDrawImage(image, errorImage, self.appConfig.placement)
 
 proc run*(self: App, context: ExecutionContext) =
   render(self, context, context.image)

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -1,5 +1,6 @@
 import frameos/types
 import frameos/values
+from frameos/utils/image import renderError, renderErrorInto
 import frameos/js_runtime/app_runtime
 import frameos/js_runtime/runtime
 import frameos/channels
@@ -8,6 +9,8 @@ import tables, json, os, zippy, chroma, pixie, jsony, sequtils, options, strutil
 import apps/apps
 
 const TRACING = false
+when defined(frameosEmbedded):
+  const EmbeddedMaxCachedImageBytes = 1024 * 1024
 
 proc appSourcesFromSceneApps(scene: FrameScene, keyword: string): JsonNode =
   if scene of InterpretedFrameScene:
@@ -189,6 +192,17 @@ proc withCache(scene: InterpretedFrameScene,
     scene.logger.log(payload)
 
   let fresh = compute()
+  when defined(frameosEmbedded):
+    # Never retain frame-sized images in the node cache on embedded: image
+    # producers decode straight into the render canvas, so the cached value
+    # aliases a canvas-sized RGBA buffer (7.7MB at 1200x1600). Pinning it
+    # across renders means the next render needs a second canvas and OOMs
+    # the module (and a cache hit would draw the aliased, since-overwritten
+    # canvas anyway). Re-running the producer costs a re-download; small
+    # images still cache.
+    if fresh.kind == fkImage and not fresh.img.isNil and
+        fresh.img.width * fresh.img.height * 4 > EmbeddedMaxCachedImageBytes:
+      return fresh
   scene.cacheValues[nodeId] = fresh
   if cacheDurationEnabled:
     scene.cacheTimes[nodeId] = epochTime()
@@ -413,7 +427,36 @@ proc runNode*(self: FrameScene, nodeId: NodeId, context: ExecutionContext, asDat
                 "error": $e.msg,
                 "stacktrace": e.getStackTrace()
               })
-              # Leave field at default; still proceed.
+              # If this input takes an image, hand the consumer an image with
+              # the producer's error on it ("response too large", HTTP errors,
+              # …) — a nil image would only render as "No image provided".
+              # Non-image fields reject the value and keep their defaults.
+              try:
+                when defined(frameosEmbedded):
+                  # Reuse the live canvas for the error frame: allocating a
+                  # second full-frame image next to it OOMs memory-tight
+                  # devices. Paint only after the field accepted the image,
+                  # so a non-image field mismatch leaves the canvas untouched.
+                  if context.hasImage and not context.image.isNil:
+                    setInterpretedAppField(keyword, app, inputName,
+                      Value(kind: fkImage, img: context.image))
+                    renderErrorInto(context.image, context.image.width,
+                      context.image.height, $e.msg)
+                  else:
+                    setInterpretedAppField(keyword, app, inputName,
+                      Value(kind: fkImage, img: renderError(self.frameConfig.width,
+                        self.frameConfig.height, $e.msg)))
+                else:
+                  let errorWidth =
+                    if context.hasImage and not context.image.isNil: context.image.width
+                    else: self.frameConfig.width
+                  let errorHeight =
+                    if context.hasImage and not context.image.isNil: context.image.height
+                    else: self.frameConfig.height
+                  setInterpretedAppField(keyword, app, inputName,
+                    Value(kind: fkImage, img: renderError(errorWidth, errorHeight, $e.msg)))
+              except Exception:
+                discard # Leave field at default; still proceed.
 
       if self.appInlineInputsForNodeId.hasKey(currentNodeId):
         let inlineConnected = self.appInlineInputsForNodeId[currentNodeId]

--- a/frameos/src/frameos/tests/test_embedded_image_url.nim
+++ b/frameos/src/frameos/tests/test_embedded_image_url.nim
@@ -1,0 +1,29 @@
+# RULE: frames NEVER fetch images through a backend proxy, and oversized
+# sources are fixed with better on-device streaming decode — not host-side
+# resize params. This test pins that remote URLs pass through unrewritten
+# (the pre-existing unsplash rewrite is the only exception).
+import std/[strutils, unittest]
+import pixie
+
+import ../utils/image
+
+suite "embedded remote image URLs (no proxies, ever)":
+  let target = newImage(1200, 1600)
+
+  test "unsplash URLs keep their pre-existing host-side resize params":
+    let rewritten = embeddedSizedRemoteImageUrl(
+      "https://images.unsplash.com/photo-123?ixid=abc", target)
+    check rewritten.startsWith("https://images.unsplash.com/photo-123")
+    check "w=800" in rewritten
+    check "h=800" in rewritten
+    check "fit=crop" in rewritten
+
+  test "all other hosts pass through unchanged — never rewritten to a proxy":
+    let gallery = "https://gallery.frameos.net/image?category=building-art-styles"
+    check embeddedSizedRemoteImageUrl(gallery, target) == gallery
+    let other = "https://example.com/huge.png"
+    check embeddedSizedRemoteImageUrl(other, target) == other
+
+  test "non-http and target-less calls pass through unchanged":
+    check embeddedSizedRemoteImageUrl("file:///tmp/a.png", target) == "file:///tmp/a.png"
+    check embeddedSizedRemoteImageUrl("https://example.com/a.png", nil) == "https://example.com/a.png"

--- a/frameos/src/frameos/tests/test_interpreter_errors.nim
+++ b/frameos/src/frameos/tests/test_interpreter_errors.nim
@@ -2,6 +2,7 @@ import std/[json, tables, strutils, unittest]
 import pixie
 import ../channels
 import ../interpreter
+import ../../apps/data/frameOSGallery/app as galleryApp
 import ../types
 import ../values
 
@@ -331,3 +332,50 @@ suite "interpreter error paths":
     finally:
       setUploadedInterpretedScenes(initTable[SceneId, ExportedInterpretedScene]())
       resetInterpretedScenes()
+
+  test "failed image download paints the error instead of 'No image provided'":
+    let savedHook = galleryApp.galleryDownloadHook
+    galleryApp.galleryDownloadHook =
+      proc(url: string, maxBytes: int, target: Image, fit: ScaledDecodeFit): Image =
+        raise newException(ValueError, "response too large: 2601969 > 1409024 bytes")
+    defer: galleryApp.galleryDownloadHook = savedHook
+
+    let sceneId = "tests/interpreter-errors/image-producer-error".SceneId
+    let exported = ExportedInterpretedScene(
+      name: "image producer error",
+      backgroundColor: parseHtmlColor("#000000"),
+      refreshInterval: 1.0,
+      publicStateFields: @[],
+      nodes: @[
+        node(10, "event", %*{"keyword": "render"}),
+        node(20, "app", %*{"keyword": "render/image", "config": {}}),
+        node(30, "app", %*{
+          "keyword": "data/frameOSGallery",
+          "config": {"category": "random"}
+        })
+      ],
+      edges: @[
+        edge(100, 10, "next", 20, "prev"),
+        edge(101, 30, "fieldOutput", 20, "fieldInput/image")
+      ]
+    )
+
+    withUploadedScene(sceneId, exported) do (store: LogStore, scene: FrameScene):
+      let rendered = render(scene, ctx(scene, "render"))
+      # The failure reason is logged, and nothing says "No image provided"
+      var sawDetail = false
+      for entry in store.entries:
+        if entry.kind != JObject:
+          continue
+        for key in ["message", "error"]:
+          if entry.hasKey(key):
+            check "No image provided" notin entry[key].getStr()
+            if "response too large" in entry[key].getStr():
+              sawDetail = true
+      check sawDetail
+      # ...and the canvas shows the error image, not the plain background
+      var nonBackground = 0
+      for pixel in rendered.data:
+        if pixel.r.int + pixel.g.int + pixel.b.int > 96:
+          inc nonBackground
+      check nonBackground > rendered.data.len div 2

--- a/frameos/src/frameos/utils/app_images.nim
+++ b/frameos/src/frameos/utils/app_images.nim
@@ -35,6 +35,18 @@ proc contextImageTarget*(self: AppRoot, context: ExecutionContext,
     else: self.frameConfig.renderHeight()
   newImage(width, height)
 
+proc renderErrorForContext*(self: AppRoot, context: ExecutionContext, message: string): Image =
+  ## Error frame for image producers. On embedded the producer's success path
+  ## decodes straight into the context canvas, so the error path must reuse
+  ## that canvas too — a second full-frame allocation next to the live canvas
+  ## is exactly what OOMs a 16MB module.
+  when defined(frameosEmbedded):
+    let target = context.contextImage()
+    if not target.isNil:
+      renderErrorInto(target, target.width, target.height, message)
+      return target
+  renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
+
 proc scaledDecodeFitForFrame*(frameConfig: FrameConfig): ScaledDecodeFit =
   ## The decode-time fit that best matches the frame's scaling mode when an
   ## image is decoded straight into a region-sized target on embedded builds.

--- a/frameos/src/frameos/utils/http_client.nim
+++ b/frameos/src/frameos/utils/http_client.nim
@@ -31,11 +31,22 @@ when defined(frameosEmbedded) or defined(frameosWasm):
       status*: string
       body*: string
 
+    HttpBodyChunk* = object
+      ## One piece of a response body. Embedded targets download into
+      ## fixed-size PSRAM chunks so no response needs one large contiguous
+      ## allocation; decoders consume the chunks as segments.
+      data*: pointer
+      len*: int
+
     BoundedHttpBufferResponse* = object
       code*: int
       status*: string
-      body*: pointer
-      bodyLen*: int
+      body*: pointer # Contiguous view; nil when the body spans >1 chunk
+      bodyLen*: int  # Total length across all chunks
+      chunks*: seq[HttpBodyChunk]
+      when defined(frameosEmbedded):
+        rawChunks: pointer
+        rawChunkCount: csize_t
 
     HttpResponseMetadata* = object
       contentLength*: int
@@ -48,6 +59,21 @@ when defined(frameosEmbedded) or defined(frameosWasm):
                             outStatus: ptr cint, outLen: ptr csize_t):
                             pointer {.importc: "fos_nim_http_request", cdecl.}
   proc fos_nim_http_free(p: pointer) {.importc: "fos_nim_http_free", cdecl.}
+
+  when defined(frameosEmbedded):
+    type FosNimHttpChunk {.pure.} = object
+      data: pointer
+      len: csize_t
+
+    proc fos_nim_http_request_chunked(httpMethod: cstring, url: cstring,
+                            body: pointer, bodyLen: csize_t,
+                            headers: pointer, headersLen: csize_t,
+                            timeoutMs: cint, maxBytes: csize_t,
+                            outStatus: ptr cint, outChunkCount: ptr csize_t):
+                            ptr UncheckedArray[FosNimHttpChunk]
+                            {.importc: "fos_nim_http_request_chunked", cdecl.}
+    proc fos_nim_http_free_chunks(chunks: pointer, count: csize_t)
+                            {.importc: "fos_nim_http_free_chunks", cdecl.}
 
   proc encodeSimpleHeaders(headers: seq[SimpleHttpHeader]): string =
     for header in headers:
@@ -64,10 +90,20 @@ when defined(frameosEmbedded) or defined(frameosWasm):
       raise newException(IOError, &"HTTP response exceeded {maxBytes} bytes")
 
   proc freeHttpBufferResponse*(response: var BoundedHttpBufferResponse) =
+    when defined(frameosEmbedded):
+      if response.rawChunks != nil:
+        fos_nim_http_free_chunks(response.rawChunks, response.rawChunkCount)
+        response.rawChunks = nil
+        response.rawChunkCount = 0
+        response.body = nil
+        response.bodyLen = 0
+        response.chunks = @[]
+        return
     if response.body != nil:
       fos_nim_http_free(response.body)
       response.body = nil
       response.bodyLen = 0
+      response.chunks = @[]
 
   proc boundedRequestBuffer*(
       url: string,
@@ -86,21 +122,47 @@ when defined(frameosEmbedded) or defined(frameosWasm):
     if not (url.startsWith("http://") or url.startsWith("https://")):
       raise newException(ValueError, &"Invalid HTTP URL: {url}")
     var status: cint = 0
-    var outLen: csize_t = 0
     let bodyPtr = if body.len > 0: unsafeAddr body[0] else: nil
     let headerBlock = encodeSimpleHeaders(headers)
     let headerPtr = if headerBlock.len > 0: unsafeAddr headerBlock[0] else: nil
-    let buf = fos_nim_http_request(httpMethod.cstring, url.cstring,
-                                   bodyPtr, body.len.csize_t,
-                                   headerPtr, headerBlock.len.csize_t,
-                                   timeoutMs.cint, maxBytes.csize_t,
-                                   addr status, addr outLen)
-    if buf == nil and status == 0:
-      raise newException(IOError, &"HTTP request failed: {url}")
-    result.code = status.int
-    result.status = $status
-    result.body = buf
-    result.bodyLen = outLen.int
+    when defined(frameosEmbedded):
+      var chunkCount: csize_t = 0
+      let rawChunks = fos_nim_http_request_chunked(httpMethod.cstring, url.cstring,
+                                     bodyPtr, body.len.csize_t,
+                                     headerPtr, headerBlock.len.csize_t,
+                                     timeoutMs.cint, maxBytes.csize_t,
+                                     addr status, addr chunkCount)
+      if rawChunks == nil and status == 0:
+        raise newException(IOError, &"HTTP request failed: {url}")
+      result.code = status.int
+      result.status = $status
+      result.rawChunks = rawChunks
+      result.rawChunkCount = chunkCount
+      var total = 0
+      if rawChunks != nil:
+        result.chunks = newSeq[HttpBodyChunk](chunkCount.int)
+        for i in 0 ..< chunkCount.int:
+          result.chunks[i] = HttpBodyChunk(
+            data: rawChunks[i].data, len: rawChunks[i].len.int)
+          total += rawChunks[i].len.int
+      result.bodyLen = total
+      if result.chunks.len == 1:
+        result.body = result.chunks[0].data
+    else:
+      var outLen: csize_t = 0
+      let buf = fos_nim_http_request(httpMethod.cstring, url.cstring,
+                                     bodyPtr, body.len.csize_t,
+                                     headerPtr, headerBlock.len.csize_t,
+                                     timeoutMs.cint, maxBytes.csize_t,
+                                     addr status, addr outLen)
+      if buf == nil and status == 0:
+        raise newException(IOError, &"HTTP request failed: {url}")
+      result.code = status.int
+      result.status = $status
+      result.body = buf
+      result.bodyLen = outLen.int
+      if buf != nil:
+        result.chunks = @[HttpBodyChunk(data: buf, len: outLen.int)]
 
   proc boundedRequest*(
       url: string,
@@ -127,9 +189,13 @@ when defined(frameosEmbedded) or defined(frameosWasm):
     try:
       result.code = response.code
       result.status = response.status
-      if response.body != nil and response.bodyLen > 0:
+      if response.bodyLen > 0:
         result.body = newString(response.bodyLen)
-        copyMem(addr result.body[0], response.body, response.bodyLen)
+        var pos = 0
+        for chunk in response.chunks:
+          if chunk.len > 0:
+            copyMem(addr result.body[pos], chunk.data, chunk.len)
+            pos += chunk.len
     finally:
       response.freeHttpBufferResponse()
 

--- a/frameos/src/frameos/utils/image.nim
+++ b/frameos/src/frameos/utils/image.nim
@@ -19,6 +19,7 @@ when defined(frameosEmbedded):
   import pixie/fileformats/bmp
   import pixie/fileformats/jpeg
   import pixie/fileformats/png
+  import pixie/inflatestream
 when not defined(frameosEmbedded) and not defined(frameosWasm):
   # No child processes on FreeRTOS or WebAssembly: ImageMagick/exiftool
   # fallbacks are compiled out and pixie does all decoding.
@@ -32,12 +33,12 @@ const ExifToolTimeoutMs = 10_000
 const DisplayDecodeMaxEdge* = 2048
 const DisplayDecodeMaxPixels* = DisplayDecodeMaxEdge * DisplayDecodeMaxEdge
 const ImageEngineImageMagick* = "imagemagick"
+const EmbeddedMaxRemoteSourceWidth = 800
 when defined(frameosEmbedded):
   const EmbeddedSmallDecodeCopyBytes = 512 * 1024
   const EmbeddedMaxDirectDecodeCopyBytes = 2 * 1024 * 1024
   const EmbeddedMaxDirectPngBytes = 6 * 1024 * 1024
   const EmbeddedMaxDirectRgbaBytes = 5 * 1024 * 1024
-  const EmbeddedMaxRemoteSourceWidth = 800
 
 var runtimeImageEngine = ""
 
@@ -298,12 +299,15 @@ when defined(frameosEmbedded):
       if len > EmbeddedMaxDirectPngBytes:
         raise newException(PixieError,
           &"Direct on-device PNG decode over {EmbeddedMaxDirectPngBytes div 1024}K needs the low-memory media proxy; fetched {len div 1024}K")
-      guardEmbeddedDirectDecode(data, len, format)
       GC_fullCollect()
       when compiles(decodePngScaledInto(data, len, target, fit)):
+        # Streamed scanline decode: pixie's own decode budget guards the
+        # peak (a row plus fixed overhead), so the full-RGBA guard would
+        # only reject images this path never allocates whole.
         decodePngScaledInto(data, len, target, fit)
         return target
       else:
+        guardEmbeddedDirectDecode(data, len, format)
         target.scaleAndDrawImage(decodeImageWithFallback(data, len), scaledFitPlacement(fit))
         return target
     decodeImageWithFallback(data, len)
@@ -328,23 +332,25 @@ when defined(frameosEmbedded):
       if data.len > EmbeddedMaxDirectPngBytes:
         raise newException(PixieError,
           &"Direct on-device PNG decode over {EmbeddedMaxDirectPngBytes div 1024}K needs the low-memory media proxy; fetched {data.len div 1024}K")
-      guardEmbeddedDirectDecode(data.cstring, data.len, format)
       GC_fullCollect()
       when compiles(decodePngScaledInto(data, target, fit)):
+        # Streamed scanline decode; see the pointer variant above
         decodePngScaledInto(data, target, fit)
         return target
       else:
+        guardEmbeddedDirectDecode(data.cstring, data.len, format)
         target.scaleAndDrawImage(decodeImageWithFallback(data), scaledFitPlacement(fit))
         return target
     decodeImageWithFallback(data)
 
   proc httpErrorDetail(response: BoundedHttpBufferResponse): string =
-    if response.body == nil or response.bodyLen <= 0:
+    if response.chunks.len == 0 or response.bodyLen <= 0:
       return ""
-    let copyLen = min(response.bodyLen, 512)
+    let first = response.chunks[0]
+    let copyLen = min(first.len, 512)
     var snippet = newString(copyLen)
     if copyLen > 0:
-      copyMem(addr snippet[0], response.body, copyLen)
+      copyMem(addr snippet[0], first.data, copyLen)
     if response.bodyLen > copyLen:
       snippet.add("...")
     ": " & snippet
@@ -538,43 +544,78 @@ proc decodeDataUrlInto*(dataUrl: string, target: Image, fit = fitCover): Image =
     return decodeImageWithFallback(decodedData, target, fit)
   return decodeImageWithFallback(decodedData)
 
+proc upsertQueryParam(query, key, value: string): string =
+  var parts = if query.len > 0: query.split('&') else: @[]
+  var updated = false
+  for part in parts.mitems:
+    let equals = part.find('=')
+    let partKey = if equals >= 0: part[0 ..< equals] else: part
+    if partKey == key:
+      part = encodeUrl(key) & "=" & encodeUrl(value)
+      updated = true
+  if not updated:
+    parts.add(encodeUrl(key) & "=" & encodeUrl(value))
+  parts.join("&")
+
+# RULE: NEVER route frame image downloads through a backend/image proxy, and
+# don't reach for host-side resize params as the fix either. Frames render
+# independently, from the original source. When a source serves images too
+# large for on-device decode, THE fix is better streaming on-device
+# (incremental inflate + row-by-row unfilter/scale into the target, so a
+# multi-MB PNG needs its compressed body plus a few rows — not a full-size
+# RGBA buffer). Proxies are for in-browser previews only. The unsplash
+# rewrite below predates this rule and stays as-is.
+proc embeddedSizedRemoteImageUrl*(url: string, target: Image): string =
+  if target.isNil or target.width <= 0 or target.height <= 0:
+    return url
+  var parsed: Uri
+  try:
+    parsed = parseUri(url)
+  except CatchableError:
+    return url
+  if parsed.scheme notin ["http", "https"]:
+    return url
+
+  case parsed.hostname.toLowerAscii()
+  of "images.unsplash.com":
+    let requestedWidth = min(target.width, EmbeddedMaxRemoteSourceWidth)
+    let requestedHeight = min(target.height, EmbeddedMaxRemoteSourceWidth)
+    parsed.query = upsertQueryParam(parsed.query, "w", $requestedWidth)
+    parsed.query = upsertQueryParam(parsed.query, "h", $requestedHeight)
+    parsed.query = upsertQueryParam(parsed.query, "fit", "crop")
+    if parsed.query.find("auto=") < 0:
+      parsed.query = upsertQueryParam(parsed.query, "auto", "format")
+    return $parsed
+  else:
+    return url
+
 when defined(frameosEmbedded):
-  proc upsertQueryParam(query, key, value: string): string =
-    var parts = if query.len > 0: query.split('&') else: @[]
-    var updated = false
-    for part in parts.mitems:
-      let equals = part.find('=')
-      let partKey = if equals >= 0: part[0 ..< equals] else: part
-      if partKey == key:
-        part = encodeUrl(key) & "=" & encodeUrl(value)
-        updated = true
-    if not updated:
-      parts.add(encodeUrl(key) & "=" & encodeUrl(value))
-    parts.join("&")
-
-  proc embeddedSizedRemoteImageUrl(url: string, target: Image): string =
-    if target.isNil or target.width <= 0 or target.height <= 0:
-      return url
-    var parsed: Uri
-    try:
-      parsed = parseUri(url)
-    except CatchableError:
-      return url
-    if parsed.scheme notin ["http", "https"]:
-      return url
-
-    case parsed.hostname.toLowerAscii()
-    of "images.unsplash.com":
-      let requestedWidth = min(target.width, EmbeddedMaxRemoteSourceWidth)
-      let requestedHeight = min(target.height, EmbeddedMaxRemoteSourceWidth)
-      parsed.query = upsertQueryParam(parsed.query, "w", $requestedWidth)
-      parsed.query = upsertQueryParam(parsed.query, "h", $requestedHeight)
-      parsed.query = upsertQueryParam(parsed.query, "fit", "crop")
-      if parsed.query.find("auto=") < 0:
-        parsed.query = upsertQueryParam(parsed.query, "auto", "format")
-      return $parsed
-    else:
-      return url
+  proc decodeImageChunks(chunks: seq[HttpBodyChunk], totalLen: int,
+      target: Image, fit: ScaledDecodeFit): Image =
+    ## Decodes an image whose bytes arrived in multiple download chunks.
+    ## PNGs stream straight from the chunks as inflate segments — no
+    ## contiguous copy of the file is ever assembled; other formats
+    ## coalesce into one buffer first.
+    let first = chunks[0]
+    if first.len > 8 and equalMem(first.data, pngSignature[0].unsafeAddr, 8) and
+        not target.isNil and target.width > 0 and target.height > 0:
+      GC_fullCollect()
+      when compiles(decodePngScaledInto([InflateSegment()], target, fit)):
+        var segments = newSeq[InflateSegment](chunks.len)
+        for i, chunk in chunks:
+          segments[i] = InflateSegment(
+            data: cast[ptr UncheckedArray[uint8]](chunk.data), len: chunk.len)
+        decodePngScaledInto(segments, target, fit)
+        return target
+    var data = newString(totalLen)
+    var pos = 0
+    for chunk in chunks:
+      if chunk.len > 0:
+        copyMem(addr data[pos], chunk.data, chunk.len)
+        pos += chunk.len
+    if not target.isNil and target.width > 0 and target.height > 0:
+      return decodeImageWithFallback(data, target, fit)
+    decodeImageWithFallback(data)
 
   proc downloadImageFromResolvedBuffer(url: string, maxBytes: int, target: Image = nil,
       headers: seq[SimpleHttpHeader] = @[], fit = fitCover):
@@ -584,7 +625,9 @@ when defined(frameosEmbedded):
       if response.code >= 400:
         raise newException(HttpRequestError, "HTTP " & response.status & httpErrorDetail(response))
       let image =
-        if not target.isNil:
+        if response.chunks.len > 1:
+          decodeImageChunks(response.chunks, response.bodyLen, target, fit)
+        elif not target.isNil:
           decodeImageWithFallback(response.body, response.bodyLen, target, fit)
         else:
           decodeImageWithFallback(response.body, response.bodyLen)

--- a/frameos/src/frameos/values.nim
+++ b/frameos/src/frameos/values.nim
@@ -37,7 +37,9 @@ template expectKind(v: Value; k: FieldKind) =
     raise newException(ValueError, "Value is " & $v.kind & ", expected " & $k)
 
 proc asString*(v: Value): string {.inline.} =
-  assert v.kind in {fkString, fkText}; v.s
+  if v.kind notin {fkString, fkText}:
+    raise newException(ValueError, "Value is " & $v.kind & ", expected fkString or fkText")
+  v.s
 proc asFloat*(v: Value): float64 {.inline.} =
   case v.kind
   of fkFloat:

--- a/frontend/src/models/embeddedUsbLogsModel.ts
+++ b/frontend/src/models/embeddedUsbLogsModel.ts
@@ -43,6 +43,7 @@ interface UsbLogSession {
 const sessions = new Map<number, UsbLogSession>()
 const lastPorts = new Map<number, SerialPort>()
 const usbApiCommandLocks = new Map<number, Promise<void>>()
+const serialPortReconnectEligible = new WeakMap<SerialPort, boolean>()
 
 interface EmbeddedUsbApiCommandOptions {
   payload?: string | Uint8Array
@@ -50,6 +51,11 @@ interface EmbeddedUsbApiCommandOptions {
   promptIfNeeded?: boolean
   port?: SerialPort
   mirrorOutput?: boolean
+  // Keep the port open after the command instead of close/reopen per call.
+  // Open/close churn toggles DTR/RTS, which can spuriously reset
+  // USB-Serial/JTAG boards — use this when polling (e.g. waiting for the
+  // board to boot after flashing).
+  keepOpen?: boolean
 }
 
 function sleep(ms: number): Promise<void> {
@@ -146,6 +152,73 @@ function appendSelectedUsbPort(frameId: number, port: SerialPort): void {
   lastPorts.set(frameId, port)
 }
 
+function serialPortIsConnected(port: SerialPort): boolean {
+  // SerialPort.connected is Chrome 117+; treat missing support as connected.
+  return (port as { connected?: boolean }).connected !== false
+}
+
+function matchingSerialPorts(original: SerialPort, ports: SerialPort[]): SerialPort[] {
+  const info = original.getInfo()
+  return ports.filter((port) => {
+    const portInfo = port.getInfo()
+    return portInfo.usbVendorId === info.usbVendorId && portInfo.usbProductId === info.usbProductId
+  })
+}
+
+/** Snapshot whether this is the only granted board with its VID/PID before an
+ * operation that may make it re-enumerate. Object identity is the only stable
+ * distinction Web Serial exposes for otherwise identical boards. */
+export async function prepareSerialPortReconnect(original: SerialPort): Promise<void> {
+  try {
+    const granted = matchingSerialPorts(original, await navigator.serial.getPorts())
+    serialPortReconnectEligible.set(original, granted.length === 1 && granted[0] === original)
+  } catch (error) {
+    // If the granted-port inventory cannot be inspected, fail closed and
+    // require an explicit selection instead of risking another board.
+    serialPortReconnectEligible.set(original, false)
+  }
+}
+
+export function serialPortReconnectRequiresReselection(original: SerialPort): boolean {
+  return serialPortReconnectEligible.get(original) === false
+}
+
+// When the board reboots (e.g. after flashing), its USB device re-enumerates
+// and the SerialPort object we hold goes permanently stale — every open()
+// fails with NetworkError. The replacement object is already granted, so it
+// shows up in getPorts(); match it by USB vendor/product id.
+export function isSerialPortGoneError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /failed to open serial port|device has been lost|port is closed/i.test(message)
+}
+
+export async function resolveLiveSerialPort(original: SerialPort): Promise<SerialPort | null> {
+  let ports: SerialPort[] = []
+  try {
+    ports = await navigator.serial.getPorts()
+  } catch (error) {
+    return null
+  }
+  const connected = matchingSerialPorts(original, ports).filter(serialPortIsConnected)
+  // Prefer the original object so a second board with the same vendor/product
+  // id is never picked while the original is still alive
+  if (connected.includes(original)) {
+    return original
+  }
+  if (serialPortReconnectEligible.get(original) !== true) {
+    return null
+  }
+  if (connected.length !== 1) {
+    if (connected.length > 1) {
+      serialPortReconnectEligible.set(original, false)
+    }
+    return null
+  }
+  const replacement = connected[0]
+  serialPortReconnectEligible.set(replacement, true)
+  return replacement
+}
+
 async function withUsbApiCommandLock<T>(frameId: number, operation: () => Promise<T>): Promise<T> {
   const previousLock = usbApiCommandLocks.get(frameId)
   if (previousLock) {
@@ -171,7 +244,19 @@ async function withUsbApiCommandLock<T>(frameId: number, operation: () => Promis
 }
 
 export function embeddedUsbApiCanUse(frameId: number): boolean {
-  return webSerialSupported() && (sessions.has(frameId) || lastPorts.has(frameId))
+  // Only claim USB is usable when the remembered port is still connected —
+  // a port granted earlier in the session goes stale once the board is
+  // unplugged, and callers that prefer USB over HTTP must fall through to
+  // the network path instead of timing out against a dead port.
+  if (!webSerialSupported()) {
+    return false
+  }
+  const sessionPort = sessions.get(frameId)?.port
+  if (sessionPort && serialPortIsConnected(sessionPort)) {
+    return true
+  }
+  const lastPort = lastPorts.get(frameId)
+  return lastPort !== undefined && serialPortIsConnected(lastPort)
 }
 
 export function embeddedUsbApiCanPrompt(): boolean {
@@ -247,7 +332,9 @@ function parseUsbCommandReady(command: string, text: string): boolean {
 
 function parseUsbCommandResult(command: string, text: string): EmbeddedUsbApiCommandResult | null {
   const expectedCommand = usbApiResponseCommand(command)
-  const errorMatch = text.match(/__FRAMEOS_USB_ERROR__\s+(\S+)\s+(\S+)\s*([^\r\n]*)/)
+  // Require the trailing newline so a chunk boundary mid-line can't
+  // truncate the error to its first characters ("image failed: E")
+  const errorMatch = text.match(/__FRAMEOS_USB_ERROR__\s+(\S+)\s+(\S+)[ \t]*([^\r\n]*)\r?\n/)
   if (errorMatch) {
     if (errorMatch[1] !== expectedCommand) {
       return null
@@ -320,7 +407,8 @@ async function runUsbApiCommandOnPort(
   command: string,
   payload?: Uint8Array,
   timeoutMs = 30000,
-  onText?: (text: string) => void
+  onText?: (text: string) => void,
+  keepOpen = false
 ): Promise<EmbeddedUsbApiCommandResult> {
   const encoder = new TextEncoder()
   const decoder = new TextDecoder()
@@ -334,7 +422,7 @@ async function runUsbApiCommandOnPort(
     onText?.(decoded)
   }
   try {
-    await openPort(port, { resetBaud: true })
+    await openPort(port, { resetBaud: !keepOpen })
     if (!port.readable || !port.writable) {
       throw new Error('USB serial port is not open')
     }
@@ -444,10 +532,10 @@ async function runEmbeddedUsbApiCommandLocked(
     throw new Error('No USB serial port selected for this frame')
   }
   appendSelectedUsbPort(frameId, port)
-  const payload =
-    typeof options?.payload === 'string'
-      ? new TextEncoder().encode(options.payload)
-      : options?.payload
+  if (!serialPortReconnectEligible.has(port)) {
+    await prepareSerialPortReconnect(port)
+  }
+  const payload = typeof options?.payload === 'string' ? new TextEncoder().encode(options.payload) : options?.payload
   appendUsbLine(frameId, `[USB API] ${command}${payload ? ` (${payload.byteLength} bytes)` : ''}`)
   if (payload) {
     appendUsbLine(frameId, `[USB API] waiting for ${command} ready marker`)
@@ -475,7 +563,41 @@ async function runEmbeddedUsbApiCommandLocked(
       message: `Sending USB command: ${command}`,
       status: 'connecting',
     })
-    const result = await runUsbApiCommandOnPort(port, command, payload, options?.timeoutMs, appendCommandLogText)
+    let result: EmbeddedUsbApiCommandResult
+    try {
+      result = await runUsbApiCommandOnPort(
+        port,
+        command,
+        payload,
+        options?.timeoutMs,
+        appendCommandLogText,
+        options?.keepOpen
+      )
+    } catch (error) {
+      const replacement = isSerialPortGoneError(error) ? await resolveLiveSerialPort(port) : null
+      if (!replacement || replacement === port) {
+        if (isSerialPortGoneError(error) && serialPortReconnectRequiresReselection(port)) {
+          if (lastPorts.get(frameId) === port) {
+            lastPorts.delete(frameId)
+          }
+          throw new Error(
+            'Multiple identical USB devices are available. Select the target board again before sending data.'
+          )
+        }
+        throw error
+      }
+      appendUsbLine(frameId, `[USB API] USB device re-enumerated; retrying ${command} on the new port`)
+      port = replacement
+      appendSelectedUsbPort(frameId, port)
+      result = await runUsbApiCommandOnPort(
+        port,
+        command,
+        payload,
+        options?.timeoutMs,
+        appendCommandLogText,
+        options?.keepOpen
+      )
+    }
     flushCommandLogText()
     appendUsbLine(frameId, `[USB API] ${command} complete`)
     return result
@@ -487,7 +609,9 @@ async function runEmbeddedUsbApiCommandLocked(
     if (hadLogStream) {
       await startEmbeddedUsbLogStream(frameId, port)
     } else {
-      await closePort(port)
+      if (!options?.keepOpen) {
+        await closePort(port)
+      }
       embeddedUsbLogsModel.actions.setUsbLogStreamState(frameId, {
         message: null,
         status: 'idle',

--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -111,8 +111,13 @@ const embeddedFirmwareRecoveryAttempts = new Map<number, number>()
 const EMBEDDED_FIRMWARE_RECOVERY_ATTEMPT_LIMIT = 2
 const embeddedUsbImageRefreshTimers = new Map<number, ReturnType<typeof window.setTimeout>>()
 const embeddedUsbImageRefreshesInFlight = new Set<number>()
+const embeddedUsbImageRefreshRetries = new Map<number, number>()
 const EMBEDDED_USB_IMAGE_REFRESH_DELAY_MS = 1500
 const EMBEDDED_USB_IMAGE_REFRESH_TIMEOUT_MS = 45000
+// The first render after a deploy takes minutes on e-paper; keep asking
+// until a preview exists (12 x 20s covers the slowest panels)
+const EMBEDDED_USB_IMAGE_RETRY_DELAY_MS = 20000
+const EMBEDDED_USB_IMAGE_RETRY_LIMIT = 12
 const EMBEDDED_USB_UPLOAD_MIN_TIMEOUT_MS = 45000
 const EMBEDDED_USB_UPLOAD_BASE_TIMEOUT_MS = 30000
 const EMBEDDED_USB_UPLOAD_TIMEOUT_MS_PER_KB = 250
@@ -231,14 +236,31 @@ async function refreshEmbeddedUsbFrameImage(frameId: number): Promise<void> {
       entityImagesModel.actions.updateEntityImage(`frames/${frameId}`, `scene_images/${sceneId}`)
     }
     socketLogic.actions.frameRendered(frameId)
+    embeddedUsbImageRefreshRetries.delete(frameId)
   } catch (error) {
-    console.warn('Failed to update frame image over USB', error)
+    const detail = error instanceof Error ? error.message : String(error)
+    if (/no preview rendered yet|preview snapshot was not retained/i.test(detail)) {
+      // Expected right after a deploy: the first render is still in
+      // progress. Quietly retry until a preview exists.
+      const attempts = (embeddedUsbImageRefreshRetries.get(frameId) ?? 0) + 1
+      if (attempts <= EMBEDDED_USB_IMAGE_RETRY_LIMIT) {
+        embeddedUsbImageRefreshRetries.set(frameId, attempts)
+        scheduleEmbeddedUsbFrameImageRefresh(frameId, EMBEDDED_USB_IMAGE_RETRY_DELAY_MS)
+      } else {
+        embeddedUsbImageRefreshRetries.delete(frameId)
+      }
+    } else {
+      console.warn('Failed to update frame image over USB', error)
+    }
   } finally {
     embeddedUsbImageRefreshesInFlight.delete(frameId)
   }
 }
 
-export function scheduleEmbeddedUsbFrameImageRefresh(frameId: number): void {
+export function scheduleEmbeddedUsbFrameImageRefresh(
+  frameId: number,
+  delayMs: number = EMBEDDED_USB_IMAGE_REFRESH_DELAY_MS
+): void {
   if (!embeddedUsbApiCanUse(frameId) || typeof window === 'undefined') {
     return
   }
@@ -251,7 +273,7 @@ export function scheduleEmbeddedUsbFrameImageRefresh(frameId: number): void {
     window.setTimeout(() => {
       embeddedUsbImageRefreshTimers.delete(frameId)
       void refreshEmbeddedUsbFrameImage(frameId)
-    }, EMBEDDED_USB_IMAGE_REFRESH_DELAY_MS)
+    }, delayMs)
   )
 }
 
@@ -656,9 +678,16 @@ export const framesModel = kea<framesModelType>([
       })
       try {
         const frame = values.frames[id]
+        let usbSucceeded = false
         if ((frame?.mode ?? 'rpios') === 'embedded' && embeddedUsbApiCanUse(id)) {
-          await runEmbeddedUsbApiCommand(id, 'render', { timeoutMs: 10000 })
-        } else {
+          try {
+            await runEmbeddedUsbApiCommand(id, 'render', { timeoutMs: 10000 })
+            usbSucceeded = true
+          } catch (error) {
+            // Stale/busy USB port — fall through to the HTTP event.
+          }
+        }
+        if (!usbSucceeded) {
           const response = await apiFetch(`/api/frames/${id}/event/render`, { method: 'POST' })
           if (!response.ok) {
             throw new Error('Failed to send render event')

--- a/frontend/src/scenes/frame/panels/Scenes/controlLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/controlLogic.tsx
@@ -145,18 +145,17 @@ export const controlLogic = kea<controlLogicType>([
         detail: scene?.name || sceneId,
       })
       try {
+        let usbSucceeded = false
         if ((values.frame?.mode ?? 'rpios') === 'embedded' && embeddedUsbApiCanUse(props.frameId)) {
-          await runEmbeddedUsbApiCommand(props.frameId, 'scene-payload', { payload: sceneId, timeoutMs: 10000 })
-          actions.currentSceneChanged(sceneId)
-          socketLogic.actions.updateFrame({ id: props.frameId, active_scene_id: sceneId } as FrameType)
-          longRunningTasksModel.actions.finishTask({
-            frameId: props.frameId,
-            kind: 'activate',
-            sceneId,
-            status: 'success',
-            detail: scene?.name || sceneId,
-          })
-        } else {
+          try {
+            await runEmbeddedUsbApiCommand(props.frameId, 'scene-payload', { payload: sceneId, timeoutMs: 10000 })
+            usbSucceeded = true
+          } catch (error) {
+            // A stale or busy USB port must not strand a network-reachable
+            // frame — fall through to the HTTP event below.
+          }
+        }
+        if (!usbSucceeded) {
           const response = await apiFetch(`/api/frames/${props.frameId}/event/setCurrentScene`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -166,16 +165,16 @@ export const controlLogic = kea<controlLogicType>([
             throw new Error('Failed to send scene activation event')
           }
           await response.text()
-          actions.currentSceneChanged(sceneId)
-          socketLogic.actions.updateFrame({ id: props.frameId, active_scene_id: sceneId } as FrameType)
-          longRunningTasksModel.actions.finishTask({
-            frameId: props.frameId,
-            kind: 'activate',
-            sceneId,
-            status: 'success',
-            detail: scene?.name || sceneId,
-          })
         }
+        actions.currentSceneChanged(sceneId)
+        socketLogic.actions.updateFrame({ id: props.frameId, active_scene_id: sceneId } as FrameType)
+        longRunningTasksModel.actions.finishTask({
+          frameId: props.frameId,
+          kind: 'activate',
+          sceneId,
+          status: 'success',
+          detail: scene?.name || sceneId,
+        })
       } catch (error) {
         longRunningTasksModel.actions.taskFailed({
           frameId: props.frameId,

--- a/frontend/src/scenes/frame/panels/Scenes/scenesLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/scenesLogic.tsx
@@ -709,14 +709,21 @@ export const scenesLogic = kea<scenesLogicType>([
           sceneId: scene.id,
           ...(resolvedState && Object.keys(resolvedState).length > 0 ? { state: resolvedState } : {}),
         }
+        let usbSucceeded = false
         if ((values.frame?.mode ?? 'rpios') === 'embedded' && embeddedUsbApiCanUse(props.frameId)) {
-          const payloadBytes = new TextEncoder().encode(JSON.stringify(payload))
-          await runEmbeddedUsbApiCommand(props.frameId, 'upload-scenes', {
-            payload: payloadBytes,
-            timeoutMs: embeddedUsbUploadTimeoutMs(payloadBytes.byteLength),
-          })
-          scheduleEmbeddedUsbFrameImageRefresh(props.frameId)
-        } else {
+          try {
+            const payloadBytes = new TextEncoder().encode(JSON.stringify(payload))
+            await runEmbeddedUsbApiCommand(props.frameId, 'upload-scenes', {
+              payload: payloadBytes,
+              timeoutMs: embeddedUsbUploadTimeoutMs(payloadBytes.byteLength),
+            })
+            scheduleEmbeddedUsbFrameImageRefresh(props.frameId)
+            usbSucceeded = true
+          } catch (error) {
+            // Stale/busy USB port — fall through to the HTTP event.
+          }
+        }
+        if (!usbSucceeded) {
           const response = await apiFetch(`/api/frames/${props.frameId}/event/uploadScenes`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { BoltIcon, CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
 import { useActions, useValues } from 'kea'
-import type { IEspLoaderTerminal, Transport as EspTransport } from 'esptool-js'
+import type { ESPLoader, IEspLoaderTerminal, Transport as EspTransport } from 'esptool-js'
 
 import { Spinner } from '../../components/Spinner'
 import {
@@ -9,14 +9,16 @@ import {
   embeddedUsbLogStreamSessionPort,
   embeddedUsbLogsModel,
   isEmbeddedUsbLogStreamOpen,
+  prepareSerialPortReconnect,
+  resolveLiveSerialPort,
   runEmbeddedUsbApiCommand,
+  serialPortReconnectRequiresReselection,
   startEmbeddedUsbLogStream,
   stopEmbeddedUsbLogStream,
 } from '../../models/embeddedUsbLogsModel'
 import { embeddedUsbUploadTimeoutMs, framesModel, scheduleEmbeddedUsbFrameImageRefresh } from '../../models/framesModel'
 import type { FrameType } from '../../types'
 import { apiFetch } from '../../utils/apiFetch'
-import { frameLogic } from '../frame/frameLogic'
 import { workspaceLogic } from './workspaceLogic'
 
 type FlashPhase = 'idle' | 'connecting' | 'preparing' | 'flashing' | 'done' | 'error'
@@ -27,15 +29,57 @@ type TraceableTransportInternals = { trace: (message: string) => void; lastTrace
 const FIRMWARE_POLL_INTERVAL_MS = 3000
 const FIRMWARE_POLL_TIMEOUT_MS = 10 * 60 * 1000
 const POST_FLASH_BOOT_WAIT_MS = 7000
-const POST_FLASH_USB_READY_TIMEOUT_MS = 120000
+// First boot after an erase-all flash formats the 24MB SPIFFS state
+// partition before the console starts — measured ~180s on a XIAO ESP32-S3
+// with 32MB flash. Wait well past that.
+const POST_FLASH_USB_READY_TIMEOUT_MS = 360000
 const POST_FLASH_USB_READY_COMMAND_TIMEOUT_MS = 8000
 const POST_FLASH_USB_READY_POLL_MS = 2500
+const POST_FLASH_USB_RESET_HINT_MS = 240000
 const POST_FLASH_SCENE_UPLOAD_ATTEMPTS = 3
 const POST_FLASH_SCENE_UPLOAD_RETRY_MS = 3000
 const ESP_FLASH_SIZES = new Set<EspFlashSize>(['4MB', '8MB', '16MB', '32MB'])
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// ESP32-S3 RTC_CNTL registers, values from esptool's targets/esp32s3.py
+const S3_RTC_CNTL_OPTION1_REG = 0x6000812c
+const S3_RTC_CNTL_FORCE_DOWNLOAD_BOOT_MASK = 0x1
+const S3_RTC_CNTL_WDTCONFIG0_REG = 0x60008098
+const S3_RTC_CNTL_WDTCONFIG1_REG = 0x6000809c
+const S3_RTC_CNTL_WDTWPROTECT_REG = 0x600080b0
+const S3_RTC_CNTL_WDT_WKEY = 0x50d83aa1
+// WDT_EN | STG0=reset system | sys reset length | cpu reset length
+const S3_RTC_WDT_RESET_CONFIG = (0x80000000 | (5 << 28) | (1 << 8) | 2) >>> 0
+
+// Reset the chip via the RTC watchdog, like `esptool --after watchdog-reset`.
+// A DTR/RTS reset pulse goes through the USB-Serial/JTAG strap logic, which on
+// some boards (XIAO ESP32-S3) latches the chip back into ROM download mode so
+// the app never boots after flashing (arduino-esp32#6762). The watchdog reset
+// runs over the flasher-stub protocol and never touches the strap pins.
+async function watchdogResetAfterFlash(loader: ESPLoader): Promise<boolean> {
+  if (loader.chip?.CHIP_NAME !== 'ESP32-S3') {
+    return false
+  }
+  try {
+    await loader.writeReg(S3_RTC_CNTL_OPTION1_REG, 0, S3_RTC_CNTL_FORCE_DOWNLOAD_BOOT_MASK)
+    await loader.writeReg(S3_RTC_CNTL_WDTWPROTECT_REG, S3_RTC_CNTL_WDT_WKEY)
+    await loader.writeReg(S3_RTC_CNTL_WDTCONFIG1_REG, 2000)
+  } catch (error) {
+    return false
+  }
+  // The watchdog fires ~20ms after the arming write — often before the
+  // arming or lock command's response makes it back, dropping the USB
+  // device mid-exchange. Errors from here on mean the reset happened,
+  // which is the success case.
+  try {
+    await loader.writeReg(S3_RTC_CNTL_WDTCONFIG0_REG, S3_RTC_WDT_RESET_CONFIG)
+    await loader.writeReg(S3_RTC_CNTL_WDTWPROTECT_REG, 0)
+  } catch (error) {}
+  await sleep(500)
+  return true
 }
 
 type FirmwareStatus = NonNullable<NonNullable<FrameType['embedded']>['firmware']>
@@ -223,7 +267,9 @@ async function ensureFirmwareReady(frameId: number, onStatus: (message: string) 
 }
 
 async function downloadFirmware(downloadUrl: string): Promise<Uint8Array> {
-  const response = await apiFetch(downloadUrl)
+  // Firmware paths are replaced in place after rebuilds. Bypass any older
+  // cached response even when talking to a backend that supplied a stable URL.
+  const response = await apiFetch(downloadUrl, { cache: 'no-store' })
   if (!response.ok) {
     throw new Error('Failed to download firmware image')
   }
@@ -253,6 +299,7 @@ async function uploadScenesOverUsbAfterFlash(
         payload,
         port,
         timeoutMs: embeddedUsbUploadTimeoutMs(payload.byteLength),
+        keepOpen: true,
       })
       return true
     } catch (error) {
@@ -291,31 +338,52 @@ function usbStatusSummary(text: string | undefined): string {
   }
 }
 
+// Returns the port the board answered on: the watchdog reset after flashing
+// re-enumerates the USB device, so the original SerialPort object may have
+// been replaced by a fresh grant from getPorts().
 async function waitForUsbApiReadyAfterFlash(
   frame: FrameType,
   port: SerialPort,
   onStatus: (message: string) => void
-): Promise<void> {
-  const deadline = Date.now() + POST_FLASH_USB_READY_TIMEOUT_MS
+): Promise<SerialPort> {
+  const started = Date.now()
+  const deadline = started + POST_FLASH_USB_READY_TIMEOUT_MS
   let attempt = 0
   let lastError: unknown = null
-  onStatus('Waiting for board USB API')
+  let resetHintShown = false
+  onStatus('Waiting for board USB API. A brand-new or fully erased board formats its storage first (~3 minutes).')
 
   while (Date.now() < deadline) {
     attempt += 1
+    const livePort = await resolveLiveSerialPort(port)
+    if (livePort && livePort !== port) {
+      appendBrowserFlashLog(frame.id, 'USB device re-enumerated after reboot; switching to the new port.')
+      port = livePort
+    } else if (!livePort && serialPortReconnectRequiresReselection(port)) {
+      throw new Error(
+        'Multiple identical USB devices are available. Select the target board again before uploading scenes.'
+      )
+    }
     try {
       const result = await runEmbeddedUsbApiCommand(frame.id, 'status', {
         port,
         timeoutMs: Math.min(POST_FLASH_USB_READY_COMMAND_TIMEOUT_MS, Math.max(1000, deadline - Date.now())),
         mirrorOutput: false,
+        keepOpen: true,
       })
       appendBrowserFlashLog(frame.id, usbStatusSummary(result.text))
-      return
+      return port
     } catch (error) {
       lastError = error
       if (attempt === 1 || attempt % 4 === 0) {
         const detail = error instanceof Error ? error.message : String(error)
         appendBrowserFlashLog(frame.id, `USB API not ready yet: ${detail}`)
+      }
+      if (!resetHintShown && Date.now() - started > POST_FLASH_USB_RESET_HINT_MS) {
+        resetHintShown = true
+        onStatus(
+          'Board still not responding after the storage-format window. Try pressing its RESET button — it may be stuck in download mode.'
+        )
       }
       await sleep(Math.min(POST_FLASH_USB_READY_POLL_MS, Math.max(0, deadline - Date.now())))
     }
@@ -325,7 +393,10 @@ async function waitForUsbApiReadyAfterFlash(
   throw new Error(`Timed out waiting for board USB API after reboot: ${detail}`)
 }
 
-function usbConnectionButtonLabel(usbLogStreamState: { status?: string } | undefined, usbLogStreamOpen: boolean): string {
+function usbConnectionButtonLabel(
+  usbLogStreamState: { status?: string } | undefined,
+  usbLogStreamOpen: boolean
+): string {
   return usbLogStreamState?.status === 'selecting'
     ? 'Select USB port'
     : usbLogStreamState?.status === 'connecting'
@@ -392,7 +463,6 @@ export function EmbeddedWebFlasher({
   const [phase, setPhase] = useState<FlashPhase>('idle')
   const [message, setMessage] = useState<string | null>(null)
   const [progress, setProgress] = useState<number | null>(null)
-  const { setDeployDrawerView } = useActions(frameLogic({ frameId: frame.id }))
   const { openFrameToolBehindDrawer } = useActions(workspaceLogic)
   const { usbLogStreamStatesByFrameId } = useValues(embeddedUsbLogsModel)
 
@@ -423,7 +493,10 @@ export function EmbeddedWebFlasher({
     setPhase('connecting')
     setProgress(null)
     setFlashMessage('Selecting USB port')
-    setDeployDrawerView('embedded')
+    // Do not switch drawer views here: the firmware section renders inline
+    // in the main deploy view too, and swapping views would unmount THIS
+    // component instance — the flash keeps running, but its progress bar
+    // and status messages update a dead instance and vanish.
     try {
       // Must run inside the click gesture, before any other await
       const activeLogPort = embeddedUsbLogStreamSessionPort(frame.id)
@@ -433,6 +506,7 @@ export function EmbeddedWebFlasher({
         setMessage(null)
         return
       }
+      await prepareSerialPortReconnect(port)
       openFrameToolBehindDrawer(frame.id, 'logs')
       appendBrowserFlashLog(frame.id, 'USB port selected')
 
@@ -457,29 +531,39 @@ export function EmbeddedWebFlasher({
       const firmware = await downloadFirmware(downloadUrl)
 
       setPhase('flashing')
-      setFlashMessage(`Erasing ${flashSize} flash and flashing ${Math.round(firmware.length / 1024)}KB to ${chip}`)
+      setFlashMessage(`Flashing ${Math.round(firmware.length / 1024)}KB to ${chip}`)
       await loader.writeFlash({
         fileArray: [{ data: firmware, address: flashOffset }],
         flashSize,
         flashMode: 'keep',
         flashFreq: 'keep',
-        // Browser flashing is our "known good" provisioning path. Erase first so
-        // stale NVS, old RF calibration, or cached scenes from an earlier
-        // partition layout cannot override the freshly baked frame defaults.
-        eraseAll: true,
+        // eraseAll off: the merged image's FF padding already overwrites NVS,
+        // otadata and RF calibration (they sit inside the written range), so
+        // the freshly baked frame defaults win. The state partition beyond it
+        // survives, sparing the ~3 minute SPIFFS format on every re-flash —
+        // scenes are re-uploaded by this flow right after boot anyway.
+        eraseAll: false,
         compress: true,
         reportProgress: (_fileIndex, written, total) => {
           setProgress(total > 0 ? Math.round((written / total) * 100) : null)
         },
       })
-      // esptool-js's built-in hard reset never asserts RTS, which leaves
-      // USB-Serial/JTAG boards (e.g. XIAO ESP32-S3) stuck in the flasher
-      // stub. Pulse the reset line the way the esptool CLI does.
-      await transport.setDTR(false)
-      await transport.setRTS(true)
-      await sleep(100)
-      await transport.setRTS(false)
-      await transport.setDTR(false)
+      // Prefer a watchdog reset: a DTR/RTS pulse can strap USB-Serial/JTAG
+      // boards back into ROM download mode instead of booting the app. Fall
+      // back to pulsing the reset line the way the esptool CLI does —
+      // esptool-js's built-in hard reset never asserts RTS at all.
+      if (!(await watchdogResetAfterFlash(loader))) {
+        try {
+          await transport.setDTR(false)
+          await transport.setRTS(true)
+          await sleep(100)
+          await transport.setRTS(false)
+          await transport.setDTR(false)
+        } catch (error) {
+          // The port disappears if the chip already reset mid-command; the
+          // post-flash USB API wait re-acquires it and sorts out the rest.
+        }
+      }
 
       setPhase('preparing')
       setProgress(null)
@@ -489,12 +573,11 @@ export function EmbeddedWebFlasher({
       setPhase('error')
       setProgress(null)
       const detail = error instanceof Error ? error.message : String(error)
-      const displayMessage =
-        /No port selected/i.test(detail)
-          ? null
-          : /Failed to open serial port/i.test(detail)
-          ? 'Could not open the serial port. Close other serial monitors and try again.'
-          : detail
+      const displayMessage = /No port selected/i.test(detail)
+        ? null
+        : /Failed to open serial port/i.test(detail)
+        ? 'Could not open the serial port. Close other serial monitors and try again.'
+        : detail
       setMessage(displayMessage)
       if (/No port selected/i.test(detail)) {
         setPhase('idle')
@@ -511,7 +594,7 @@ export function EmbeddedWebFlasher({
       if (streamLogsAfterFlash && port) {
         try {
           await sleep(POST_FLASH_BOOT_WAIT_MS)
-          await waitForUsbApiReadyAfterFlash(frame, port, setFlashMessage)
+          port = await waitForUsbApiReadyAfterFlash(frame, port, setFlashMessage)
           const scenesUploaded = await uploadScenesOverUsbAfterFlash(frame, port, setFlashMessage)
           if (scenesUploaded) {
             const completeResponse = await apiFetch(`/api/frames/${frame.id}/embedded/usb_deploy_complete`, {
@@ -524,6 +607,10 @@ export function EmbeddedWebFlasher({
             scheduleEmbeddedUsbFrameImageRefresh(frame.id)
             setPhase('done')
             setFlashMessage(`Firmware flashed and ${frame.scenes?.length ?? 0} scene(s) uploaded.`)
+            appendBrowserFlashLog(
+              frame.id,
+              'The frame is rendering its first scene — e-paper refreshes take a few minutes; the preview appears when it finishes.'
+            )
           } else {
             setPhase('done')
             setFlashMessage('Firmware flashed. No scenes configured to upload.')

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -52,7 +52,7 @@ import { buildRemoteUpgradeNotice, frameosGitHubReleaseUrl, type RemoteUpgradeNo
 import { frameCompilationModeOptions } from '../../utils/frameBuildOptions'
 import { logsLogic } from '../frame/panels/Logs/logsLogic'
 import { settingsLogic } from '../settings/settingsLogic'
-import { EmbeddedUsbConnectionButton, EmbeddedWebFlasher } from './EmbeddedWebFlasher'
+import { EmbeddedWebFlasher } from './EmbeddedWebFlasher'
 import { frameBootstrapLogic } from './frameBootstrapLogic'
 import { workspaceLogic } from './workspaceLogic'
 import { timezoneOptions } from '../../decorators/timezones'
@@ -1949,7 +1949,6 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
   const deployPlanLogs = deployPlanLogsSince(logs, deployPlansLoadingStartedAt)
   const isBuildrootFrame = (frame.mode ?? 'rpios') === 'buildroot'
   const isEmbeddedFrame = (frame.mode ?? 'rpios') === 'embedded'
-  const webSerialSupported = typeof navigator !== 'undefined' && 'serial' in navigator
   const embeddedFastDeployReady = isEmbeddedFrame && frameHasActivityLog(frame)
   const hasSuccessfulDeploy = Boolean(
     frame.last_successful_deploy_at || frame.last_successful_deploy || embeddedFastDeployReady
@@ -2048,8 +2047,8 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
             <EmbeddedFirmwareSection
               frame={frame}
               onBack={embeddedFastDeployReady ? showMainDeployView : undefined}
-              onDownload={() => closeAndRun(() => downloadEmbeddedFirmware(frame.id))}
-              onOtaUpdate={() => closeAndRun(() => applyEmbeddedFirmwareOta(frame.id))}
+              onDownload={() => downloadEmbeddedFirmware(frame.id)}
+              onOtaUpdate={() => applyEmbeddedFirmwareOta(frame.id)}
             />
           ) : activeDeployDrawerView === 'sdCard' ? (
             <BuildrootSdCardSection
@@ -2176,35 +2175,12 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
                       </div>
                     </section>
                   ) : null}
-                  {isEmbeddedFrame && webSerialSupported ? (
-                    <section className="space-y-2">
-                      <DrawerHeading>USB connection</DrawerHeading>
-                      <div className="frame-tool-card flex flex-wrap items-start justify-between gap-3 rounded-[22px] p-4">
-                        <div className="frame-tool-muted min-w-0 flex-1 text-sm leading-5">
-                          Connect this browser to the board over USB for browser flashing, previews, logs, and fast
-                          deploys when HTTP is unavailable.
-                          {needsEsp32UsbJtagPortGuidance(frame) ? (
-                            <span className="mt-2 block">
-                              For the 13.3&quot; ESP32 board, pick
-                              <span className="font-semibold text-[color:var(--tool-strong)]">
-                                {' '}
-                                USB JTAG/serial debug unit
-                              </span>
-                              {' '}
-                              for FrameOS logs, previews, fast deploy scene uploads, and browser flash with scene
-                              upload. Use
-                              <span className="font-semibold text-[color:var(--tool-strong)]">
-                                {' '}
-                                USB single serial
-                              </span>
-                              {' '}
-                              only for manual/recovery flashing; it cannot answer FrameOS USB commands after boot.
-                            </span>
-                          ) : null}
-                        </div>
-                        <EmbeddedUsbConnectionButton frame={frame} className="shrink-0" />
-                      </div>
-                    </section>
+                  {isEmbeddedFrame ? (
+                    <EmbeddedFirmwareSection
+                      frame={frame}
+                      onDownload={() => downloadEmbeddedFirmware(frame.id)}
+                      onOtaUpdate={() => closeAndRun(() => applyEmbeddedFirmwareOta(frame.id))}
+                    />
                   ) : null}
                   {deployChangeDetails.length > 0 ? (
                     <section className="space-y-2">
@@ -2220,7 +2196,6 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
                     </section>
                   ) : null}
                   <DeployBuildOptionsSection frame={frame} frameForm={frameForm} />
-                  {isEmbeddedFrame ? <FirmwareFootprintVisualization frame={frame} /> : null}
                 </div>
               )}
             </>
@@ -2306,15 +2281,7 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
               >
                 Fast deploy
               </button>
-              {isEmbeddedFrame ? (
-                <button
-                  type="button"
-                  onClick={() => showDeployDrawerView('embedded')}
-                  className="frameos-secondary-button rounded-lg px-4 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-                >
-                  Firmware
-                </button>
-              ) : (
+              {!isEmbeddedFrame ? (
                 <button
                   type="button"
                   onClick={() => closeAndRun(saveAndFullDeployFrame)}
@@ -2325,7 +2292,7 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
                 >
                   Full deploy
                 </button>
-              )}
+              ) : null}
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

Split out of #257 (FrameOS Cloud link). Device runtime, firmware pipeline, and embedded frontend workflows:

### Device runtime (Nim + ESP-IDF glue)
- Streaming decode of multi-MB PNGs and chunked HTTP bodies — downloads are no longer size-limited by socket fragmentation
- Image download failures paint an error frame instead of "No image provided"; render errors paint into the live canvas
- Frame-sized images are not pinned in the scene node cache; OOM-aborted renders that leak the heap beyond recovery trigger a restart
- Serialized `scenes.json` writers; console polls sleep a full tick
- Documented the **no-image-proxies-for-frames** rule (AGENTS.md, ESP32 README, code comments)

### Firmware pipeline (backend)
- Content-addressed firmware download URLs with `no-store` responses
- Stale firmware cache invalidates on source changes
- Reliable OTA acknowledgement; the state partition survives re-flashing

### Frontend (USB / flasher)
- USB serial render lifecycle events with Pi event parity; post-deploy USB preview retries until the first render exists
- USB commands fall back to HTTP when the port is stale; boards that re-enumerate among identical devices require explicit reselection
- Flasher keeps progress visible after the inline-controls move; reliable post-flash reboot and reconnect

## Test plan
- `pytest app/api/tests/test_embedded_firmware.py app/api/tests/test_embedded_device.py` — 61 passed
- `nim c -r src/frameos/tests/test_embedded_image_url.nim` and `test_interpreter_errors.nim` — all green
- `pnpm --dir frontend run build` — typecheck + build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)