### PR TITLE
Prebuilt deps: ARMv6 quickjs (fixes armv6 cross-build CI)

### DIFF
--- a/tools/prebuilt-deps/Dockerfile.quickjs
+++ b/tools/prebuilt-deps/Dockerfile.quickjs
@@ -13,6 +13,16 @@ ARG BUILDPLATFORM
 ARG QUICKJS_VERSION=2026-06-04
 ARG QUICKJS_SHA256=b376e839b322978313d929fd20663b11ba58b75df5a46c126dd19ea2fa70ad2a
 
+# Optional standalone cross toolchain (e.g. Bootlin armv6-eabihf for the
+# Raspberry Pi Zero W, which has no matching container platform). When set,
+# the container runs on its native platform and cross-compiles instead.
+ARG CROSS_TOOLCHAIN_URL=
+ARG CROSS_TOOLCHAIN_SHA256=
+ARG CROSS_PREFIX=
+# readelf Tag_CPU_arch value the produced objects must report (e.g. "v6");
+# guards against silently shipping code for the wrong CPU generation.
+ARG CROSS_EXPECTED_CPU_ARCH=
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -26,16 +36,39 @@ RUN apt-get update \
       openssl \
     && rm -rf /var/lib/apt/lists/*
 
+RUN set -euxo pipefail \
+    && if [ -n "${CROSS_TOOLCHAIN_URL}" ]; then \
+      curl -fsSL -o /tmp/toolchain.tar.xz "${CROSS_TOOLCHAIN_URL}" \
+      && echo "${CROSS_TOOLCHAIN_SHA256}  /tmp/toolchain.tar.xz" | sha256sum -c - \
+      && mkdir -p /opt/toolchains \
+      && tar -C /opt/toolchains -xf /tmp/toolchain.tar.xz \
+      && rm /tmp/toolchain.tar.xz \
+      && toolchain_dir="$(find /opt/toolchains -mindepth 1 -maxdepth 1 -type d)" \
+      && if [ -x "${toolchain_dir}/relocate-sdk.sh" ]; then "${toolchain_dir}/relocate-sdk.sh"; fi \
+      && ln -s "${toolchain_dir}" /opt/cross \
+      && "/opt/cross/bin/${CROSS_PREFIX}gcc" --version; \
+    fi
+
 WORKDIR /build
 RUN mkdir -p /artifacts
 
 RUN set -euxo pipefail \
+    && export PATH="/opt/cross/bin:${PATH}" \
     && curl -fsSL -o quickjs.tar.xz "https://bellard.org/quickjs/quickjs-${QUICKJS_VERSION}.tar.xz" \
     && echo "${QUICKJS_SHA256}  quickjs.tar.xz" | sha256sum -c - \
     && tar -xf quickjs.tar.xz \
     && rm quickjs.tar.xz \
     && cd quickjs-${QUICKJS_VERSION} \
-    && make libquickjs.a \
+    && make ${CROSS_PREFIX:+CROSS_PREFIX=${CROSS_PREFIX}} libquickjs.a \
+    && if [ -n "${CROSS_EXPECTED_CPU_ARCH}" ]; then \
+      mkdir /tmp/qjs-verify \
+      && (cd /tmp/qjs-verify && "${CROSS_PREFIX}ar" x "/build/quickjs-${QUICKJS_VERSION}/libquickjs.a") \
+      && obj="$(find /tmp/qjs-verify -name '*.o' | head -1)" \
+      && readelf -A "${obj}" \
+      && readelf -A "${obj}" | grep -q "Tag_CPU_arch: ${CROSS_EXPECTED_CPU_ARCH}\$" \
+      && readelf -A "${obj}" | grep -q "Tag_ABI_VFP_args: VFP registers" \
+      && rm -rf /tmp/qjs-verify; \
+    fi \
     && mkdir -p /artifacts/lib /artifacts/include/quickjs \
     && cp libquickjs.a /artifacts/lib/ \
     && cp quickjs.h quickjs-libc.h /artifacts/include/quickjs/ \

--- a/tools/prebuilt-deps/Dockerfile.quickjs
+++ b/tools/prebuilt-deps/Dockerfile.quickjs
@@ -19,8 +19,9 @@ ARG QUICKJS_SHA256=b376e839b322978313d929fd20663b11ba58b75df5a46c126dd19ea2fa70a
 ARG CROSS_TOOLCHAIN_URL=
 ARG CROSS_TOOLCHAIN_SHA256=
 ARG CROSS_PREFIX=
-# readelf Tag_CPU_arch value the produced objects must report (e.g. "v6");
-# guards against silently shipping code for the wrong CPU generation.
+# readelf Tag_CPU_arch value the produced objects must report (e.g. "v6KZ"
+# for the ARM1176 in the Pi Zero W); guards against silently shipping code
+# for the wrong CPU generation.
 ARG CROSS_EXPECTED_CPU_ARCH=
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tools/prebuilt-deps/README.md
+++ b/tools/prebuilt-deps/README.md
@@ -8,6 +8,14 @@ matching one of the following releases and architectures:
 - Ubuntu **24.04** LTS (Noble Numbat)
 - Ubuntu **26.04** LTS
 - **armhf** (32‑bit ARMv7), **arm64** (AArch64) and **amd64** (x86_64)
+- **armv6** (32‑bit ARMv6 hard-float, Raspberry Pi Zero W / 1): no distro
+  publishes `linux/arm/v6` containers, so `debian-bookworm-armv6` builds in an
+  amd64 container with the Bootlin `armv6-eabihf` toolchain (pinned in
+  `build.sh`, keep in sync with `backend/app/utils/cross_toolchain_packages.py`)
+  and verifies the produced objects are `Tag_CPU_arch: v6` hard-float. This
+  target ships **quickjs only** — nim tarballs bootstrap CI runners and dev
+  hosts (always amd64/arm64); frames compile pre-generated C sources with the
+  device gcc and never run nim.
 
 ## Requirements
 

--- a/tools/prebuilt-deps/build.sh
+++ b/tools/prebuilt-deps/build.sh
@@ -10,10 +10,14 @@ QUICKJS_SHA256="${QUICKJS_SHA256:-b376e839b322978313d929fd20663b11ba58b75df5a46c
 
 declare -a COMPONENTS=("nim" "quickjs")
 
-# TODO(armv6): the debian-bookworm-armv6 cross target (Pi Zero W Buildroot
-# images) has no matching container platform, so it is absent here; quickjs is
-# rebuilt in-container by the cross compiler instead. Publishing armv6
-# prebuilts needs a Bootlin-toolchain build path in this script.
+# ARMv6 hard-float (Raspberry Pi Zero W / 1). No distro publishes
+# linux/arm/v6 containers, so this target builds in an amd64 container with
+# the Bootlin armv6-eabihf toolchain. Keep the tarball pin in sync with
+# backend/app/utils/cross_toolchain_packages.py.
+ARMV6_TOOLCHAIN_URL="${ARMV6_TOOLCHAIN_URL:-https://toolchains.bootlin.com/downloads/releases/toolchains/armv6-eabihf/tarballs/armv6-eabihf--glibc--stable-2024.05-1.tar.xz}"
+ARMV6_TOOLCHAIN_SHA256="${ARMV6_TOOLCHAIN_SHA256:-2924afaa0d47e046339fe70bf526db5a19edaa58d87c6758a861ef41e2781368}"
+ARMV6_CROSS_PREFIX="arm-buildroot-linux-gnueabihf-"
+
 TARGET_MATRIX=(
   "debian|bullseye|armhf|linux/arm/v7|debian:bullseye"
   "debian|bullseye|arm64|linux/arm64|debian:bullseye"
@@ -21,6 +25,7 @@ TARGET_MATRIX=(
   "debian|bookworm|armhf|linux/arm/v7|debian:bookworm"
   "debian|bookworm|arm64|linux/arm64|debian:bookworm"
   "debian|bookworm|amd64|linux/amd64|debian:bookworm"
+  "debian|bookworm|armv6|linux/amd64|debian:bookworm"
   "debian|trixie|armhf|linux/arm/v7|debian:trixie"
   "debian|trixie|arm64|linux/arm64|debian:trixie"
   "debian|trixie|amd64|linux/amd64|debian:trixie"
@@ -29,6 +34,18 @@ TARGET_MATRIX=(
   "ubuntu|26.04|arm64|linux/arm64|ubuntu:26.04"
   "ubuntu|26.04|amd64|linux/amd64|ubuntu:26.04"
 )
+
+# nim tarballs only bootstrap CI runners and dev hosts (amd64/arm64); frames
+# compile pre-generated C sources with the device gcc and never run nim.
+# armv6 targets therefore ship quickjs only.
+target_components() {
+  local arch="$1"
+  if [[ "${arch}" == "armv6" ]]; then
+    printf '%s' "quickjs"
+  else
+    printf '%s' "${COMPONENTS[*]}"
+  fi
+}
 
 get_target_entry() {
   local search_target="$1"
@@ -74,13 +91,17 @@ command -v docker >/dev/null 2>&1 || { echo "docker is required" >&2; exit 1; }
 mkdir -p "${OUTPUT_BASE}"
 
 component_marker() {
-  local component="$1" target="$2" release="$3" platform="$4"
+  local component="$1" target="$2" release="$3" platform="$4" arch="$5"
+  local cross_suffix=""
+  if [[ "${arch}" == "armv6" ]]; then
+    cross_suffix="|${ARMV6_TOOLCHAIN_URL}|${ARMV6_TOOLCHAIN_SHA256}"
+  fi
   case "${component}" in
     nim)
-      printf '%s|%s|%s|%s|%s' "${target}" "${component}" "${release}" "${platform}" "${NIM_VERSION}"
+      printf '%s|%s|%s|%s|%s%s' "${target}" "${component}" "${release}" "${platform}" "${NIM_VERSION}" "${cross_suffix}"
       ;;
     quickjs)
-      printf '%s|%s|%s|%s|%s|%s' "${target}" "${component}" "${release}" "${platform}" "${QUICKJS_VERSION}" "${QUICKJS_SHA256}"
+      printf '%s|%s|%s|%s|%s|%s%s' "${target}" "${component}" "${release}" "${platform}" "${QUICKJS_VERSION}" "${QUICKJS_SHA256}" "${cross_suffix}"
       ;;
     *)
       echo "Unknown component '${component}'" >&2
@@ -99,9 +120,20 @@ for target in "${REQUESTED_TARGETS[@]}"; do
   dest="${OUTPUT_BASE}/${target}"
   mkdir -p "${dest}"
 
-  echo "\n=== Target ${target} (${distro} ${release}, platform ${platform}) ===" >&2
+  echo "\n=== Target ${target} (${distro} ${release}, arch ${arch}, platform ${platform}) ===" >&2
 
-  for component in "${COMPONENTS[@]}"; do
+  cross_args=()
+  if [[ "${arch}" == "armv6" ]]; then
+    cross_args=(
+      "--build-arg" "CROSS_TOOLCHAIN_URL=${ARMV6_TOOLCHAIN_URL}"
+      "--build-arg" "CROSS_TOOLCHAIN_SHA256=${ARMV6_TOOLCHAIN_SHA256}"
+      "--build-arg" "CROSS_PREFIX=${ARMV6_CROSS_PREFIX}"
+      "--build-arg" "CROSS_EXPECTED_CPU_ARCH=v6"
+    )
+  fi
+
+  read -r -a target_component_list <<<"$(target_components "${arch}")"
+  for component in "${target_component_list[@]}"; do
     component_args=()
     case "${component}" in
       nim)
@@ -115,6 +147,7 @@ for target in "${REQUESTED_TARGETS[@]}"; do
         component_args=(
           "--build-arg" "QUICKJS_VERSION=${QUICKJS_VERSION}"
           "--build-arg" "QUICKJS_SHA256=${QUICKJS_SHA256}"
+          "${cross_args[@]}"
         )
         ;;
       *)
@@ -124,7 +157,7 @@ for target in "${REQUESTED_TARGETS[@]}"; do
     esac
     comp_dest="${dest}/${subdir}"
     marker_file="${comp_dest}/.build-info"
-    expected_marker="$(component_marker "${component}" "${target}" "${release}" "${platform}")"
+    expected_marker="$(component_marker "${component}" "${target}" "${release}" "${platform}" "${arch}")"
 
     if [[ -f "${marker_file}" ]]; then
       existing_marker="$(<"${marker_file}")"
@@ -156,6 +189,17 @@ for target in "${REQUESTED_TARGETS[@]}"; do
     printf '%s' "${expected_marker}" > "${marker_file}"
   done
 
+  components_json=""
+  version_lines=""
+  for component in "${target_component_list[@]}"; do
+    [[ -n "${components_json}" ]] && components_json+=", "
+    components_json+="\"${component}\""
+    case "${component}" in
+      nim) version_lines+="  \"nim_version\": \"${NIM_VERSION}\","$'\n' ;;
+      quickjs) version_lines+="  \"quickjs_version\": \"${QUICKJS_VERSION}\","$'\n' ;;
+    esac
+  done
+
   cat >"${dest}/metadata.json" <<META
 {
   "target": "${target}",
@@ -163,8 +207,7 @@ for target in "${REQUESTED_TARGETS[@]}"; do
   "release": "${release}",
   "arch": "${arch}",
   "platform": "${platform}",
-  "nim_version": "${NIM_VERSION}",
-  "quickjs_version": "${QUICKJS_VERSION}"
+${version_lines}  "components": [${components_json}]
 }
 META
 done

--- a/tools/prebuilt-deps/build.sh
+++ b/tools/prebuilt-deps/build.sh
@@ -128,7 +128,7 @@ for target in "${REQUESTED_TARGETS[@]}"; do
       "--build-arg" "CROSS_TOOLCHAIN_URL=${ARMV6_TOOLCHAIN_URL}"
       "--build-arg" "CROSS_TOOLCHAIN_SHA256=${ARMV6_TOOLCHAIN_SHA256}"
       "--build-arg" "CROSS_PREFIX=${ARMV6_CROSS_PREFIX}"
-      "--build-arg" "CROSS_EXPECTED_CPU_ARCH=v6"
+      "--build-arg" "CROSS_EXPECTED_CPU_ARCH=v6KZ"
     )
   fi
 
@@ -147,7 +147,7 @@ for target in "${REQUESTED_TARGETS[@]}"; do
         component_args=(
           "--build-arg" "QUICKJS_VERSION=${QUICKJS_VERSION}"
           "--build-arg" "QUICKJS_SHA256=${QUICKJS_SHA256}"
-          "${cross_args[@]}"
+          ${cross_args[@]+"${cross_args[@]}"}
         )
         ;;
       *)
@@ -189,6 +189,13 @@ for target in "${REQUESTED_TARGETS[@]}"; do
     printf '%s' "${expected_marker}" > "${marker_file}"
   done
 
+  # The matrix platform column is the docker *build* platform; armv6 builds
+  # in an amd64 container but targets linux/arm/v6.
+  metadata_platform="${platform}"
+  if [[ "${arch}" == "armv6" ]]; then
+    metadata_platform="linux/arm/v6"
+  fi
+
   components_json=""
   version_lines=""
   for component in "${target_component_list[@]}"; do
@@ -206,7 +213,7 @@ for target in "${REQUESTED_TARGETS[@]}"; do
   "distribution": "${distro}",
   "release": "${release}",
   "arch": "${arch}",
-  "platform": "${platform}",
+  "platform": "${metadata_platform}",
 ${version_lines}  "components": [${components_json}]
 }
 META

--- a/tools/prebuilt-deps/manifest.json
+++ b/tools/prebuilt-deps/manifest.json
@@ -220,6 +220,20 @@
         "nim": "eef2e35b2d5449a224d21261d7eafbd5",
         "quickjs": "f650e3c456995d519185f2e3352d87b6"
       }
+    },
+    {
+      "target": "debian-bookworm-armv6",
+      "versions": {
+        "quickjs": "2026-06-04"
+      },
+      "object_key": null,
+      "updated_at": "2026-08-02T01:41:16.941115+00:00",
+      "component_keys": {
+        "quickjs": "prebuilt-deps/debian-bookworm-armv6/quickjs-2026-06-04.tar.gz"
+      },
+      "component_md5sums": {
+        "quickjs": "73958f663dbe5ea19c21b86cbdd70989"
+      }
     }
   ]
 }

--- a/tools/prebuilt-deps/r2_sync.py
+++ b/tools/prebuilt-deps/r2_sync.py
@@ -78,7 +78,6 @@ DEFAULT_BUCKET = os.environ.get("R2_BUCKET", "frameos-archive")
 DEFAULT_PREFIX = os.environ.get("R2_PREFIX", "prebuilt-deps")
 
 # Keep the target matrix in sync with tools/prebuilt-deps/build.sh
-# TODO(armv6): no debian-bookworm-armv6 entry yet; see tools/prebuilt-deps/build.sh.
 DEFAULT_TARGETS = [
     "debian-bullseye-armhf",
     "debian-bullseye-arm64",
@@ -86,6 +85,9 @@ DEFAULT_TARGETS = [
     "debian-bookworm-armhf",
     "debian-bookworm-arm64",
     "debian-bookworm-amd64",
+    # ARMv6 (Raspberry Pi Zero W / 1): quickjs only — nim tarballs bootstrap
+    # CI runners and dev hosts, which are never armv6.
+    "debian-bookworm-armv6",
     "debian-trixie-armhf",
     "debian-trixie-arm64",
     "debian-trixie-amd64",
@@ -99,6 +101,7 @@ TARGET_PLATFORMS = {
     "armhf": "linux/arm/v7",
     "arm64": "linux/arm64",
     "amd64": "linux/amd64",
+    "armv6": "linux/arm/v6",
 }
 
 
@@ -257,18 +260,25 @@ def s3_client():
     )
 
 
+def metadata_components(metadata: Dict[str, str]) -> List[str]:
+    components = metadata.get("components")
+    if isinstance(components, list) and components:
+        return [str(component) for component in components]
+    return list(COMPONENTS)
+
+
 def package_identifier(metadata: Dict[str, str]) -> str:
-    return (
-        f"{metadata['target']}/"
-        f"nim-{metadata['nim_version']}_"
-        f"quickjs-{metadata['quickjs_version']}"
+    parts = "_".join(
+        f"{component}-{metadata.get(f'{component}_version', '')}"
+        for component in metadata_components(metadata)
     )
+    return f"{metadata['target']}/{parts}"
 
 
 def versions_from_metadata(metadata: Dict[str, str]) -> Dict[str, str]:
     return {
-        "nim": metadata.get("nim_version", ""),
-        "quickjs": metadata.get("quickjs_version", ""),
+        component: metadata.get(f"{component}_version", "")
+        for component in metadata_components(metadata)
     }
 
 
@@ -296,15 +306,19 @@ def component_object_key(prefix: str, target: str, component: str, version: str)
 def write_local_metadata(entry: ManifestEntry, target_dir: Path) -> None:
     distro, release, arch = target_distro_release_arch(entry.target)
     platform = TARGET_PLATFORMS.get(arch, "")
+    components = [component for component in COMPONENTS if entry.versions.get(component)]
+    if not components:
+        components = list(COMPONENTS)
     payload = {
         "target": entry.target,
         "distribution": distro,
         "release": release,
         "arch": arch,
         "platform": platform,
-        "nim_version": entry.versions.get("nim", ""),
-        "quickjs_version": entry.versions.get("quickjs", ""),
+        "components": components,
     }
+    for component in components:
+        payload[f"{component}_version"] = entry.versions.get(component, "")
     target_dir.mkdir(parents=True, exist_ok=True)
     target_file = target_dir / "metadata.json"
     target_file.write_text(json.dumps(payload, indent=2) + "\n")
@@ -434,7 +448,7 @@ def prepare_upload_target(
     component_keys: Dict[str, str] = {}
     component_md5sums: Dict[str, str] = {}
     components_to_upload = []
-    for component in COMPONENTS:
+    for component in metadata_components(metadata):
         version = component_version(metadata, component)
         if not version:
             print(


### PR DESCRIPTION
## What

Fixes the failing `cross-build (debian-bookworm-armv6, ...)` CI check (seen on #274 post-merge and #275): the new ARMv6 cross target had no published quickjs prebuilt, and the source-tree fallback has nothing to build from in CI.

#274 was squash-merged just before the prebuilt-deps commits landed on its branch, so this PR carries them plus the published manifest entry:

- **`debian-bookworm-armv6` target in `tools/prebuilt-deps`**: quickjs cross-compiles in an amd64 container with the pinned Bootlin armv6-eabihf toolchain (same pin as `cross_toolchain_packages.py`). The Dockerfile self-verifies the output — asserts `Tag_CPU_arch: v6KZ` (ARM1176) and hard-float `Tag_ABI_VFP_args: VFP registers` on the archive objects before packaging.
- **quickjs only**: nim tarballs bootstrap CI runners and dev hosts (always amd64/arm64); frames compile pre-generated C with the device gcc and never run nim. `build.sh` metadata and `r2_sync.py` now carry a per-target `components` list so quickjs-only targets upload/download cleanly.
- **Manifest entry** for the artifact already uploaded to R2 (`prebuilt-deps/debian-bookworm-armv6/quickjs-2026-06-04.tar.gz`, md5 verified via `https://archive.frameos.net`). With this checked in, `resolve_prebuilt_target("debian","bookworm","armv6l")` resolves to a downloadable quickjs and the armv6 cross build goes green.

## Testing

- armv6 build verified on a real x86_64 host: `Tag_CPU_arch: v6KZ`, `VFPv2`, VFP-registers ABI (the verification gate caught my initial wrong `v6` expectation).
- Full `debian-bookworm-amd64` regression build (nim + quickjs) passes with the two-component metadata.
- Published tarball fetched back from `archive.frameos.net` with matching md5; `fetch_prebuilt_manifest()` resolves the new entry.

After merging, re-run the failed check on #275 — it should pick up the prebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)