### PR TITLE
Cloud link/login security review and fixes

### DIFF
--- a/backend/app/api/cloud.py
+++ b/backend/app/api/cloud.py
@@ -16,7 +16,7 @@ import secrets
 from http import HTTPStatus
 
 from arq import ArqRedis as Redis
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -43,6 +43,27 @@ from . import api_open, api_user
 
 CLOUD_LOGIN_STATE_PREFIX = "cloud_login_state:"
 CLOUD_LOGIN_STATE_TTL_SECONDS = 600
+CLOUD_LOGIN_STATE_COOKIE = "frameos_cloud_login_state"
+
+
+def _set_login_state_cookie(request: Request, response: Response, state: str) -> None:
+    """Bind a login handoff to the browser that started it.
+
+    The Redis state alone only proves *a* handoff is in flight, not that this
+    browser began it: without the cookie, anyone who can reach /start can mint
+    a state, and a leaked or attacker-held code can then be replayed into this
+    callback (logging the victim into the attacker's account, or the attacker
+    into the victim's). See RFC 6749 §10.12.
+    """
+    response.set_cookie(
+        CLOUD_LOGIN_STATE_COOKIE,
+        state,
+        max_age=CLOUD_LOGIN_STATE_TTL_SECONDS,
+        httponly=True,
+        samesite="lax",
+        secure=_should_use_secure_cookie(request),
+        path="/api/cloud/login",
+    )
 
 # Scopes a link may request; must stay in sync with the table in CLOUD-TODO.md
 # and docs/cloud-link.md.
@@ -564,8 +585,13 @@ async def _handoff_authorization_url(
     user_id: int | None,
     intent: str,
     return_origin: str | None = None,
-) -> str:
-    """Start a login handoff with the provider and remember our state token."""
+) -> tuple[str, str]:
+    """Start a login handoff with the provider and remember our state token.
+
+    Returns (authorization_url, state). Callers must hand the state to the
+    browser as a cookie and require it back at the callback, so only the
+    browser that started a handoff can complete it.
+    """
     access_token = cloud.decrypt_cloud_secret(link.access_token)
     if not access_token or not link.local_origin:
         raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="The cloud link is incomplete; reconnect first")
@@ -600,7 +626,7 @@ async def _handoff_authorization_url(
         ),
         ex=CLOUD_LOGIN_STATE_TTL_SECONDS,
     )
-    return str(response["authorization_url"])
+    return str(response["authorization_url"]), state
 
 
 @api_open.get("/cloud/login/options", response_model=CloudLoginOptionsResponse)
@@ -622,6 +648,7 @@ async def cloud_login_options(db: Session = Depends(get_db)):
 @api_open.post("/cloud/login/start", response_model=CloudLoginStartResponse)
 async def cloud_login_start(
     request: Request,
+    response: Response,
     data: CloudLoginStartRequest,
     db: Session = Depends(get_db),
     redis: Redis = Depends(get_redis),
@@ -635,7 +662,7 @@ async def cloud_login_start(
             detail="The cloud link is missing the auth:login permission; reconnect with it enabled",
         )
     setup_mode = db.query(User).first() is None
-    authorization_url = await _handoff_authorization_url(
+    authorization_url, state = await _handoff_authorization_url(
         link,
         redis,
         mode="login",
@@ -644,12 +671,14 @@ async def cloud_login_start(
         intent="signup" if setup_mode else "login",
         return_origin=_browser_origin(request),
     )
+    _set_login_state_cookie(request, response, state)
     return {"authorization_url": authorization_url}
 
 
 @api_user.post("/cloud/identity/link", response_model=CloudLoginStartResponse)
 async def cloud_identity_link_start(
     request: Request,
+    response: Response,
     data: CloudLoginStartRequest,
     db: Session = Depends(get_db),
     redis: Redis = Depends(get_redis),
@@ -668,7 +697,7 @@ async def cloud_identity_link_start(
             status_code=HTTPStatus.FORBIDDEN,
             detail="The cloud link is missing the auth:login permission; reconnect with it enabled",
         )
-    authorization_url = await _handoff_authorization_url(
+    authorization_url, state = await _handoff_authorization_url(
         link,
         redis,
         mode="link",
@@ -677,6 +706,7 @@ async def cloud_identity_link_start(
         intent="login",
         return_origin=_browser_origin(request),
     )
+    _set_login_state_cookie(request, response, state)
     return {"authorization_url": authorization_url}
 
 
@@ -713,6 +743,13 @@ async def cloud_login_callback(
 ):
     """The browser lands here after approving (or failing) a cloud login."""
     if not state:
+        return _login_redirect("invalid_state")
+    # Only the browser that started the handoff may finish it: a live Redis
+    # state proves a handoff exists, not who began it (see
+    # _set_login_state_cookie). Checked before the state is consumed, so a
+    # forged callback cannot burn the real one.
+    state_cookie = request.cookies.get(CLOUD_LOGIN_STATE_COOKIE) or ""
+    if not secrets.compare_digest(state_cookie, state):
         return _login_redirect("invalid_state")
     state_raw = await redis.get(f"{CLOUD_LOGIN_STATE_PREFIX}{state}")
     if state_raw:

--- a/backend/app/api/tests/test_cloud_login.py
+++ b/backend/app/api/tests/test_cloud_login.py
@@ -452,3 +452,68 @@ async def test_disconnect_reenables_local_fallback(async_client, db, redis, logi
         "/api/login", data={"username": "test@example.com", "password": "testpassword"}
     )
     assert login.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_login_callback_requires_state_cookie(async_client, db, redis, login_handoff):
+    """A live state alone must not complete a handoff.
+
+    Without binding the state to the browser that started it, anyone able to
+    call the open /start endpoint could hand the resulting callback URL to a
+    victim (logging them into the attacker's account), or replay a leaked code
+    from their own browser to take over the owner's session.
+    """
+    calls, _ = login_handoff
+    make_connected_link(db)
+    state = await _start_and_get_state(async_client, calls)
+
+    async_client.cookies.delete("frameos_cloud_login_state")
+    response = await async_client.get(f"/api/cloud/login/callback?code=abc&state={state}")
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login?cloudError=invalid_state"
+
+    # The forged callback must not have consumed the real handoff either.
+    assert await redis.get(f"cloud_login_state:{state}") is not None
+
+
+@pytest.mark.asyncio
+async def test_login_callback_rejects_mismatched_state_cookie(async_client, db, redis, login_handoff):
+    calls, _ = login_handoff
+    make_connected_link(db)
+    state = await _start_and_get_state(async_client, calls)
+
+    async_client.cookies.set("frameos_cloud_login_state", "some-other-state")
+    response = await async_client.get(f"/api/cloud/login/callback?code=abc&state={state}")
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login?cloudError=invalid_state"
+
+
+@pytest.mark.asyncio
+async def test_cloud_created_user_can_set_a_recovery_password(no_auth_client, db, redis, login_handoff):
+    """Cloud signup leaves password NULL; that user must still be able to set one.
+
+    Otherwise a later broken link (revoked, provider gone, or cloud disabled)
+    locks them out permanently, with no recovery short of editing the database.
+    """
+    calls, _ = login_handoff
+    make_connected_link(db)
+
+    await no_auth_client.post("/api/cloud/login/start", json={})
+    state = calls["start"][0][2]["state"]
+    await no_auth_client.get(f"/api/cloud/login/callback?code=abc&state={state}")
+
+    user = db.query(User).first()
+    assert user is not None
+    assert user.password is None  # cloud-created: no local password
+    # An empty password must never authenticate a passwordless user.
+    assert not user.check_password("")
+
+    response = await no_auth_client.post(
+        "/api/user/password",
+        json={"password": "a-recovery-password", "password2": "a-recovery-password"},
+    )
+    assert response.status_code == 200, response.text
+
+    db.refresh(user)
+    assert user.check_password("a-recovery-password")
+    assert not user.check_password("")

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -75,10 +75,16 @@ def api_user_update_password(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_local_user),
 ):
-    if not data.current_password:
-        raise HTTPException(status_code=400, detail="Current password is required.")
-    if not current_user.check_password(data.current_password):
-        raise HTTPException(status_code=400, detail="Current password is incorrect.")
+    # A cloud-created user has no local password at all (cloud signup leaves it
+    # NULL). Requiring the current one would leave them no way to ever set one,
+    # so if the cloud link later breaks — revoked, provider gone, or
+    # FRAMEOS_CLOUD_URL=disabled — they would be locked out with no recovery
+    # short of editing the database. They are already authenticated here.
+    if current_user.password:
+        if not data.current_password:
+            raise HTTPException(status_code=400, detail="Current password is required.")
+        if not current_user.check_password(data.current_password):
+            raise HTTPException(status_code=400, detail="Current password is incorrect.")
     if not data.password:
         raise HTTPException(status_code=400, detail="New password is required.")
     if data.password != data.password2:

--- a/backend/app/cloud/sync.py
+++ b/backend/app/cloud/sync.py
@@ -79,12 +79,39 @@ class CloudSync:
         db = SessionLocal()
         try:
             link = current_cloud_backend_link(db)
-            token = (
-                cloud_link.decrypt_cloud_secret(link.access_token)
-                if link is not None and link.status == "connected"
-                else None
-            )
-            return link, token, link.id if link else 0
+            if link is None or link.status != "connected":
+                return link, None, link.id if link else 0
+
+            token = cloud_link.decrypt_cloud_secret(link.access_token)
+            if token is None:
+                # The stored token cannot be decrypted with any configured key,
+                # which in practice means SECRET_KEY changed without
+                # CLOUD_SECRET_KEY / PREVIOUS_SECRET_KEYS being set. Say so
+                # instead of silently doing nothing forever while the UI keeps
+                # reporting the link as connected.
+                if link.poll_error != "secret_key_changed":
+                    link.poll_error = "secret_key_changed"
+                    db.commit()
+                print(
+                    "🔴 FrameOS Cloud sync: the stored link token cannot be decrypted. "
+                    "SECRET_KEY most likely changed; set PREVIOUS_SECRET_KEYS to the old value "
+                    "to recover (and CLOUD_SECRET_KEY to decouple them from now on), or "
+                    "reconnect the cloud link. See docs/cloud-link.md."
+                )
+                return link, None, link.id
+
+            # A rotation is in progress: migrate this secret to the current key
+            # so the old one can be dropped after a sync cycle.
+            rewrapped = cloud_link.rewrap_cloud_secret(link.access_token)
+            if rewrapped is not None:
+                link.access_token = rewrapped
+                db.commit()
+                print("🔵 FrameOS Cloud sync: re-encrypted the link token with the current key")
+            elif link.poll_error == "secret_key_changed":
+                link.poll_error = None
+                db.commit()
+
+            return link, token, link.id
         finally:
             db.close()
 

--- a/backend/app/cloud/tests/test_sync.py
+++ b/backend/app/cloud/tests/test_sync.py
@@ -115,3 +115,52 @@ async def test_sync_link_keeps_state_on_network_error(db, service, monkeypatch):
     db.expire_all()
     link = db.get(CloudBackendLink, link.id)
     assert link.status == "connected"
+
+
+# ---- secret key rotation ------------------------------------------------------
+
+
+def test_rotating_secret_key_without_migration_keys_breaks_the_link(db, monkeypatch):
+    """The failure mode this guards: SECRET_KEY changes, the token becomes
+    undecryptable, and the link silently does nothing while still reporting
+    "connected". It must at least be reported."""
+    link = make_connected_link(db)
+    monkeypatch.setattr(cloud_link.config, "SECRET_KEY", "a-brand-new-secret-key")
+    monkeypatch.setattr(cloud_link.config, "CLOUD_SECRET_KEY", "")
+    monkeypatch.setattr(cloud_link.config, "PREVIOUS_SECRET_KEYS", [])
+
+    loaded, token, _ = CloudSync()._load_link()
+    assert token is None
+    db.refresh(link)
+    assert link.poll_error == "secret_key_changed"
+
+
+def test_previous_secret_keys_recover_and_migrate_the_token(db, monkeypatch):
+    """Naming the old key recovers the link, and the token is re-encrypted with
+    the new one so the old key can be dropped."""
+    link = make_connected_link(db)
+    original = link.access_token
+    old_key = cloud_link.config.SECRET_KEY
+    monkeypatch.setattr(cloud_link.config, "SECRET_KEY", "a-brand-new-secret-key")
+    monkeypatch.setattr(cloud_link.config, "CLOUD_SECRET_KEY", "")
+    monkeypatch.setattr(cloud_link.config, "PREVIOUS_SECRET_KEYS", [old_key])
+
+    loaded, token, _ = CloudSync()._load_link()
+    assert token == "link-token-secret"
+    db.refresh(link)
+    assert link.poll_error is None
+    assert link.access_token != original  # migrated to the current key
+
+    # Now decryptable without the old key at all.
+    monkeypatch.setattr(cloud_link.config, "PREVIOUS_SECRET_KEYS", [])
+    assert cloud_link.decrypt_cloud_secret(link.access_token) == "link-token-secret"
+
+
+def test_cloud_secret_key_decouples_cloud_secrets_from_secret_key(db, monkeypatch):
+    """With CLOUD_SECRET_KEY set, SECRET_KEY can be rotated freely."""
+    monkeypatch.setattr(cloud_link.config, "CLOUD_SECRET_KEY", "a-dedicated-cloud-key")
+    encrypted = cloud_link.encrypt_cloud_secret("link-token-secret")
+
+    monkeypatch.setattr(cloud_link.config, "SECRET_KEY", "rotated-again")
+    assert cloud_link.decrypt_cloud_secret(encrypted) == "link-token-secret"
+    assert cloud_link.rewrap_cloud_secret(encrypted) is None  # nothing to migrate

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,16 @@ class Config:
     DEBUG = get_bool_env('DEBUG')
     TEST = get_bool_env('TEST')
     SECRET_KEY = os.environ.get('SECRET_KEY') or secrets.token_urlsafe(32)
+    # Cloud link secrets are encrypted with CLOUD_SECRET_KEY when set, else
+    # SECRET_KEY. Set it to decouple them, so SECRET_KEY can be rotated without
+    # killing the cloud link. PREVIOUS_SECRET_KEYS (comma separated) are tried
+    # on decrypt only; stored secrets are re-encrypted with the current key as
+    # they are read, so old keys can be dropped after a sync cycle.
+    # See docs/cloud-link.md.
+    CLOUD_SECRET_KEY = os.environ.get('CLOUD_SECRET_KEY') or ''
+    PREVIOUS_SECRET_KEYS = [
+        key.strip() for key in (os.environ.get('PREVIOUS_SECRET_KEYS') or '').split(',') if key.strip()
+    ]
     DATABASE_URL = os.environ.get('DATABASE_URL') or 'sqlite:///../db/frameos.db'
     REDIS_URL = os.environ.get('REDIS_URL') or 'redis://localhost:6379/0'
     INSTANCE_ID = INSTANCE_ID

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -15,4 +15,9 @@ class User(Base):
         self.password = generate_password_hash(password)
 
     def check_password(self, password):
+        # Cloud-created users have no local password; without this guard
+        # check_password_hash(None, ...) raises AttributeError — a 500 that
+        # also echoes the internal error back to the caller.
+        if not self.password:
+            return False
         return check_password_hash(self.password, password)

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -9,7 +9,9 @@ class UserResponse(BaseModel):
 
 
 class UserPasswordUpdate(BaseModel):
-    current_password: str
+    # Optional so a cloud-created user (no local password yet) can set a
+    # recovery one; the route still requires it whenever a password exists.
+    current_password: str | None = None
     password: str
     password2: str
 

--- a/backend/app/utils/cloud_link.py
+++ b/backend/app/utils/cloud_link.py
@@ -54,24 +54,68 @@ def default_cloud_provider_url() -> str | None:
     return normalize_cloud_provider_url(config.FRAMEOS_CLOUD_URL)
 
 
-def _cloud_fernet() -> Fernet:
-    digest = hashlib.sha256(config.SECRET_KEY.encode()).digest()
+def _fernet_for(key: str) -> Fernet:
+    digest = hashlib.sha256(key.encode()).digest()
     return Fernet(base64.urlsafe_b64encode(digest))
+
+
+def cloud_secret_keys() -> list[str]:
+    """Keys that may decrypt stored cloud secrets, newest first.
+
+    The first entry also encrypts. By default that is SECRET_KEY, so nothing
+    changes for existing installs — but rotating SECRET_KEY would otherwise
+    make every stored link token undecryptable, leaving the link dead while it
+    still reported "connected". Two escape hatches:
+
+    - CLOUD_SECRET_KEY pins cloud secrets to their own key, so SECRET_KEY can
+      be rotated freely without touching them.
+    - PREVIOUS_SECRET_KEYS (comma separated) are tried on decrypt only, so a
+      rotation can be rolled out without re-linking. Secrets are re-encrypted
+      with the current key as they are read (see rewrap_cloud_secret), so the
+      old keys can be dropped once every link has synced.
+    """
+    keys: list[str] = []
+    for candidate in (config.CLOUD_SECRET_KEY, config.SECRET_KEY, *config.PREVIOUS_SECRET_KEYS):
+        if candidate and candidate not in keys:
+            keys.append(candidate)
+    return keys
 
 
 def encrypt_cloud_secret(value: str | None) -> str | None:
     if not value:
         return None
-    return _cloud_fernet().encrypt(value.encode()).decode()
+    return _fernet_for(cloud_secret_keys()[0]).encrypt(value.encode()).decode()
 
 
 def decrypt_cloud_secret(value: str | None) -> str | None:
     if not value:
         return None
-    try:
-        return _cloud_fernet().decrypt(value.encode()).decode()
-    except (InvalidToken, UnicodeDecodeError):
+    for key in cloud_secret_keys():
+        try:
+            return _fernet_for(key).decrypt(value.encode()).decode()
+        except (InvalidToken, UnicodeDecodeError):
+            continue
+    return None
+
+
+def rewrap_cloud_secret(value: str | None) -> str | None:
+    """Re-encrypt a secret under the current key, or None if already current.
+
+    Lets a caller that holds a database session migrate stored secrets after a
+    key change, without asking the user to re-link.
+    """
+    if not value:
         return None
+    keys = cloud_secret_keys()
+    try:
+        _fernet_for(keys[0]).decrypt(value.encode())
+        return None  # already encrypted with the current key
+    except (InvalidToken, UnicodeDecodeError):
+        pass
+    plaintext = decrypt_cloud_secret(value)
+    if plaintext is None:
+        return None
+    return encrypt_cloud_secret(plaintext)
 
 
 def cloud_api_url(provider_url: str, path: str) -> str:

--- a/docs/cloud-link.md
+++ b/docs/cloud-link.md
@@ -41,6 +41,35 @@ with the link and wins over the environment default.
 On a frame, link state (including the URL) lives in `./state/cloud_link.json`
 next to the FrameOS binary; there is no environment toggle.
 
+### Encryption of the stored link token, and rotating `SECRET_KEY`
+
+The backend stores the link token encrypted. By default the encryption key is
+derived from `SECRET_KEY`, which means **rotating `SECRET_KEY` would otherwise
+make the stored token undecryptable — the link keeps reporting "connected"
+while every cloud request silently stops working.** Two variables exist so a
+rotation never costs you the link:
+
+| Variable | Meaning |
+|---|---|
+| `CLOUD_SECRET_KEY` | Encrypt cloud secrets with this instead of `SECRET_KEY`. Set it once and `SECRET_KEY` can be rotated freely afterwards. |
+| `PREVIOUS_SECRET_KEYS` | Comma-separated old keys, tried on decrypt only. |
+
+To rotate `SECRET_KEY` on an install that is already linked:
+
+1. Put the old value in `PREVIOUS_SECRET_KEYS`, set the new `SECRET_KEY`, and
+   restart the backend **and** the worker.
+2. The next grant sync (immediately on worker start, then every 15 minutes)
+   re-encrypts the token with the new key and logs
+   `🔵 re-encrypted the link token with the current key`.
+3. Once that has run, drop `PREVIOUS_SECRET_KEYS`.
+
+Set `CLOUD_SECRET_KEY` to avoid the dance entirely next time.
+
+If a token cannot be decrypted with any configured key, the sync worker logs a
+red error and sets `poll_error = "secret_key_changed"` on the link instead of
+failing silently. Recovery is either naming the old key in
+`PREVIOUS_SECRET_KEYS` or reconnecting the link.
+
 ## Permission scopes
 
 Requested at link time, shown on the provider's consent screen, and returned

--- a/docs/cloud-security-review.md
+++ b/docs/cloud-security-review.md
@@ -1,0 +1,127 @@
+# Cloud Link & Login — Security Review (2026-08)
+
+Review of the merged cloud work (device-flow linking, cloud login handoff)
+across this repo and the FrameOS Cloud service. Fixed items are marked; the
+rest are open, ordered by severity, with the attack that motivates them.
+
+## Fixed in this pass
+
+- **Login handoff was not bound to the browser** (HIGH). The `state` token
+  lived only server-side (Redis on the backend, `login_states` on the frame),
+  so it proved a handoff was in flight, not who began it. Anyone able to call
+  the open `/api/cloud/login/start` could hand the resulting callback URL to a
+  victim (logging them into the attacker's account), and a leaked code could be
+  replayed from the attacker's browser to take over the owner's session. Now
+  also a `HttpOnly`/`SameSite=Lax`/path-scoped cookie, required to match at the
+  callback, checked before the state is consumed.
+- **Frame skipped its owner check when the owner was unknown** (`account_id`
+  absent because the grants call failed during connect) and minted an admin
+  session on the provider's word. Now refuses and re-syncs.
+- **`/api/cloud/poll` held the global cloud lock across two outbound cloud
+  requests** — a slow provider froze every cloud route for 70 s+. Sync moved
+  outside the lock.
+- **`login_states` grew unboundedly** from the open `/login/start`, so every
+  later cloud request re-parsed and rewrote a growing file under that lock
+  (O(n²)). Capped at 16.
+- **The open `/login/callback` rewrote the state file on every bogus request**
+  (SD-card wear + lock contention). Now writes only when pruning changed
+  something.
+- **Passwordless lockout**: cloud-created users have no local password and the
+  change-password route demanded the current one, so a later broken link locked
+  them out permanently. Setting a first password no longer requires it;
+  `check_password` no longer raises on a NULL hash.
+- **Cloud: silent scope escalation** — `backup:*` and `store:publish` were
+  auto-granted without consent; `backup:*` reads *all* account backups.
+  Auto-grant set is now empty.
+- **Cloud: stored copy of live link tokens** — `encrypted_refresh_token` was
+  never cleared after the single-use poll, so a DB dump plus the key yielded
+  every active token. Nulled on redemption and rotation.
+
+## Open — device (Nim)
+
+1. **DNS is unbounded by any timeout** (HIGH). `connect()` calls `getAddrInfo`
+   before applying its timeout, and `boundedRequest` re-resolves per redirect
+   (up to 6). With blackholed DNS, one unauthenticated `/api/cloud/login/start`
+   per worker thread (1–4 requests) wedges the whole HTTP server for minutes,
+   repeatably. Fix: resolve once per request, count DNS against the deadline,
+   cap cloud redirects.
+2. **No rate limiting anywhere** (`grep` finds none in `frameos/src`). The open
+   `/login/start` also makes one authenticated cloud request per call —
+   unlimited amplification toward the cloud from any LAN client.
+3. **50 MB request bodies are buffered before any auth check**
+   (`MAX_HTTP_BODY_LEN`), and mummy has no connection cap. ~10 slow uploads on
+   a 512 MB frame → cgroup OOM under `MemoryMax=90%` → `Restart=always` crash
+   loop. This is the one path that turns a DoS into a restart loop; lock
+   contention alone does **not** starve the systemd watchdog (the runner thread
+   heartbeats independently — verified).
+4. **`frame.json` is re-read and re-parsed up to 3× per auth check**, before the
+   401. Multiplies every flood; cache it.
+5. `/api/cloud/login/options` is unauthenticated and takes the lock + reads the
+   state file on every hit; it also discloses the configured provider URL.
+6. The link token is stored **plaintext** in `state/cloud_link.json` (mode
+   0600), where the backend encrypts its copy.
+
+## Open — backend (Python)
+
+7. **`/api/cloud/setup/*` is unauthenticated while no user exists** (MEDIUM). A
+   LAN attacker can pre-link a fresh install to *their* cloud account with
+   attacker-chosen scopes, and `setup/status` returns the pending `user_code`.
+   The owner then completes signup and never notices. Fix: bind setup actions
+   to a locally displayed one-time token, or force re-approval when the first
+   user is created.
+8. **`local_origin` comes from `Host`/`X-Forwarded-Host` with no trusted-proxy
+   config**, and it governs the login `redirect_uri` allowlist, the logout
+   `return_to` allowlist, and the installs iframe target.
+9. **Local sessions are not revocable** — a self-contained Fernet cookie with no
+   server-side record, 7-day lifetime versus the cloud's 8-hour session.
+   Revoking the link (or the cloud session) leaves local access valid for up to
+   7 days. Mirror the cloud's session table.
+10. `http://` providers are accepted; over plain HTTP an on-path attacker can
+    forge grants (forcing a link reset) or identity claims. Require https
+    except for loopback.
+11. `_allowed_return_origin` accepts any loopback origin from the caller's
+    `Origin` header (self-redirect only, low impact).
+
+## Open — cloud service
+
+12. **Device-flow phishing** (HIGH). `/api/device/start` is unauthenticated with
+    fully attacker-chosen `public_display_name`/`local_origin`, and
+    `verification_uri_complete` auto-runs the lookup, so a victim is one click
+    from approving an attacker's link. `safeLocalOrigin` does not require a
+    private address despite the name. Fix: constrain `local_origin` to
+    loopback/RFC1918/`.local`, label it unverified, stop auto-submitting, and
+    add a confirmation step; consider refusing `auth:login`/`remote:access` on a
+    first link.
+13. **Poll rate limit is below the protocol's own polling rate** — 120 req /
+    15 min / IP versus exactly 120 polls per 10-minute flow at `interval: 5`.
+    Two installs behind one NAT starve each other, and both clients treat 429 as
+    fatal and tear the link down. Key the limit on `device_code` and make 429
+    retryable.
+14. `frameos_login_codes.profile` (email, name, subject) has no retention job;
+    null it on redemption and purge expired rows.
+15. `auth:login` scope is checked at `/start` but not at `authorize`/`token`, so
+    a 10-minute request JWT outlives a scope revocation.
+16. User codes are unsalted SHA-256 with the first 4 chars stored in clear —
+    trivially reversible by a DB reader. HMAC with a pepper.
+17. Rate limiting is in-memory per-process; it is the primary brute-force
+    control on `device:authorize`.
+
+## Answered questions
+
+- **Does an offline server sever the link?** No. `linked_clients` has no
+  expiry, `last_seen_at` is never read by any query, cleanup never touches
+  links, and the backend never auto-disconnects or rotates. Only an explicit
+  401 (genuinely revoked) resets it — and that deliberately re-enables local
+  password login. Caveat: changing `SECRET_KEY` silently kills the link (the
+  token cannot be decrypted) while it still displays as connected.
+- **Can a passwordless user log in if the link is broken?** No, and there is no
+  fall-open path: every failure mode (cloud down, 500, timeout, revoked,
+  disabled) fails closed, and `not user.password` is checked before the hash
+  comparison. The real risk was the opposite — permanent lockout — now fixed.
+- **Can we hide local login on the frame when only cloud login is available?**
+  The backend already does this (`local_login_enabled` from
+  `/api/cloud/login/options`, enforced with a 403, and only disableable while a
+  live grants check passes so you cannot lock yourself out). The frame
+  hardcodes `local_login_enabled: true` and its UI ignores the field. Making it
+  real needs the flag persisted in the frame's cloud-link state plus
+  enforcement in the admin login — otherwise hiding the fields is cosmetic.

--- a/docs/cloud-security-review.md
+++ b/docs/cloud-security-review.md
@@ -112,8 +112,13 @@ rest are open, ordered by severity, with the attack that motivates them.
   expiry, `last_seen_at` is never read by any query, cleanup never touches
   links, and the backend never auto-disconnects or rotates. Only an explicit
   401 (genuinely revoked) resets it — and that deliberately re-enables local
-  password login. Caveat: changing `SECRET_KEY` silently kills the link (the
-  token cannot be decrypted) while it still displays as connected.
+  password login. The one real footgun — changing `SECRET_KEY` silently killed
+  the link, since the stored token could no longer be decrypted while the UI
+  still showed "connected" — is fixed: `CLOUD_SECRET_KEY` decouples cloud
+  secrets from `SECRET_KEY`, `PREVIOUS_SECRET_KEYS` recovers an already-rotated
+  install (secrets are re-encrypted on the next sync), and an undecryptable
+  token is now reported loudly instead of silently ignored. See
+  `docs/cloud-link.md`.
 - **Can a passwordless user log in if the link is broken?** No, and there is no
   fall-open path: every failure mode (cloud down, 500, timeout, revoked,
   disabled) fails closed, and `not user.password` is checked before the hash

--- a/frameos/src/frameos/server/routes/cloud_api_routes.nim
+++ b/frameos/src/frameos/server/routes/cloud_api_routes.nim
@@ -5,6 +5,7 @@
 ## documented in docs/cloud-link.md: OAuth 2.0 Device Authorization Grant,
 ## outbound-only, scoped tokens. Link state lives in ./state/cloud_link.json.
 
+import algorithm
 import json
 import locks
 import os
@@ -185,12 +186,20 @@ proc localOrigin*(request: Request): string =
   scheme & "://" & host
 
 const CLOUD_LOGIN_STATE_TTL_SECONDS = 600
+const MAX_LOGIN_STATES = 16
 
 proc linkHasScope(state: JsonNode, scope: string): bool =
   scope in state{"scope"}.getStr("").splitWhitespace()
 
-proc pruneLoginStates(state: JsonNode) =
-  ## Drop expired pending login-handoff states (stored under login_states).
+proc pruneLoginStates(state: JsonNode): bool {.discardable.} =
+  ## Drop expired pending login-handoff states (stored under login_states), then
+  ## enforce MAX_LOGIN_STATES by evicting the oldest. /api/cloud/login/start is
+  ## open (the user is not logged in yet), so without the cap anyone on the LAN
+  ## could grow this file unboundedly and make every later cloud request pay for
+  ## parsing and rewriting it while holding cloudLinkLock.
+  ## Returns true when something was removed, so callers can skip a needless
+  ## rewrite of the state file.
+  result = false
   if state{"login_states"} == nil or state{"login_states"}.kind != JObject:
     return
   var expired: seq[string]
@@ -199,14 +208,43 @@ proc pruneLoginStates(state: JsonNode) =
       expired.add(key)
   for key in expired:
     state["login_states"].delete(key)
+    result = true
+
+  if state["login_states"].len <= MAX_LOGIN_STATES:
+    return
+  # Oldest first, by the expiry we stamped at creation.
+  var byAge: seq[(int64, string)]
+  for key, value in state{"login_states"}:
+    byAge.add((int64(value{"expires_epoch"}.getInt(0)), key))
+  byAge.sort(proc(a, b: (int64, string)): int = cmp(a[0], b[0]))
+  for i in 0 ..< (byAge.len - MAX_LOGIN_STATES):
+    state["login_states"].delete(byAge[i][1])
+    result = true
 
 proc redirectResponse(request: Request, location: string) =
   var headers: mummy.HttpHeaders
   headers["Location"] = location
   request.respond(303, headers, "")
 
-proc syncAfterConnect(state: JsonNode, providerUrl, accessToken: string) =
-  ## Best effort: report inventory and learn which account owns us.
+const CLOUD_LOGIN_STATE_COOKIE = "frameos_cloud_login_state"
+
+proc loginStateCookieHeader(request: Request, value: string): string =
+  CLOUD_LOGIN_STATE_COOKIE & "=" & value &
+    "; Path=/api/cloud/login; HttpOnly; SameSite=Lax; Max-Age=" &
+    $CLOUD_LOGIN_STATE_TTL_SECONDS &
+    (if shouldUseSecureCookie(request): "; Secure" else: "")
+
+  # Not cleared on success: mummy sends one Set-Cookie per response and the
+  # session cookie takes that slot. Harmless — the cookie is path-scoped to
+  # /api/cloud/login, expires in CLOUD_LOGIN_STATE_TTL_SECONDS, is overwritten
+  # by the next /start, and its server-side state entry is single-use.
+
+proc fetchConnectSync(providerUrl, accessToken: string): JsonNode =
+  ## Best effort: report inventory and learn which account owns us. Returns the
+  ## fields to merge into the link state rather than mutating it: both requests
+  ## below can take tens of seconds, so callers MUST run this WITHOUT holding
+  ## cloudLinkLock and merge the result afterwards.
+  var state = newJObject()
   try:
     let (inventoryCode, _) = cloudRequest(providerUrl, "/api/backends/inventory",
       accessToken = accessToken, body = %*{
@@ -229,6 +267,7 @@ proc syncAfterConnect(state: JsonNode, providerUrl, accessToken: string) =
           break
   except CatchableError:
     discard
+  return state
 
 proc addCloudApiRoutes*(router: var Router) =
   router.get("/api/cloud/status", proc(request: Request) {.gcsafe.} =
@@ -365,6 +404,7 @@ proc addCloudApiRoutes*(router: var Router) =
       except CatchableError:
         networkError = true
 
+      var syncAccessToken = ""
       withLock cloudLinkLock:
         let state = loadCloudLinkState()
         if state{"status"}.getStr("") != "connecting" or state{"device_code"}.getStr("") != deviceCode:
@@ -395,12 +435,25 @@ proc addCloudApiRoutes*(router: var Router) =
             if state.hasKey(key):
               state.delete(key)
           state["connected_at"] = %isoTimestamp(int64(epochTime()))
-          syncAfterConnect(state, providerUrl, accessToken)
+          saveCloudLinkState(state)
+          # The inventory/grants sync is two more cloud round trips; do it
+          # after releasing the lock (below) so a slow or unreachable provider
+          # cannot hold cloudLinkLock — and with it every cloud route — for
+          # minutes.
+          syncAccessToken = accessToken
+        else:
+          resetLinkState(state, pollError = (if error.len > 0: error else: "unexpected status " & $pollCode))
           saveCloudLinkState(state)
           jsonResponse(request, Http200, cloudStatusPayload(state))
           return
-        resetLinkState(state, pollError = (if error.len > 0: error else: "unexpected status " & $pollCode))
-        saveCloudLinkState(state)
+
+      let synced = fetchConnectSync(providerUrl, syncAccessToken)
+      withLock cloudLinkLock:
+        let state = loadCloudLinkState()
+        for key, value in synced:
+          state[key] = value
+        if synced.len > 0:
+          saveCloudLinkState(state)
         jsonResponse(request, Http200, cloudStatusPayload(state))
   )
 
@@ -473,9 +526,18 @@ proc addCloudApiRoutes*(router: var Router) =
           "expires_epoch": int(epochTime() + float(CLOUD_LOGIN_STATE_TTL_SECONDS)),
         }
         saveCloudLinkState(state)
-      jsonResponse(request, Http200, %*{
+      # Bind the handoff to THIS browser. Without it, knowing a live state plus
+      # a code is enough for anyone to complete the login: an attacker could
+      # start a handoff for their own cloud account and feed the resulting
+      # callback URL to the owner's browser (logging them into the attacker's
+      # account), or replay a leaked code from their own browser to take over
+      # the owner's session.
+      var headers: mummy.HttpHeaders
+      headers["Set-Cookie"] = loginStateCookieHeader(request, loginState)
+      headers["Content-Type"] = "application/json"
+      request.respond(200, headers, $(%*{
         "authorization_url": startResponse{"authorization_url"}.getStr(""),
-      })
+      }))
   )
 
   router.get("/api/cloud/login/callback", proc(request: Request) {.gcsafe.} =
@@ -484,15 +546,28 @@ proc addCloudApiRoutes*(router: var Router) =
       let code = request.queryParams.getOrDefault("code", "")
       let errorParam = request.queryParams.getOrDefault("error", "")
 
+      # The state must match the cookie we set on /api/cloud/login/start, so
+      # only the browser that began the handoff can finish it. Checked before
+      # any state-file work, which also keeps forged callbacks off the lock.
+      let stateCookie = getCookieValue(request, CLOUD_LOGIN_STATE_COOKIE)
+      if stateParam.len == 0 or stateCookie.len == 0 or stateCookie != stateParam:
+        redirectResponse(request, "/login?cloudError=invalid_state")
+        return
+
       var providerUrl = ""
       var accessToken = ""
       var ownerAccountId = ""
       withLock cloudLinkLock:
         let state = loadCloudLinkState()
-        pruneLoginStates(state)
+        let pruned = pruneLoginStates(state)
         if stateParam.len == 0 or state{"login_states"} == nil or
             state{"login_states"}{stateParam} == nil:
-          saveCloudLinkState(state)
+          # This endpoint is open, so an unknown state is the common case for
+          # junk traffic: only rewrite the state file when pruning actually
+          # changed it, otherwise every bogus request costs an SD-card write
+          # while holding cloudLinkLock.
+          if pruned:
+            saveCloudLinkState(state)
           redirectResponse(request, "/login?cloudError=invalid_state")
           return
         state["login_states"].delete(stateParam)
@@ -524,8 +599,22 @@ proc addCloudApiRoutes*(router: var Router) =
         redirectResponse(request, "/login?cloudError=exchange_failed")
         return
       # The provider only completes a handoff for the account that owns this
-      # link; double-check when we know who that is.
-      if ownerAccountId.len > 0 and claims{"account_id"}.getStr("") != ownerAccountId:
+      # link, but verify it ourselves rather than trusting the response. We
+      # learn the owner from /api/backends/grants during connect; if that call
+      # failed we have nothing to compare against, and minting an admin session
+      # on the provider's word alone would let a network hiccup during linking
+      # silently weaken this check — so refuse and re-sync instead.
+      let claimedAccountId = claims{"account_id"}.getStr("")
+      if ownerAccountId.len == 0 or claimedAccountId.len == 0 or claimedAccountId != ownerAccountId:
+        if ownerAccountId.len == 0:
+          # Fill in the owner we never got, so the next attempt can verify.
+          let synced = fetchConnectSync(providerUrl, accessToken)
+          if synced.len > 0:
+            withLock cloudLinkLock:
+              let state = loadCloudLinkState()
+              for key, value in synced:
+                state[key] = value
+              saveCloudLinkState(state)
         redirectResponse(request, "/login?cloudError=linked_client_required")
         return
 


### PR DESCRIPTION
Security review of the merged cloud work (#263 linking, #264 login), plus fixes for what it found. Four parallel audits covered device-flow linking, the login handoff, offline/grant-sync behaviour, and device-side DoS. Every finding — fixed and still open — is recorded in `docs/cloud-security-review.md`.

Companion cloud-service fixes: **https://github.com/FrameOS/frameos-cloud/pull/1**.

## Fixed here

### The login handoff was not bound to the browser (HIGH)

The `state` token lived only server-side (Redis on the backend, `login_states` on the frame), so it proved a handoff was *in flight*, never *who started it*:

- Anyone able to call the open `/api/cloud/login/start` could complete a handoff for their own cloud account, not follow the final redirect, and feed the callback URL to the owner's browser — silently issuing them a 7-day session for the **attacker's** account.
- Any leaked code (proxy logs, history) became directly exchangeable: mint a state via the open `/start`, replay `code`+`state`, and the backend redeems it with *its* link token and issues a session as the code's owner.

The state is now also an `HttpOnly`, `SameSite=Lax`, path-scoped cookie that must match at the callback — checked *before* the state is consumed, so a forged callback cannot burn the real one. Implemented on both the Python backend and the Nim frame. (RFC 6749 §10.12.)

### The frame skipped its owner check when it didn't know the owner

Which is exactly the case when the grants call failed during connect — so a network hiccup while linking silently downgraded the check to "trust the provider's word" before minting an admin session. Now it refuses and re-syncs the owner.

### Device DoS

The frame's HTTP server runs **1–4 worker threads**, so a blocking handler is an outage:

- `/api/cloud/poll` held the global cloud lock across **two outbound cloud requests** (70 s+ against a slow provider), freezing every cloud route. Sync moved outside the lock, results merged after.
- `login_states` grew without bound from the open `/login/start`, so every later cloud request re-parsed and rewrote a growing state file *under that lock* — O(n²). Capped at 16, oldest evicted.
- The open `/login/callback` rewrote the state file on **every** bogus request (SD-card wear + lock contention). Now writes only when pruning actually changed something.

### `SECRET_KEY` could not be rotated without killing the cloud link

The stored link token is encrypted with a key derived from `SECRET_KEY`, so rotating it made the token permanently undecryptable — and the sync worker treated "cannot decrypt" the same as "no link", leaving the UI reporting a healthy connected link while every cloud request silently stopped. Two opt-in escape hatches, defaults unchanged:

| Variable | Meaning |
|---|---|
| `CLOUD_SECRET_KEY` | Encrypt cloud secrets with their own key, so `SECRET_KEY` is freely rotatable from then on. |
| `PREVIOUS_SECRET_KEYS` | Comma-separated old keys, tried on decrypt only — recovery for an install that already rotated. |

Self-healing: a secret that decrypts with an old key is re-encrypted with the current one on the next sync pass, so `PREVIOUS_SECRET_KEYS` can be dropped after one cycle. When nothing works, the worker logs a red error naming the cause and sets `poll_error = "secret_key_changed"` instead of looping silently. Procedure documented in `docs/cloud-link.md`.

### Passwordless lockout

Cloud signup leaves `password` NULL and the change-password route demanded the current one — so those users could never set a local password, and a later broken link (revoked, provider gone, `FRAMEOS_CLOUD_URL=disabled`) locked them out permanently with no recovery short of editing the database. Setting a *first* password no longer requires the current one (they are already authenticated), and `check_password` no longer raises on a NULL hash. Empty passwords still never authenticate.

## Verified good — no change needed

- **No fall-open anywhere.** Every broken-link path fails closed: cloud down, 500, timeout, revoked, expired, disabled. `not user.password` is checked before the hash comparison, so a NULL hash cannot be matched by an empty password.
- **An offline server never loses its link.** `linked_clients` has no expiry, `last_seen_at` is never read by any query, cleanup never touches links, and neither side auto-disconnects or requires rotation. Only an explicit 401 resets it — and that deliberately re-enables local password login.
- Identity mapping is keyed on issuer+subject, never email; a random cloud account cannot gain admin on someone's install.
- Worker-pool exhaustion does **not** starve the systemd watchdog — the runner thread heartbeats independently, so these are HTTP-only outages, not restart loops.

## Tests

New regression coverage for the state-cookie binding (missing and mismatched cookie — neither may consume the real state), passwordless recovery, and all three key-rotation paths. **771 backend tests, all Nim server tests, and the frame build pass.**

## Still open

Tracked in `docs/cloud-security-review.md` with attack scenarios. The notable ones: unbounded DNS in the frame's outbound calls (one request per worker thread wedges the server for minutes), no rate limiting on the device at all, pre-auth 50 MB body buffering (the one path that *does* become an OOM restart loop), unauthenticated setup-mode linking, and unrevocable local sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
