### PR TITLE
Stop Cloudflare pinning the previous /frames bundle for four hours

### DIFF
--- a/cloud/apps/auth-web/next.config.ts
+++ b/cloud/apps/auth-web/next.config.ts
@@ -128,6 +128,20 @@ function createNextConfig(phase: string): NextConfig {
           source: "/frameos-editor/index.html",
         },
         {
+          // The frames SPA references hashless assets
+          // (/frames-app/static/main.js): with no origin cache-control,
+          // Cloudflare's 4-hour default TTL kept serving the previous
+          // deploy's UI after every release. no-cache forces revalidation
+          // while the ETag keeps repeat loads as cheap 304s.
+          headers: [
+            {
+              key: "Cache-Control",
+              value: "no-cache",
+            },
+          ],
+          source: "/frames-app/:path*",
+        },
+        {
           headers: [noStoreHeader],
           source: "/account/:path*",
         },


### PR DESCRIPTION
The frames SPA shell is served no-store, but the hashless static assets it references (`/frames-app/static/main.js|css`) had no origin cache-control — so Cloudflare applied its 4-hour default TTL and a reload right after a deploy kept showing the previous UI (observed after today's deploys: `cache-control: public, max-age=14400` on main.js). `no-cache` on `/frames-app/:path*` forces revalidation on every load while the ETag keeps repeat loads as cheap 304s, so each deploy is visible on the next normal reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)