### PR TITLE
Sort nameless frames without crashing the workspace home

### DIFF
--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -64,7 +64,9 @@ function sanitizeFrameForStore(frame: FrameType): FrameType {
 
 function sortFrames(frames: FrameType[]): FrameType[] {
   return frames.sort(
-    (a, b) => a.frame_host.localeCompare(b.frame_host) || (a.ssh_user || '').localeCompare(b.ssh_user || '')
+    (a, b) =>
+      // Cloud frames can have no frame_host at all (fresh enrollment).
+      (a.frame_host || '').localeCompare(b.frame_host || '') || (a.ssh_user || '').localeCompare(b.ssh_user || '')
   )
 }
 

--- a/frontend/src/scenes/workspace/frameStatusGroups.ts
+++ b/frontend/src/scenes/workspace/frameStatusGroups.ts
@@ -8,7 +8,9 @@ export interface FrameStatusGroup {
 }
 
 function frameSortName(frame: FrameType): string {
-  return (frame.name || frameHost(frame)).trim()
+  // A freshly enrolled cloud frame can have neither a name nor a host —
+  // undefined here crashed the home list's sort into a white screen.
+  return String(frame.name ?? frameHost(frame) ?? frame.id ?? '').trim()
 }
 
 function sortFramesAlphabetically(frames: FrameType[]): FrameType[] {

--- a/frontend/src/scenes/workspace/workspaceLogic.tsx
+++ b/frontend/src/scenes/workspace/workspaceLogic.tsx
@@ -529,7 +529,9 @@ function frameIsActiveInCurrentState(frame: FrameType): boolean {
 }
 
 function frameSortName(frame: FrameType): string {
-  return (frame.name || frameHost(frame)).trim()
+  // A freshly enrolled cloud frame can have neither a name nor a host —
+  // undefined here crashed the home list's sort into a white screen.
+  return String(frame.name ?? frameHost(frame) ?? frame.id ?? '').trim()
 }
 
 function compareFramesForHome(first: FrameType, second: FrameType): number {


### PR DESCRIPTION
A freshly enrolled cloud frame can arrive with neither a name nor a host — `frameSortName` returned undefined and the home list's `localeCompare` sort white-screened the whole workspace (hit right after the new 'frame enrolled → open it' flow). Both copies of the helper now fall back name → host → id → ''.

🤖 Generated with [Claude Code](https://claude.com/claude-code)