### PR TITLE
Cloud workspace: real thumbnails, persistent saves, asset writes, wasm proxy

### DIFF
--- a/cloud-frontend/build.mjs
+++ b/cloud-frontend/build.mjs
@@ -139,6 +139,27 @@ const sharedDepsPlugin = {
   },
 }
 
+// Monaco's workers load by fixed URL (configureMonaco.ts:
+// {assets_base_path}/static/monaco/<name>.js), so they are built separately
+// with stable, unhashed names — the shell never references them, the main
+// bundle constructs their URLs at runtime. Self-contained (no splitting):
+// a worker cannot share chunks with the DOM bundle anyway.
+const monacoWorkerNames = ['editor.worker', 'json.worker', 'css.worker', 'html.worker', 'ts.worker']
+await build({
+  absWorkingDir: __dirname,
+  entryPoints: monacoWorkerNames.map((name) => ({
+    in: `../frontend/src/monaco/${name}.ts`,
+    out: `monaco/${name}`,
+  })),
+  bundle: true,
+  format: 'esm',
+  splitting: false,
+  outdir: staticDir,
+  minify: true,
+  sourcemap: isDev,
+  tsconfig: path.resolve(__dirname, 'tsconfig.json'),
+})
+
 const buildOptions = {
   absWorkingDir: __dirname,
   entryPoints: ['src/main.tsx'],

--- a/cloud-frontend/src/cloudConfig.ts
+++ b/cloud-frontend/src/cloudConfig.ts
@@ -25,6 +25,9 @@ interface CloudAppConfig {
   cloud_origin?: string
   cloud_scenes_url?: string
   cloud_theme_cookie_domain?: string
+  /** Read by livePreviewLogic straight off FRAMEOS_APP_CONFIG: the wasm
+   * preview's same-origin HTTP proxy (/api/store/preview-proxy). */
+  preview_proxy_url?: string
 }
 
 function config(): CloudAppConfig {

--- a/cloud-frontend/src/main.tsx
+++ b/cloud-frontend/src/main.tsx
@@ -1,4 +1,10 @@
 import { createRoot } from 'react-dom/client'
+// Point @monaco-editor/react at the bundled monaco BEFORE anything renders an
+// editor: without this it lazy-loads monaco from a CDN, which the cloud's CSP
+// blocks — every Monaco surface (app sources, scene JSON, code nodes) then
+// fails with a bare script error. The workers it spawns are bundled by
+// build.mjs into static/monaco/ (same contract as the other bundles).
+import '../../frontend/src/utils/configureMonaco'
 import { App } from './scenes/App'
 import './index.css'
 import { initKea } from '../../frontend/src/initKea'

--- a/cloud/apps/auth-web/app/api/account/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/route.ts
@@ -1,0 +1,141 @@
+import { and, eq, sql } from "drizzle-orm";
+import { strToU8, zipSync } from "fflate";
+import { storeScenes } from "@frameos-cloud/db";
+import { NextRequest } from "next/server";
+import { csrfResponse } from "../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../src/lib/device-flow";
+import {
+  identityRateLimitResponse,
+  rateLimitResponse,
+} from "../../../../src/lib/rate-limit";
+import { readSession } from "../../../../src/lib/session";
+import { maxPublishesPerHour, maxSceneZipBytes } from "../../../../src/lib/store";
+import { publishStoreScene } from "../../../../src/lib/store-publish";
+
+export const runtime = "nodejs";
+
+const maxSceneNameChars = 128;
+// Try "name", "name 2", … before giving up. Publishing resolves "same
+// account + same name" to the EXISTING scene and appends a version — correct
+// for republish, wrong for "create new" — so this route disambiguates first.
+const maxNameAttempts = 20;
+
+function zipFolderName(name: string): string {
+  const safe = name.replace(/[^A-Za-z0-9 _-]/g, "_").trim();
+  return (safe.length > 0 ? safe : "scene").slice(0, 64);
+}
+
+async function nameIsTaken(
+  db: NonNullable<ReturnType<typeof requireDatabase>["db"]>,
+  accountId: string,
+  name: string,
+) {
+  const [clash] = await db
+    .select({ id: storeScenes.id })
+    .from(storeScenes)
+    .where(
+      and(
+        eq(storeScenes.accountId, accountId),
+        sql`lower(${storeScenes.name}) = lower(${name})`,
+      ),
+    )
+    .limit(1);
+  return clash !== undefined;
+}
+
+// Create a NEW private cloud scene from raw scenes JSON — the workspace's
+// "save this frame's edited scenes to my account" path, which has no ZIP to
+// upload. The route builds the canonical template ZIP (the exact layout
+// backend/app/api/templates.py template_zip_bytes produces) and hands it to
+// publishStoreScene, so quotas, moderation, classification, slugging and
+// audit all apply exactly as for an upload. Unlike upload/republish, a name
+// clash creates "name 2" instead of silently versioning the other scene.
+export async function POST(request: NextRequest) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(request, "account:scene-create", {
+    limit: 60,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const accountLimited = await identityRateLimitResponse(
+    session.accountId,
+    "store:publish",
+    { limit: maxPublishesPerHour, windowMs: 60 * 60 * 1000 },
+  );
+  if (accountLimited) {
+    return accountLimited;
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+
+  const body = await readJsonObject(request);
+  const requestedName =
+    typeof body.name === "string" ? body.name.trim().slice(0, maxSceneNameChars) : "";
+  const name = requestedName.length > 0 ? requestedName : "Untitled scene";
+  if (!Array.isArray(body.scenes) || body.scenes.length === 0) {
+    return jsonError("invalid_scenes", 400);
+  }
+  const description =
+    typeof body.description === "string"
+      ? body.description.trim().slice(0, 2000)
+      : undefined;
+
+  let finalName = name;
+  if (await nameIsTaken(db, session.accountId, finalName)) {
+    let resolved = false;
+    for (let suffix = 2; suffix <= maxNameAttempts; suffix += 1) {
+      const candidate = `${name.slice(0, maxSceneNameChars - 4)} ${suffix}`;
+      if (!(await nameIsTaken(db, session.accountId, candidate))) {
+        finalName = candidate;
+        resolved = true;
+        break;
+      }
+    }
+    if (!resolved) {
+      return jsonError("scene_name_taken", 409, { name });
+    }
+  }
+
+  const folder = zipFolderName(finalName);
+  const manifest = {
+    name: finalName,
+    ...(description ? { description } : {}),
+    scenes: "./scenes.json",
+  };
+  const content = Buffer.from(
+    zipSync({
+      [`${folder}/template.json`]: strToU8(JSON.stringify(manifest, null, 2)),
+      [`${folder}/scenes.json`]: strToU8(JSON.stringify(body.scenes, null, 2)),
+    }),
+  );
+  if (content.length > maxSceneZipBytes) {
+    return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
+  }
+
+  return publishStoreScene(db, {
+    accountId: session.accountId,
+    actor: {
+      accountId: session.accountId,
+      providerSubject: session.providerSubject,
+    },
+    content,
+    description,
+    name: finalName,
+    visibility: "private",
+  });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/asset/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/asset/route.ts
@@ -1,9 +1,11 @@
-import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
-import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
 import { NextRequest, NextResponse } from "next/server";
 import { jsonError, requireDatabase } from "../../../../../src/lib/device-flow";
 import {
-  enqueueFrameCommand,
+  cachedAssetFile,
+  queueAssetGetIfIdle,
+  recentFailedAssetGet,
+} from "../../../../../src/lib/frame-asset-cache";
+import {
   frameForAccount,
   maxAssetPathChars,
 } from "../../../../../src/lib/frames";
@@ -12,7 +14,6 @@ import { readSession } from "../../../../../src/lib/session";
 
 export const runtime = "nodejs";
 
-const fetchCommandTtlMs = 2 * 60 * 1000;
 // A cached copy this old is re-requested in the background on the next hit;
 // the stale bytes still serve immediately (assets on a frame rarely change,
 // and a sleeping battery frame must not block every thumbnail).
@@ -54,59 +55,6 @@ function normalizeAssetPath(raw: string): string | undefined {
 function contentDisposition(kind: "attachment" | "inline", filename: string) {
   const safe = filename.replace(/[^\w. -]/g, "_").slice(0, 255);
   return `${kind}; filename="${safe || "asset"}"`;
-}
-
-type Db = NonNullable<ReturnType<typeof requireDatabase>["db"]>;
-
-async function cachedAssetFile(
-  db: Db,
-  frameId: string,
-  path: string,
-  thumb: boolean,
-) {
-  const [row] = await db
-    .select()
-    .from(frameAssetFiles)
-    .where(
-      and(
-        eq(frameAssetFiles.frameId, frameId),
-        eq(frameAssetFiles.path, path),
-        eq(frameAssetFiles.thumb, thumb),
-      ),
-    )
-    .limit(1);
-  return row;
-}
-
-async function outstandingFetch(
-  db: Db,
-  frameId: string,
-  path: string,
-  thumb: boolean,
-) {
-  // Payload equality is checked in JS: the handful of live asset_get rows per
-  // frame does not justify a jsonb index.
-  const rows = await db
-    .select({ id: frameCommands.id, payload: frameCommands.payload })
-    .from(frameCommands)
-    .where(
-      and(
-        eq(frameCommands.frameId, frameId),
-        eq(frameCommands.type, "asset_get"),
-        inArray(frameCommands.status, ["pending", "sent"]),
-        or(
-          isNull(frameCommands.expiresAt),
-          gt(frameCommands.expiresAt, new Date()),
-        ),
-      ),
-    );
-  return rows.find((row) => {
-    const payload =
-      row.payload && typeof row.payload === "object"
-        ? (row.payload as Record<string, unknown>)
-        : {};
-    return payload.path === path && (payload.thumb === true) === thumb;
-  });
 }
 
 function assetResponse(
@@ -177,15 +125,7 @@ export async function GET(
   const needsFetch =
     !cached || now - cached.updatedAt.getTime() > cacheStaleAfterMs;
   if (needsFetch && frame.status === "active") {
-    if (!(await outstandingFetch(db, frame.id, path, thumb))) {
-      await enqueueFrameCommand(db, {
-        createdByAccountId: session.accountId,
-        frameId: frame.id,
-        payload: { path, ...(thumb ? { thumb: true } : {}) },
-        ttlMs: fetchCommandTtlMs,
-        type: "asset_get",
-      });
-    }
+    await queueAssetGetIfIdle(db, session.accountId, frame.id, path, thumb);
   }
   if (cached) {
     // Stale-while-revalidate: the refresh (if any) was queued above and the
@@ -208,24 +148,13 @@ export async function GET(
     // the connection open for nothing. Only THIS path's recent command
     // counts — an old failure for some other file must not poison every
     // later request for this frame.
-    const failedCommands = await db
-      .select({ error: frameCommands.error, payload: frameCommands.payload })
-      .from(frameCommands)
-      .where(
-        and(
-          eq(frameCommands.frameId, frame.id),
-          eq(frameCommands.type, "asset_get"),
-          eq(frameCommands.status, "failed"),
-          gt(frameCommands.createdAt, new Date(now - 60_000)),
-        ),
-      );
-    const refused = failedCommands.find((row) => {
-      const payload =
-        row.payload && typeof row.payload === "object"
-          ? (row.payload as Record<string, unknown>)
-          : {};
-      return payload.path === path && (payload.thumb === true) === thumb;
-    });
+    const refused = await recentFailedAssetGet(
+      db,
+      frame.id,
+      path,
+      thumb,
+      60_000,
+    );
     if (refused) {
       return jsonError(refused.error ?? "asset_fetch_failed", 404);
     }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/delete/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/delete/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  invalidateCachedAssetSubtree,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Delete a file or folder under the frame's assets directory —
+// form-urlencoded `path`, `{message}` back, same as the backend's delete.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const path = normalizeAssetPath(String(form.get("path") ?? ""));
+  if (!path || hiddenWritePath(path)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const result = await runAssetWriteCommand(
+    db,
+    accountId,
+    frame.id,
+    "asset_delete",
+    { path },
+  );
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  await invalidateCachedAssetSubtree(db, frame.id, path);
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({ message: "Deleted" });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/mkdir/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/mkdir/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Create a folder under the frame's assets directory — form-urlencoded
+// `path`, `{message}` back, same as the self-hosted backend's mkdir.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const path = normalizeAssetPath(String(form.get("path") ?? ""));
+  if (!path || hiddenWritePath(path)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const result = await runAssetWriteCommand(
+    db,
+    accountId,
+    frame.id,
+    "asset_mkdir",
+    { path },
+  );
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({ message: "Created" });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/rename/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/rename/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  invalidateCachedAssetSubtree,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Rename/move a file or folder under the frame's assets directory —
+// form-urlencoded `src` + `dst`, `{message}` back, same as the backend.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const src = normalizeAssetPath(String(form.get("src") ?? ""));
+  const dst = normalizeAssetPath(String(form.get("dst") ?? ""));
+  if (!src || !dst || hiddenWritePath(src) || hiddenWritePath(dst)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const result = await runAssetWriteCommand(
+    db,
+    accountId,
+    frame.id,
+    "asset_rename",
+    { dst, src },
+  );
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  // Both sides go: the src subtree is gone from the device, and any stale
+  // rows under dst (a rename onto a previously cached path) are wrong now.
+  await invalidateCachedAssetSubtree(db, frame.id, src);
+  await invalidateCachedAssetSubtree(db, frame.id, dst);
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({ message: "Renamed" });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/upload/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/upload/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  invalidateCachedAssetSubtree,
+  maxAssetUploadBytes,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+  sanitizedUploadFilename,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Upload one file into the frame's assets directory — the multipart contract
+// the shared SPA's uploadDroppedFiles already speaks against the self-hosted
+// backend (FormData{file, path}), answered with the stored entry. The bytes
+// ride an asset_put command (base64 in a single WS frame), so the size cap is
+// far below the backend's: files past it need a chunked verb that does not
+// exist yet, and the error says so instead of stalling.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const file = form.get("file");
+  if (!(file instanceof File)) {
+    return jsonError("file_required", 400);
+  }
+  if (file.size === 0) {
+    return jsonError("file_empty", 400);
+  }
+  if (file.size > maxAssetUploadBytes) {
+    return jsonError("too_large", 413, { max_bytes: maxAssetUploadBytes });
+  }
+  const rawSubdir = String(form.get("path") ?? "").trim();
+  let subdir = "";
+  if (rawSubdir.length > 0) {
+    const normalized = normalizeAssetPath(rawSubdir);
+    if (!normalized) {
+      return jsonError("invalid_path", 400);
+    }
+    subdir = normalized;
+  }
+  const filename = sanitizedUploadFilename(file.name ?? "");
+  const targetPath = subdir ? `${subdir}/${filename}` : filename;
+  if (hiddenWritePath(targetPath)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const data = Buffer.from(await file.arrayBuffer()).toString("base64");
+  const result = await runAssetWriteCommand(db, accountId, frame.id, "asset_put", {
+    data,
+    path: targetPath,
+  });
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  await invalidateCachedAssetSubtree(db, frame.id, targetPath);
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({
+    is_dir: false,
+    mtime: Math.floor(Date.now() / 1000),
+    path: targetPath,
+    size: file.size,
+  });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scene_images/[sceneId]/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scene_images/[sceneId]/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flow";
+import {
+  cachedAssetFile,
+  queueAssetGetIfIdle,
+  recentFailedAssetGet,
+  sceneSnapshotAssetPath,
+} from "../../../../../../src/lib/frame-asset-cache";
 import { frameForAccount } from "../../../../../../src/lib/frames";
 import {
   resolveStoreSceneForFrameScene,
@@ -10,13 +16,59 @@ import { readSession } from "../../../../../../src/lib/session";
 
 export const runtime = "nodejs";
 
+// Scene tiles re-render often; a snapshot this old is re-requested in the
+// background while the stale bytes still serve. Shorter than the generic
+// asset route's 15 min — a deploy changes what a scene renders.
+const snapshotStaleAfterMs = 5 * 60 * 1000;
+// A device that just said not_found (scene never rendered, ESP32 with no
+// snapshot store) is not asked again for this long — tiles poll, and every
+// poll re-queueing a doomed command would keep the frame busy for nothing.
+const refusalMemoryMs = 5 * 60 * 1000;
+// Only reached when there is no store cover to serve meanwhile: bounded by
+// what an <img> tolerates, and short enough not to pile up connections when
+// a frame is asleep.
+const longPollTotalMs = 10_000;
+const longPollStepMs = 750;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function imageResponse(content: Buffer, contentType: string, maxAge: number) {
+  return new NextResponse(new Uint8Array(content), {
+    headers: {
+      // Private: these bytes describe one user's frame. Held briefly so a
+      // re-render does not re-download every tile; the SPA busts with ?t=.
+      "cache-control": `private, max-age=${maxAge}`,
+      "content-length": String(content.length),
+      "content-type": contentType || "image/png",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+// Device snapshots change on every deploy and scene switch; store covers only
+// on republish.
+const snapshotBrowserMaxAge = 60;
+const coverBrowserMaxAge = 300;
+
 // Per-scene preview — the exact route the shared SPA's scene tiles already
-// call (cloud/docs/cloud-workspace-gaps.md item 2). Short-term implementation:
-// serve the cover image of the store scene the assignment installed. The SPA
-// passes the RUNTIME scene id (from the zip's scenes.json, hydrated into the
-// tiles), so scene-images.ts maps it back to the owning store scene; the raw
-// store uuid works too. Owning the frame is the authorization — its assigned
-// scenes' covers are, by construction, content the account installed.
+// call (cloud/docs/cloud-workspace-gaps.md item 2). Priority order:
+//
+//   1. The device's own snapshot: the runner writes a per-scene PNG under
+//      {assets}/.frameos/scene_images/ on first render and every scene
+//      switch, and the existing asset_get verb can stream it — the hub
+//      caches it in frame_asset_files like any other asset. ?thumb=1 rides
+//      the device's 320x320 thumbnail path, so tiles stay small.
+//   2. The cover image of the store scene an assignment installed (the
+//      short-term serve that used to be the whole implementation). The SPA
+//      passes the RUNTIME scene id, so scene-images.ts maps it back to the
+//      owning store scene; the raw store uuid works too.
+//   3. When neither exists yet, a brief long-poll for the queued device
+//      fetch, then an honest 404.
+//
+// Owning the frame is the authorization — its scenes' renders and covers
+// are, by construction, content the account put there.
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ frameId: string; sceneId: string }> },
@@ -42,27 +94,78 @@ export async function GET(
     return jsonError("invalid_frame", 404);
   }
 
+  const thumb = request.nextUrl.searchParams.get("thumb") === "1";
+  const snapshotPath = sceneSnapshotAssetPath(sceneId);
+
+  const cached = await cachedAssetFile(db, frame.id, snapshotPath, thumb);
+  const now = Date.now();
+  const needsFetch =
+    !cached || now - cached.updatedAt.getTime() > snapshotStaleAfterMs;
+  let refused = needsFetch
+    ? await recentFailedAssetGet(
+        db,
+        frame.id,
+        snapshotPath,
+        thumb,
+        refusalMemoryMs,
+      )
+    : undefined;
+  if (needsFetch && !refused && frame.status === "active") {
+    await queueAssetGetIfIdle(
+      db,
+      session.accountId,
+      frame.id,
+      snapshotPath,
+      thumb,
+    );
+  }
+  if (cached) {
+    // Stale-while-revalidate: the refresh (if any) was queued above.
+    return imageResponse(cached.content, cached.contentType, snapshotBrowserMaxAge);
+  }
+
+  const cover = await storeSceneCover(db, frame.id, sceneId);
+  if (cover) {
+    return imageResponse(cover.content, cover.contentType, coverBrowserMaxAge);
+  }
+
+  // Long-polling only makes sense for a frame that is on the socket right
+  // now; a sleeping frame still gets the queued fetch on its next sync, and
+  // the tile heals on a later request.
+  if (refused || frame.status !== "active" || !frame.connected) {
+    return jsonError("no_image", 404);
+  }
+  const deadline = now + longPollTotalMs;
+  while (Date.now() < deadline) {
+    await sleep(longPollStepMs);
+    const row = await cachedAssetFile(db, frame.id, snapshotPath, thumb);
+    if (row) {
+      return imageResponse(row.content, row.contentType, snapshotBrowserMaxAge);
+    }
+    refused = await recentFailedAssetGet(
+      db,
+      frame.id,
+      snapshotPath,
+      thumb,
+      60_000,
+    );
+    if (refused) {
+      return jsonError("no_image", 404);
+    }
+  }
+  return jsonError("no_image", 404);
+}
+
+type Db = NonNullable<ReturnType<typeof requireDatabase>["db"]>;
+
+async function storeSceneCover(db: Db, frameId: string, sceneId: string) {
   const storeSceneId = await resolveStoreSceneForFrameScene(
     db,
-    frame.id,
+    frameId,
     sceneId,
   );
   if (!storeSceneId) {
-    return jsonError("no_image", 404);
+    return undefined;
   }
-  const image = await storeSceneCoverImage(db, storeSceneId);
-  if (!image) {
-    return jsonError("no_image", 404);
-  }
-  return new NextResponse(new Uint8Array(image.content), {
-    headers: {
-      // Covers change rarely (only on republish/regallery); the frame page
-      // may poll tiles, so let the browser hold them briefly — but privately,
-      // this sits behind a session.
-      "cache-control": "private, max-age=300",
-      "content-length": String(image.content.length),
-      "content-type": image.contentType,
-      "x-content-type-options": "nosniff",
-    },
-  });
+  return await storeSceneCoverImage(db, storeSceneId);
 }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
@@ -126,6 +126,16 @@ export async function POST(
   if (!Array.isArray(body.scenes) || body.scenes.length > maxScenesPerFrame) {
     return jsonError("invalid_scenes", 400);
   }
+  // Optional: which RUNTIME scene the push should activate — the workspace's
+  // save passes the currently active scene so a deploy never yanks the
+  // display to another scene. The device ignores an id that is not in the
+  // payload (it then activates the first scene), so only shape is validated.
+  const activeSceneId =
+    typeof body.scene_id === "string" &&
+    body.scene_id.length > 0 &&
+    body.scene_id.length <= 256
+      ? body.scene_id
+      : undefined;
   const requested: { sceneId: string; sceneVersion: number | null }[] = [];
   for (const entry of body.scenes) {
     if (!entry || typeof entry !== "object") {
@@ -247,7 +257,11 @@ export async function POST(
   const command = await enqueueFrameCommand(db, {
     createdByAccountId: session.accountId,
     frameId: frame.id,
-    payload: { checksum: payload.checksum, scenes: payload.scenes },
+    payload: {
+      checksum: payload.checksum,
+      scenes: payload.scenes,
+      ...(activeSceneId ? { scene_id: activeSceneId } : {}),
+    },
     type: "set_scenes",
   });
 

--- a/cloud/apps/auth-web/app/api/frames/enroll/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/enroll/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   authenticateLinkedClient,
   linkedClientHasScope,
+  linkedClientScopes,
 } from "../../../../src/lib/backend-auth";
 import {
   jsonError,
@@ -27,6 +28,18 @@ import { createEncryptedSecretToken, hashSecret } from "../../../../src/lib/secr
 export const runtime = "nodejs";
 
 const wsPath = "/api/frames/ws";
+
+// What a claim-token enrollment grants (see the linked-client insert below).
+// The response's `scope` string must list ALL of it: the device stores that
+// string as its local scope list and gates its own telemetry push loops on
+// it — reporting only frame:managed here is how frames ended up never
+// sending a single log line while the hub sat ready to accept them.
+const claimTokenGrantedScopes = [
+  frameManagedScope,
+  frameTelemetryLogsScope,
+  frameTelemetryMetricsScope,
+];
+const claimTokenScopeString = claimTokenGrantedScopes.join(" ");
 
 // Same set the frames-app shell route uses to decide "is this a dev server".
 const localHosts = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
@@ -218,11 +231,7 @@ async function enrollWithClaimToken(
             // (the hub refuses every log_batch with insufficient_scope and
             // nothing in the UI says why). The LOCAL switch on the device
             // (send_logs) remains the privacy control.
-            requestedScopes: [
-              frameManagedScope,
-              frameTelemetryLogsScope,
-              frameTelemetryMetricsScope,
-            ],
+            requestedScopes: claimTokenGrantedScopes,
           },
           publicDisplayName: name,
           tokenReference: accessToken.tokenReference,
@@ -283,7 +292,7 @@ async function enrollWithClaimToken(
   return NextResponse.json({
     access_token: result.accessTokenValue,
     frame_id: result.frame.id,
-    scope: frameManagedScope,
+    scope: claimTokenScopeString,
     status: result.frame.status,
     token_type: "Bearer",
     ws_path: wsPath,
@@ -346,7 +355,7 @@ async function replayEnrollment(
   return NextResponse.json({
     access_token: accessToken.token,
     frame_id: existing.frame.id,
-    scope: frameManagedScope,
+    scope: claimTokenScopeString,
     status: existing.frame.status,
     token_type: "Bearer",
     ws_path: wsPath,
@@ -397,7 +406,10 @@ async function enrollLinkedFrame(
       .where(eq(frames.id, existing.id));
     return NextResponse.json({
       frame_id: existing.id,
-      scope: frameManagedScope,
+      // The full grant, not just frame:managed — the device unions this into
+      // its local scope string (Flow B is additive) and enables its
+      // telemetry push loops from it.
+      scope: linkedClientScopes(linkedClient).join(" "),
       status: existing.status,
       ws_path: wsPath,
       ...(wsUrl ? { ws_url: wsUrl } : {}),
@@ -440,7 +452,7 @@ async function enrollLinkedFrame(
 
   return NextResponse.json({
     frame_id: frame.id,
-    scope: frameManagedScope,
+    scope: linkedClientScopes(linkedClient).join(" "),
     status: frame.status,
     ws_path: wsPath,
     ...(wsUrl ? { ws_url: wsUrl } : {}),

--- a/cloud/apps/auth-web/app/frames/[[...path]]/route.ts
+++ b/cloud/apps/auth-web/app/frames/[[...path]]/route.ts
@@ -83,6 +83,11 @@ function appConfigLines(): string[] {
     // deployment it would set a host-only cookie that shadows the shared one
     // and the two surfaces would disagree again.
     `cloud_theme_cookie_domain: ${JSON.stringify(getSessionCookieDomain() ?? "")},`,
+    // The wasm live preview's CORS escape hatch: the same anonymous,
+    // rate-limited proxy the store's scene pages use. Without it the SPA
+    // would try the backend's project-scoped proxy path, which the cloud
+    // does not serve, and every external fetch in a preview dies on CORS.
+    `preview_proxy_url: ${JSON.stringify("/api/store/preview-proxy")},`,
   ];
 }
 

--- a/cloud/apps/auth-web/src/lib/frame-asset-cache.test.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-cache.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAssetPath, sceneSnapshotAssetPath } from "./frame-asset-cache";
+import { hiddenWritePath, sanitizedUploadFilename } from "./frame-asset-write";
+
+// These mirror device-side Nim code byte for byte — sceneImageFilename in
+// frameos/src/frameos/scenes.nim and sanitizeAssetComponent in
+// admin_api_assets_routes.nim. A drift here means thumbnails silently 404
+// (wrong snapshot path) or upload responses name a file that does not exist.
+
+describe("sceneSnapshotAssetPath", () => {
+  it("builds the runner's snapshot path for a plain runtime id", () => {
+    // md5("abc") — the device hashes the PUBLIC id (uploaded/ prefix stripped).
+    expect(sceneSnapshotAssetPath("abc")).toBe(
+      ".frameos/scene_images/abc-900150983cd24fb0d6963f7d28e17f72.png",
+    );
+  });
+
+  it("strips the uploaded/ prefix like sceneImagePublicId does", () => {
+    expect(sceneSnapshotAssetPath("uploaded/abc")).toBe(
+      sceneSnapshotAssetPath("abc"),
+    );
+  });
+
+  it("replaces unsafe characters, strips edge punctuation, caps at 64", () => {
+    const path = sceneSnapshotAssetPath("../../etc");
+    // '/' becomes '_', then leading '.'/'_' are stripped: a single flat
+    // filename component, never a traversal.
+    expect(path.startsWith(".frameos/scene_images/etc-")).toBe(true);
+    expect(path.split("/").length).toBe(3);
+
+    const long = "x".repeat(100);
+    const longPath = sceneSnapshotAssetPath(long);
+    const filename = longPath.split("/").pop()!;
+    expect(filename.startsWith("x".repeat(64) + "-")).toBe(true);
+    expect(filename).not.toContain("x".repeat(65));
+  });
+
+  it("falls back to 'scene' when nothing survives sanitizing", () => {
+    expect(sceneSnapshotAssetPath("///").split("/").pop()!.startsWith("scene-")).toBe(
+      true,
+    );
+  });
+});
+
+describe("sanitizedUploadFilename", () => {
+  it("mirrors the device's component sanitizer", () => {
+    expect(sanitizedUploadFilename("My Photo (1).jpg")).toBe("My_Photo__1_.jpg");
+    expect(sanitizedUploadFilename("nested/dir/cat.png")).toBe("cat.png");
+    expect(sanitizedUploadFilename("...")).toBe("uploaded_file");
+    expect(sanitizedUploadFilename("")).toBe("uploaded_file");
+    // '-' survives edge stripping (the device only strips '_' and '.').
+    expect(sanitizedUploadFilename("-dash.bin")).toBe("-dash.bin");
+  });
+});
+
+describe("hiddenWritePath", () => {
+  it("refuses any dot-component, allows plain paths", () => {
+    expect(hiddenWritePath(".frameos/scene_images/x.png")).toBe(true);
+    expect(hiddenWritePath("photos/.thumbs/x.jpg")).toBe(true);
+    expect(hiddenWritePath("photos/cat.jpg")).toBe(false);
+    expect(hiddenWritePath("dot.folder/file")).toBe(false);
+  });
+});
+
+describe("normalizeAssetPath", () => {
+  it("strips ./ and leading slashes, refuses traversal and empties", () => {
+    expect(normalizeAssetPath("./photos/cat.jpg")).toBe("photos/cat.jpg");
+    expect(normalizeAssetPath("/photos/cat.jpg")).toBe("photos/cat.jpg");
+    expect(normalizeAssetPath("photos/../secret")).toBeUndefined();
+    expect(normalizeAssetPath("  ")).toBeUndefined();
+  });
+});

--- a/cloud/apps/auth-web/src/lib/frame-asset-cache.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-cache.ts
@@ -1,0 +1,173 @@
+// The hub's device-asset cache, shared by the routes that read it: one row
+// per (frame, path, thumb) in frame_asset_files, filled by asset_get /
+// image_get chunk streams (frame-hub handleAssetChunk) and pruned LRU by
+// storeFrameAssetFile. The /asset route serves arbitrary device files from
+// it; the /scene_images route uses it for the device's own per-scene
+// snapshots. Kept out of frames.ts (device write path) on purpose.
+
+import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
+import {
+  enqueueFrameCommand,
+  maxAssetPathChars,
+  type FramesDatabase,
+} from "./frames";
+
+export const assetFetchCommandTtlMs = 2 * 60 * 1000;
+
+/**
+ * Relative, bounded, no traversal — the device re-validates independently
+ * (resolveAssetPath on the Nim side), this just refuses obvious garbage
+ * before it costs a queued command.
+ */
+export function normalizeAssetPath(raw: string): string | undefined {
+  let path = raw.trim();
+  while (path.startsWith("./")) {
+    path = path.slice(2);
+  }
+  while (path.startsWith("/")) {
+    path = path.slice(1);
+  }
+  if (
+    path.length === 0 ||
+    path.length > maxAssetPathChars ||
+    path.split("/").includes("..")
+  ) {
+    return undefined;
+  }
+  return path;
+}
+
+export async function cachedAssetFile(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+) {
+  const [row] = await db
+    .select()
+    .from(frameAssetFiles)
+    .where(
+      and(
+        eq(frameAssetFiles.frameId, frameId),
+        eq(frameAssetFiles.path, path),
+        eq(frameAssetFiles.thumb, thumb),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+function payloadMatches(
+  payload: unknown,
+  path: string,
+  thumb: boolean,
+): boolean {
+  const record =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+  return record.path === path && (record.thumb === true) === thumb;
+}
+
+export async function outstandingAssetGet(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+) {
+  // Payload equality is checked in JS: the handful of live asset_get rows per
+  // frame does not justify a jsonb index.
+  const rows = await db
+    .select({ id: frameCommands.id, payload: frameCommands.payload })
+    .from(frameCommands)
+    .where(
+      and(
+        eq(frameCommands.frameId, frameId),
+        eq(frameCommands.type, "asset_get"),
+        inArray(frameCommands.status, ["pending", "sent"]),
+        or(
+          isNull(frameCommands.expiresAt),
+          gt(frameCommands.expiresAt, new Date()),
+        ),
+      ),
+    );
+  return rows.find((row) => payloadMatches(row.payload, path, thumb));
+}
+
+/**
+ * A recent `failed` asset_get for this exact path+thumb — the device refused
+ * (not_found, too_large, …). Callers use it to stop long-polling early and to
+ * avoid re-queueing a fetch the device just said no to.
+ */
+export async function recentFailedAssetGet(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+  withinMs: number,
+) {
+  const rows = await db
+    .select({ error: frameCommands.error, payload: frameCommands.payload })
+    .from(frameCommands)
+    .where(
+      and(
+        eq(frameCommands.frameId, frameId),
+        eq(frameCommands.type, "asset_get"),
+        eq(frameCommands.status, "failed"),
+        gt(frameCommands.createdAt, new Date(Date.now() - withinMs)),
+      ),
+    );
+  return rows.find((row) => payloadMatches(row.payload, path, thumb));
+}
+
+/** Queue an asset_get unless an equivalent one is already in flight. */
+export async function queueAssetGetIfIdle(
+  db: Parameters<typeof enqueueFrameCommand>[0],
+  accountId: string,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+) {
+  if (await outstandingAssetGet(db, frameId, path, thumb)) {
+    return;
+  }
+  await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    payload: { path, ...(thumb ? { thumb: true } : {}) },
+    ttlMs: assetFetchCommandTtlMs,
+    type: "asset_get",
+  });
+}
+
+/**
+ * Where the device keeps its own snapshot of a scene, relative to its assets
+ * root. Byte-for-byte mirror of sceneImageFilename in
+ * frameos/src/frameos/scenes.nim — the runner writes
+ * {assets}/.frameos/scene_images/{sanitized}-{md5(publicId)}.png on the first
+ * render of each scene and on every scene switch, and asset_get can read it
+ * (the dot-directory is hidden from assets_list, not from asset_get).
+ * Runtime scene ids arrive both bare and as "uploaded/<id>"; the device
+ * strips the prefix, so we do too.
+ */
+export function sceneSnapshotAssetPath(sceneId: string): string {
+  const uploadedPrefix = "uploaded/";
+  const publicId = sceneId.startsWith(uploadedPrefix)
+    ? sceneId.slice(uploadedPrefix.length)
+    : sceneId;
+  let safe = "";
+  for (const ch of publicId) {
+    safe += /[A-Za-z0-9._-]/.test(ch) ? ch : "_";
+  }
+  safe = safe.replace(/^[_.-]+/, "").replace(/[_.-]+$/, "");
+  if (safe.length === 0) {
+    safe = "scene";
+  }
+  if (safe.length > 64) {
+    safe = safe.slice(0, 64);
+  }
+  const digest = createHash("md5").update(publicId).digest("hex");
+  return `.frameos/scene_images/${safe}-${digest}.png`;
+}

--- a/cloud/apps/auth-web/src/lib/frame-asset-write.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-write.ts
@@ -1,0 +1,215 @@
+// Asset mutations for cloud-managed frames: enqueue a write verb
+// (asset_put / asset_mkdir / asset_delete / asset_rename), wait for the
+// device's ack, and keep the hub-side caches honest afterwards. The routes
+// under app/api/frames/[frameId]/assets/* mirror the self-hosted backend's
+// client contract so the shared SPA needs no cloud branch.
+
+import { and, eq, like, or } from "drizzle-orm";
+import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
+import type { NextRequest } from "next/server";
+import { csrfResponse } from "./csrf";
+import { jsonError, requireDatabase } from "./device-flow";
+import {
+  enqueueFrameCommand,
+  frameForAccount,
+  supersedePendingCommands,
+  type FramesDatabase,
+} from "./frames";
+import { rateLimitResponse } from "./rate-limit";
+import { readSession } from "./session";
+
+type CommandDatabase = Parameters<typeof enqueueFrameCommand>[0];
+
+// Mirror of HubMaxAssetUploadBytes (frameos/src/frameos/cloud/hub_client.nim):
+// an upload rides a single base64-encoded WS frame under the device's 4 MiB
+// inbound cap. Bigger files need a chunked verb that does not exist yet.
+export const maxAssetUploadBytes = 2_621_440;
+
+const commandTtlMs = 2 * 60 * 1000;
+// Mutations are user-blocking (a dialog waits on them), so wait about as
+// long as the asset long-poll does before calling the frame unreachable.
+const ackTimeoutMs = 30_000;
+const ackPollStepMs = 500;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * The filename the device will actually store, mirroring
+ * sanitizeAssetComponent(extractFilename(...), "uploaded_file", allowDot) in
+ * admin_api_assets_routes.nim — the ack's payload does not survive into
+ * frame_commands, so the route predicts the stored path instead.
+ */
+export function sanitizedUploadFilename(filename: string): string {
+  const base = filename.split("/").pop() ?? "";
+  let safe = "";
+  for (const ch of base) {
+    safe += /[A-Za-z0-9._-]/.test(ch) ? ch : "_";
+  }
+  safe = safe.replace(/^[_.]+/, "").replace(/[_.]+$/, "");
+  return safe.length > 0 ? safe : "uploaded_file";
+}
+
+/**
+ * Mirror of the device's refusedWritePath: writes never touch dot-directories
+ * (.thumbs, .frameos) — refusing here spares a queued command the device
+ * would reject anyway.
+ */
+export function hiddenWritePath(path: string): boolean {
+  return path
+    .split("/")
+    .some((component) => component.length > 0 && component.startsWith("."));
+}
+
+export type AssetCommandResult =
+  | { ok: true }
+  | { ok: false; error: string; timedOut?: boolean };
+
+/**
+ * Enqueue one write verb and long-poll its ack. Resolves ok on the device's
+ * ack, with the device's wire error on refusal, and with timedOut when the
+ * frame did not answer in time — the command stays queued, so a sleeping
+ * frame still applies it on its next sync; the caller just cannot claim it
+ * happened yet.
+ */
+export async function runAssetWriteCommand(
+  db: CommandDatabase,
+  accountId: string,
+  frameId: string,
+  type: "asset_put" | "asset_mkdir" | "asset_delete" | "asset_rename",
+  payload: Record<string, unknown>,
+): Promise<AssetCommandResult> {
+  const command = await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    payload,
+    ttlMs: commandTtlMs,
+    type,
+  });
+  if (!command) {
+    return { ok: false, error: "command_not_queued" };
+  }
+  const deadline = Date.now() + ackTimeoutMs;
+  while (Date.now() < deadline) {
+    await sleep(ackPollStepMs);
+    const [row] = await db
+      .select({ error: frameCommands.error, status: frameCommands.status })
+      .from(frameCommands)
+      .where(eq(frameCommands.id, command.id))
+      .limit(1);
+    if (!row) {
+      return { ok: false, error: "command_lost" };
+    }
+    if (row.status === "acked") {
+      return { ok: true };
+    }
+    if (row.status === "failed" || row.status === "expired") {
+      return { ok: false, error: row.error ?? "asset_write_failed" };
+    }
+  }
+  return { ok: false, error: "frame_unreachable", timedOut: true };
+}
+
+/**
+ * Drop cached file bytes for a path (both thumb variants) and, for
+ * directories, everything under it — after a delete or rename the cache
+ * would otherwise keep serving the old bytes for up to the staleness window.
+ */
+export async function invalidateCachedAssetSubtree(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+) {
+  // Escape LIKE metacharacters in the path so "10%" or "a_b" folders do not
+  // widen the invalidation to unrelated rows.
+  const prefix = path.replace(/([\\%_])/g, "\\$1");
+  await db
+    .delete(frameAssetFiles)
+    .where(
+      and(
+        eq(frameAssetFiles.frameId, frameId),
+        or(
+          eq(frameAssetFiles.path, path),
+          like(frameAssetFiles.path, `${prefix}/%`),
+        ),
+      ),
+    );
+}
+
+/**
+ * The shared guard rail for every asset mutation route: CSRF, rate limit,
+ * session, database, frame ownership, and the frame being active. Returns
+ * either an error response to relay or the context to work with.
+ */
+export async function assetWriteRequestContext(
+  request: NextRequest,
+  frameId: string,
+): Promise<
+  | { response: Response }
+  | {
+      response?: undefined;
+      db: CommandDatabase;
+      accountId: string;
+      frame: NonNullable<Awaited<ReturnType<typeof frameForAccount>>>;
+    }
+> {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return { response: csrf };
+  }
+  const limited = await rateLimitResponse(request, "frames:asset_write", {
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return { response: limited };
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return { response: jsonError("login_required", 401) };
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return { response: response! };
+  }
+  const frame = await frameForAccount(db, session.accountId, frameId);
+  if (!frame) {
+    return { response: jsonError("invalid_frame", 404) };
+  }
+  if (frame.status !== "active") {
+    return { response: jsonError("frame_not_active", 409) };
+  }
+  return { db, accountId: session.accountId, frame };
+}
+
+/** Map a device refusal / queue outcome onto an HTTP error response. */
+export function assetWriteErrorResponse(
+  result: Extract<AssetCommandResult, { ok: false }>,
+) {
+  if (result.timedOut) {
+    return jsonError(result.error, 504);
+  }
+  const status =
+    result.error === "not_found"
+      ? 404
+      : result.error === "too_large"
+        ? 413
+        : 400;
+  return jsonError(result.error, status);
+}
+
+/** Queue a fresh assets_list so the panel's next refresh shows the change. */
+export async function queueAssetsListRefresh(
+  db: CommandDatabase,
+  accountId: string,
+  frameId: string,
+) {
+  await supersedePendingCommands(db, frameId, "assets_list");
+  await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    ttlMs: commandTtlMs,
+    type: "assets_list",
+  });
+}

--- a/cloud/apps/auth-web/src/test/integration/frame-scene-images.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frame-scene-images.integration.test.ts
@@ -9,6 +9,8 @@ import { zipSync } from "fflate";
 import { NextRequest } from "next/server";
 import {
   createDb,
+  frameAssetFiles,
+  frameCommands,
   frames,
   frameSceneAssignments,
   linkedClients,
@@ -19,6 +21,7 @@ import {
 } from "@frameos-cloud/db";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET as getSceneImage } from "../../../app/api/frames/[frameId]/scene_images/[sceneId]/route";
+import { sceneSnapshotAssetPath } from "../../lib/frame-asset-cache";
 import { resetRateLimitForTests } from "../../lib/rate-limit";
 import { resetSceneImageCacheForTests } from "../../lib/scene-images";
 import { hashSecret } from "../../lib/secrets";
@@ -352,5 +355,85 @@ describe("GET /api/frames/{id}/scene_images/{sceneId}", () => {
     expect(Buffer.from(await second.arrayBuffer()).toString()).toBe(
       "cached-bytes",
     );
+  });
+
+  it("prefers the device's cached snapshot over the store cover", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Snapshotted",
+      previewImage: Buffer.from("cover-bytes"),
+      previewImageType: "image/jpeg",
+      runtimeSceneIds: ["runtime-snap"],
+    });
+    await assignScene(frame.id, scene.id);
+    await db.insert(frameAssetFiles).values({
+      content: Buffer.from("device-render"),
+      contentType: "image/png",
+      frameId: frame.id,
+      path: sceneSnapshotAssetPath("runtime-snap"),
+      sizeBytes: "device-render".length,
+      thumb: false,
+    });
+
+    const response = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-snap`),
+      routeParams(frame.id, "runtime-snap"),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=60");
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "device-render",
+    );
+  });
+
+  it("queues an asset_get for the snapshot and serves the cover meanwhile", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Fetching",
+      previewImage: Buffer.from("cover-bytes"),
+      previewImageType: "image/jpeg",
+      runtimeSceneIds: ["runtime-fetch"],
+    });
+    await assignScene(frame.id, scene.id);
+
+    const response = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-fetch?thumb=1`),
+      routeParams(frame.id, "runtime-fetch"),
+    );
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "cover-bytes",
+    );
+    const queued = await db
+      .select({ payload: frameCommands.payload, type: frameCommands.type })
+      .from(frameCommands)
+      .where(eq(frameCommands.frameId, frame.id));
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.type).toBe("asset_get");
+    expect(queued[0]!.payload).toEqual({
+      path: sceneSnapshotAssetPath("runtime-fetch"),
+      thumb: true,
+    });
+  });
+
+  it("404s fast for an unmapped scene on a disconnected frame, still queueing the fetch", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+
+    const started = Date.now();
+    const response = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-unknown`),
+      routeParams(frame.id, "runtime-unknown"),
+    );
+    expect(response.status).toBe(404);
+    // No long poll: the frame is not connected, so waiting cannot help.
+    expect(Date.now() - started).toBeLessThan(5000);
+    const queued = await db
+      .select({ type: frameCommands.type })
+      .from(frameCommands)
+      .where(eq(frameCommands.frameId, frame.id));
+    expect(queued.map((row) => row.type)).toEqual(["asset_get"]);
   });
 });

--- a/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
@@ -293,11 +293,15 @@ describe("cloud-managed frame enrollment", () => {
     const payload = (await response.json()) as Record<string, unknown>;
     expect(payload.status).toBe("pending");
     expect(payload.token_type).toBe("Bearer");
-    expect(payload.scope).toBe("frame:managed");
+    // The FULL grant, not just frame:managed — the device stores this string
+    // as its local scope list and gates its telemetry push loops on it.
+    expect(payload.scope).toBe(
+      "frame:managed telemetry:logs telemetry:metrics",
+    );
     expect(payload.ws_path).toBe("/api/frames/ws");
     expect(typeof payload.access_token).toBe("string");
 
-    // The linked client is real and carries only the managed scope.
+    // The linked client is real and carries the claim-token grant.
     const [frame] = await db
       .select()
       .from(frames)

--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -524,6 +524,12 @@ export async function startFrameHub(
         JSON.stringify({
           id: randomUUID(),
           pending_commands: pendingCount,
+          // What this link is granted, so the device can enable the matching
+          // push loops. Load-bearing for older enrollments: their enroll
+          // response under-reported the scope string as just frame:managed,
+          // so without this a frame never learns it may send telemetry
+          // (docs/cloud-frames.md session start).
+          scopes: session.scopes,
           type: "ready",
         }),
       );

--- a/cloud/docs/cloud-workspace-gaps.md
+++ b/cloud/docs/cloud-workspace-gaps.md
@@ -1,5 +1,29 @@
 # Cloud workspace: the road to full frame control
 
+> Status (2026-08-05, cloud-workspace-fixes): item **2** got its long-term
+> half — `/scene_images/{sceneId}` now serves the DEVICE's own per-scene
+> snapshot first (the runner already writes
+> `{assets}/.frameos/scene_images/{name}-{md5}.png` on every scene switch;
+> the route fetches it through the existing `asset_get` verb +
+> `frame_asset_files` cache, `?thumb=1` riding the device's 320×320
+> thumbnailer) and falls back to store covers. Item **3** grew real
+> persistence: cloud Save & Deploy now saves edited scenes to the account
+> (new versions of assigned private scenes via `/api/account/scenes/{id}/
+> content`, brand-new scenes via the new `POST /api/account/scenes`
+> create-from-JSON route), updates the assignment list and pushes it — the
+> ad-hoc uploadScenes push is only the fallback when persistence fails. The
+> Assets panel is read-write on cloud: new wire verbs `asset_put` /
+> `asset_mkdir` / `asset_delete` / `asset_rename` (docs/cloud-frames.md;
+> dot-directories refused, 2.5 MiB single-frame upload cap) behind
+> backend-contract routes `/api/frames/{id}/assets/{upload,mkdir,delete,
+> rename}`. The wasm live preview proxies external fetches through
+> `/api/store/preview-proxy` on cloud (injected `preview_proxy_url` +
+> `isCloudMode()` fallback in livePreviewLogic — it used to resolve the
+> backend's project-scoped proxy path, fail, and leave every fetch to die on
+> CORS). Monaco + app sources work in the cloud workspace (bundled monaco +
+> workers in cloud-frontend, embedded builtin app sources), and the tab
+> title says FrameOS Cloud.
+
 > Status (2026-08-03, this branch): items **4** and **5** are done, item **8**
 > is done (tiles hydrate from the server), and asset browsing shipped as a new
 > surface: `assets_list`/`asset_get` wire verbs (docs/cloud-frames.md), hub

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -223,14 +223,22 @@ but not in this device's profile), `message_too_large`, `invalid_json`,
 | `assets_list` | `{}` | bare ack, then a separate `{"id", "type": "assets", "assets": [{"path", "size", "mtime", "is_dir"?}…], "truncated"?: true}` message with the same `id`. Paths are **relative to the device's assets directory** (`assets_path`, default `/srv/assets`) — never absolute. A device may bound the listing (the reference cap is 5000 entries) and must then say so with `"truncated": true` rather than silently stopping |
 | `image_get` | `{}` | the frame's current rendered image. Bare ack, then the same `asset_chunk` stream `asset_get` uses (same `id` correlation, same caps); the first chunk's `content_type` says what the device produces (the Linux runtime sends `image/png` of its last render, the ESP32 packs `image/bmp` from its framebuffer). `ok: false` ack with `no_image` when nothing has rendered yet, `busy` on a small device already streaming |
 | `asset_get` | `{"path": "…", "thumb"?: true}` | read one file from the assets directory. Failure is an ordinary `ok: false` ack: `invalid_path` (traversal, absolute, or outside the assets directory), `not_found`, `is_directory`, `too_large` (the reference cap is **8 MiB** raw), `busy` (a small device already streaming another file). Success is a bare ack followed by one or more `{"id", "type": "asset_chunk", "seq": 0…N, "data": "<base64>", "done": bool}` messages with the same `id`, in order; the first chunk also carries `"size"` (total raw bytes), `"mtime"` and `"content_type"`. A read that fails after the ack ends the stream with `{"type": "asset_chunk", "id", "error": "…", "done": true}` and the provider discards the partial file. With `thumb`, a device that can generate thumbnails (Linux) returns a small preview; a device that cannot (ESP32) returns the original bytes |
+| `asset_put` | `{"path": "…", "data": "<base64>"}` | store one file in the assets directory. The whole payload rides a single message, so the raw size is bounded well under the inbound frame cap (the reference device cap is **2.5 MiB** raw — `too_large` past it); the filename component is sanitized by the device exactly like a local admin upload, parent folders are created as needed, and an existing file at the path is replaced. Errors: `invalid_path` (traversal, absolute, outside the assets directory, or a dot-directory — see below), `invalid_data` (empty or undecodable base64), `too_large`, `write_failed`. The ack carries `"asset": {"path" (relative, as stored), "size", "mtime", "is_dir"}` |
+| `asset_mkdir` | `{"path": "…"}` | create a folder (and parents) in the assets directory. Errors: `invalid_path`, `write_failed` |
+| `asset_delete` | `{"path": "…"}` | delete a file or folder (recursively) in the assets directory. Errors: `invalid_path`, `not_found`, `write_failed` |
+| `asset_rename` | `{"src": "…", "dst": "…"}` | rename/move a file or folder within the assets directory (the destination's parent folders are created). Errors: `invalid_path`, `not_found`, `write_failed` |
 
 Explicitly absent, by design (see `cloud/docs/cloud-frames.md`): shell/exec,
 PTY, arbitrary file read/write, SSH anything, network/WiFi config, admin
 credentials, update URLs, agent/profile state, compiled scene deploys. The
-`assets_list`/`asset_get` verbs are deliberately not a file API: they are
-read-only, confined to the assets directory (the same user-content directory
-the local admin's Assets panel serves), and the device — not the provider —
-resolves and bounds every path.
+asset verbs are deliberately not a file API: they are confined to the assets
+directory (the same user-content directory the local admin's Assets panel
+serves), and the device — not the provider — resolves and bounds every path.
+Additionally, the write verbs (`asset_put`/`asset_mkdir`/`asset_delete`/
+`asset_rename`) refuse any path containing a dot-component: dot-directories
+(`.thumbs`, `.frameos`) are the device's own plumbing (thumbnail cache, scene
+snapshots) — readable via `asset_get` where the provider knows a specific
+path, but never writable from the wire.
 
 ### Device profiles
 
@@ -244,7 +252,7 @@ drains either way.
 | Profile | Implements | Answers `unsupported_verb` for |
 |---|---|---|
 | Full (Linux/Raspberry Pi FrameOS) | the whole table | — |
-| ESP32 (microcontroller firmware) | `set_scenes`, `set_current_scene`, `get_state`, `render`, `reboot`, `restart_runtime` (identical to `reboot`: on ESP32 the runtime *is* the firmware), `assets_list`, `asset_get` (both only while the SD card is mounted — otherwise an empty listing / `not_found`; `thumb` is ignored and the original bytes are returned), `image_get` (`image/bmp`) | `set_schedule`, `set_settings`, `get_logs`, `get_metrics`, `notify_update_available` |
+| ESP32 (microcontroller firmware) | `set_scenes`, `set_current_scene`, `get_state`, `render`, `reboot`, `restart_runtime` (identical to `reboot`: on ESP32 the runtime *is* the firmware), `assets_list`, `asset_get` (both only while the SD card is mounted — otherwise an empty listing / `not_found`; `thumb` is ignored and the original bytes are returned), `image_get` (`image/bmp`) | `set_schedule`, `set_settings`, `get_logs`, `get_metrics`, `notify_update_available`, `asset_put`, `asset_mkdir`, `asset_delete`, `asset_rename` |
 
 The ESP32 profile is a subset because the firmware has no scheduler, no log
 buffer and no metrics buffer to expose, and updates itself from its own

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -179,8 +179,13 @@ profile they target rather than relying on the cap.
    64-byte signature; the provider verifies the signature against the same
    decoded bytes it generated. (Signing the base64 text is the obvious
    mistake, and it fails silently — the socket simply closes.)
-4. Provider → frame: `{"type": "ready", "pending_commands": N}` — then drains
-   the durable per-frame command queue in order.
+4. Provider → frame: `{"type": "ready", "pending_commands": N,
+   "scopes"?: ["frame:managed", "telemetry:logs", …]}` — then drains the
+   durable per-frame command queue in order. The optional `scopes` array is
+   the link's currently granted scope list; a device should treat it as
+   additive truth and enable the matching push loops (telemetry above all) —
+   it is how a frame whose enrollment response under-reported the grant
+   learns it may send logs and metrics without re-enrolling.
 
 The provider must verify the signature against the enrolled public key and
 close the socket on mismatch, with WebSocket close code **4401** (also used

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -1355,7 +1355,9 @@ static void ws_handle_message(const char *data, size_t len)
         /* provider-side notices; nothing to do */
     } else if (strcmp(type, "set_schedule") == 0 || strcmp(type, "set_settings") == 0 ||
                strcmp(type, "get_logs") == 0 || strcmp(type, "get_metrics") == 0 ||
-               strcmp(type, "notify_update_available") == 0) {
+               strcmp(type, "notify_update_available") == 0 ||
+               strcmp(type, "asset_put") == 0 || strcmp(type, "asset_mkdir") == 0 ||
+               strcmp(type, "asset_delete") == 0 || strcmp(type, "asset_rename") == 0) {
         /* Documented verbs the esp32 profile does not implement. Answering
          * `unsupported_verb` (not `unknown_verb`) lets a provider tell "this
          * device profile is smaller" apart from "you sent something that is

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -222,6 +222,25 @@ proc persistScenesChecksum(checksum: string) {.gcsafe.} =
       state["scenes_checksum"] = %checksum
       saveCloudLinkState(state)
 
+proc persistProviderScopes(scopes: seq[string]): bool {.gcsafe.} =
+  ## Union the scopes the provider announced in its `ready` message into the
+  ## link state. Additive on purpose (removals arrive as a fresh enroll or a
+  ## link reset, never silently): older enroll responses under-reported the
+  ## grant as just frame:managed, so this is how an already-enrolled frame
+  ## learns it may send telemetry. Returns true when anything changed; the
+  ## save bumps the link generation, which the session loop already watches.
+  {.gcsafe.}:
+    if scopes.len == 0:
+      return false
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      let existing = state{"scope"}.getStr("")
+      let merged = unionScopeString(existing, scopes.join(" "))
+      if merged != existing:
+        state["scope"] = %merged
+        saveCloudLinkState(state)
+        result = true
+
 proc providerExemptHostPort(providerUrl: string): string =
   ## "host:port" for the provider's own API endpoint. The local admin linked
   ## this provider deliberately (possibly a dev provider on the LAN), so its
@@ -1131,9 +1150,11 @@ proc recvJsonWithin(socket: WebSocket, timeoutMs: int): Future[JsonNode] {.async
   except JsonParsingError:
     result = %*{}
 
-proc runHandshake(socket: WebSocket, ctx: CloudVerbContext) {.async.} =
+proc runHandshake(socket: WebSocket, ctx: CloudVerbContext): Future[JsonNode] {.async.} =
   ## hello → challenge → auth → ready. Raises CloudHubAuthError when the
-  ## provider rejects the signature or the handshake stalls.
+  ## provider rejects the signature or the handshake stalls. Returns the
+  ## `ready` message — it carries `pending_commands` and (newer hubs) the
+  ## link's granted `scopes`.
   var hello = helloStatePayload(ctx.frameConfig, ctx.scenesChecksum)
   hello["type"] = %"hello"
   await socket.send($hello)
@@ -1171,7 +1192,7 @@ proc runHandshake(socket: WebSocket, ctx: CloudVerbContext) {.async.} =
     let ready = await recvJsonWithin(socket, HubHandshakeTimeoutMs)
     let msgType = ready{"type"}.getStr("")
     if msgType == "ready":
-      break
+      return ready
     if msgType == "error":
       raise newException(CloudHubAuthError,
         "Provider rejected device authentication: " & ready{"error"}.getStr(""))
@@ -1253,8 +1274,28 @@ proc runHubSession(frameConfig: FrameConfig, link: HubLinkSnapshot):
   let pingInterval = min(HubPingIntervalSeconds, idleTimeout / 3)
   result = sessionDisconnected
   try:
-    await runHandshake(socket, ctx)
+    let ready = await runHandshake(socket, ctx)
     log(%*{"event": "cloud:hub:connected", "provider": link.providerUrl})
+    # The hub announces the link's granted scopes in `ready`. Merge anything
+    # new into the local link state — this is how frames whose enroll response
+    # under-reported the grant (older providers said only frame:managed)
+    # finally learn they may push telemetry. The generation-watch below picks
+    # up the persisted change; the in-memory flags update here so the very
+    # first session already forwards logs.
+    let readyScopes = ready{"scopes"}
+    if readyScopes != nil and readyScopes.kind == JArray:
+      var announced: seq[string] = @[]
+      for scope in readyScopes:
+        if scope.kind == JString and scope.getStr("").len > 0:
+          announced.add(scope.getStr(""))
+      if persistProviderScopes(announced):
+        generation = currentCloudLinkGeneration()
+        for scope in announced:
+          if scope notin ctx.scopes:
+            ctx.scopes.add(scope)
+        logsGranted = "telemetry:logs" in ctx.scopes
+        metricsGranted = "telemetry:metrics" in ctx.scopes
+        log(%*{"event": "cloud:hub:scopesUpdated", "scopes": ctx.scopes.join(" ")})
     if logsGranted:
       # Drop anything queued before this session so the provider only gets
       # lines from its own watch window.

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -10,11 +10,14 @@
 ## arbitrary file read/write verb, no SSH anything, no compiled-scene deploy —
 ## the code for those capabilities simply does not exist here, so no
 ## provider-side compromise or configuration flag can reach them. The only
-## file access is `assets_list`/`asset_get`: read-only, resolved and bounded
-## on-device inside the assets directory (admin_api_assets_routes'
-## resolveAssetPath — the same guard the local Assets panel uses). Anything
-## outside the verb table is answered with `unknown_verb` and audit-logged
-## through the normal log pipeline (`cloud:audit`).
+## file access is the asset verb family (`assets_list`/`asset_get` plus the
+## write verbs `asset_put`/`asset_mkdir`/`asset_delete`/`asset_rename`):
+## resolved and bounded on-device inside the assets directory
+## (admin_api_assets_routes' resolveAssetPath — the same guard the local
+## Assets panel uses), with writes additionally refused for dot-directories
+## (`.frameos`, `.thumbs` — the device's own plumbing). Anything outside the
+## verb table is answered with `unknown_verb` and audit-logged through the
+## normal log pipeline (`cloud:audit`).
 ##
 ## Frames keep working when the provider is down: this thread only ever pushes
 ## data out and reacts to messages; rendering, schedules and the local admin
@@ -96,6 +99,10 @@ const
   # folder. Over the cap the listing says `truncated: true` — never a silent
   # stop (a partial listing that looks complete is worse than none).
   HubMaxAssetListEntries* = 5000
+  # `asset_put` rides a single inbound frame (there is no cloud→device chunk
+  # stream), so the raw payload must survive base64 inflation plus envelope
+  # inside HubMaxInboundBytes. 2.5 MiB raw ≈ 3.4 MiB encoded.
+  HubMaxAssetUploadBytes* = 2_621_440
 
 # Declarative settings a provider may push; every key maps onto an existing
 # frame.json field through the same persist path the local admin uses. Must
@@ -157,6 +164,14 @@ type
     ## paths relative to the assets directory (docs/cloud-frames.md).
     listAssetsFn*: proc(): JsonNode {.gcsafe.}
     readAssetFn*: proc(path: string, thumb: bool): AssetReadResult {.gcsafe.}
+    ## Write verbs. writeAssetFn returns the stored entry as
+    ## {"path" (relative), "size", "mtime", "is_dir"}; all four raise
+    ## ValueError for a path the guard refuses and OSError for a filesystem
+    ## failure — the handlers translate those into wire errors.
+    writeAssetFn*: proc(path: string, data: string): JsonNode {.gcsafe.}
+    mkdirAssetFn*: proc(path: string) {.gcsafe.}
+    deleteAssetFn*: proc(path: string) {.gcsafe.}
+    renameAssetFn*: proc(src: string, dst: string) {.gcsafe.}
     ## The current rendered image for `image_get` (error "no_image" until the
     ## first render).
     getImageFn*: proc(): AssetReadResult {.gcsafe.}
@@ -352,6 +367,17 @@ proc defaultReadAsset(path: string, thumb: bool): AssetReadResult {.gcsafe.} =
       contentType: if thumb: "image/jpeg" else: contentTypeForFilePath(fullPath),
       mtime: getFileInfo(fullPath).lastWriteTime.toUnix())
 
+proc defaultWriteAsset(path: string, data: string): JsonNode {.gcsafe.} =
+  ## Store one uploaded file. resolveAssetUploadPath sanitizes the filename
+  ## component exactly like the local admin upload does, so the provider
+  ## cannot smuggle path tricks through the name; the returned path is the
+  ## relative path actually written.
+  {.gcsafe.}:
+    let (dir, name, ext) = splitFile(path)
+    var payload = saveAssetUploadPayload(dir, name & ext, data)
+    payload["path"] = %relativeAssetPath(payload{"path"}.getStr(""))
+    payload
+
 proc defaultCloudVerbContext*(frameConfig: FrameConfig, scopes: seq[string],
                               scenesChecksum: string): CloudVerbContext {.gcsafe.} =
   {.gcsafe.}:
@@ -385,6 +411,18 @@ proc defaultCloudVerbContext*(frameConfig: FrameConfig, scopes: seq[string],
       readAssetFn: proc(path: string, thumb: bool): AssetReadResult {.gcsafe.} =
         {.gcsafe.}:
           defaultReadAsset(path, thumb),
+      writeAssetFn: proc(path: string, data: string): JsonNode {.gcsafe.} =
+        {.gcsafe.}:
+          defaultWriteAsset(path, data),
+      mkdirAssetFn: proc(path: string) {.gcsafe.} =
+        {.gcsafe.}:
+          createAssetDirectory(path),
+      deleteAssetFn: proc(path: string) {.gcsafe.} =
+        {.gcsafe.}:
+          deleteAssetEntry(path),
+      renameAssetFn: proc(src: string, dst: string) {.gcsafe.} =
+        {.gcsafe.}:
+          renameAssetEntry(src, dst),
       getImageFn: proc(): AssetReadResult {.gcsafe.} =
         {.gcsafe.}:
           try:
@@ -698,6 +736,107 @@ proc handleImageGet(ctx: CloudVerbContext, id: JsonNode): CloudVerbReply =
   ctx.audit("image_get", true)
   CloudVerbReply(ack: ackOk(id), extra: assetChunkExtras(id, image))
 
+proc assetWriteError(error: ref CatchableError): string =
+  ## The write helpers raise ValueError for guard refusals and OSError for
+  ## filesystem trouble; "Asset not found" is the one OSError worth naming.
+  if error of ValueError:
+    "invalid_path"
+  elif error.msg == "Asset not found":
+    "not_found"
+  else:
+    "write_failed"
+
+proc refusedWritePath(path: string): bool =
+  ## Writes never touch dot-directories: `.thumbs` and `.frameos` (scene
+  ## snapshots) are the device's own plumbing. asset_get deliberately CAN
+  ## read them (that is how the provider fetches scene snapshots), but a
+  ## provider must not be able to plant or destroy files there.
+  hiddenAssetPath(path.strip())
+
+proc handleAssetPut(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.writeAssetFn.isNil:
+    ctx.audit("asset_put", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let path = msg{"path"}.getStr("")
+  if path.len == 0 or refusedWritePath(path):
+    ctx.audit("asset_put", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  let encoded = msg{"data"}.getStr("")
+  var data: string
+  try:
+    data = decode(encoded)
+  except CatchableError:
+    ctx.audit("asset_put", false, "invalid_data")
+    return CloudVerbReply(ack: ackError(id, "invalid_data"))
+  if data.len == 0:
+    ctx.audit("asset_put", false, "invalid_data")
+    return CloudVerbReply(ack: ackError(id, "invalid_data"))
+  if data.len > HubMaxAssetUploadBytes:
+    ctx.audit("asset_put", false, "too_large")
+    return CloudVerbReply(ack: ackError(id, "too_large"))
+  try:
+    let stored = ctx.writeAssetFn(path, data)
+    ctx.audit("asset_put", true)
+    var ack = ackOk(id)
+    ack["asset"] = stored
+    CloudVerbReply(ack: ack)
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_put", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
+proc handleAssetMkdir(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.mkdirAssetFn.isNil:
+    ctx.audit("asset_mkdir", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let path = msg{"path"}.getStr("")
+  if path.len == 0 or refusedWritePath(path):
+    ctx.audit("asset_mkdir", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  try:
+    ctx.mkdirAssetFn(path)
+    ctx.audit("asset_mkdir", true)
+    CloudVerbReply(ack: ackOk(id))
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_mkdir", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
+proc handleAssetDelete(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.deleteAssetFn.isNil:
+    ctx.audit("asset_delete", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let path = msg{"path"}.getStr("")
+  if path.len == 0 or refusedWritePath(path):
+    ctx.audit("asset_delete", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  try:
+    ctx.deleteAssetFn(path)
+    ctx.audit("asset_delete", true)
+    CloudVerbReply(ack: ackOk(id))
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_delete", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
+proc handleAssetRename(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.renameAssetFn.isNil:
+    ctx.audit("asset_rename", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let src = msg{"src"}.getStr("")
+  let dst = msg{"dst"}.getStr("")
+  if src.len == 0 or dst.len == 0 or refusedWritePath(src) or refusedWritePath(dst):
+    ctx.audit("asset_rename", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  try:
+    ctx.renameAssetFn(src, dst)
+    ctx.audit("asset_rename", true)
+    CloudVerbReply(ack: ackOk(id))
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_rename", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
 proc handleGetLogs(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
   if not ctx.hasScope("telemetry:logs"):
     ctx.audit("get_logs", false, "insufficient_scope")
@@ -761,6 +900,14 @@ proc handleCloudVerb*(ctx: CloudVerbContext, msg: JsonNode): CloudVerbReply {.gc
     result = handleAssetsList(ctx, id)
   of "asset_get":
     result = handleAssetGet(ctx, id, msg)
+  of "asset_put":
+    result = handleAssetPut(ctx, id, msg)
+  of "asset_mkdir":
+    result = handleAssetMkdir(ctx, id, msg)
+  of "asset_delete":
+    result = handleAssetDelete(ctx, id, msg)
+  of "asset_rename":
+    result = handleAssetRename(ctx, id, msg)
   of "image_get":
     result = handleImageGet(ctx, id)
   of "render":

--- a/frameos/src/frameos/cloud/tests/test_hub_verbs.nim
+++ b/frameos/src/frameos/cloud/tests/test_hub_verbs.nim
@@ -13,6 +13,10 @@ type
     dropEvents: bool ## simulates a full runtime event queue
     assetReads: seq[(string, bool)]
     assetData: string ## what readAssetFn serves for "photos/cat.jpg"
+    assetWrites: seq[(string, string)]
+    assetMkdirs: seq[string]
+    assetDeletes: seq[string]
+    assetRenames: seq[(string, string)]
 
 proc makeContext(recorded: Recorded, scopes: seq[string] = @[]): CloudVerbContext =
   CloudVerbContext(
@@ -56,6 +60,19 @@ proc makeContext(recorded: Recorded, scopes: seq[string] = @[]): CloudVerbContex
         AssetReadResult(error: "no_image")
       else:
         AssetReadResult(data: "png-bytes", contentType: "image/png", mtime: 1700000002),
+    writeAssetFn: proc(path: string, data: string): JsonNode {.gcsafe.} =
+      if path == "denied.bin":
+        raise newException(ValueError, "Invalid asset path")
+      recorded.assetWrites.add((path, data))
+      %*{"path": path, "size": data.len, "mtime": 1700000003, "is_dir": false},
+    mkdirAssetFn: proc(path: string) {.gcsafe.} =
+      recorded.assetMkdirs.add(path),
+    deleteAssetFn: proc(path: string) {.gcsafe.} =
+      if path == "missing.bin":
+        raise newException(OSError, "Asset not found")
+      recorded.assetDeletes.add(path),
+    renameAssetFn: proc(src: string, dst: string) {.gcsafe.} =
+      recorded.assetRenames.add((src, dst)),
     rebootFn: proc() {.gcsafe.} =
       recorded.reboots += 1,
     auditFn: proc(payload: JsonNode) {.gcsafe.} =
@@ -426,6 +443,73 @@ suite "cloud hub verb dispatcher":
     })
     check refused.ack{"error"}.getStr("") == "no_image"
     check refused.extra.len == 0
+
+  test "asset_put stores decoded bytes and acks the stored entry":
+    let recorded = Recorded()
+    let reply = handleCloudVerb(makeContext(recorded), %*{
+      "id": "p1", "type": "asset_put",
+      "path": "photos/new.jpg", "data": encode("fresh-bytes"),
+    })
+    check reply.ack{"ok"}.getBool(false) == true
+    check reply.ack{"asset"}{"path"}.getStr("") == "photos/new.jpg"
+    check reply.ack{"asset"}{"size"}.getInt(0) == "fresh-bytes".len
+    check recorded.assetWrites == @[("photos/new.jpg", "fresh-bytes")]
+
+  test "asset_put refuses bad payloads without touching the filesystem":
+    let recorded = Recorded()
+    let ctx = makeContext(recorded)
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "data": encode("x"),
+    }).ack{"error"}.getStr("") == "invalid_path"
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "path": "a.bin", "data": "",
+    }).ack{"error"}.getStr("") == "invalid_data"
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "path": "a.bin", "data": "not-base64!!!",
+    }).ack{"error"}.getStr("") == "invalid_data"
+    # Guard refusals from the write helper surface as invalid_path.
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "path": "denied.bin", "data": encode("x"),
+    }).ack{"error"}.getStr("") == "invalid_path"
+    check recorded.assetWrites.len == 0
+
+  test "asset write verbs never touch dot-directories":
+    let recorded = Recorded()
+    let ctx = makeContext(recorded)
+    for message in [
+      %*{"type": "asset_put", "path": ".frameos/scene_images/x.png", "data": encode("x")},
+      %*{"type": "asset_mkdir", "path": ".thumbs/sub"},
+      %*{"type": "asset_delete", "path": ".frameos"},
+      %*{"type": "asset_rename", "src": "ok.bin", "dst": ".thumbs/ok.bin"},
+      %*{"type": "asset_rename", "src": ".thumbs/x.jpg", "dst": "ok.bin"},
+    ]:
+      check handleCloudVerb(ctx, message).ack{"error"}.getStr("") == "invalid_path"
+    check recorded.assetWrites.len == 0
+    check recorded.assetMkdirs.len == 0
+    check recorded.assetDeletes.len == 0
+    check recorded.assetRenames.len == 0
+
+  test "asset_mkdir, asset_delete and asset_rename dispatch and map errors":
+    let recorded = Recorded()
+    let ctx = makeContext(recorded)
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_mkdir", "path": "albums/summer",
+    }).ack{"ok"}.getBool(false) == true
+    check recorded.assetMkdirs == @["albums/summer"]
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_delete", "path": "photos/old.jpg",
+    }).ack{"ok"}.getBool(false) == true
+    check recorded.assetDeletes == @["photos/old.jpg"]
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_delete", "path": "missing.bin",
+    }).ack{"error"}.getStr("") == "not_found"
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_rename", "src": "photos/cat.jpg", "dst": "photos/dog.jpg",
+    }).ack{"ok"}.getBool(false) == true
+    check recorded.assetRenames == @[("photos/cat.jpg", "photos/dog.jpg")]
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_rename", "src": "", "dst": "x.bin",
+    }).ack{"error"}.getStr("") == "invalid_path"
 
   test "reboot and restart_runtime use the injected implementations":
     let recorded = Recorded()

--- a/frameos/src/system/index/scene.nim
+++ b/frameos/src/system/index/scene.nim
@@ -1,16 +1,23 @@
 {.warning[UnusedImport]: off.}
 import pixie, json, strformat, strutils, sequtils, options, os, tables, algorithm
 import std/monotimes
+import std/uri
 import zippy
 
 import frameos/values
 import frameos/types
 import frameos/channels
+import frameos/cloud/link_state
 import frameos/utils/url
 import frameos/utils/time
 import apps/render/text/app as render_textApp
 import scenes/scenes as compiledScenes
 import system/options as sceneOptions
+
+# Sockets exist on the device runtimes only — the wasm/embedded builds render
+# this scene too, and there the address lines just say "unknown".
+when not defined(frameosWasm) and not defined(frameosEmbedded):
+  import std/net as system_net
 
 const DEBUG = true
 let PUBLIC_STATE_FIELDS*: seq[StateField] = @[]
@@ -71,18 +78,89 @@ proc buildSceneList*(self: Scene): seq[(string, string)] =
   ordered.sort(proc(a, b: (string, string)): int = cmpIgnoreCase(a[1], b[1]))
   return ordered
 
+proc defaultRouteInterface*(): string =
+  ## The interface carrying the default route ("wlan0", "eth0"), from
+  ## /proc/net/route — Linux only, empty anywhere else. Pure file read, no
+  ## child processes.
+  try:
+    if fileExists("/proc/net/route"):
+      for line in readFile("/proc/net/route").splitLines():
+        let cols = line.splitWhitespace()
+        if cols.len >= 2 and cols[1] == "00000000":
+          return cols[0]
+  except CatchableError:
+    discard
+  ""
+
+proc primaryIpAddress*(): string =
+  ## The local address the kernel would route external traffic through:
+  ## "connect" a UDP socket to a public address (no packet is sent) and read
+  ## the socket's own address back. Empty when there is no usable network.
+  when defined(frameosWasm) or defined(frameosEmbedded):
+    ""
+  else:
+    try:
+      let socket = system_net.newSocket(system_net.Domain.AF_INET,
+        system_net.SockType.SOCK_DGRAM, system_net.Protocol.IPPROTO_UDP)
+      defer: socket.close()
+      socket.connect("1.1.1.1", system_net.Port(53))
+      let (address, _) = socket.getLocalAddr()
+      if address.len > 0 and address != "0.0.0.0":
+        return address
+      ""
+    except CatchableError:
+      ""
+
+proc cloudProviderHostname(state: JsonNode): string =
+  let providerUrl = providerUrlFromState(state)
+  try:
+    let parsed = parseUri(providerUrl)
+    if parsed.hostname.len > 0:
+      return parsed.hostname
+  except CatchableError:
+    discard
+  providerUrl
+
+proc managementLine*(frameConfig: FrameConfig): string =
+  ## Who controls this frame: FrameOS Cloud (managed enrollment), a
+  ## self-hosted backend, or nobody (standalone). The old "Server:
+  ## not configured:8989" line lied on cloud-managed frames, whose
+  ## server_host is deliberately empty.
+  let linkState = loadCloudLinkState()
+  if linkState{"mode"}.getStr("") == "managed":
+    let host = cloudProviderHostname(linkState)
+    let status = linkState{"status"}.getStr("disconnected")
+    return &"Managed via: FrameOS Cloud ({host}, {status})"
+  let serverHost = frameConfig.serverHost
+  if serverHost.len > 0 and serverHost notin ["localhost", "127.0.0.1", "::1"]:
+    let serverPort = if frameConfig.serverPort > 0: $frameConfig.serverPort else: "?"
+    return &"Managed via: self-hosted backend ({serverHost}:{serverPort})"
+  "Managed via: standalone (no server configured)"
+
 proc buildSceneListText*(self: Scene): string =
   let entries = self.buildSceneList()
   let frameConfig = self.frameConfig
   let resolution = &"{frameConfig.width}x{frameConfig.height}"
   let deviceName = if frameConfig.name.len > 0: frameConfig.name else: "Unnamed frame"
   let deviceType = if frameConfig.device.len > 0: frameConfig.device else: "unknown device"
-  let serverHost = if frameConfig.serverHost.len > 0: frameConfig.serverHost else: "not configured"
-  let serverPort = if frameConfig.serverPort > 0: $frameConfig.serverPort else: "?"
-  let frameHost = if frameConfig.frameHost.len > 0: frameConfig.frameHost else: "0.0.0.0"
+  let ipAddress = primaryIpAddress()
+  let networkInterface = defaultRouteInterface()
+  let networkLine =
+    if ipAddress.len > 0 and networkInterface.len > 0:
+      &"Network: {ipAddress} ({networkInterface})"
+    elif ipAddress.len > 0:
+      &"Network: {ipAddress}"
+    else:
+      "Network: not connected"
+  # 0.0.0.0 means "listening everywhere" — as a URL it helps nobody, so show
+  # the address the network actually reaches this frame on when we know it.
+  let configuredFrameHost = if frameConfig.frameHost.len > 0: frameConfig.frameHost else: "0.0.0.0"
+  let frameHost =
+    if configuredFrameHost == "0.0.0.0" and ipAddress.len > 0: ipAddress
+    else: configuredFrameHost
   let framePort = if publicPort(frameConfig) > 0: $publicPort(frameConfig) else: "?"
   let frameScheme = publicScheme(frameConfig)
-  let agentAccess = if frameConfig.agent != nil and frameConfig.agent.agentEnabled: "enabled" else: "disabled"
+  let remoteControl = if frameConfig.agent != nil and frameConfig.agent.agentEnabled: "enabled" else: "disabled"
   var lines: seq[string] = @[
     "FrameOS System Info",
     "",
@@ -91,9 +169,10 @@ proc buildSceneListText*(self: Scene): string =
     &"Resolution: {resolution}",
     &"Rotation: {frameConfig.rotate}°",
     &"Time zone: {frameConfig.timeZone}",
-    &"Server: {serverHost}:{serverPort}",
+    networkLine,
+    managementLine(frameConfig),
     &"Frame: {frameScheme}://{frameHost}:{framePort}",
-    &"Agent access: {agentAccess}",
+    &"FrameOS Remote control: {remoteControl}",
     ""
   ]
   if entries.len == 0:

--- a/frameos/src/system/index/tests/test_scene.nim
+++ b/frameos/src/system/index/tests/test_scene.nim
@@ -81,8 +81,35 @@ suite "system/index scene":
       check "Resolution: 800x480" in text
       check "Rotation: 90" in text
       check "Time zone: Europe/Brussels" in text
-      check "Server: frameos.local:8989" in text
+      check "Network: " in text
+      check "Managed via: self-hosted backend (frameos.local:8989)" in text
       check "Frame: http://192.168.1.50:8787" in text
-      check "Agent access: disabled" in text
+      check "FrameOS Remote control: disabled" in text
       check "Installed Scenes" in text
       check "1. Default Scene" in text
+
+  test "management line prefers the cloud link and falls back to standalone":
+    # loadCloudLinkState reads ./state/cloud_link.json relative to the cwd, so
+    # run this from a scratch directory we control.
+    let previousDir = getCurrentDir()
+    let tempDir = getTempDir() / ("frameos-index-scene-link-" & $epochTime())
+    createDir(tempDir / "state")
+    setCurrentDir(tempDir)
+    try:
+      var config = testConfig()
+      config.serverHost = ""
+      check index_scene.managementLine(config) == "Managed via: standalone (no server configured)"
+
+      config.serverHost = "localhost"
+      check index_scene.managementLine(config) == "Managed via: standalone (no server configured)"
+
+      writeFile("state" / "cloud_link.json", $(%*{
+        "mode": "managed",
+        "status": "connected",
+        "provider_url": "https://cloud.frameos.net",
+      }))
+      check index_scene.managementLine(config) ==
+        "Managed via: FrameOS Cloud (cloud.frameos.net, connected)"
+    finally:
+      setCurrentDir(previousDir)
+      removeDir(tempDir)

--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -131,6 +131,19 @@ const cloudFrameSceneHydrationsInFlight = new Set<FrameId>()
 const cloudFrameScenesHydratedAt = new Map<FrameId, number>()
 const CLOUD_FRAME_SCENES_REFRESH_MS = 60_000
 
+/**
+ * Drop cached scenes.json bodies for one store scene (all pinned versions and
+ * 'latest'). A content save publishes a new version, and the '@latest' cache
+ * key would otherwise keep serving the pre-save body until a reload.
+ */
+export function clearCloudSceneJsonCache(storeSceneId: string): void {
+  for (const key of [...cloudSceneJsonCache.keys()]) {
+    if (key.startsWith(`${storeSceneId}@`)) {
+      cloudSceneJsonCache.delete(key)
+    }
+  }
+}
+
 async function fetchCloudFrameScenes(frameId: FrameId): Promise<FrameScene[]> {
   const rows = await listCloudFrameScenes(frameId)
   const scenes: FrameScene[] = []

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -25,6 +25,8 @@ import { duplicateScenes } from '../../utils/duplicateScenes'
 import { apiFetch } from '../../utils/apiFetch'
 import { isCloudMode } from '../../utils/cloudMode'
 import { pushCloudFrameSettings } from '../../utils/cloudFrameApi'
+import { persistAndPushCloudFrameScenes } from '../../utils/cloudFrameScenesSave'
+import { clearCloudSceneJsonCache } from '../../models/framesModel'
 import { getBasePath } from '../../utils/getBasePath'
 import { projectApiPath, projectApiPathFromCache } from '../../utils/projectApi'
 import { longRunningTasksModel } from '../../models/longRunningTasksModel'
@@ -2293,9 +2295,12 @@ export const frameLogic = kea<frameLogicType>([
     // push (the same call saveFrameForm makes) — but a form whose only
     // pending changes are scenes maps onto no settings at all, which
     // saveFrameForm treats as an error on a plain Save. Here it is fine: the
-    // scenes ARE the deploy, pushed by framesModel.deployFrame through the
-    // uploadScenes shim (set_scenes). So push what maps, ignore "nothing
-    // mapped", then hand over to the cloud deploy path.
+    // scenes are persisted separately — each edited scene becomes a new
+    // version of its private cloud scene (new scenes are created), the
+    // assignment list is updated, and POST /api/frames/{id}/scenes pushes the
+    // checksummed result to the device. That push IS the deploy; the ad-hoc
+    // uploadScenes shim stays as the fallback when persistence fails, so the
+    // frame still updates even if the cloud refuses a scene.
     const cloudSaveAndDeploy = async (): Promise<void> => {
       try {
         await pushCloudFrameSettings(props.frameId, normalizeFrameForSubmit(values.frameForm))
@@ -2316,7 +2321,49 @@ export const frameLogic = kea<frameLogicType>([
         longRunningTasksModel.actions.taskFailed({ frameId: props.frameId, kind: 'save', detail })
         throw error
       }
-      framesModel.actions.deployFrame(props.frameId, false)
+      const scenes = values.frameForm?.scenes ?? values.frame?.scenes ?? []
+      if (!scenes.length) {
+        framesModel.actions.deployFrame(props.frameId, false)
+        return
+      }
+      longRunningTasksModel.actions.startTask({
+        frameId: props.frameId,
+        kind: 'deploy',
+        title: 'Deploying scenes',
+        detail: 'Saving scenes to your cloud account',
+      })
+      try {
+        const outcome = await persistAndPushCloudFrameScenes(
+          props.frameId,
+          scenes,
+          values.frame?.active_scene_id
+        )
+        for (const storeSceneId of outcome.changedStoreSceneIds) {
+          clearCloudSceneJsonCache(storeSceneId)
+        }
+        framesModel.actions.hydrateCloudFrameScenes(props.frameId, true)
+        framesModel.actions.loadFrame(props.frameId)
+        longRunningTasksModel.actions.finishTask({
+          frameId: props.frameId,
+          kind: 'deploy',
+          status: 'success',
+          detail: [
+            'Saved to your cloud scenes — the frame applies them as soon as it syncs',
+            ...outcome.notes,
+          ].join('. '),
+        })
+      } catch (error) {
+        // Persistence failed (rate limit, moderation, offline store…) — the
+        // ad-hoc push still deploys the edited scenes to the device, it just
+        // cannot save them; deployFrame reports its own outcome.
+        const message = error instanceof Error ? error.message : String(error)
+        longRunningTasksModel.actions.taskFailed({
+          frameId: props.frameId,
+          kind: 'deploy',
+          detail: `Could not save the scenes to your cloud account (${message}) — pushing them straight to the frame instead`,
+        })
+        framesModel.actions.deployFrame(props.frameId, false)
+      }
     }
 
     return {

--- a/frontend/src/scenes/frame/panels/Assets/Assets.tsx
+++ b/frontend/src/scenes/frame/panels/Assets/Assets.tsx
@@ -597,9 +597,10 @@ export function Assets({ scrollContainer = true }: AssetsProps = {}): JSX.Elemen
   const { toggleShowSystemFolders } = useActions(assetsLogic(assetsLogicProps))
   const { setFrameAssetFolderExpanded } = useActions(workspaceLogic)
   // Font sync pulls from the backend's own store; the on-device panel and the
-  // cloud have nothing to sync from. Cloud is read-only wholesale — its wire
-  // contract is assets_list/asset_get and nothing else.
-  const readOnly = workspaceMode() === 'cloud'
+  // cloud have nothing to sync from. Everything else works on every control
+  // plane — the cloud speaks asset_put/asset_mkdir/asset_delete/asset_rename
+  // through /api/frames/{id}/assets/* since cloud-workspace-fixes.
+  const readOnly = false
   const showSyncAction = workspaceMode() === 'backend'
 
   // syncAssets registers a long-running task toast, so no need to open logs

--- a/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
@@ -447,9 +447,9 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
 
           <div className="frameos-muted shrink-0 text-xs">
             Runs the scene with the FrameOS interpreter compiled to WebAssembly, in your browser. Apps that fetch
-            external URLs are routed through the backend to get around browser CORS restrictions, so images and data
-            load — the device itself fetches them directly. Device-only apps (screenshots, camera snapshots) are
-            unavailable.
+            external URLs are routed through a same-origin proxy to get around browser CORS restrictions, so images
+            and data load — the device itself fetches them directly. Device-only apps (screenshots, camera snapshots)
+            are unavailable.
           </div>
         </div>
 

--- a/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
@@ -4,6 +4,8 @@ import { router } from 'kea-router'
 import { FrameScene, GPIOButton, RepositoryType, TemplateType, FrameId } from '../../../../types'
 import { apiFetch } from '../../../../utils/apiFetch'
 import { assetUrl } from '../../../../utils/assetUrl'
+import { isCloudMode } from '../../../../utils/cloudMode'
+import { isFrameControlMode } from '../../../../utils/frameControlMode'
 import { getBasePath } from '../../../../utils/getBasePath'
 import { projectApiPath } from '../../../../utils/projectApi'
 import { frameLogic } from '../../frameLogic'
@@ -291,16 +293,19 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
 
       // Fetch the frame's assembled settings (app API keys etc.) so data apps
       // that need secrets can run in the preview. Best-effort: a scene with no
-      // secret-using apps still previews fine if this fails.
+      // secret-using apps still previews fine if this fails. The cloud stores
+      // no backend settings and serves no such route, so don't ask it.
       let settings: Record<string, any> = {}
-      try {
-        const response = await apiFetch(`/api/frames/${frameId}/scene_preview_settings`)
-        if (response.ok) {
-          const data = await response.json()
-          settings = data?.settings ?? {}
+      if (!isCloudMode()) {
+        try {
+          const response = await apiFetch(`/api/frames/${frameId}/scene_preview_settings`)
+          if (response.ok) {
+            const data = await response.json()
+            settings = data?.settings ?? {}
+          }
+        } catch (error) {
+          // fall through with empty settings
         }
-      } catch (error) {
-        // fall through with empty settings
       }
       // User-entered keys (setPreviewSettings) win over the backend's, merged
       // per settings group.
@@ -309,7 +314,7 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       }
       const settingsJson = JSON.stringify(settings)
 
-      // Same-origin backend proxy so the runtime's HTTP requests (image apps,
+      // Same-origin proxy so the runtime's HTTP requests (image apps,
       // weather, ...) work despite CORS — the worker's sync XHR carries auth
       // cookies to it. Resolve the project-prefixed absolute path up front.
       // An embedding page (the standalone editor bundle) can supply its own
@@ -318,6 +323,14 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       const configuredProxyUrl = (window as any).FRAMEOS_APP_CONFIG?.preview_proxy_url
       if (typeof configuredProxyUrl === 'string' && configuredProxyUrl) {
         proxyUrl = configuredProxyUrl
+      } else if (isCloudMode()) {
+        // The cloud has no project-scoped backend proxy; it serves the same
+        // anonymous, rate-limited proxy the store's preview pages use. Also
+        // the fallback for a shell served without injected app config.
+        proxyUrl = getBasePath() + '/api/store/preview-proxy'
+      } else if (isFrameControlMode()) {
+        // The frame's own web server has no proxy endpoint — leave the
+        // preview direct-only rather than probing routes that don't exist.
       } else {
         try {
           proxyUrl = getBasePath() + (await projectApiPath(`/api/frames/${frameId}/scene_preview_proxy`))

--- a/frontend/src/scenes/workspace/FrameosShell.tsx
+++ b/frontend/src/scenes/workspace/FrameosShell.tsx
@@ -45,9 +45,12 @@ import { DeployToFrameIcon } from './FrameChangeStatusIcon'
 import { FrameRenameModal } from './FrameActionsMenu'
 import { isInFrameAdminMode } from '../../utils/frameAdmin'
 import { getFrameControlFrameId } from '../../utils/frameControlMode'
+import { isCloudMode } from '../../utils/cloudMode'
 import type { FrameId } from '../../types'
 
-const DEFAULT_BROWSER_TITLE = 'FrameOS Backend'
+// The tab title's suffix names the surface being used: the shared SPA also
+// serves cloud.frameos.net/frames, where "FrameOS Backend" is a lie.
+const DEFAULT_BROWSER_TITLE = isCloudMode() ? 'FrameOS Cloud' : 'FrameOS Backend'
 
 interface FrameosShellProps {
   mode: WorkspaceMode

--- a/frontend/src/scenes/workspace/systemAppSourceLogic.ts
+++ b/frontend/src/scenes/workspace/systemAppSourceLogic.ts
@@ -2,8 +2,8 @@ import { actions, afterMount, kea, key, path, props, propsChanged, reducers, sel
 import { loaders } from 'kea-loaders'
 
 import type { systemAppSourceLogicType } from './systemAppSourceLogicType'
-import { apiFetch } from '../../utils/apiFetch'
 import { buildAppTypeDeclarations } from '../../utils/appTypeDeclarations'
+import { loadAppSources } from '../../utils/sceneApps'
 
 export interface SystemAppSourceLogicProps {
   keyword: string | null
@@ -47,11 +47,10 @@ export const systemAppSourceLogic = kea<systemAppSourceLogicType>([
           }
 
           try {
-            const response = await apiFetch(`/api/apps/source?keyword=${encodeURIComponent(props.keyword)}`)
-            if (!response.ok) {
-              throw new Error('Failed to fetch app sources')
-            }
-            const sources = withoutGeneratedSources((await response.json()) as Record<string, string>)
+            // Embedded catalogs first, the backend API second (loadAppSources)
+            // — on control planes without /api/apps/source (the cloud, the
+            // on-device admin) the embedded sources are the only copy.
+            const sources = withoutGeneratedSources(await loadAppSources(props.keyword))
             actions.setActiveFile(firstSourceFile(sources))
             return sources
           } catch (error) {

--- a/frontend/src/utils/cloudFrameApi.ts
+++ b/frontend/src/utils/cloudFrameApi.ts
@@ -159,6 +159,90 @@ export async function listCloudFrameScenes(frameId: FrameId): Promise<CloudFrame
 }
 
 /**
+ * Replace a cloud frame's assignment list outright and push it to the device
+ * (POST /api/frames/{id}/scenes enqueues the checksummed set_scenes). Pass
+ * `activeSceneId` (a RUNTIME scene id) to keep the current scene on screen —
+ * the device otherwise activates the first scene of the payload.
+ */
+export async function setCloudFrameScenes(
+  frameId: FrameId,
+  scenes: readonly { scene_id: string; scene_version?: number | null }[],
+  activeSceneId?: string
+): Promise<void> {
+  const response = await apiFetch(`/api/frames/${frameId}/scenes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      scenes: scenes.map((scene) => ({
+        scene_id: scene.scene_id,
+        ...(scene.scene_version ? { scene_version: scene.scene_version } : {}),
+      })),
+      ...(activeSceneId ? { scene_id: activeSceneId } : {}),
+    }),
+  })
+  await assertOk(response, 'Failed to update the frame scene list')
+}
+
+/**
+ * The scenes.json body of a store scene — the exact payload the device
+ * receives over set_scenes, carrying the runtime scene ids. Null when the
+ * scene is unreadable (pulled, network) so callers can leave it untouched.
+ */
+export async function fetchStoreSceneScenesJson(storeSceneId: string): Promise<FrameScene[] | null> {
+  try {
+    const response = await apiFetch(`/api/store/scenes/${storeSceneId}/scenes.json`)
+    if (!response.ok) {
+      return null
+    }
+    const json = await response.json()
+    return Array.isArray(json) && json.length > 0 ? (json as FrameScene[]) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Create a NEW private cloud scene from raw scenes JSON
+ * (POST /api/account/scenes — cloud only). Returns the store scene id.
+ */
+export async function createCloudAccountScene(
+  name: string,
+  scenes: readonly Partial<FrameScene>[],
+  description?: string
+): Promise<string> {
+  const response = await apiFetch(`/api/account/scenes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, scenes, ...(description ? { description } : {}) }),
+  })
+  await assertOk(response, `Failed to save "${name}" to your cloud scenes`)
+  const data = (await response.json()) as { scene?: { id?: string } }
+  if (!data.scene?.id) {
+    throw new Error(`Failed to save "${name}" to your cloud scenes (no scene id returned)`)
+  }
+  return data.scene.id
+}
+
+/**
+ * Replace a private cloud scene's contents with new scenes JSON, publishing a
+ * new immutable version (POST /api/account/scenes/{id}/content). Returns the
+ * new version number when the server reports one.
+ */
+export async function updateCloudAccountSceneContent(
+  storeSceneId: string,
+  scenes: readonly Partial<FrameScene>[]
+): Promise<number | undefined> {
+  const response = await apiFetch(`/api/account/scenes/${storeSceneId}/content`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ scenes }),
+  })
+  await assertOk(response, 'Failed to save the scene changes to your cloud scenes')
+  const data = (await response.json()) as { scene?: { version?: number } }
+  return typeof data.scene?.version === 'number' ? data.scene.version : undefined
+}
+
+/**
  * Assign a store scene to a cloud-managed frame. This is the cloud's actual
  * scene contract: POST /api/frames/{id}/scenes takes the full ordered list of
  * STORE scene ids, persists it server-side and enqueues a set_scenes push to

--- a/frontend/src/utils/cloudFrameScenesSave.ts
+++ b/frontend/src/utils/cloudFrameScenesSave.ts
@@ -1,0 +1,151 @@
+import type { FrameScene } from '../types'
+import {
+  cloudDeployActiveSceneId,
+  createCloudAccountScene,
+  fetchStoreSceneScenesJson,
+  listCloudFrameScenes,
+  setCloudFrameScenes,
+  updateCloudAccountSceneContent,
+} from './cloudFrameApi'
+import type { FrameId } from './frameId'
+
+// Cloud "Save & Deploy" persistence (cloud-workspace-fixes): the edited scene
+// graphs in the workspace form become durable server-side state instead of an
+// ad-hoc set_scenes push that only the device remembers.
+//
+//   * a form scene that came from an assigned store scene updates that store
+//     scene's contents (a new immutable version via /api/account/scenes/
+//     {id}/content) — multi-scene packs keep their other scenes;
+//   * a form scene with no owning assignment becomes a NEW private cloud
+//     scene (/api/account/scenes) and is appended to the assignment list;
+//   * assignments whose every runtime scene was removed from the form are
+//     dropped;
+//   * finally the full assignment list goes to POST /api/frames/{id}/scenes,
+//     which persists it and enqueues the checksummed set_scenes push — the
+//     deploy. The device's scenes_checksum then matches assigned_checksum,
+//     so the workspace shows in-sync and /scene_images resolves server truth.
+//
+// Editing a store scene the account does NOT own (a public install) cannot
+// update in place; the fallback forks the edited content into a new private
+// scene and swaps the assignment to it.
+
+export interface CloudScenePersistOutcome {
+  /** Store scene ids whose content changed or that were newly created. */
+  changedStoreSceneIds: string[]
+  /** Human-readable notes for non-fatal fallbacks (shown in the deploy toast). */
+  notes: string[]
+}
+
+interface AssignmentPlan {
+  scene_id: string
+  scene_version?: number | null
+}
+
+function sceneName(scene: Partial<FrameScene>): string {
+  return (scene.name ?? '').trim() || 'Untitled scene'
+}
+
+function scenesEqual(a: readonly Partial<FrameScene>[], b: readonly Partial<FrameScene>[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+/**
+ * Persist the workspace's edited scene list server-side, then push the
+ * resulting assignment list to the device. Throws only when the final push
+ * fails — per-scene persistence failures degrade to notes so one refused
+ * scene does not lose the rest of the save.
+ */
+export async function persistAndPushCloudFrameScenes(
+  frameId: FrameId,
+  formScenes: readonly FrameScene[],
+  activeSceneId?: string | null
+): Promise<CloudScenePersistOutcome> {
+  const rows = await listCloudFrameScenes(frameId)
+  const formById = new Map<string, FrameScene>()
+  for (const scene of formScenes) {
+    if (scene?.id) {
+      formById.set(scene.id, scene)
+    }
+  }
+
+  const changedStoreSceneIds: string[] = []
+  const notes: string[] = []
+  const assignments: AssignmentPlan[] = []
+  const claimedRuntimeIds = new Set<string>()
+
+  for (const row of rows) {
+    const stored = await fetchStoreSceneScenesJson(row.scene_id)
+    if (!stored) {
+      // Unreadable (pulled scene, transient error): keep the assignment
+      // untouched rather than guessing — its runtime scenes also stay
+      // unclaimed, which would duplicate them as new private scenes, so
+      // claim whatever the form still holds under this assignment's id.
+      assignments.push({ scene_id: row.scene_id, scene_version: row.scene_version ?? null })
+      if (formById.has(row.scene_id)) {
+        claimedRuntimeIds.add(row.scene_id)
+      }
+      continue
+    }
+
+    const storedIds = stored.map((scene) => scene.id).filter(Boolean)
+    const presentIds = storedIds.filter((id) => formById.has(id))
+    for (const id of presentIds) {
+      claimedRuntimeIds.add(id)
+    }
+    if (presentIds.length === 0) {
+      // Every runtime scene of this pack was removed from the frame.
+      continue
+    }
+
+    const updated = stored.map((scene) => formById.get(scene.id) ?? scene)
+    if (scenesEqual(stored, updated)) {
+      assignments.push({ scene_id: row.scene_id, scene_version: row.scene_version ?? null })
+      continue
+    }
+
+    try {
+      const version = await updateCloudAccountSceneContent(row.scene_id, updated)
+      changedStoreSceneIds.push(row.scene_id)
+      assignments.push({
+        scene_id: row.scene_id,
+        // A pinned assignment follows the edit it just made; an unpinned one
+        // keeps tracking latest (which now IS the edit).
+        scene_version: row.scene_version ? (version ?? null) : null,
+      })
+    } catch (error) {
+      // Not ours to edit (public install), name clash, moderation… — fork the
+      // edited content into a new private scene and swap the assignment.
+      try {
+        const name = row.name || sceneName(updated[0] ?? {})
+        const newSceneId = await createCloudAccountScene(name, updated)
+        changedStoreSceneIds.push(newSceneId)
+        assignments.push({ scene_id: newSceneId })
+        notes.push(`Saved the edited "${name}" as a new private cloud scene`)
+      } catch (forkError) {
+        const message = forkError instanceof Error ? forkError.message : String(forkError)
+        notes.push(`Kept "${row.name ?? row.scene_id}" unchanged in the cloud: ${message}`)
+        assignments.push({ scene_id: row.scene_id, scene_version: row.scene_version ?? null })
+      }
+    }
+  }
+
+  // Scenes with no owning assignment: newly created in the workspace (or
+  // deployed ad-hoc before this flow existed). Each becomes its own private
+  // cloud scene, in form order.
+  for (const scene of formScenes) {
+    if (!scene?.id || claimedRuntimeIds.has(scene.id)) {
+      continue
+    }
+    const name = sceneName(scene)
+    const newSceneId = await createCloudAccountScene(name, [scene])
+    changedStoreSceneIds.push(newSceneId)
+    assignments.push({ scene_id: newSceneId })
+  }
+
+  await setCloudFrameScenes(
+    frameId,
+    assignments,
+    cloudDeployActiveSceneId(activeSceneId, formScenes) ?? undefined
+  )
+  return { changedStoreSceneIds, notes }
+}


### PR DESCRIPTION
Closes the biggest cloud-workspace gaps found on the first real Pi Zero 2 W SD-card frame (`cloud/docs/cloud-workspace-gaps.md` updated with the new status).

## Scene thumbnails (`scene_images` 404s)
`GET /api/frames/{id}/scene_images/{sceneId}` now serves the **device's own per-scene snapshot** first: the runner already writes `{assets}/.frameos/scene_images/{name}-{md5}.png` on every scene switch, and the existing `asset_get` verb can stream it (`?thumb=1` rides the device's 320×320 thumbnailer). Fetched through the `frame_asset_files` cache with stale-while-revalidate; store covers stay as the fallback; long-polls only for connected frames. Shared cache plumbing extracted into `src/lib/frame-asset-cache.ts`, with `sceneSnapshotAssetPath` mirroring `sceneImageFilename` in `scenes.nim` byte for byte (unit-tested).

## Cloud Save & Deploy persists
- Edited scenes become new versions of their private cloud scenes (`POST /api/account/scenes/{id}/content`).
- New scenes become new private cloud scenes via a new create-from-JSON route (`POST /api/account/scenes`): canonical template zip built server-side and handed to `publishStoreScene` (quotas/moderation/audit apply); names are deduplicated ("name 2") instead of silently versioning a same-named scene.
- The assignment push (`POST /api/frames/{id}/scenes`, which now accepts `scene_id` so a deploy keeps the active scene on screen) is the deploy — device checksum then matches `assigned_checksum`, so the workspace shows in-sync and tiles resolve server truth. The ad-hoc `uploadScenes` push is only the fallback when persistence fails.

## Assets panel: read-write on cloud
New wire verbs `asset_put` / `asset_mkdir` / `asset_delete` / `asset_rename` (`docs/cloud-frames.md`): confined to the assets dir by the same `resolveAssetPath` guard as the local admin, dot-directories (`.thumbs`, `.frameos`) never writable, uploads capped at 2.5 MiB raw (single WS frame — no cloud→device chunk stream exists). Cloud routes mirror the backend's client contract at `/api/frames/{id}/assets/{upload,mkdir,delete,rename}` (enqueue → long-poll ack → invalidate caches → refresh listing), so the shared SPA just drops its cloud read-only gate. ESP32 answers `unsupported_verb`.

## WASM live preview CORS on cloud
`livePreviewLogic` resolved the backend's project-scoped proxy path unconditionally; on cloud that fails silently and every external fetch died on CORS (the "CyberPunk EU" gallery scene). The served shell now injects `preview_proxy_url: "/api/store/preview-proxy"` (the same anonymous rate-limited proxy the store pages use) with an `isCloudMode()` client fallback; frame-control mode stops probing routes the device doesn't serve; the `scene_preview_settings` fetch is skipped on cloud; tooltip copy updated ("same-origin proxy").

## Apps page on cloud
- Monaco: `cloud-frontend` never imported `configureMonaco`, so `@monaco-editor/react` pulled monaco from a CDN the CSP blocks → bare script error. Now imports it and `build.mjs` bundles the five workers unhashed into `static/monaco/`.
- App sources: `systemAppSourceLogic` goes through `loadAppSources()` (embedded builtin/repo catalogs first), so `/api/apps/source` 404s no longer blank the page.

## System-info boot scene
- `Managed via: FrameOS Cloud (cloud.frameos.net, connected)` / `self-hosted backend (host:port)` / `standalone` — from `state/cloud_link.json`; no more `Server: not configured:8989` on cloud frames.
- `Network: 192.168.1.23 (wlan0)` via a UDP-connect local-address probe + `/proc/net/route` (no child processes; gated off wasm/embedded builds), and the frame URL substitutes the real IP for `0.0.0.0`.
- "Agent access" → "FrameOS Remote control".

Also: the browser tab on cloud.frameos.net/frames now says **FrameOS Cloud** (was hardcoded "FrameOS Backend").

## Testing
- Nim: `test_hub_verbs` (+4 new tests incl. dot-directory write refusals), `test_scene` (+ cloud/standalone management-line test), `nim check` on `hub_client.nim`.
- auth-web: typecheck, 331 unit tests, 179 integration tests (3 new for the snapshot-first thumbnail path), eslint.
- Frontend: `tsc` clean; cloud-frontend bundle builds with the monaco workers.
- Not yet hardware-verified: the asset write verbs end-to-end on the bench frame (protocol mirrors asset_get; unit-tested with stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)