### PR TITLE
Cloud storage quotas + SD images personalized like the cloud

### DIFF
--- a/backend/app/api/cloud.py
+++ b/backend/app/api/cloud.py
@@ -254,6 +254,10 @@ def _status_payload(db: Session, link: CloudBackendLink | None, user: User | Non
             "last_inventory_sync_at": link.last_inventory_sync_at.isoformat()
             if link.last_inventory_sync_at
             else None,
+            # Snapshot from the provider's grants response (15-min sync):
+            # {scenes: {private_bytes, private_max_bytes, public_bytes},
+            #  backups: {bytes, max_bytes}, frame_logs: {bytes, max_bytes}}.
+            "usage": link.cloud_usage if isinstance(link.cloud_usage, dict) else None,
         }
         # A pending feature change awaiting owner approval on the provider.
         if link.device_code:

--- a/backend/app/cloud/sync.py
+++ b/backend/app/cloud/sync.py
@@ -183,6 +183,12 @@ class CloudSync:
             if owner:
                 link.cloud_account_id = owner.get("account_id")
                 link.cloud_account_email = owner.get("account_email")
+            # Storage usage + limits ride along on the grants response; cache
+            # the snapshot so /api/cloud/status can show quota headroom
+            # without another provider round trip.
+            usage = response.get("usage")
+            if isinstance(usage, dict):
+                link.cloud_usage = usage
             link.last_grant_sync_at = datetime.datetime.utcnow()
 
             seen_accounts = set()

--- a/backend/app/cloud/tests/test_sync.py
+++ b/backend/app/cloud/tests/test_sync.py
@@ -45,7 +45,12 @@ def cloud_calls(monkeypatch):
                 "grants": [
                     {"account_id": "acc-1", "account_email": "owner@example.com", "role": "owner"},
                     {"account_id": "acc-2", "account_email": "guest@example.com", "role": "member"},
-                ]
+                ],
+                "usage": {
+                    "scenes": {"private_bytes": 123, "private_max_bytes": 209715200, "public_bytes": 456},
+                    "backups": {"bytes": 7, "max_bytes": 104857600},
+                    "frame_logs": {"bytes": 8, "max_bytes": 104857600},
+                },
             },
         ),
         "inventory": (200, {"status": "synced"}),
@@ -79,6 +84,9 @@ async def test_sync_link_updates_grants_and_memberships(db, service, cloud_calls
     assert link.cloud_account_email == "owner@example.com"
     assert link.last_grant_sync_at is not None
     assert link.last_inventory_sync_at is not None
+    # The storage usage + limits snapshot rides along on the grants response.
+    assert link.cloud_usage["scenes"]["private_bytes"] == 123
+    assert link.cloud_usage["backups"]["max_bytes"] == 104857600
 
     memberships = db.query(CloudMembership).order_by(CloudMembership.cloud_account_id).all()
     assert [(m.cloud_account_id, m.role) for m in memberships] == [("acc-1", "owner"), ("acc-2", "member")]

--- a/backend/app/models/cloud.py
+++ b/backend/app/models/cloud.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.orm import Session, mapped_column, relationship
 
 from app.database import Base
@@ -76,6 +76,11 @@ class CloudBackendLink(Base):
     backup_key_fingerprint = mapped_column(String(16), nullable=True)
     last_inventory_sync_at = mapped_column(DateTime, nullable=True)
     last_grant_sync_at = mapped_column(DateTime, nullable=True)
+    # Storage usage + limits snapshot from the provider's grants response
+    # (docs/cloud-link.md), refreshed on the 15-minute sync — shown in the
+    # cloud settings section so users see quota headroom without visiting the
+    # provider.
+    cloud_usage = mapped_column(JSON, nullable=True)
     revoked_at = mapped_column(DateTime, nullable=True)
     created_at = mapped_column(DateTime, nullable=False, default=func.current_timestamp())
     updated_at = mapped_column(DateTime, nullable=False, default=func.current_timestamp())

--- a/backend/app/tasks/buildroot_image.py
+++ b/backend/app/tasks/buildroot_image.py
@@ -41,14 +41,21 @@ from app.tasks.binary_builder import FrameBinaryBuilder, FrameBinaryBuildResult
 from app.tasks.deploy_remote import RemoteDeployer
 from app.tasks.precompiled_remote import download_precompiled_remote_release
 from app.tasks.precompiled_frameos import frame_compiled_scene_count, release_version
+from app.tasks.sd_image_blob_patch import (
+    build_setup_blob_payload,
+    patch_setup_blob_into_image,
+)
 from app.tasks.setup_json_reset import (
     BOOT_AUTHORIZED_KEYS_FILE,
     BOOT_CLOUD_CONFIG_FILE,
     BOOT_HOSTNAME_FILE,
     BOOT_ROOT_PASSWORD_FILE,
+    BOOT_SETUP_BLOB_FILE,
     BOOT_WIFI_CONNECTION_FILE,
+    SETUP_BLOB_MEMBERS,
     SETUP_JSON_RESET_SCRIPT_PATH,
     SETUP_JSON_RESET_SERVICE_NAME,
+    render_setup_blob_region,
     render_setup_json_reset_script,
     render_setup_json_reset_service,
     setup_json_reset_enabled,
@@ -1167,16 +1174,34 @@ class BuildrootImageBuilder:
             base_entry: dict[str, Any] | None = None
             compose_image = None
             precompiled_sd_image = None
+            personalization_mode: str | None = None
             if self._can_use_precompiled_sd_image():
-                compose_image = await self._precompiled_sd_image_patch_image()
-                precompiled_sd_image = await self._try_compose_precompiled_sd_image(
+                # Cheapest first: pure in-place byte patching of the release
+                # image's frameos-setup.bin placeholder — the same mechanism
+                # the cloud's in-browser SD builder uses, needing no mtools,
+                # debugfs or docker anywhere. Falls through to the partition
+                # patching path for older release images without the
+                # placeholder or payloads too big for the region.
+                precompiled_sd_image = await self._try_patch_precompiled_sd_image(
                     temp_dir=temp_dir,
                     output_path=raw_output_path,
                     bootstrap_frame=bootstrap_frame,
                     setup_payload=setup_payload,
-                    image=compose_image,
-                    allow_fallback=self.build_environment_provider != "none",
                 )
+                if precompiled_sd_image is not None:
+                    personalization_mode = "placeholder"
+                else:
+                    compose_image = await self._precompiled_sd_image_patch_image()
+                    precompiled_sd_image = await self._try_compose_precompiled_sd_image(
+                        temp_dir=temp_dir,
+                        output_path=raw_output_path,
+                        bootstrap_frame=bootstrap_frame,
+                        setup_payload=setup_payload,
+                        image=compose_image,
+                        allow_fallback=self.build_environment_provider != "none",
+                    )
+                    if precompiled_sd_image is not None:
+                        personalization_mode = "partition-patch"
             if precompiled_sd_image is None and self.build_environment_provider == "none":
                 raise RuntimeError(
                     buildroot_sd_image_no_build_environment_message(
@@ -1261,6 +1286,7 @@ class BuildrootImageBuilder:
                         "precompiledSdImage": {
                             "releaseUrl": precompiled_sd_image.release_url,
                             "cacheHit": precompiled_sd_image.cache_hit,
+                            "personalization": personalization_mode,
                         },
                     }
                     if precompiled_sd_image is not None
@@ -1359,6 +1385,98 @@ class BuildrootImageBuilder:
         host is for compiling, which is the part that actually wants the CPU.
         """
         return self._host_has_boot_patch_tools()
+
+    async def _try_patch_precompiled_sd_image(
+        self,
+        *,
+        temp_dir: Path,
+        output_path: Path,
+        bootstrap_frame: Frame | Any,
+        setup_payload: dict[str, Any],
+    ) -> PrecompiledBuildrootSdImageResult | None:
+        """Personalize a release image by patching its setup-blob placeholder.
+
+        Pure byte surgery on the gunzipped .img — the /boot personalization
+        files ride a gzipped tar inside the fixed-size frameos-setup.bin
+        region, and the first-boot script extracts them (config.txt comes
+        from `frameos setup` running drivers.setup on-device, so no boot
+        partition merge is needed). Returns None whenever anything makes
+        this path inapplicable — no release image, no placeholder in it
+        (older release), payload too big — and the caller falls back.
+        """
+        if not self._can_use_precompiled_sd_image():
+            return None
+
+        precompiled_sd_image = await download_precompiled_buildroot_sd_image(
+            platform=self.platform.key,
+            logger=self._log,
+        )
+        if precompiled_sd_image is None:
+            return None
+
+        overlay_dir = temp_dir / "blob-overlay"
+        self._stage_boot_overlay(
+            overlay_dir=overlay_dir,
+            bootstrap_frame=bootstrap_frame,
+            setup_payload=setup_payload,
+        )
+        boot_dir = overlay_dir / "boot"
+        boot_files: dict[str, bytes] = {}
+        for name in SETUP_BLOB_MEMBERS:
+            member_path = boot_dir / name
+            if member_path.is_file():
+                boot_files[name] = member_path.read_bytes()
+        if "frameos-setup.json" not in boot_files:
+            # Without the setup payload the first boot would have nothing to
+            # apply; the partition-patching path handles whatever this is.
+            return None
+
+        try:
+            payload = build_setup_blob_payload(boot_files)
+            # Fail on size before spending time gunzipping ~1.5 GB.
+            render_setup_blob_region(payload)
+        except ValueError as exc:
+            await self._log(
+                "stdout",
+                f"Setup payload does not fit the in-image placeholder ({exc}); "
+                "falling back to partition patching",
+            )
+            return None
+
+        await self._log(
+            "stdout",
+            f"Personalizing precompiled SD image {precompiled_sd_image.archive_path.name} "
+            "via its setup-blob placeholder",
+        )
+        try:
+            await self._with_progress_updates(
+                "Still unpacking precompiled Buildroot SD image",
+                asyncio.to_thread(
+                    self._prepare_precompiled_release_image,
+                    precompiled_sd_image.archive_path,
+                    output_path,
+                ),
+            )
+            patched = await asyncio.to_thread(
+                patch_setup_blob_into_image, output_path, payload
+            )
+        except Exception as exc:
+            output_path.unlink(missing_ok=True)
+            await self._log(
+                "stderr",
+                f"Could not patch the precompiled SD image in place: {exc}. "
+                "Falling back to partition patching.",
+            )
+            return None
+        if not patched:
+            output_path.unlink(missing_ok=True)
+            await self._log(
+                "stdout",
+                "Release image carries no setup-blob placeholder (pre-placeholder "
+                "release); falling back to partition patching",
+            )
+            return None
+        return precompiled_sd_image
 
     async def _try_compose_precompiled_sd_image(
         self,
@@ -2659,8 +2777,11 @@ PY
                 Path(BOOT_WIFI_CONNECTION_FILE).name,
                 Path(BOOT_AUTHORIZED_KEYS_FILE).name,
                 # Backend-personalized images are self-hosted; never ship a
-                # (stale) cloud-enrollment personalization file on them.
+                # (stale) cloud-enrollment personalization file on them. The
+                # setup-blob placeholder is equally dead weight here — this
+                # path writes the personalization files directly.
                 Path(BOOT_CLOUD_CONFIG_FILE).name,
+                Path(BOOT_SETUP_BLOB_FILE).name,
                 setup_relpath,
             }
         )

--- a/backend/app/tasks/sd_image_blob_patch.py
+++ b/backend/app/tasks/sd_image_blob_patch.py
@@ -1,0 +1,132 @@
+"""In-place personalization of prebuilt SD images via the setup-blob placeholder.
+
+The Python sibling of the cloud's in-browser frameos-cloud.txt patcher
+(cloud-frontend/src/lib/sd-image-patch.ts), for the SELF-HOSTED backend's
+bigger payload: release images ship /boot/frameos-setup.bin as a fixed-size
+all-comments region (setup_json_reset.render_setup_blob_placeholder), and
+this module finds that region in the raw .img and overwrites it in place —
+no mtools, no debugfs, no docker, no partition parsing. The FAT metadata
+never changes because the file keeps its exact size.
+
+The payload is a gzipped POSIX tar of the /boot/frameos-* personalization
+files; busybox `gunzip | tar -x` unpacks it in the first-boot script.
+"""
+from __future__ import annotations
+
+import gzip
+import io
+import mmap
+import tarfile
+from pathlib import Path
+
+from app.tasks.setup_json_reset import (
+    SETUP_BLOB_MAGIC,
+    SETUP_BLOB_MEMBERS,
+    SETUP_BLOB_PLACEHOLDER_SIZE,
+    render_setup_blob_region,
+)
+
+# The magic must sit inside the FAT boot partition, which starts within the
+# first few MiB of the image; 64 MiB leaves generous headroom for partition
+# table changes without scanning gigabytes of rootfs.
+DEFAULT_SEARCH_LIMIT = 64 * 1024 * 1024
+
+_MAGIC_BYTES = (SETUP_BLOB_MAGIC + "\n").encode("ascii")
+
+
+def build_setup_blob_payload(boot_files: dict[str, bytes]) -> bytes:
+    """Gzipped tar of the given /boot personalization files.
+
+    Only SETUP_BLOB_MEMBERS names are accepted — the on-device extractor
+    installs exactly that allow-list, so anything else would be dead bytes.
+    Deterministic output (fixed mtimes/owners), so identical inputs produce
+    identical images.
+    """
+    for name in boot_files:
+        if name not in SETUP_BLOB_MEMBERS:
+            raise ValueError(f"{name} is not an allowed setup blob member")
+    buffer = io.BytesIO()
+    # mtime=0 keeps the gzip header deterministic.
+    with gzip.GzipFile(fileobj=buffer, mode="wb", mtime=0) as gz:
+        with tarfile.open(fileobj=gz, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+            for name in SETUP_BLOB_MEMBERS:
+                content = boot_files.get(name)
+                if content is None:
+                    continue
+                info = tarfile.TarInfo(name=name)
+                info.size = len(content)
+                info.mode = 0o600
+                info.mtime = 0
+                tar.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+def _region_is_pristine(region: memoryview) -> bool:
+    """True when the bytes after the magic look like the untouched placeholder.
+
+    Mirrors the browser patcher's check: ASCII only, every line starting with
+    '#'. Anything else is a decoy occurrence of the magic (or an already
+    personalized image) and must not be overwritten.
+    """
+    at_line_start = False  # the magic line's own newline starts the first line
+    for byte in region:
+        if byte == 0x0A:
+            at_line_start = True
+            continue
+        if at_line_start and byte != 0x23:  # '#'
+            return False
+        at_line_start = False
+        if byte < 0x09 or byte > 0x7E:
+            return False
+    return True
+
+
+def find_setup_blob_region(
+    image_path: Path, *, search_limit: int = DEFAULT_SEARCH_LIMIT
+) -> int | None:
+    """Byte offset of the pristine placeholder region in the raw image, or None."""
+    file_size = image_path.stat().st_size
+    if file_size < len(_MAGIC_BYTES):
+        return None
+    with image_path.open("rb") as handle:
+        with mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mapped:
+            limit = min(file_size, search_limit)
+            position = 0
+            while True:
+                offset = mapped.find(_MAGIC_BYTES, position, limit)
+                if offset < 0:
+                    return None
+                if offset + SETUP_BLOB_PLACEHOLDER_SIZE > file_size:
+                    return None
+                # A plain bytes copy (8 MiB) rather than a memoryview: a live
+                # view into the mmap would block its close with BufferError.
+                region = mapped[
+                    offset + len(_MAGIC_BYTES) : offset + SETUP_BLOB_PLACEHOLDER_SIZE
+                ]
+                if _region_is_pristine(memoryview(region)):
+                    return offset
+                # A decoy (e.g. the magic quoted inside some other file):
+                # keep scanning one byte later, like the browser patcher.
+                position = offset + 1
+
+
+def patch_setup_blob_into_image(
+    image_path: Path,
+    payload: bytes,
+    *,
+    search_limit: int = DEFAULT_SEARCH_LIMIT,
+) -> bool:
+    """Overwrite the placeholder region in the raw .img with the payload.
+
+    Returns False when the image carries no pristine placeholder (an older
+    release) — callers fall back to server-side partition patching. Raises
+    ValueError when the payload cannot fit the region.
+    """
+    region = render_setup_blob_region(payload)
+    offset = find_setup_blob_region(image_path, search_limit=search_limit)
+    if offset is None:
+        return False
+    with image_path.open("r+b") as handle:
+        handle.seek(offset)
+        handle.write(region)
+    return True

--- a/backend/app/tasks/setup_json_reset.py
+++ b/backend/app/tasks/setup_json_reset.py
@@ -83,6 +83,90 @@ def render_cloud_config_placeholder() -> bytes:
     return placeholder
 
 
+# --- Release-image placeholder for /boot/frameos-setup.bin -------------------
+#
+# The big sibling of the frameos-cloud.txt placeholder, for SELF-HOSTED
+# backend personalization: a backend-managed frame needs the whole
+# frameos-setup.json payload (frame.json + scenes — multi-megabyte) plus the
+# hostname / WiFi / SSH / root-password boot files, which the 4096-byte cloud
+# region cannot hold. Generic release images pre-create this file as an
+# all-comments region of exactly SETUP_BLOB_PLACEHOLDER_SIZE bytes; a
+# personalizer overwrites the region IN PLACE in the raw .img — no FAT
+# metadata changes, no mtools/debugfs, no rebuild — with:
+#
+#   line 1: the magic (unchanged)
+#   line 2: "size=<decimal>" — byte length of the payload that follows
+#   payload: a gzipped POSIX tar of the /boot/frameos-* personalization
+#            files (busybox `gunzip | tar -x` unpacks it on-device)
+#   padding: "#" bytes to exactly SETUP_BLOB_PLACEHOLDER_SIZE
+#
+# On first boot the script below extracts the allow-listed members into
+# /boot, shreds the blob, and lets the existing per-file handlers run —
+# display/driver config comes from `frameos setup` itself (drivers.setup
+# writes config.txt and requests the reboot), so no boot-partition merge is
+# needed. Neither the magic line nor the total size may ever change.
+BOOT_SETUP_BLOB_FILE = "/boot/frameos-setup.bin"
+SETUP_BLOB_MAGIC = "# FRAMEOS-SETUP-BLOB-V1"
+SETUP_BLOB_PLACEHOLDER_SIZE = 8 * 1024 * 1024
+# The /boot files a blob may deliver. Extraction copies exactly these names
+# out of the archive — a hostile tar cannot plant anything else.
+SETUP_BLOB_MEMBERS = (
+    "frameos-setup.json",
+    "frameos-hostname",
+    "frameos-wifi.nmconnection",
+    "frameos-authorized_keys",
+    "frameos-root-password",
+)
+
+_SETUP_BLOB_PLACEHOLDER_HEADER = (
+    SETUP_BLOB_MAGIC
+    + """
+#
+# FrameOS first-boot personalization blob. Generic images ship this file as
+# a fixed-size all-comments placeholder; a FrameOS backend's "Build SD card"
+# flow overwrites the region in place with a size header and a gzipped tar
+# of /boot personalization files (frameos-setup.json, frameos-hostname,
+# frameos-wifi.nmconnection, frameos-authorized_keys,
+# frameos-root-password). It is read once on first boot, applied, and
+# zero-overwritten (it may hold WiFi and access secrets). While the second
+# line is a comment like this one it is ignored and left in place, so the
+# image stays generic.
+"""
+)
+
+
+def render_setup_blob_placeholder() -> bytes:
+    """The canonical all-comments /boot/frameos-setup.bin placeholder."""
+    header = _SETUP_BLOB_PLACEHOLDER_HEADER.encode("ascii")
+    remaining = SETUP_BLOB_PLACEHOLDER_SIZE - len(header)
+    if remaining < 0:
+        raise ValueError("Setup blob placeholder header exceeds the fixed placeholder size")
+    full_lines, partial = divmod(remaining, len(CLOUD_CONFIG_PLACEHOLDER_PAD_LINE))
+    placeholder = header + CLOUD_CONFIG_PLACEHOLDER_PAD_LINE * full_lines + b"#" * partial
+    if len(placeholder) != SETUP_BLOB_PLACEHOLDER_SIZE:
+        raise AssertionError("Setup blob placeholder is not exactly SETUP_BLOB_PLACEHOLDER_SIZE bytes")
+    return placeholder
+
+
+def render_setup_blob_region(payload: bytes) -> bytes:
+    """A personalized frameos-setup.bin region: magic, size header, payload, padding.
+
+    Raises ValueError when the payload cannot fit — callers fall back to the
+    server-side partition-patching path.
+    """
+    header = (SETUP_BLOB_MAGIC + "\n" + f"size={len(payload)}\n").encode("ascii")
+    remaining = SETUP_BLOB_PLACEHOLDER_SIZE - len(header) - len(payload)
+    if remaining < 0:
+        raise ValueError(
+            f"Setup blob payload of {len(payload)} bytes does not fit the "
+            f"{SETUP_BLOB_PLACEHOLDER_SIZE}-byte placeholder region"
+        )
+    region = header + payload + b"#" * remaining
+    if len(region) != SETUP_BLOB_PLACEHOLDER_SIZE:
+        raise AssertionError("Setup blob region is not exactly SETUP_BLOB_PLACEHOLDER_SIZE bytes")
+    return region
+
+
 def setup_json_reset_file_path(frame: Frame | Any, *, default_if_missing: bool = False) -> str:
     if getattr(frame, "mode", None) != "buildroot" and not default_if_missing:
         return ""
@@ -112,6 +196,7 @@ ETC_DIR="${FRAMEOS_ETC_DIR:-/etc}"
 
 SETUP_FILE=__SETUP_FILE_EXPR__
 CLOUD_FILE=__CLOUD_FILE_EXPR__
+SETUP_BLOB_FILE=__SETUP_BLOB_FILE_EXPR__
 LOG_FILE=__LOG_FILE_EXPR__
 STATUS_FILE="${TMPDIR:-/tmp}/frameos-setup-reset.status"
 HOSTNAME_FILE=__HOSTNAME_FILE_EXPR__
@@ -195,6 +280,60 @@ json_fallback_sanitize() {
 cloud_config_has_key_lines() {
   [ -f "$CLOUD_FILE" ] || return 1
   tr -d '\\r' < "$CLOUD_FILE" | grep -v '^[[:space:]]*#' | grep -q '='
+}
+
+# Has $SETUP_BLOB_FILE been personalized? Generic images ship it as an
+# all-comments placeholder; a personalizer rewrites its second line to
+# "size=<bytes>". Only the first two lines are read — the payload after them
+# is binary.
+setup_blob_is_personalized() {
+  [ -f "$SETUP_BLOB_FILE" ] || return 1
+  sed -n '2p' "$SETUP_BLOB_FILE" | tr -d '\\r' | grep -q '^size=[0-9][0-9]*$'
+}
+
+# Unpack the personalization blob: skip the two header lines, gunzip+untar
+# the payload into a scratch dir, install only the allow-listed member names
+# into their /boot destinations, then shred the blob (it holds the same
+# secrets its member files do). The per-file handlers below then treat the
+# extracted files exactly like ones staged at image-build time.
+handle_setup_blob() {
+  echo "Extracting first-boot personalization from $SETUP_BLOB_FILE"
+  blob_magic_line="$(head -n 1 "$SETUP_BLOB_FILE" | tr -d '\\r')"
+  blob_size_line="$(sed -n '2p' "$SETUP_BLOB_FILE" | tr -d '\\r')"
+  blob_payload_size="${blob_size_line#size=}"
+  # +2 for the two newlines the header lines end with.
+  blob_header_size=$(( ${#blob_magic_line} + ${#blob_size_line} + 2 ))
+  blob_extract_dir="${TMPDIR:-/tmp}/frameos-setup-blob.$$"
+  rm -rf "$blob_extract_dir"
+  mkdir -p "$blob_extract_dir"
+  if ! tail -c +$((blob_header_size + 1)) "$SETUP_BLOB_FILE" \\
+      | head -c "$blob_payload_size" \\
+      | gunzip \\
+      | tar -x -C "$blob_extract_dir"; then
+    echo "Error: failed to extract the setup blob; leaving it in place for retry"
+    rm -rf "$blob_extract_dir"
+    return 1
+  fi
+  for blob_pair in \\
+      "frameos-setup.json:$SETUP_FILE" \\
+      "frameos-hostname:$HOSTNAME_FILE" \\
+      "frameos-wifi.nmconnection:$WIFI_CONNECTION_FILE" \\
+      "frameos-authorized_keys:$AUTHORIZED_KEYS_FILE" \\
+      "frameos-root-password:$ROOT_PASSWORD_FILE"; do
+    blob_member="${blob_pair%%:*}"
+    blob_target="${blob_pair#*:}"
+    if [ -f "$blob_extract_dir/$blob_member" ]; then
+      echo "Setup blob provides $blob_member"
+      if ! install -m 600 "$blob_extract_dir/$blob_member" "$blob_target"; then
+        echo "Error: failed to install $blob_member from the setup blob"
+        rm -rf "$blob_extract_dir"
+        return 1
+      fi
+    fi
+  done
+  rm -rf "$blob_extract_dir"
+  shred_remove_file "$SETUP_BLOB_FILE" || echo "Warning: failed to remove $SETUP_BLOB_FILE"
+  return 0
 }
 
 handle_cloud_config() {
@@ -477,6 +616,12 @@ else
   echo "Warning: failed to remount root filesystem read-write"
 fi
 
+if setup_blob_is_personalized; then
+  if ! handle_setup_blob; then
+    return 1
+  fi
+fi
+
 if [ -f "$HOSTNAME_FILE" ]; then
   echo "Installing hostname from $HOSTNAME_FILE"
   if ! install -m 644 "$HOSTNAME_FILE" "$ETC_DIR"/hostname; then
@@ -584,14 +729,15 @@ echo "FrameOS first-boot setup ended at $(date -Iseconds 2>/dev/null || date) wi
 return "$setup_status"
 }
 
-# Nothing to do: no setup JSON, and either no cloud personalization file at
-# all or only the untouched all-comments placeholder that generic release
-# images ship. Exit before run_setup so a placeholder-only image does no work
-# on any boot: no "mount -o remount,rw /" (which is never undone), no line
-# appended to the log on the FAT boot partition, and no reinstalling
-# /boot/frameos-hostname and /boot/frameos-wifi.nmconnection over /etc (which
-# would clobber on-device edits every boot).
-if [ ! -f "$SETUP_FILE" ] && ! cloud_config_has_key_lines; then
+# Nothing to do: no setup JSON, and neither personalization region carries
+# real content (generic release images ship both frameos-cloud.txt and
+# frameos-setup.bin as untouched all-comments placeholders). Exit before
+# run_setup so a placeholder-only image does no work on any boot: no
+# "mount -o remount,rw /" (which is never undone), no line appended to the
+# log on the FAT boot partition, and no reinstalling /boot/frameos-hostname
+# and /boot/frameos-wifi.nmconnection over /etc (which would clobber
+# on-device edits every boot).
+if [ ! -f "$SETUP_FILE" ] && ! cloud_config_has_key_lines && ! setup_blob_is_personalized; then
   exit 0
 fi
 
@@ -758,6 +904,7 @@ def render_setup_json_reset_script(setup_file_path: str, uses_network_manager: b
         "__WPA_SUPPLICANT_FROM_CLOUD__": "" if uses_network_manager else _WPA_SUPPLICANT_FROM_CLOUD,
         "__SETUP_FILE_EXPR__": _boot_path_expression(setup_file_path),
         "__CLOUD_FILE_EXPR__": _boot_path_expression(BOOT_CLOUD_CONFIG_FILE),
+        "__SETUP_BLOB_FILE_EXPR__": _boot_path_expression(BOOT_SETUP_BLOB_FILE),
         "__LOG_FILE_EXPR__": _boot_path_expression(BOOT_SETUP_RESET_LOG_FILE),
         "__HOSTNAME_FILE_EXPR__": _boot_path_expression(BOOT_HOSTNAME_FILE),
         "__WIFI_CONNECTION_FILE_EXPR__": _boot_path_expression(BOOT_WIFI_CONNECTION_FILE),

--- a/backend/app/tasks/tests/test_sd_image_blob_patch.py
+++ b/backend/app/tasks/tests/test_sd_image_blob_patch.py
@@ -1,0 +1,129 @@
+"""In-place setup-blob patching of raw SD images (sd_image_blob_patch)."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from app.tasks.sd_image_blob_patch import (
+    build_setup_blob_payload,
+    find_setup_blob_region,
+    patch_setup_blob_into_image,
+)
+from app.tasks.setup_json_reset import (
+    SETUP_BLOB_MAGIC,
+    SETUP_BLOB_PLACEHOLDER_SIZE,
+    render_setup_blob_placeholder,
+    render_setup_blob_region,
+)
+
+FILES = {
+    "frameos-setup.json": b'{"name": "Patched frame"}',
+    "frameos-hostname": b"patched-frame\n",
+    "frameos-wifi.nmconnection": b"[wifi]\nssid=PatchNet\n",
+}
+
+
+def _fake_image(tmp_path: Path, *, with_placeholder: bool = True, decoy: bool = False) -> Path:
+    # Junk that cannot contain the magic, a decoy occurrence of the magic
+    # inside "some other file", then the real placeholder, then more junk —
+    # roughly how the region sits inside a FAT partition of a real image.
+    image = tmp_path / "fake.img"
+    parts = [b"\xa5" * (1024 * 1024)]
+    if decoy:
+        parts.append(b"documentation: the magic line is " + SETUP_BLOB_MAGIC.encode() + b"\nummm binary\x00\x01")
+        parts.append(b"\xa5" * 4096)
+    if with_placeholder:
+        parts.append(render_setup_blob_placeholder())
+    parts.append(b"\x5a" * (1024 * 1024))
+    image.write_bytes(b"".join(parts))
+    return image
+
+
+def _extract_blob(region: bytes) -> dict[str, bytes]:
+    header_end = region.index(b"\n", region.index(b"\n") + 1) + 1
+    size_line = region[: header_end].split(b"\n")[1]
+    assert size_line.startswith(b"size=")
+    payload_size = int(size_line[len(b"size=") :])
+    payload = region[header_end : header_end + payload_size]
+    files: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(gzip.decompress(payload)), mode="r:") as tar:
+        for member in tar.getmembers():
+            extracted = tar.extractfile(member)
+            assert extracted is not None
+            files[member.name] = extracted.read()
+    return files
+
+
+def test_round_trip_patch_and_extract(tmp_path):
+    image = _fake_image(tmp_path, decoy=True)
+    original = image.read_bytes()
+    payload = build_setup_blob_payload(FILES)
+
+    assert patch_setup_blob_into_image(image, payload) is True
+
+    patched = image.read_bytes()
+    assert len(patched) == len(original)
+    offset = find_region_offset_for_test(original)
+    # Everything outside the region is untouched.
+    assert patched[:offset] == original[:offset]
+    assert patched[offset + SETUP_BLOB_PLACEHOLDER_SIZE :] == original[offset + SETUP_BLOB_PLACEHOLDER_SIZE :]
+    # The region unpacks to exactly the input files.
+    region = patched[offset : offset + SETUP_BLOB_PLACEHOLDER_SIZE]
+    assert _extract_blob(region) == FILES
+
+
+def find_region_offset_for_test(image_bytes: bytes) -> int:
+    placeholder = render_setup_blob_placeholder()
+    offset = image_bytes.find(placeholder)
+    assert offset >= 0
+    return offset
+
+
+def test_decoy_magic_is_skipped(tmp_path):
+    image = _fake_image(tmp_path, decoy=True)
+    original = image.read_bytes()
+    real_offset = find_region_offset_for_test(original)
+    assert find_setup_blob_region(image) == real_offset
+
+
+def test_image_without_placeholder_is_left_alone(tmp_path):
+    image = _fake_image(tmp_path, with_placeholder=False, decoy=True)
+    original = image.read_bytes()
+    assert patch_setup_blob_into_image(image, build_setup_blob_payload(FILES)) is False
+    assert image.read_bytes() == original
+
+
+def test_oversized_payload_is_refused_before_touching_the_image(tmp_path):
+    image = _fake_image(tmp_path)
+    original = image.read_bytes()
+    # Deterministic but incompressible content, so the gzipped payload really
+    # overflows the region (a repeating pattern would compress to nothing).
+    import hashlib
+
+    digest = b"seed"
+    chunks = []
+    total = 0
+    while total <= SETUP_BLOB_PLACEHOLDER_SIZE:
+        digest = hashlib.sha256(digest).digest()
+        chunks.append(digest)
+        total += len(digest)
+    huge = {"frameos-setup.json": b"".join(chunks)}
+    with pytest.raises(ValueError):
+        patch_setup_blob_into_image(image, build_setup_blob_payload(huge))
+    assert image.read_bytes() == original
+
+
+def test_payload_rejects_unknown_member_names():
+    with pytest.raises(ValueError):
+        build_setup_blob_payload({"../../etc/passwd": b"nope"})
+
+
+def test_region_render_is_exactly_placeholder_sized():
+    region = render_setup_blob_region(build_setup_blob_payload(FILES))
+    assert len(region) == SETUP_BLOB_PLACEHOLDER_SIZE
+    assert region.startswith((SETUP_BLOB_MAGIC + "\n").encode("ascii"))

--- a/backend/app/tasks/tests/test_setup_json_reset.py
+++ b/backend/app/tasks/tests/test_setup_json_reset.py
@@ -657,3 +657,98 @@ def test_wpa_supplicant_config_is_never_written_with_a_plaintext_psk_in_the_log(
     assert result.returncode == 0, result.stdout + result.stderr
     assert "topsecret123" not in result.stdout
     assert "topsecret123" not in sandbox.log_file.read_text(encoding="utf-8")
+
+
+# --- The frameos-setup.bin personalization blob ------------------------------
+
+
+def _personalized_blob(files: dict[str, bytes]) -> bytes:
+    from app.tasks.sd_image_blob_patch import build_setup_blob_payload
+    from app.tasks.setup_json_reset import render_setup_blob_region
+
+    return render_setup_blob_region(build_setup_blob_payload(files))
+
+
+def test_setup_blob_placeholder_layout():
+    from app.tasks.setup_json_reset import (
+        SETUP_BLOB_MAGIC,
+        SETUP_BLOB_PLACEHOLDER_SIZE,
+        render_setup_blob_placeholder,
+    )
+
+    placeholder = render_setup_blob_placeholder()
+    assert len(placeholder) == SETUP_BLOB_PLACEHOLDER_SIZE
+    text = placeholder.decode("ascii")
+    lines = text.split("\n")
+    assert lines[0] == SETUP_BLOB_MAGIC
+    # Every line is a comment: the personalizer verifies this before daring
+    # to overwrite the region, and first boot treats it as "not personalized".
+    assert all(line.startswith("#") for line in lines if line)
+
+
+def test_pristine_setup_blob_is_a_no_op_and_left_in_place(tmp_path):
+    from app.tasks.setup_json_reset import render_setup_blob_placeholder
+
+    sandbox = Sandbox(tmp_path)
+    sandbox.add_fake_frameos()
+    blob = sandbox.boot / "frameos-setup.bin"
+    placeholder = render_setup_blob_placeholder()
+    blob.write_bytes(placeholder)
+
+    result = sandbox.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    # The bottom gate exits before run_setup: no log file, no remount, and
+    # the placeholder survives byte for byte.
+    assert not sandbox.log_file.exists()
+    assert sandbox.mount_calls() == ""
+    assert blob.read_bytes() == placeholder
+
+
+def test_personalized_setup_blob_extracts_installs_and_shreds(tmp_path):
+    sandbox = Sandbox(tmp_path)
+    argv_log = sandbox.add_fake_frameos(exit_status=0)
+    blob = sandbox.boot / "frameos-setup.bin"
+    blob.write_bytes(
+        _personalized_blob(
+            {
+                "frameos-setup.json": json.dumps({"name": "Blob frame"}).encode("utf-8"),
+                "frameos-hostname": b"blob-frame\n",
+                "frameos-wifi.nmconnection": b"[wifi]\nssid=BlobNet\n",
+                "frameos-authorized_keys": b"ssh-ed25519 AAAA blob@test\n",
+            }
+        )
+    )
+    shadow = sandbox.shadow_link(blob)
+
+    result = sandbox.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Extracting first-boot personalization" in result.stdout
+    # The extracted setup JSON drove a real `frameos setup --with-setup=...`.
+    argv = argv_log.read_text(encoding="utf-8")
+    assert "--with-setup=" in argv
+    # The member files went through the existing per-file handlers.
+    assert (sandbox.etc / "hostname").read_text(encoding="utf-8") == "blob-frame\n"
+    assert sandbox.wifi_file.read_text(encoding="utf-8") == "[wifi]\nssid=BlobNet\n"
+    # The blob held every secret its members did: zero-overwritten, removed.
+    assert not blob.exists()
+    assert set(shadow.read_bytes()) == {0}
+    # The extracted setup JSON was shredded by the existing handler too.
+    assert not (sandbox.boot / "frameos-setup.json").exists()
+
+
+def test_setup_blob_without_optional_members_installs_only_what_it_has(tmp_path):
+    sandbox = Sandbox(tmp_path)
+    sandbox.add_fake_frameos(exit_status=0)
+    blob = sandbox.boot / "frameos-setup.bin"
+    blob.write_bytes(
+        _personalized_blob({"frameos-setup.json": b'{"name": "Minimal"}'})
+    )
+
+    result = sandbox.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not (sandbox.etc / "hostname").exists()
+    assert not sandbox.wifi_file.exists()
+    assert not blob.exists()

--- a/backend/migrations/versions/e7a3b9c4d2f6_cloud_usage_snapshot.py
+++ b/backend/migrations/versions/e7a3b9c4d2f6_cloud_usage_snapshot.py
@@ -1,0 +1,25 @@
+"""Cache the cloud account's storage usage + quota snapshot on the link
+
+The provider's grants response now carries a `usage` block (private scene
+bytes vs quota, backups, frame logs — public scenes are free). The 15-minute
+sync stores it here so the cloud settings section can show quota headroom
+without an extra round trip to the provider.
+
+Revision ID: e7a3b9c4d2f6
+Revises: d3f1a75c92e4
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e7a3b9c4d2f6"
+down_revision = "d3f1a75c92e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("cloud_backend_link", sa.Column("cloud_usage", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("cloud_backend_link", "cloud_usage")

--- a/cloud-frontend/build.mjs
+++ b/cloud-frontend/build.mjs
@@ -139,6 +139,27 @@ const sharedDepsPlugin = {
   },
 }
 
+// Monaco's workers load by fixed URL (configureMonaco.ts:
+// {assets_base_path}/static/monaco/<name>.js), so they are built separately
+// with stable, unhashed names — the shell never references them, the main
+// bundle constructs their URLs at runtime. Self-contained (no splitting):
+// a worker cannot share chunks with the DOM bundle anyway.
+const monacoWorkerNames = ['editor.worker', 'json.worker', 'css.worker', 'html.worker', 'ts.worker']
+await build({
+  absWorkingDir: __dirname,
+  entryPoints: monacoWorkerNames.map((name) => ({
+    in: `../frontend/src/monaco/${name}.ts`,
+    out: `monaco/${name}`,
+  })),
+  bundle: true,
+  format: 'esm',
+  splitting: false,
+  outdir: staticDir,
+  minify: true,
+  sourcemap: isDev,
+  tsconfig: path.resolve(__dirname, 'tsconfig.json'),
+})
+
 const buildOptions = {
   absWorkingDir: __dirname,
   entryPoints: ['src/main.tsx'],

--- a/cloud-frontend/src/cloudConfig.ts
+++ b/cloud-frontend/src/cloudConfig.ts
@@ -25,6 +25,9 @@ interface CloudAppConfig {
   cloud_origin?: string
   cloud_scenes_url?: string
   cloud_theme_cookie_domain?: string
+  /** Read by livePreviewLogic straight off FRAMEOS_APP_CONFIG: the wasm
+   * preview's same-origin HTTP proxy (/api/store/preview-proxy). */
+  preview_proxy_url?: string
 }
 
 function config(): CloudAppConfig {

--- a/cloud-frontend/src/main.tsx
+++ b/cloud-frontend/src/main.tsx
@@ -1,4 +1,10 @@
 import { createRoot } from 'react-dom/client'
+// Point @monaco-editor/react at the bundled monaco BEFORE anything renders an
+// editor: without this it lazy-loads monaco from a CDN, which the cloud's CSP
+// blocks — every Monaco surface (app sources, scene JSON, code nodes) then
+// fails with a bare script error. The workers it spawns are bundled by
+// build.mjs into static/monaco/ (same contract as the other bundles).
+import '../../frontend/src/utils/configureMonaco'
 import { App } from './scenes/App'
 import './index.css'
 import { initKea } from '../../frontend/src/initKea'

--- a/cloud/apps/auth-web/app/account/layout.tsx
+++ b/cloud/apps/auth-web/app/account/layout.tsx
@@ -5,12 +5,9 @@ import {
   accounts,
   clientBackups,
   createDb,
-  frameLogs,
   frames,
   linkedClients,
-  storeSceneImages,
   storeScenes,
-  storeSceneVersions,
 } from "@frameos-cloud/db";
 import { AccountNav } from "../../src/components/AccountNav";
 import { AppShell } from "../../src/components/AppShell";
@@ -18,6 +15,7 @@ import { UserIdentifier } from "../../src/components/UserIdentifier";
 import { getAccountUrl, getCloudBaseUrl } from "../../src/lib/env";
 import { formatBytes } from "../../src/lib/format";
 import { readSession } from "../../src/lib/session";
+import { accountUsage, type AccountUsage } from "../../src/lib/usage";
 
 // Shared chrome for all /account pages: sign-in gate, app shell, the account
 // header, and the section navigation with each section's headline number as
@@ -43,24 +41,16 @@ export default async function AccountLayout({
   let installCount = 0;
   let sceneCount = 0;
   let backupCount = 0;
-  let backupBytes = 0;
-  let sceneBytes = 0;
   let frameCount = 0;
-  let frameLogBytes = 0;
+  let usage: AccountUsage | null = null;
 
   if (session.accountId) {
     const accountId = session.accountId;
     const db = createDb();
-    const [
-      [row],
-      installs,
-      scenes,
-      backups,
-      sceneVersionSizes,
-      sceneImageSizes,
-      frameRows,
-      frameLogSizes,
-    ] = await Promise.all([
+    // Byte sums come from the same accountUsage() helper the quota
+    // enforcement and /api/backends/grants use — one definition of "used".
+    const [[row], installs, scenes, backups, frameRows, usageSnapshot] =
+      await Promise.all([
         db
           .select({ isSuperadmin: accounts.isSuperadmin })
           .from(accounts)
@@ -76,33 +66,13 @@ export default async function AccountLayout({
             ),
           ),
         db
-          .select({
-            count: sql<number>`count(*)::int`,
-            previewBytes: sql<number>`coalesce(sum(octet_length(${storeScenes.previewImage})), 0)::float8`,
-          })
+          .select({ count: sql<number>`count(*)::int` })
           .from(storeScenes)
           .where(eq(storeScenes.accountId, accountId)),
         db
-          .select({
-            bytes: sql<number>`coalesce(sum(${clientBackups.sizeBytes}), 0)::float8`,
-            count: sql<number>`count(*)::int`,
-          })
+          .select({ count: sql<number>`count(*)::int` })
           .from(clientBackups)
           .where(eq(clientBackups.accountId, accountId)),
-        db
-          .select({
-            bytes: sql<number>`coalesce(sum(${storeSceneVersions.sizeBytes}), 0)::float8`,
-          })
-          .from(storeSceneVersions)
-          .innerJoin(storeScenes, eq(storeSceneVersions.sceneId, storeScenes.id))
-          .where(eq(storeScenes.accountId, accountId)),
-        db
-          .select({
-            bytes: sql<number>`coalesce(sum(octet_length(${storeSceneImages.content})), 0)::float8`,
-          })
-          .from(storeSceneImages)
-          .innerJoin(storeScenes, eq(storeSceneImages.sceneId, storeScenes.id))
-          .where(eq(storeScenes.accountId, accountId)),
         db
           .select({ count: sql<number>`count(*)::int` })
           .from(frames)
@@ -112,28 +82,22 @@ export default async function AccountLayout({
               sql`${frames.status} <> 'revoked'`,
             ),
           ),
-        db
-          .select({
-            bytes: sql<number>`coalesce(sum(${frameLogs.sizeBytes}), 0)::float8`,
-          })
-          .from(frameLogs)
-          .innerJoin(frames, eq(frameLogs.frameId, frames.id))
-          .where(eq(frames.accountId, accountId)),
+        accountUsage(db, accountId),
       ]);
     isSuperadmin = row?.isSuperadmin ?? false;
     installCount = installs[0]?.count ?? 0;
     sceneCount = scenes[0]?.count ?? 0;
     backupCount = backups[0]?.count ?? 0;
-    backupBytes = backups[0]?.bytes ?? 0;
-    sceneBytes =
-      (sceneVersionSizes[0]?.bytes ?? 0) +
-      (sceneImageSizes[0]?.bytes ?? 0) +
-      (scenes[0]?.previewBytes ?? 0);
     frameCount = frameRows[0]?.count ?? 0;
-    frameLogBytes = frameLogSizes[0]?.bytes ?? 0;
+    usage = usageSnapshot;
   }
 
-  const storageBytes = backupBytes + sceneBytes + frameLogBytes;
+  const storageBytes = usage
+    ? usage.scenes.private_bytes +
+      usage.scenes.public_bytes +
+      usage.backups.bytes +
+      usage.frame_logs.bytes
+    : 0;
 
   return (
     <AppShell isSuperadmin={isSuperadmin} title="FrameOS Account">
@@ -148,12 +112,21 @@ export default async function AccountLayout({
         <div>
           <h1>{session?.name ?? "FrameOS Cloud account"}</h1>
           <p className="copy">{session?.email}</p>
-          {session?.accountId ? (
+          {session?.accountId && usage ? (
             <p className="copy">
               Storage used: {formatBytes(storageBytes)}
-              {storageBytes > 0
-                ? ` — backups ${formatBytes(backupBytes)} · store scenes ${formatBytes(sceneBytes)} · frame logs ${formatBytes(frameLogBytes)}`
+              {" — "}
+              private scenes {formatBytes(usage.scenes.private_bytes)} of{" "}
+              {formatBytes(usage.scenes.private_max_bytes)}
+              {usage.scenes.public_bytes > 0
+                ? ` · public scenes ${formatBytes(usage.scenes.public_bytes)} (free)`
                 : ""}
+              {" · "}
+              backups {formatBytes(usage.backups.bytes)} of{" "}
+              {formatBytes(usage.backups.max_bytes)}
+              {" · "}
+              frame logs {formatBytes(usage.frame_logs.bytes)} of{" "}
+              {formatBytes(usage.frame_logs.max_bytes)}
             </p>
           ) : null}
         </div>

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
@@ -23,6 +23,10 @@ import {
   validateSceneZip,
 } from "../../../../../../src/lib/store";
 import { loadOwnedScene } from "../../../../../../src/lib/store-owner";
+import {
+  maxPrivateSceneBytesPerAccount,
+  privateSceneBytesForAccount,
+} from "../../../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -162,6 +166,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
   }
   if (content.length > maxSceneZipBytes) {
     return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
+  }
+  // Every save appends an immutable version; without this check the editor
+  // was the one write path that ignored the account byte quota entirely.
+  // Public scenes are free (usage.ts).
+  if (scene.visibility !== "public") {
+    const privateBytes = await privateSceneBytesForAccount(db, session.accountId!);
+    if (privateBytes + content.length > maxPrivateSceneBytesPerAccount) {
+      return jsonError("storage_quota_exceeded", 403, {
+        max_bytes: maxPrivateSceneBytesPerAccount,
+        private_bytes: Math.round(privateBytes),
+      });
+    }
   }
 
   const validated = validateSceneZip(content);

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/fork/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/fork/route.ts
@@ -23,13 +23,16 @@ import {
   maxNewScenesPerDay,
   maxSceneZipBytes,
   maxScenesPerAccount,
-  maxStoreBytesPerAccount,
   rebuildZipWithScenes,
   sceneSummary,
   slugifyName,
   slugSuffix,
   validateSceneZip,
 } from "../../../../../../src/lib/store";
+import {
+  maxPrivateSceneBytesPerAccount,
+  privateSceneBytesForAccount,
+} from "../../../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -88,23 +91,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
     return jsonError("invalid_scenes", 400);
   }
 
-  // Same per-account quotas as publishing a new scene.
+  // Same per-account quotas as publishing a new scene. Forks are born
+  // private, so their bytes always count against the private-scene quota.
   const [quota] = await db
-    .select({
-      bytes: sql<number>`coalesce(sum(${storeSceneVersions.sizeBytes}), 0)::bigint`,
-      scenes: sql<number>`count(distinct ${storeScenes.id})::int`,
-    })
+    .select({ scenes: sql<number>`count(*)::int` })
     .from(storeScenes)
-    .leftJoin(
-      storeSceneVersions,
-      eq(storeSceneVersions.sceneId, storeScenes.id),
-    )
     .where(eq(storeScenes.accountId, accountId));
   if ((quota?.scenes ?? 0) >= maxScenesPerAccount) {
     return jsonError("scene_quota_exceeded", 403, {
       max_scenes: maxScenesPerAccount,
     });
   }
+  const privateBytes = await privateSceneBytesForAccount(db, accountId);
   const dailyLimited = await identityRateLimitResponse(accountId, "store:fork", {
     limit: maxNewScenesPerDay,
     windowMs: 24 * 60 * 60 * 1000,
@@ -172,9 +170,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
   if (content.length > maxSceneZipBytes) {
     return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
   }
-  if (Number(quota?.bytes ?? 0) + content.length > maxStoreBytesPerAccount) {
+  if (privateBytes + content.length > maxPrivateSceneBytesPerAccount) {
     return jsonError("storage_quota_exceeded", 403, {
-      max_bytes: maxStoreBytesPerAccount,
+      max_bytes: maxPrivateSceneBytesPerAccount,
+      private_bytes: Math.round(privateBytes),
     });
   }
 

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/images/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/images/route.ts
@@ -13,6 +13,10 @@ import {
 } from "../../../../../../src/lib/store";
 import { syncLatestSceneZipPreview } from "../../../../../../src/lib/store-image-sync";
 import { loadOwnedScene } from "../../../../../../src/lib/store-owner";
+import {
+  maxPrivateSceneBytesPerAccount,
+  privateSceneBytesForAccount,
+} from "../../../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -58,6 +62,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
     return jsonError("image_quota_exceeded", 403, {
       max_images: maxImagesPerScene,
     });
+  }
+  // Gallery bytes count into the private-scene quota (they always did in the
+  // usage display; this write path just never checked). Public scenes are
+  // free (usage.ts).
+  if (scene.visibility !== "public") {
+    const privateBytes = await privateSceneBytesForAccount(db, session.accountId!);
+    if (privateBytes + content.length > maxPrivateSceneBytesPerAccount) {
+      return jsonError("storage_quota_exceeded", 403, {
+        max_bytes: maxPrivateSceneBytesPerAccount,
+        private_bytes: Math.round(privateBytes),
+      });
+    }
   }
 
   const moderation = await moderateStoreContent({

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/route.ts
@@ -21,6 +21,11 @@ import {
   validateSceneZip,
 } from "../../../../../src/lib/store";
 import { loadOwnedScene } from "../../../../../src/lib/store-owner";
+import {
+  maxPrivateSceneBytesPerAccount,
+  privateSceneBytesForAccount,
+  sceneBytesTotal,
+} from "../../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -59,6 +64,22 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     // confusing at best, so reject it outright.
     if (scene.status === "pulled") {
       return jsonError("scene_pulled", 403);
+    }
+    // Public scenes are quota-free, so making one private moves its bytes
+    // back onto the meter — refuse the flip when it would land the account
+    // over quota instead of letting the toggle dodge every other check.
+    if (visibility === "private" && scene.visibility === "public") {
+      const [privateBytes, flippedBytes] = await Promise.all([
+        privateSceneBytesForAccount(db, session.accountId!),
+        sceneBytesTotal(db, scene.id),
+      ]);
+      if (privateBytes + flippedBytes > maxPrivateSceneBytesPerAccount) {
+        return jsonError("storage_quota_exceeded", 403, {
+          max_bytes: maxPrivateSceneBytesPerAccount,
+          private_bytes: Math.round(privateBytes),
+          scene_bytes: Math.round(flippedBytes),
+        });
+      }
     }
     changes.visibility = visibility;
   }

--- a/cloud/apps/auth-web/app/api/account/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/route.ts
@@ -1,0 +1,141 @@
+import { and, eq, sql } from "drizzle-orm";
+import { strToU8, zipSync } from "fflate";
+import { storeScenes } from "@frameos-cloud/db";
+import { NextRequest } from "next/server";
+import { csrfResponse } from "../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../src/lib/device-flow";
+import {
+  identityRateLimitResponse,
+  rateLimitResponse,
+} from "../../../../src/lib/rate-limit";
+import { readSession } from "../../../../src/lib/session";
+import { maxPublishesPerHour, maxSceneZipBytes } from "../../../../src/lib/store";
+import { publishStoreScene } from "../../../../src/lib/store-publish";
+
+export const runtime = "nodejs";
+
+const maxSceneNameChars = 128;
+// Try "name", "name 2", … before giving up. Publishing resolves "same
+// account + same name" to the EXISTING scene and appends a version — correct
+// for republish, wrong for "create new" — so this route disambiguates first.
+const maxNameAttempts = 20;
+
+function zipFolderName(name: string): string {
+  const safe = name.replace(/[^A-Za-z0-9 _-]/g, "_").trim();
+  return (safe.length > 0 ? safe : "scene").slice(0, 64);
+}
+
+async function nameIsTaken(
+  db: NonNullable<ReturnType<typeof requireDatabase>["db"]>,
+  accountId: string,
+  name: string,
+) {
+  const [clash] = await db
+    .select({ id: storeScenes.id })
+    .from(storeScenes)
+    .where(
+      and(
+        eq(storeScenes.accountId, accountId),
+        sql`lower(${storeScenes.name}) = lower(${name})`,
+      ),
+    )
+    .limit(1);
+  return clash !== undefined;
+}
+
+// Create a NEW private cloud scene from raw scenes JSON — the workspace's
+// "save this frame's edited scenes to my account" path, which has no ZIP to
+// upload. The route builds the canonical template ZIP (the exact layout
+// backend/app/api/templates.py template_zip_bytes produces) and hands it to
+// publishStoreScene, so quotas, moderation, classification, slugging and
+// audit all apply exactly as for an upload. Unlike upload/republish, a name
+// clash creates "name 2" instead of silently versioning the other scene.
+export async function POST(request: NextRequest) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(request, "account:scene-create", {
+    limit: 60,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const accountLimited = await identityRateLimitResponse(
+    session.accountId,
+    "store:publish",
+    { limit: maxPublishesPerHour, windowMs: 60 * 60 * 1000 },
+  );
+  if (accountLimited) {
+    return accountLimited;
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+
+  const body = await readJsonObject(request);
+  const requestedName =
+    typeof body.name === "string" ? body.name.trim().slice(0, maxSceneNameChars) : "";
+  const name = requestedName.length > 0 ? requestedName : "Untitled scene";
+  if (!Array.isArray(body.scenes) || body.scenes.length === 0) {
+    return jsonError("invalid_scenes", 400);
+  }
+  const description =
+    typeof body.description === "string"
+      ? body.description.trim().slice(0, 2000)
+      : undefined;
+
+  let finalName = name;
+  if (await nameIsTaken(db, session.accountId, finalName)) {
+    let resolved = false;
+    for (let suffix = 2; suffix <= maxNameAttempts; suffix += 1) {
+      const candidate = `${name.slice(0, maxSceneNameChars - 4)} ${suffix}`;
+      if (!(await nameIsTaken(db, session.accountId, candidate))) {
+        finalName = candidate;
+        resolved = true;
+        break;
+      }
+    }
+    if (!resolved) {
+      return jsonError("scene_name_taken", 409, { name });
+    }
+  }
+
+  const folder = zipFolderName(finalName);
+  const manifest = {
+    name: finalName,
+    ...(description ? { description } : {}),
+    scenes: "./scenes.json",
+  };
+  const content = Buffer.from(
+    zipSync({
+      [`${folder}/template.json`]: strToU8(JSON.stringify(manifest, null, 2)),
+      [`${folder}/scenes.json`]: strToU8(JSON.stringify(body.scenes, null, 2)),
+    }),
+  );
+  if (content.length > maxSceneZipBytes) {
+    return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
+  }
+
+  return publishStoreScene(db, {
+    accountId: session.accountId,
+    actor: {
+      accountId: session.accountId,
+      providerSubject: session.providerSubject,
+    },
+    content,
+    description,
+    name: finalName,
+    visibility: "private",
+  });
+}

--- a/cloud/apps/auth-web/app/api/backends/backups/route.ts
+++ b/cloud/apps/auth-web/app/api/backends/backups/route.ts
@@ -23,6 +23,7 @@ import {
   requireDatabase,
 } from "../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { maxBackupBytesPerAccount } from "../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -139,14 +140,20 @@ export async function POST(request: NextRequest) {
   const name = parseOptionalString(body.name)?.slice(0, 256);
   const contentType = parseOptionalString(body.content_type)?.slice(0, 128);
 
-  // Count-based quota; replacing an existing item never fails the check.
+  // Count quota (replacing an existing item never fails it) plus the account
+  // byte quota — replacements only count the size delta, so re-uploading a
+  // same-size backup always succeeds even at the limit.
   const [countRow] = await db
-    .select({ count: sql<number>`count(*)::int` })
+    .select({
+      bytes: sql<number>`coalesce(sum(${clientBackups.sizeBytes}), 0)::float8`,
+      count: sql<number>`count(*)::int`,
+    })
     .from(clientBackups)
     .where(eq(clientBackups.accountId, linkedClient.accountId));
   const count = countRow?.count ?? 0;
+  const accountBytes = Number(countRow?.bytes ?? 0);
   const [existing] = await db
-    .select({ id: clientBackups.id })
+    .select({ id: clientBackups.id, sizeBytes: clientBackups.sizeBytes })
     .from(clientBackups)
     .where(
       and(
@@ -159,6 +166,14 @@ export async function POST(request: NextRequest) {
   if (!existing && count >= maxBackupsPerAccount) {
     return jsonError("backup_quota_exceeded", 403, {
       max_backups: maxBackupsPerAccount,
+    });
+  }
+  const bytesAfterSave =
+    accountBytes - (existing?.sizeBytes ?? 0) + content.length;
+  if (bytesAfterSave > maxBackupBytesPerAccount) {
+    return jsonError("backup_storage_quota_exceeded", 403, {
+      max_bytes: maxBackupBytesPerAccount,
+      used_bytes: Math.round(accountBytes),
     });
   }
 

--- a/cloud/apps/auth-web/app/api/backends/grants/route.ts
+++ b/cloud/apps/auth-web/app/api/backends/grants/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { authenticateLinkedClient } from "../../../../src/lib/backend-auth";
 import { jsonError, requireDatabase } from "../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { accountUsage } from "../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -32,11 +33,18 @@ export async function GET(request: NextRequest) {
   // Display/contact snapshot only, so the backend can show "Connected as
   // <email>"; account identity stays keyed on the provider identity, never on
   // this email (see the accounts schema note).
-  const [account] = await db
-    .select({ primaryEmail: accounts.primaryEmail })
-    .from(accounts)
-    .where(eq(accounts.id, linkedClient.accountId))
-    .limit(1);
+  const [[account], usage] = await Promise.all([
+    db
+      .select({ primaryEmail: accounts.primaryEmail })
+      .from(accounts)
+      .where(eq(accounts.id, linkedClient.accountId))
+      .limit(1),
+    // Storage usage + limits ride along on the 15-minute grants poll, so
+    // linked backends (and their frames) can show "X of Y used" without a
+    // second endpoint. The limits are included so no client hardcodes them —
+    // paid tiers will raise them per account later.
+    accountUsage(db, linkedClient.accountId),
+  ]);
 
   return NextResponse.json({
     grants: [
@@ -48,5 +56,6 @@ export async function GET(request: NextRequest) {
       },
     ],
     linked_client_id: linkedClient.id,
+    usage,
   });
 }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/asset/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/asset/route.ts
@@ -1,9 +1,11 @@
-import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
-import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
 import { NextRequest, NextResponse } from "next/server";
 import { jsonError, requireDatabase } from "../../../../../src/lib/device-flow";
 import {
-  enqueueFrameCommand,
+  cachedAssetFile,
+  queueAssetGetIfIdle,
+  recentFailedAssetGet,
+} from "../../../../../src/lib/frame-asset-cache";
+import {
   frameForAccount,
   maxAssetPathChars,
 } from "../../../../../src/lib/frames";
@@ -12,7 +14,6 @@ import { readSession } from "../../../../../src/lib/session";
 
 export const runtime = "nodejs";
 
-const fetchCommandTtlMs = 2 * 60 * 1000;
 // A cached copy this old is re-requested in the background on the next hit;
 // the stale bytes still serve immediately (assets on a frame rarely change,
 // and a sleeping battery frame must not block every thumbnail).
@@ -54,59 +55,6 @@ function normalizeAssetPath(raw: string): string | undefined {
 function contentDisposition(kind: "attachment" | "inline", filename: string) {
   const safe = filename.replace(/[^\w. -]/g, "_").slice(0, 255);
   return `${kind}; filename="${safe || "asset"}"`;
-}
-
-type Db = NonNullable<ReturnType<typeof requireDatabase>["db"]>;
-
-async function cachedAssetFile(
-  db: Db,
-  frameId: string,
-  path: string,
-  thumb: boolean,
-) {
-  const [row] = await db
-    .select()
-    .from(frameAssetFiles)
-    .where(
-      and(
-        eq(frameAssetFiles.frameId, frameId),
-        eq(frameAssetFiles.path, path),
-        eq(frameAssetFiles.thumb, thumb),
-      ),
-    )
-    .limit(1);
-  return row;
-}
-
-async function outstandingFetch(
-  db: Db,
-  frameId: string,
-  path: string,
-  thumb: boolean,
-) {
-  // Payload equality is checked in JS: the handful of live asset_get rows per
-  // frame does not justify a jsonb index.
-  const rows = await db
-    .select({ id: frameCommands.id, payload: frameCommands.payload })
-    .from(frameCommands)
-    .where(
-      and(
-        eq(frameCommands.frameId, frameId),
-        eq(frameCommands.type, "asset_get"),
-        inArray(frameCommands.status, ["pending", "sent"]),
-        or(
-          isNull(frameCommands.expiresAt),
-          gt(frameCommands.expiresAt, new Date()),
-        ),
-      ),
-    );
-  return rows.find((row) => {
-    const payload =
-      row.payload && typeof row.payload === "object"
-        ? (row.payload as Record<string, unknown>)
-        : {};
-    return payload.path === path && (payload.thumb === true) === thumb;
-  });
 }
 
 function assetResponse(
@@ -177,15 +125,7 @@ export async function GET(
   const needsFetch =
     !cached || now - cached.updatedAt.getTime() > cacheStaleAfterMs;
   if (needsFetch && frame.status === "active") {
-    if (!(await outstandingFetch(db, frame.id, path, thumb))) {
-      await enqueueFrameCommand(db, {
-        createdByAccountId: session.accountId,
-        frameId: frame.id,
-        payload: { path, ...(thumb ? { thumb: true } : {}) },
-        ttlMs: fetchCommandTtlMs,
-        type: "asset_get",
-      });
-    }
+    await queueAssetGetIfIdle(db, session.accountId, frame.id, path, thumb);
   }
   if (cached) {
     // Stale-while-revalidate: the refresh (if any) was queued above and the
@@ -208,24 +148,13 @@ export async function GET(
     // the connection open for nothing. Only THIS path's recent command
     // counts — an old failure for some other file must not poison every
     // later request for this frame.
-    const failedCommands = await db
-      .select({ error: frameCommands.error, payload: frameCommands.payload })
-      .from(frameCommands)
-      .where(
-        and(
-          eq(frameCommands.frameId, frame.id),
-          eq(frameCommands.type, "asset_get"),
-          eq(frameCommands.status, "failed"),
-          gt(frameCommands.createdAt, new Date(now - 60_000)),
-        ),
-      );
-    const refused = failedCommands.find((row) => {
-      const payload =
-        row.payload && typeof row.payload === "object"
-          ? (row.payload as Record<string, unknown>)
-          : {};
-      return payload.path === path && (payload.thumb === true) === thumb;
-    });
+    const refused = await recentFailedAssetGet(
+      db,
+      frame.id,
+      path,
+      thumb,
+      60_000,
+    );
     if (refused) {
       return jsonError(refused.error ?? "asset_fetch_failed", 404);
     }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/delete/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/delete/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  invalidateCachedAssetSubtree,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Delete a file or folder under the frame's assets directory —
+// form-urlencoded `path`, `{message}` back, same as the backend's delete.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const path = normalizeAssetPath(String(form.get("path") ?? ""));
+  if (!path || hiddenWritePath(path)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const result = await runAssetWriteCommand(
+    db,
+    accountId,
+    frame.id,
+    "asset_delete",
+    { path },
+  );
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  await invalidateCachedAssetSubtree(db, frame.id, path);
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({ message: "Deleted" });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/mkdir/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/mkdir/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Create a folder under the frame's assets directory — form-urlencoded
+// `path`, `{message}` back, same as the self-hosted backend's mkdir.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const path = normalizeAssetPath(String(form.get("path") ?? ""));
+  if (!path || hiddenWritePath(path)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const result = await runAssetWriteCommand(
+    db,
+    accountId,
+    frame.id,
+    "asset_mkdir",
+    { path },
+  );
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({ message: "Created" });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/rename/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/rename/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  invalidateCachedAssetSubtree,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Rename/move a file or folder under the frame's assets directory —
+// form-urlencoded `src` + `dst`, `{message}` back, same as the backend.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const src = normalizeAssetPath(String(form.get("src") ?? ""));
+  const dst = normalizeAssetPath(String(form.get("dst") ?? ""));
+  if (!src || !dst || hiddenWritePath(src) || hiddenWritePath(dst)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const result = await runAssetWriteCommand(
+    db,
+    accountId,
+    frame.id,
+    "asset_rename",
+    { dst, src },
+  );
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  // Both sides go: the src subtree is gone from the device, and any stale
+  // rows under dst (a rename onto a previously cached path) are wrong now.
+  await invalidateCachedAssetSubtree(db, frame.id, src);
+  await invalidateCachedAssetSubtree(db, frame.id, dst);
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({ message: "Renamed" });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/assets/upload/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/assets/upload/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsonError } from "../../../../../../src/lib/device-flow";
+import { normalizeAssetPath } from "../../../../../../src/lib/frame-asset-cache";
+import {
+  assetWriteErrorResponse,
+  assetWriteRequestContext,
+  hiddenWritePath,
+  invalidateCachedAssetSubtree,
+  maxAssetUploadBytes,
+  queueAssetsListRefresh,
+  runAssetWriteCommand,
+  sanitizedUploadFilename,
+} from "../../../../../../src/lib/frame-asset-write";
+
+export const runtime = "nodejs";
+
+// Upload one file into the frame's assets directory — the multipart contract
+// the shared SPA's uploadDroppedFiles already speaks against the self-hosted
+// backend (FormData{file, path}), answered with the stored entry. The bytes
+// ride an asset_put command (base64 in a single WS frame), so the size cap is
+// far below the backend's: files past it need a chunked verb that does not
+// exist yet, and the error says so instead of stalling.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ frameId: string }> },
+) {
+  const { frameId } = await params;
+  const context = await assetWriteRequestContext(request, frameId);
+  if (context.response) {
+    return context.response;
+  }
+  const { db, accountId, frame } = context;
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return jsonError("invalid_form", 400);
+  }
+  const file = form.get("file");
+  if (!(file instanceof File)) {
+    return jsonError("file_required", 400);
+  }
+  if (file.size === 0) {
+    return jsonError("file_empty", 400);
+  }
+  if (file.size > maxAssetUploadBytes) {
+    return jsonError("too_large", 413, { max_bytes: maxAssetUploadBytes });
+  }
+  const rawSubdir = String(form.get("path") ?? "").trim();
+  let subdir = "";
+  if (rawSubdir.length > 0) {
+    const normalized = normalizeAssetPath(rawSubdir);
+    if (!normalized) {
+      return jsonError("invalid_path", 400);
+    }
+    subdir = normalized;
+  }
+  const filename = sanitizedUploadFilename(file.name ?? "");
+  const targetPath = subdir ? `${subdir}/${filename}` : filename;
+  if (hiddenWritePath(targetPath)) {
+    return jsonError("invalid_path", 400);
+  }
+
+  const data = Buffer.from(await file.arrayBuffer()).toString("base64");
+  const result = await runAssetWriteCommand(db, accountId, frame.id, "asset_put", {
+    data,
+    path: targetPath,
+  });
+  if (!result.ok) {
+    return assetWriteErrorResponse(result);
+  }
+  await invalidateCachedAssetSubtree(db, frame.id, targetPath);
+  await queueAssetsListRefresh(db, accountId, frame.id);
+  return NextResponse.json({
+    is_dir: false,
+    mtime: Math.floor(Date.now() / 1000),
+    path: targetPath,
+    size: file.size,
+  });
+}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scene_images/[sceneId]/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scene_images/[sceneId]/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flow";
+import {
+  cachedAssetFile,
+  queueAssetGetIfIdle,
+  recentFailedAssetGet,
+  sceneSnapshotAssetPath,
+} from "../../../../../../src/lib/frame-asset-cache";
 import { frameForAccount } from "../../../../../../src/lib/frames";
 import {
   resolveStoreSceneForFrameScene,
@@ -10,13 +16,59 @@ import { readSession } from "../../../../../../src/lib/session";
 
 export const runtime = "nodejs";
 
+// Scene tiles re-render often; a snapshot this old is re-requested in the
+// background while the stale bytes still serve. Shorter than the generic
+// asset route's 15 min — a deploy changes what a scene renders.
+const snapshotStaleAfterMs = 5 * 60 * 1000;
+// A device that just said not_found (scene never rendered, ESP32 with no
+// snapshot store) is not asked again for this long — tiles poll, and every
+// poll re-queueing a doomed command would keep the frame busy for nothing.
+const refusalMemoryMs = 5 * 60 * 1000;
+// Only reached when there is no store cover to serve meanwhile: bounded by
+// what an <img> tolerates, and short enough not to pile up connections when
+// a frame is asleep.
+const longPollTotalMs = 10_000;
+const longPollStepMs = 750;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function imageResponse(content: Buffer, contentType: string, maxAge: number) {
+  return new NextResponse(new Uint8Array(content), {
+    headers: {
+      // Private: these bytes describe one user's frame. Held briefly so a
+      // re-render does not re-download every tile; the SPA busts with ?t=.
+      "cache-control": `private, max-age=${maxAge}`,
+      "content-length": String(content.length),
+      "content-type": contentType || "image/png",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+// Device snapshots change on every deploy and scene switch; store covers only
+// on republish.
+const snapshotBrowserMaxAge = 60;
+const coverBrowserMaxAge = 300;
+
 // Per-scene preview — the exact route the shared SPA's scene tiles already
-// call (cloud/docs/cloud-workspace-gaps.md item 2). Short-term implementation:
-// serve the cover image of the store scene the assignment installed. The SPA
-// passes the RUNTIME scene id (from the zip's scenes.json, hydrated into the
-// tiles), so scene-images.ts maps it back to the owning store scene; the raw
-// store uuid works too. Owning the frame is the authorization — its assigned
-// scenes' covers are, by construction, content the account installed.
+// call (cloud/docs/cloud-workspace-gaps.md item 2). Priority order:
+//
+//   1. The device's own snapshot: the runner writes a per-scene PNG under
+//      {assets}/.frameos/scene_images/ on first render and every scene
+//      switch, and the existing asset_get verb can stream it — the hub
+//      caches it in frame_asset_files like any other asset. ?thumb=1 rides
+//      the device's 320x320 thumbnail path, so tiles stay small.
+//   2. The cover image of the store scene an assignment installed (the
+//      short-term serve that used to be the whole implementation). The SPA
+//      passes the RUNTIME scene id, so scene-images.ts maps it back to the
+//      owning store scene; the raw store uuid works too.
+//   3. When neither exists yet, a brief long-poll for the queued device
+//      fetch, then an honest 404.
+//
+// Owning the frame is the authorization — its scenes' renders and covers
+// are, by construction, content the account put there.
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ frameId: string; sceneId: string }> },
@@ -42,27 +94,78 @@ export async function GET(
     return jsonError("invalid_frame", 404);
   }
 
+  const thumb = request.nextUrl.searchParams.get("thumb") === "1";
+  const snapshotPath = sceneSnapshotAssetPath(sceneId);
+
+  const cached = await cachedAssetFile(db, frame.id, snapshotPath, thumb);
+  const now = Date.now();
+  const needsFetch =
+    !cached || now - cached.updatedAt.getTime() > snapshotStaleAfterMs;
+  let refused = needsFetch
+    ? await recentFailedAssetGet(
+        db,
+        frame.id,
+        snapshotPath,
+        thumb,
+        refusalMemoryMs,
+      )
+    : undefined;
+  if (needsFetch && !refused && frame.status === "active") {
+    await queueAssetGetIfIdle(
+      db,
+      session.accountId,
+      frame.id,
+      snapshotPath,
+      thumb,
+    );
+  }
+  if (cached) {
+    // Stale-while-revalidate: the refresh (if any) was queued above.
+    return imageResponse(cached.content, cached.contentType, snapshotBrowserMaxAge);
+  }
+
+  const cover = await storeSceneCover(db, frame.id, sceneId);
+  if (cover) {
+    return imageResponse(cover.content, cover.contentType, coverBrowserMaxAge);
+  }
+
+  // Long-polling only makes sense for a frame that is on the socket right
+  // now; a sleeping frame still gets the queued fetch on its next sync, and
+  // the tile heals on a later request.
+  if (refused || frame.status !== "active" || !frame.connected) {
+    return jsonError("no_image", 404);
+  }
+  const deadline = now + longPollTotalMs;
+  while (Date.now() < deadline) {
+    await sleep(longPollStepMs);
+    const row = await cachedAssetFile(db, frame.id, snapshotPath, thumb);
+    if (row) {
+      return imageResponse(row.content, row.contentType, snapshotBrowserMaxAge);
+    }
+    refused = await recentFailedAssetGet(
+      db,
+      frame.id,
+      snapshotPath,
+      thumb,
+      60_000,
+    );
+    if (refused) {
+      return jsonError("no_image", 404);
+    }
+  }
+  return jsonError("no_image", 404);
+}
+
+type Db = NonNullable<ReturnType<typeof requireDatabase>["db"]>;
+
+async function storeSceneCover(db: Db, frameId: string, sceneId: string) {
   const storeSceneId = await resolveStoreSceneForFrameScene(
     db,
-    frame.id,
+    frameId,
     sceneId,
   );
   if (!storeSceneId) {
-    return jsonError("no_image", 404);
+    return undefined;
   }
-  const image = await storeSceneCoverImage(db, storeSceneId);
-  if (!image) {
-    return jsonError("no_image", 404);
-  }
-  return new NextResponse(new Uint8Array(image.content), {
-    headers: {
-      // Covers change rarely (only on republish/regallery); the frame page
-      // may poll tiles, so let the browser hold them briefly — but privately,
-      // this sits behind a session.
-      "cache-control": "private, max-age=300",
-      "content-length": String(image.content.length),
-      "content-type": image.contentType,
-      "x-content-type-options": "nosniff",
-    },
-  });
+  return await storeSceneCoverImage(db, storeSceneId);
 }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
@@ -126,6 +126,16 @@ export async function POST(
   if (!Array.isArray(body.scenes) || body.scenes.length > maxScenesPerFrame) {
     return jsonError("invalid_scenes", 400);
   }
+  // Optional: which RUNTIME scene the push should activate — the workspace's
+  // save passes the currently active scene so a deploy never yanks the
+  // display to another scene. The device ignores an id that is not in the
+  // payload (it then activates the first scene), so only shape is validated.
+  const activeSceneId =
+    typeof body.scene_id === "string" &&
+    body.scene_id.length > 0 &&
+    body.scene_id.length <= 256
+      ? body.scene_id
+      : undefined;
   const requested: { sceneId: string; sceneVersion: number | null }[] = [];
   for (const entry of body.scenes) {
     if (!entry || typeof entry !== "object") {
@@ -247,7 +257,11 @@ export async function POST(
   const command = await enqueueFrameCommand(db, {
     createdByAccountId: session.accountId,
     frameId: frame.id,
-    payload: { checksum: payload.checksum, scenes: payload.scenes },
+    payload: {
+      checksum: payload.checksum,
+      scenes: payload.scenes,
+      ...(activeSceneId ? { scene_id: activeSceneId } : {}),
+    },
     type: "set_scenes",
   });
 

--- a/cloud/apps/auth-web/app/api/frames/enroll/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/enroll/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   authenticateLinkedClient,
   linkedClientHasScope,
+  linkedClientScopes,
 } from "../../../../src/lib/backend-auth";
 import {
   jsonError,
@@ -27,6 +28,18 @@ import { createEncryptedSecretToken, hashSecret } from "../../../../src/lib/secr
 export const runtime = "nodejs";
 
 const wsPath = "/api/frames/ws";
+
+// What a claim-token enrollment grants (see the linked-client insert below).
+// The response's `scope` string must list ALL of it: the device stores that
+// string as its local scope list and gates its own telemetry push loops on
+// it — reporting only frame:managed here is how frames ended up never
+// sending a single log line while the hub sat ready to accept them.
+const claimTokenGrantedScopes = [
+  frameManagedScope,
+  frameTelemetryLogsScope,
+  frameTelemetryMetricsScope,
+];
+const claimTokenScopeString = claimTokenGrantedScopes.join(" ");
 
 // Same set the frames-app shell route uses to decide "is this a dev server".
 const localHosts = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
@@ -218,11 +231,7 @@ async function enrollWithClaimToken(
             // (the hub refuses every log_batch with insufficient_scope and
             // nothing in the UI says why). The LOCAL switch on the device
             // (send_logs) remains the privacy control.
-            requestedScopes: [
-              frameManagedScope,
-              frameTelemetryLogsScope,
-              frameTelemetryMetricsScope,
-            ],
+            requestedScopes: claimTokenGrantedScopes,
           },
           publicDisplayName: name,
           tokenReference: accessToken.tokenReference,
@@ -283,7 +292,7 @@ async function enrollWithClaimToken(
   return NextResponse.json({
     access_token: result.accessTokenValue,
     frame_id: result.frame.id,
-    scope: frameManagedScope,
+    scope: claimTokenScopeString,
     status: result.frame.status,
     token_type: "Bearer",
     ws_path: wsPath,
@@ -346,7 +355,7 @@ async function replayEnrollment(
   return NextResponse.json({
     access_token: accessToken.token,
     frame_id: existing.frame.id,
-    scope: frameManagedScope,
+    scope: claimTokenScopeString,
     status: existing.frame.status,
     token_type: "Bearer",
     ws_path: wsPath,
@@ -397,7 +406,10 @@ async function enrollLinkedFrame(
       .where(eq(frames.id, existing.id));
     return NextResponse.json({
       frame_id: existing.id,
-      scope: frameManagedScope,
+      // The full grant, not just frame:managed — the device unions this into
+      // its local scope string (Flow B is additive) and enables its
+      // telemetry push loops from it.
+      scope: linkedClientScopes(linkedClient).join(" "),
       status: existing.status,
       ws_path: wsPath,
       ...(wsUrl ? { ws_url: wsUrl } : {}),
@@ -440,7 +452,7 @@ async function enrollLinkedFrame(
 
   return NextResponse.json({
     frame_id: frame.id,
-    scope: frameManagedScope,
+    scope: linkedClientScopes(linkedClient).join(" "),
     status: frame.status,
     ws_path: wsPath,
     ...(wsUrl ? { ws_url: wsUrl } : {}),

--- a/cloud/apps/auth-web/app/frames/[[...path]]/route.ts
+++ b/cloud/apps/auth-web/app/frames/[[...path]]/route.ts
@@ -83,6 +83,11 @@ function appConfigLines(): string[] {
     // deployment it would set a host-only cookie that shadows the shared one
     // and the two surfaces would disagree again.
     `cloud_theme_cookie_domain: ${JSON.stringify(getSessionCookieDomain() ?? "")},`,
+    // The wasm live preview's CORS escape hatch: the same anonymous,
+    // rate-limited proxy the store's scene pages use. Without it the SPA
+    // would try the backend's project-scoped proxy path, which the cloud
+    // does not serve, and every external fetch in a preview dies on CORS.
+    `preview_proxy_url: ${JSON.stringify("/api/store/preview-proxy")},`,
   ];
 }
 

--- a/cloud/apps/auth-web/src/lib/frame-asset-cache.test.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-cache.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAssetPath, sceneSnapshotAssetPath } from "./frame-asset-cache";
+import { hiddenWritePath, sanitizedUploadFilename } from "./frame-asset-write";
+
+// These mirror device-side Nim code byte for byte — sceneImageFilename in
+// frameos/src/frameos/scenes.nim and sanitizeAssetComponent in
+// admin_api_assets_routes.nim. A drift here means thumbnails silently 404
+// (wrong snapshot path) or upload responses name a file that does not exist.
+
+describe("sceneSnapshotAssetPath", () => {
+  it("builds the runner's snapshot path for a plain runtime id", () => {
+    // md5("abc") — the device hashes the PUBLIC id (uploaded/ prefix stripped).
+    expect(sceneSnapshotAssetPath("abc")).toBe(
+      ".frameos/scene_images/abc-900150983cd24fb0d6963f7d28e17f72.png",
+    );
+  });
+
+  it("strips the uploaded/ prefix like sceneImagePublicId does", () => {
+    expect(sceneSnapshotAssetPath("uploaded/abc")).toBe(
+      sceneSnapshotAssetPath("abc"),
+    );
+  });
+
+  it("replaces unsafe characters, strips edge punctuation, caps at 64", () => {
+    const path = sceneSnapshotAssetPath("../../etc");
+    // '/' becomes '_', then leading '.'/'_' are stripped: a single flat
+    // filename component, never a traversal.
+    expect(path.startsWith(".frameos/scene_images/etc-")).toBe(true);
+    expect(path.split("/").length).toBe(3);
+
+    const long = "x".repeat(100);
+    const longPath = sceneSnapshotAssetPath(long);
+    const filename = longPath.split("/").pop()!;
+    expect(filename.startsWith("x".repeat(64) + "-")).toBe(true);
+    expect(filename).not.toContain("x".repeat(65));
+  });
+
+  it("falls back to 'scene' when nothing survives sanitizing", () => {
+    expect(sceneSnapshotAssetPath("///").split("/").pop()!.startsWith("scene-")).toBe(
+      true,
+    );
+  });
+});
+
+describe("sanitizedUploadFilename", () => {
+  it("mirrors the device's component sanitizer", () => {
+    expect(sanitizedUploadFilename("My Photo (1).jpg")).toBe("My_Photo__1_.jpg");
+    expect(sanitizedUploadFilename("nested/dir/cat.png")).toBe("cat.png");
+    expect(sanitizedUploadFilename("...")).toBe("uploaded_file");
+    expect(sanitizedUploadFilename("")).toBe("uploaded_file");
+    // '-' survives edge stripping (the device only strips '_' and '.').
+    expect(sanitizedUploadFilename("-dash.bin")).toBe("-dash.bin");
+  });
+});
+
+describe("hiddenWritePath", () => {
+  it("refuses any dot-component, allows plain paths", () => {
+    expect(hiddenWritePath(".frameos/scene_images/x.png")).toBe(true);
+    expect(hiddenWritePath("photos/.thumbs/x.jpg")).toBe(true);
+    expect(hiddenWritePath("photos/cat.jpg")).toBe(false);
+    expect(hiddenWritePath("dot.folder/file")).toBe(false);
+  });
+});
+
+describe("normalizeAssetPath", () => {
+  it("strips ./ and leading slashes, refuses traversal and empties", () => {
+    expect(normalizeAssetPath("./photos/cat.jpg")).toBe("photos/cat.jpg");
+    expect(normalizeAssetPath("/photos/cat.jpg")).toBe("photos/cat.jpg");
+    expect(normalizeAssetPath("photos/../secret")).toBeUndefined();
+    expect(normalizeAssetPath("  ")).toBeUndefined();
+  });
+});

--- a/cloud/apps/auth-web/src/lib/frame-asset-cache.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-cache.ts
@@ -1,0 +1,173 @@
+// The hub's device-asset cache, shared by the routes that read it: one row
+// per (frame, path, thumb) in frame_asset_files, filled by asset_get /
+// image_get chunk streams (frame-hub handleAssetChunk) and pruned LRU by
+// storeFrameAssetFile. The /asset route serves arbitrary device files from
+// it; the /scene_images route uses it for the device's own per-scene
+// snapshots. Kept out of frames.ts (device write path) on purpose.
+
+import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
+import {
+  enqueueFrameCommand,
+  maxAssetPathChars,
+  type FramesDatabase,
+} from "./frames";
+
+export const assetFetchCommandTtlMs = 2 * 60 * 1000;
+
+/**
+ * Relative, bounded, no traversal — the device re-validates independently
+ * (resolveAssetPath on the Nim side), this just refuses obvious garbage
+ * before it costs a queued command.
+ */
+export function normalizeAssetPath(raw: string): string | undefined {
+  let path = raw.trim();
+  while (path.startsWith("./")) {
+    path = path.slice(2);
+  }
+  while (path.startsWith("/")) {
+    path = path.slice(1);
+  }
+  if (
+    path.length === 0 ||
+    path.length > maxAssetPathChars ||
+    path.split("/").includes("..")
+  ) {
+    return undefined;
+  }
+  return path;
+}
+
+export async function cachedAssetFile(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+) {
+  const [row] = await db
+    .select()
+    .from(frameAssetFiles)
+    .where(
+      and(
+        eq(frameAssetFiles.frameId, frameId),
+        eq(frameAssetFiles.path, path),
+        eq(frameAssetFiles.thumb, thumb),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+function payloadMatches(
+  payload: unknown,
+  path: string,
+  thumb: boolean,
+): boolean {
+  const record =
+    payload && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+  return record.path === path && (record.thumb === true) === thumb;
+}
+
+export async function outstandingAssetGet(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+) {
+  // Payload equality is checked in JS: the handful of live asset_get rows per
+  // frame does not justify a jsonb index.
+  const rows = await db
+    .select({ id: frameCommands.id, payload: frameCommands.payload })
+    .from(frameCommands)
+    .where(
+      and(
+        eq(frameCommands.frameId, frameId),
+        eq(frameCommands.type, "asset_get"),
+        inArray(frameCommands.status, ["pending", "sent"]),
+        or(
+          isNull(frameCommands.expiresAt),
+          gt(frameCommands.expiresAt, new Date()),
+        ),
+      ),
+    );
+  return rows.find((row) => payloadMatches(row.payload, path, thumb));
+}
+
+/**
+ * A recent `failed` asset_get for this exact path+thumb — the device refused
+ * (not_found, too_large, …). Callers use it to stop long-polling early and to
+ * avoid re-queueing a fetch the device just said no to.
+ */
+export async function recentFailedAssetGet(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+  withinMs: number,
+) {
+  const rows = await db
+    .select({ error: frameCommands.error, payload: frameCommands.payload })
+    .from(frameCommands)
+    .where(
+      and(
+        eq(frameCommands.frameId, frameId),
+        eq(frameCommands.type, "asset_get"),
+        eq(frameCommands.status, "failed"),
+        gt(frameCommands.createdAt, new Date(Date.now() - withinMs)),
+      ),
+    );
+  return rows.find((row) => payloadMatches(row.payload, path, thumb));
+}
+
+/** Queue an asset_get unless an equivalent one is already in flight. */
+export async function queueAssetGetIfIdle(
+  db: Parameters<typeof enqueueFrameCommand>[0],
+  accountId: string,
+  frameId: string,
+  path: string,
+  thumb: boolean,
+) {
+  if (await outstandingAssetGet(db, frameId, path, thumb)) {
+    return;
+  }
+  await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    payload: { path, ...(thumb ? { thumb: true } : {}) },
+    ttlMs: assetFetchCommandTtlMs,
+    type: "asset_get",
+  });
+}
+
+/**
+ * Where the device keeps its own snapshot of a scene, relative to its assets
+ * root. Byte-for-byte mirror of sceneImageFilename in
+ * frameos/src/frameos/scenes.nim — the runner writes
+ * {assets}/.frameos/scene_images/{sanitized}-{md5(publicId)}.png on the first
+ * render of each scene and on every scene switch, and asset_get can read it
+ * (the dot-directory is hidden from assets_list, not from asset_get).
+ * Runtime scene ids arrive both bare and as "uploaded/<id>"; the device
+ * strips the prefix, so we do too.
+ */
+export function sceneSnapshotAssetPath(sceneId: string): string {
+  const uploadedPrefix = "uploaded/";
+  const publicId = sceneId.startsWith(uploadedPrefix)
+    ? sceneId.slice(uploadedPrefix.length)
+    : sceneId;
+  let safe = "";
+  for (const ch of publicId) {
+    safe += /[A-Za-z0-9._-]/.test(ch) ? ch : "_";
+  }
+  safe = safe.replace(/^[_.-]+/, "").replace(/[_.-]+$/, "");
+  if (safe.length === 0) {
+    safe = "scene";
+  }
+  if (safe.length > 64) {
+    safe = safe.slice(0, 64);
+  }
+  const digest = createHash("md5").update(publicId).digest("hex");
+  return `.frameos/scene_images/${safe}-${digest}.png`;
+}

--- a/cloud/apps/auth-web/src/lib/frame-asset-write.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-write.ts
@@ -1,0 +1,215 @@
+// Asset mutations for cloud-managed frames: enqueue a write verb
+// (asset_put / asset_mkdir / asset_delete / asset_rename), wait for the
+// device's ack, and keep the hub-side caches honest afterwards. The routes
+// under app/api/frames/[frameId]/assets/* mirror the self-hosted backend's
+// client contract so the shared SPA needs no cloud branch.
+
+import { and, eq, like, or } from "drizzle-orm";
+import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
+import type { NextRequest } from "next/server";
+import { csrfResponse } from "./csrf";
+import { jsonError, requireDatabase } from "./device-flow";
+import {
+  enqueueFrameCommand,
+  frameForAccount,
+  supersedePendingCommands,
+  type FramesDatabase,
+} from "./frames";
+import { rateLimitResponse } from "./rate-limit";
+import { readSession } from "./session";
+
+type CommandDatabase = Parameters<typeof enqueueFrameCommand>[0];
+
+// Mirror of HubMaxAssetUploadBytes (frameos/src/frameos/cloud/hub_client.nim):
+// an upload rides a single base64-encoded WS frame under the device's 4 MiB
+// inbound cap. Bigger files need a chunked verb that does not exist yet.
+export const maxAssetUploadBytes = 2_621_440;
+
+const commandTtlMs = 2 * 60 * 1000;
+// Mutations are user-blocking (a dialog waits on them), so wait about as
+// long as the asset long-poll does before calling the frame unreachable.
+const ackTimeoutMs = 30_000;
+const ackPollStepMs = 500;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * The filename the device will actually store, mirroring
+ * sanitizeAssetComponent(extractFilename(...), "uploaded_file", allowDot) in
+ * admin_api_assets_routes.nim — the ack's payload does not survive into
+ * frame_commands, so the route predicts the stored path instead.
+ */
+export function sanitizedUploadFilename(filename: string): string {
+  const base = filename.split("/").pop() ?? "";
+  let safe = "";
+  for (const ch of base) {
+    safe += /[A-Za-z0-9._-]/.test(ch) ? ch : "_";
+  }
+  safe = safe.replace(/^[_.]+/, "").replace(/[_.]+$/, "");
+  return safe.length > 0 ? safe : "uploaded_file";
+}
+
+/**
+ * Mirror of the device's refusedWritePath: writes never touch dot-directories
+ * (.thumbs, .frameos) — refusing here spares a queued command the device
+ * would reject anyway.
+ */
+export function hiddenWritePath(path: string): boolean {
+  return path
+    .split("/")
+    .some((component) => component.length > 0 && component.startsWith("."));
+}
+
+export type AssetCommandResult =
+  | { ok: true }
+  | { ok: false; error: string; timedOut?: boolean };
+
+/**
+ * Enqueue one write verb and long-poll its ack. Resolves ok on the device's
+ * ack, with the device's wire error on refusal, and with timedOut when the
+ * frame did not answer in time — the command stays queued, so a sleeping
+ * frame still applies it on its next sync; the caller just cannot claim it
+ * happened yet.
+ */
+export async function runAssetWriteCommand(
+  db: CommandDatabase,
+  accountId: string,
+  frameId: string,
+  type: "asset_put" | "asset_mkdir" | "asset_delete" | "asset_rename",
+  payload: Record<string, unknown>,
+): Promise<AssetCommandResult> {
+  const command = await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    payload,
+    ttlMs: commandTtlMs,
+    type,
+  });
+  if (!command) {
+    return { ok: false, error: "command_not_queued" };
+  }
+  const deadline = Date.now() + ackTimeoutMs;
+  while (Date.now() < deadline) {
+    await sleep(ackPollStepMs);
+    const [row] = await db
+      .select({ error: frameCommands.error, status: frameCommands.status })
+      .from(frameCommands)
+      .where(eq(frameCommands.id, command.id))
+      .limit(1);
+    if (!row) {
+      return { ok: false, error: "command_lost" };
+    }
+    if (row.status === "acked") {
+      return { ok: true };
+    }
+    if (row.status === "failed" || row.status === "expired") {
+      return { ok: false, error: row.error ?? "asset_write_failed" };
+    }
+  }
+  return { ok: false, error: "frame_unreachable", timedOut: true };
+}
+
+/**
+ * Drop cached file bytes for a path (both thumb variants) and, for
+ * directories, everything under it — after a delete or rename the cache
+ * would otherwise keep serving the old bytes for up to the staleness window.
+ */
+export async function invalidateCachedAssetSubtree(
+  db: FramesDatabase,
+  frameId: string,
+  path: string,
+) {
+  // Escape LIKE metacharacters in the path so "10%" or "a_b" folders do not
+  // widen the invalidation to unrelated rows.
+  const prefix = path.replace(/([\\%_])/g, "\\$1");
+  await db
+    .delete(frameAssetFiles)
+    .where(
+      and(
+        eq(frameAssetFiles.frameId, frameId),
+        or(
+          eq(frameAssetFiles.path, path),
+          like(frameAssetFiles.path, `${prefix}/%`),
+        ),
+      ),
+    );
+}
+
+/**
+ * The shared guard rail for every asset mutation route: CSRF, rate limit,
+ * session, database, frame ownership, and the frame being active. Returns
+ * either an error response to relay or the context to work with.
+ */
+export async function assetWriteRequestContext(
+  request: NextRequest,
+  frameId: string,
+): Promise<
+  | { response: Response }
+  | {
+      response?: undefined;
+      db: CommandDatabase;
+      accountId: string;
+      frame: NonNullable<Awaited<ReturnType<typeof frameForAccount>>>;
+    }
+> {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return { response: csrf };
+  }
+  const limited = await rateLimitResponse(request, "frames:asset_write", {
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return { response: limited };
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return { response: jsonError("login_required", 401) };
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return { response: response! };
+  }
+  const frame = await frameForAccount(db, session.accountId, frameId);
+  if (!frame) {
+    return { response: jsonError("invalid_frame", 404) };
+  }
+  if (frame.status !== "active") {
+    return { response: jsonError("frame_not_active", 409) };
+  }
+  return { db, accountId: session.accountId, frame };
+}
+
+/** Map a device refusal / queue outcome onto an HTTP error response. */
+export function assetWriteErrorResponse(
+  result: Extract<AssetCommandResult, { ok: false }>,
+) {
+  if (result.timedOut) {
+    return jsonError(result.error, 504);
+  }
+  const status =
+    result.error === "not_found"
+      ? 404
+      : result.error === "too_large"
+        ? 413
+        : 400;
+  return jsonError(result.error, status);
+}
+
+/** Queue a fresh assets_list so the panel's next refresh shows the change. */
+export async function queueAssetsListRefresh(
+  db: CommandDatabase,
+  accountId: string,
+  frameId: string,
+) {
+  await supersedePendingCommands(db, frameId, "assets_list");
+  await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    ttlMs: commandTtlMs,
+    type: "assets_list",
+  });
+}

--- a/cloud/apps/auth-web/src/lib/frames.ts
+++ b/cloud/apps/auth-web/src/lib/frames.ts
@@ -21,6 +21,12 @@ import {
 } from "@frameos-cloud/db";
 import { unzipSync } from "fflate";
 import { maxSceneZipEntries, maxSceneZipUncompressedBytes } from "./store";
+// usage.ts only type-imports from this module, so no runtime cycle.
+import {
+  cullFrameLogsOverBudget,
+  frameLogBytesForAccount,
+  maxFrameLogBytesPerAccount,
+} from "./usage";
 
 type Database = ReturnType<typeof createDb>;
 
@@ -464,6 +470,10 @@ export async function storeFrameLogs(
   db: FramesDatabase,
   frameId: string,
   logs: { timestamp: Date; payload: unknown }[],
+  // The frame's owning account, for the account-wide byte budget. Optional
+  // so older callers/tests keep working; without it only the per-frame row
+  // cap applies.
+  accountId?: string,
 ) {
   const batch = logs.slice(0, maxLogBatch).flatMap((entry) => {
     const serialized = JSON.stringify(entry.payload ?? null);
@@ -499,6 +509,17 @@ export async function storeFrameLogs(
         .where(
           and(eq(frameLogs.frameId, frameId), lt(frameLogs.id, cutoff.id + 1)),
         );
+    }
+    // Account byte budget: logs are telemetry, so over budget the OLDEST
+    // lines across the whole account are culled — never refused (a frame
+    // must not learn its logs bounced; usage.ts owns the budget).
+    if (accountId) {
+      const overBudget =
+        (await frameLogBytesForAccount(tx, accountId)) >
+        maxFrameLogBytesPerAccount;
+      if (overBudget) {
+        await cullFrameLogsOverBudget(tx, accountId);
+      }
     }
   });
   return batch.length;

--- a/cloud/apps/auth-web/src/lib/store-publish.ts
+++ b/cloud/apps/auth-web/src/lib/store-publish.ts
@@ -17,7 +17,6 @@ import {
   maxNewScenesPerDay,
   maxScenesPerAccount,
   maxSceneZipBytes,
-  maxStoreBytesPerAccount,
   maxVersionsPerScene,
   rebuildZipWithPreview,
   sceneSummary,
@@ -25,6 +24,11 @@ import {
   slugSuffix,
   validateSceneZip,
 } from "./store";
+import {
+  maxPrivateSceneBytesPerAccount,
+  privateSceneBytesForAccount,
+  sceneBytesTotal,
+} from "./usage";
 
 type PublishActor =
   | { accountId: string; providerSubject: string }
@@ -134,26 +138,38 @@ export async function publishStoreScene(
     }
   }
 
-  const [quota] = await db
-    .select({
-      bytes: sql<number>`coalesce(sum(${storeSceneVersions.sizeBytes}), 0)::bigint`,
-      scenes: sql<number>`count(distinct ${storeScenes.id})::int`,
-    })
+  const [sceneCountRow] = await db
+    .select({ scenes: sql<number>`count(*)::int` })
     .from(storeScenes)
-    .leftJoin(
-      storeSceneVersions,
-      eq(storeSceneVersions.sceneId, storeScenes.id),
-    )
     .where(eq(storeScenes.accountId, accountId));
-  if (!existing && (quota?.scenes ?? 0) >= maxScenesPerAccount) {
+  if (!existing && (sceneCountRow?.scenes ?? 0) >= maxScenesPerAccount) {
     return jsonError("scene_quota_exceeded", 403, {
       max_scenes: maxScenesPerAccount,
     });
   }
-  if (Number(quota?.bytes ?? 0) + content.length > maxStoreBytesPerAccount) {
-    return jsonError("storage_quota_exceeded", 403, {
-      max_bytes: maxStoreBytesPerAccount,
-    });
+  // Only PRIVATE scenes are metered — publishing publicly is free. The check
+  // uses the visibility this publish RESULTS in: an omitted visibility keeps
+  // an existing scene's setting and defaults a new scene to private.
+  const resultingVisibility =
+    input.visibility ?? existing?.visibility ?? "private";
+  if (resultingVisibility !== "public") {
+    const privateBytes = await privateSceneBytesForAccount(db, accountId);
+    // A version pushed onto an already-private scene adds `content.length`;
+    // if this publish also flips a public scene private, its existing bytes
+    // start counting too — fold them in so the flip cannot dodge the quota.
+    const flippingPrivateBytes =
+      existing && existing.visibility === "public"
+        ? await sceneBytesTotal(db, existing.id)
+        : 0;
+    if (
+      privateBytes + flippingPrivateBytes + content.length >
+      maxPrivateSceneBytesPerAccount
+    ) {
+      return jsonError("storage_quota_exceeded", 403, {
+        max_bytes: maxPrivateSceneBytesPerAccount,
+        private_bytes: Math.round(privateBytes),
+      });
+    }
   }
   if (!existing) {
     const [recent] = await db

--- a/cloud/apps/auth-web/src/lib/store.ts
+++ b/cloud/apps/auth-web/src/lib/store.ts
@@ -12,7 +12,8 @@ export const maxSceneZipEntries = 200;
 export const maxPreviewImageBytes = 4 * 1024 * 1024;
 export const maxImagesPerScene = 10;
 export const maxScenesPerAccount = 200;
-export const maxStoreBytesPerAccount = 100 * 1024 * 1024;
+// The byte quota moved to src/lib/usage.ts (maxPrivateSceneBytesPerAccount,
+// 200 MiB, private scenes only — public scenes are free).
 // Versions are immutable, but they are Postgres blobs: keep the newest 20 per
 // scene and prune older ones on publish (documented deviation, STORE-TODO).
 export const maxVersionsPerScene = 20;

--- a/cloud/apps/auth-web/src/lib/usage.ts
+++ b/cloud/apps/auth-web/src/lib/usage.ts
@@ -1,0 +1,215 @@
+// Account storage usage and quotas — the ONE definition both the display
+// (/account layout) and the enforcement points (store publish/fork/content,
+// gallery images, backups, frame-log culling) share. Before this existed the
+// display counted versions + gallery images + preview blobs while enforcement
+// counted versions only, and three copies of the query drifted.
+//
+// Quota philosophy (cloud/docs/cloud-frames.md "Monetization"):
+//   * PUBLIC store scenes are free — publishing for everyone costs the
+//     account nothing; only private scenes count against the scene quota.
+//   * Frame logs are telemetry: over budget the OLDEST lines are culled,
+//     never refused (a frame must not learn its logs bounced).
+//   * Scenes and backups are user data: over budget new writes are refused
+//     with a clear error, never deleted.
+// Defaults are deliberately generous; paid tiers can raise them later (the
+// limits ride along in every usage payload so UIs never hardcode them).
+
+import { eq, sql } from "drizzle-orm";
+import {
+  clientBackups,
+  frameLogs,
+  frames,
+  storeSceneImages,
+  storeScenes,
+  storeSceneVersions,
+} from "@frameos-cloud/db";
+import type { FramesDatabase } from "./frames";
+
+export const maxPrivateSceneBytesPerAccount = 200 * 1024 * 1024;
+export const maxBackupBytesPerAccount = 100 * 1024 * 1024;
+export const maxFrameLogBytesPerAccount = 100 * 1024 * 1024;
+
+export interface SceneBytesBreakdown {
+  privateBytes: number;
+  publicBytes: number;
+}
+
+const publicCase = (bytes: ReturnType<typeof sql>) =>
+  sql<number>`coalesce(sum(case when ${storeScenes.visibility} = 'public' then ${bytes} else 0 end), 0)::float8`;
+const privateCase = (bytes: ReturnType<typeof sql>) =>
+  sql<number>`coalesce(sum(case when ${storeScenes.visibility} <> 'public' then ${bytes} else 0 end), 0)::float8`;
+
+// A scene's bytes = its versions + gallery images + the primary preview
+// blob. Three flat join-aggregates (versions × images would cross-multiply
+// in a single join), each split by visibility so private (metered) and
+// public (free) stay apart.
+export async function sceneBytesForAccount(
+  db: FramesDatabase,
+  accountId: string,
+): Promise<SceneBytesBreakdown> {
+  const [[versions], [images], [previews]] = await Promise.all([
+    db
+      .select({
+        privateBytes: privateCase(sql`${storeSceneVersions.sizeBytes}`),
+        publicBytes: publicCase(sql`${storeSceneVersions.sizeBytes}`),
+      })
+      .from(storeSceneVersions)
+      .innerJoin(storeScenes, eq(storeScenes.id, storeSceneVersions.sceneId))
+      .where(eq(storeScenes.accountId, accountId)),
+    db
+      .select({
+        privateBytes: privateCase(sql`octet_length(${storeSceneImages.content})`),
+        publicBytes: publicCase(sql`octet_length(${storeSceneImages.content})`),
+      })
+      .from(storeSceneImages)
+      .innerJoin(storeScenes, eq(storeScenes.id, storeSceneImages.sceneId))
+      .where(eq(storeScenes.accountId, accountId)),
+    db
+      .select({
+        privateBytes: privateCase(
+          sql`coalesce(octet_length(${storeScenes.previewImage}), 0)`,
+        ),
+        publicBytes: publicCase(
+          sql`coalesce(octet_length(${storeScenes.previewImage}), 0)`,
+        ),
+      })
+      .from(storeScenes)
+      .where(eq(storeScenes.accountId, accountId)),
+  ]);
+  return {
+    privateBytes:
+      Number(versions?.privateBytes ?? 0) +
+      Number(images?.privateBytes ?? 0) +
+      Number(previews?.privateBytes ?? 0),
+    publicBytes:
+      Number(versions?.publicBytes ?? 0) +
+      Number(images?.publicBytes ?? 0) +
+      Number(previews?.publicBytes ?? 0),
+  };
+}
+
+/** The metered scene bytes only: everything except public scenes. */
+export async function privateSceneBytesForAccount(
+  db: FramesDatabase,
+  accountId: string,
+): Promise<number> {
+  return (await sceneBytesForAccount(db, accountId)).privateBytes;
+}
+
+/** One scene's total bytes (versions + gallery images + preview blob). */
+export async function sceneBytesTotal(
+  db: FramesDatabase,
+  sceneId: string,
+): Promise<number> {
+  const [[versions], [images], [preview]] = await Promise.all([
+    db
+      .select({
+        bytes: sql<number>`coalesce(sum(${storeSceneVersions.sizeBytes}), 0)::float8`,
+      })
+      .from(storeSceneVersions)
+      .where(eq(storeSceneVersions.sceneId, sceneId)),
+    db
+      .select({
+        bytes: sql<number>`coalesce(sum(octet_length(${storeSceneImages.content})), 0)::float8`,
+      })
+      .from(storeSceneImages)
+      .where(eq(storeSceneImages.sceneId, sceneId)),
+    db
+      .select({
+        bytes: sql<number>`coalesce(octet_length(${storeScenes.previewImage}), 0)::float8`,
+      })
+      .from(storeScenes)
+      .where(eq(storeScenes.id, sceneId)),
+  ]);
+  return (
+    Number(versions?.bytes ?? 0) +
+    Number(images?.bytes ?? 0) +
+    Number(preview?.bytes ?? 0)
+  );
+}
+
+export async function backupBytesForAccount(
+  db: FramesDatabase,
+  accountId: string,
+): Promise<number> {
+  const [row] = await db
+    .select({
+      bytes: sql<number>`coalesce(sum(${clientBackups.sizeBytes}), 0)::float8`,
+    })
+    .from(clientBackups)
+    .where(eq(clientBackups.accountId, accountId));
+  return Number(row?.bytes ?? 0);
+}
+
+export async function frameLogBytesForAccount(
+  db: FramesDatabase,
+  accountId: string,
+): Promise<number> {
+  const [row] = await db
+    .select({
+      bytes: sql<number>`coalesce(sum(${frameLogs.sizeBytes}), 0)::float8`,
+    })
+    .from(frameLogs)
+    .innerJoin(frames, eq(frames.id, frameLogs.frameId))
+    .where(eq(frames.accountId, accountId));
+  return Number(row?.bytes ?? 0);
+}
+
+/**
+ * The account's full usage snapshot, in the wire shape shared by the cloud
+ * UI, GET /api/backends/grants (linked backends cache and display it) and —
+ * later — paid tiers. snake_case: it crosses the AGPL boundary to
+ * third-party reimplementations.
+ */
+export async function accountUsage(db: FramesDatabase, accountId: string) {
+  const [scenes, backups, logs] = await Promise.all([
+    sceneBytesForAccount(db, accountId),
+    backupBytesForAccount(db, accountId),
+    frameLogBytesForAccount(db, accountId),
+  ]);
+  return {
+    backups: {
+      bytes: Math.round(backups),
+      max_bytes: maxBackupBytesPerAccount,
+    },
+    frame_logs: {
+      bytes: Math.round(logs),
+      max_bytes: maxFrameLogBytesPerAccount,
+    },
+    scenes: {
+      private_bytes: Math.round(scenes.privateBytes),
+      private_max_bytes: maxPrivateSceneBytesPerAccount,
+      // Public scenes are free; reported so UIs can say so instead of
+      // summing everything into one misleading number.
+      public_bytes: Math.round(scenes.publicBytes),
+    },
+  };
+}
+
+export type AccountUsage = Awaited<ReturnType<typeof accountUsage>>;
+
+/**
+ * Cull the OLDEST frame-log rows across the whole account until the total is
+ * back under budget. Runs inside the log-ingestion transaction; the running
+ * sum walks newest→oldest, so everything past the budget line (the oldest
+ * lines) goes in one statement. Cheap when under budget: callers gate on the
+ * SUM above first.
+ */
+export async function cullFrameLogsOverBudget(
+  db: FramesDatabase,
+  accountId: string,
+): Promise<void> {
+  await db.execute(sql`
+    with ordered as (
+      select fl.id,
+             sum(fl.size_bytes) over (order by fl.id desc) as running
+      from ${frameLogs} fl
+      join ${frames} f on f.id = fl.frame_id
+      where f.account_id = ${accountId}
+    )
+    delete from ${frameLogs}
+    where id in (
+      select id from ordered where running > ${maxFrameLogBytesPerAccount}
+    )
+  `);
+}

--- a/cloud/apps/auth-web/src/test/integration/account-usage.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/account-usage.integration.test.ts
@@ -1,0 +1,333 @@
+// Per-account storage quotas (src/lib/usage.ts): private scenes are metered,
+// public scenes are free, backups refuse over budget, frame logs cull their
+// oldest lines instead. Sizes are seeded via the size_bytes columns — the
+// same numbers the accounting sums — so no test ships hundreds of megabytes.
+import { generateKeyPairSync } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { NextRequest } from "next/server";
+import {
+  clientBackups,
+  createDb,
+  frameLogs,
+  frames,
+  linkedClients,
+  storeScenes,
+  storeSceneVersions,
+  upsertAccountFromIdentity,
+} from "@frameos-cloud/db";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET as getGrants } from "../../../app/api/backends/grants/route";
+import { POST as saveBackup } from "../../../app/api/backends/backups/route";
+import { POST as createScene } from "../../../app/api/account/scenes/route";
+import { POST as authorizeDevice } from "../../../app/api/device/authorize/route";
+import { POST as pollDevice } from "../../../app/api/device/poll/route";
+import { POST as startDevice } from "../../../app/api/device/start/route";
+import { storeFrameLogs } from "../../lib/frames";
+import { resetRateLimitForTests } from "../../lib/rate-limit";
+import { hashSecret } from "../../lib/secrets";
+import { createSession, sessionCookieName } from "../../lib/session";
+import {
+  accountUsage,
+  maxBackupBytesPerAccount,
+  maxFrameLogBytesPerAccount,
+  maxPrivateSceneBytesPerAccount,
+} from "../../lib/usage";
+
+const cookieJar = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => {
+      const value = cookieJar.get(name);
+      return value === undefined ? undefined : { name, value };
+    },
+  }),
+  headers: async () => new Headers(),
+}));
+
+const baseUrl = "http://localhost:3000";
+const issuer = "https://accounts.google.com";
+const db = createDb();
+let userCounter = 0;
+
+afterAll(async () => {
+  await db.$client.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  resetRateLimitForTests();
+  cookieJar.clear();
+  const tables = await db.execute<{ tablename: string }>(
+    sql`select tablename from pg_tables where schemaname = 'public'`,
+  );
+  const names = tables
+    .map((row) => row.tablename)
+    .filter((name) => name !== "schema_migrations")
+    .map((name) => `"${name}"`);
+  if (names.length > 0) {
+    await db.execute(sql.raw(`TRUNCATE TABLE ${names.join(", ")} CASCADE`));
+  }
+});
+
+function postJson(
+  path: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  return new NextRequest(new URL(path, baseUrl), {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json", origin: baseUrl, ...headers },
+    method: "POST",
+  });
+}
+
+async function readJson(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+async function signIn() {
+  userCounter += 1;
+  const providerSubject = `usage-user-${userCounter}`;
+  const { accountId } = await upsertAccountFromIdentity(db, {
+    displayName: `Usage Tester ${userCounter}`,
+    email: `usage-${userCounter}@example.com`,
+    emailVerified: true,
+    providerIssuer: issuer,
+    providerKey: "google",
+    providerSubject,
+  });
+  const token = await createSession(db, {
+    accountId,
+    providerIssuer: issuer,
+    providerSubject,
+  });
+  cookieJar.set(sessionCookieName, token);
+  return accountId;
+}
+
+async function seedScene(
+  accountId: string,
+  visibility: "private" | "public",
+  sizeBytes: number,
+) {
+  const [scene] = await db
+    .insert(storeScenes)
+    .values({
+      accountId,
+      latestVersion: 1,
+      name: `Seeded ${visibility} ${userCounter}-${sizeBytes}`,
+      slug: `seeded-${visibility}-${userCounter}-${sizeBytes}`,
+      status: "active",
+      visibility,
+    })
+    .returning();
+  await db.insert(storeSceneVersions).values({
+    content: Buffer.from("tiny"),
+    contentType: "application/zip",
+    sceneId: scene!.id,
+    sha256: "seeded",
+    sizeBytes,
+    version: 1,
+  });
+  return scene!;
+}
+
+function rawPublicKeyBase64() {
+  const { publicKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  return Buffer.from(spki.subarray(spki.length - 32)).toString("base64");
+}
+
+async function seedFrame(accountId: string) {
+  const [client] = await db
+    .insert(linkedClients)
+    .values({
+      accountId,
+      clientKind: "frame",
+      providerClientMetadata: { requestedScopes: ["frame:managed"] },
+      publicDisplayName: "Usage frame",
+      tokenReference: hashSecret(`fc_link_usage_${accountId}`),
+    })
+    .returning();
+  const [frame] = await db
+    .insert(frames)
+    .values({
+      accountId,
+      linkedClientId: client!.id,
+      name: "Usage frame",
+      publicKey: rawPublicKeyBase64(),
+      status: "active",
+    })
+    .returning();
+  return frame!;
+}
+
+async function linkBackend() {
+  const startResponse = await startDevice(
+    postJson("/api/device/start", {
+      local_origin: "http://10.2.2.2:8989",
+      public_display_name: "Usage Backend",
+      scopes: ["backend:link", "backup:frames"],
+    }),
+  );
+  const startPayload = await readJson(startResponse);
+  const accountId = await signIn();
+  const authorizeResponse = await authorizeDevice(
+    postJson("/api/device/authorize", { user_code: startPayload.user_code }),
+  );
+  expect(authorizeResponse.status).toBe(200);
+  const pollResponse = await pollDevice(
+    postJson("/api/device/poll", { device_code: startPayload.device_code }),
+  );
+  expect(pollResponse.status).toBe(200);
+  const { access_token: accessToken } = await readJson(pollResponse);
+  return { accessToken: accessToken as string, accountId };
+}
+
+describe("account storage usage and quotas", () => {
+  it("splits scene bytes by visibility — public scenes are free", async () => {
+    const accountId = await signIn();
+    await seedScene(accountId, "private", 5_000_000);
+    await seedScene(accountId, "public", 50_000_000);
+
+    const usage = await accountUsage(db, accountId);
+    expect(usage.scenes.private_bytes).toBe(5_000_000);
+    expect(usage.scenes.public_bytes).toBe(50_000_000);
+    expect(usage.scenes.private_max_bytes).toBe(maxPrivateSceneBytesPerAccount);
+    expect(usage.backups.max_bytes).toBe(maxBackupBytesPerAccount);
+    expect(usage.frame_logs.max_bytes).toBe(maxFrameLogBytesPerAccount);
+  });
+
+  it("refuses a new private scene over the private byte quota", async () => {
+    const accountId = await signIn();
+    await seedScene(accountId, "private", maxPrivateSceneBytesPerAccount);
+
+    const response = await createScene(
+      postJson("/api/account/scenes", {
+        name: "One scene too many",
+        scenes: [{ edges: [], id: "s1", name: "One scene too many", nodes: [] }],
+      }),
+    );
+    expect(response.status).toBe(403);
+    expect((await readJson(response)).error).toBe("storage_quota_exceeded");
+  });
+
+  it("ignores public bytes when metering a new private scene", async () => {
+    const accountId = await signIn();
+    // Way past the quota — but public, so free.
+    await seedScene(accountId, "public", maxPrivateSceneBytesPerAccount * 2);
+
+    const response = await createScene(
+      postJson("/api/account/scenes", {
+        name: "Fits fine",
+        scenes: [{ edges: [], id: "s1", name: "Fits fine", nodes: [] }],
+      }),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("enforces the backup byte quota, letting same-key replacements through", async () => {
+    const { accessToken, accountId } = await linkBackend();
+    // Fill the budget with one fat row (size_bytes is what the meter sums).
+    await db.insert(clientBackups).values({
+      accountId,
+      content: Buffer.from("tiny"),
+      itemKey: "existing",
+      kind: "frames",
+      linkedClientId: (
+        await db
+          .select({ id: linkedClients.id })
+          .from(linkedClients)
+          .where(eq(linkedClients.accountId, accountId))
+      )[0]!.id,
+      sha256: "seeded",
+      sizeBytes: maxBackupBytesPerAccount - 2,
+    });
+
+    const refused = await saveBackup(
+      postJson(
+        "/api/backends/backups",
+        {
+          content_base64: Buffer.from("abcdef").toString("base64"),
+          item_key: "new-item",
+          kind: "frames",
+        },
+        { authorization: `Bearer ${accessToken}` },
+      ),
+    );
+    expect(refused.status).toBe(403);
+    expect((await readJson(refused)).error).toBe(
+      "backup_storage_quota_exceeded",
+    );
+
+    // Replacing the existing key only counts the delta, so a small payload
+    // under the freed size passes.
+    const replaced = await saveBackup(
+      postJson(
+        "/api/backends/backups",
+        {
+          content_base64: Buffer.from("ok").toString("base64"),
+          item_key: "existing",
+          kind: "frames",
+        },
+        { authorization: `Bearer ${accessToken}` },
+      ),
+    );
+    expect(replaced.status).toBe(200);
+  });
+
+  it("culls the oldest frame logs across the account instead of refusing", async () => {
+    const accountId = await signIn();
+    const frame = await seedFrame(accountId);
+    // Three fat rows, oldest first: 40 + 40 + 40 MiB > the 100 MiB budget.
+    const fat = Math.floor(maxFrameLogBytesPerAccount * 0.4);
+    for (const label of ["oldest", "middle", "newest"]) {
+      await db.insert(frameLogs).values({
+        frameId: frame.id,
+        payload: { label },
+        sizeBytes: fat,
+        timestamp: new Date(),
+      });
+    }
+
+    const stored = await storeFrameLogs(
+      db,
+      frame.id,
+      [{ payload: { line: "fresh" }, timestamp: new Date() }],
+      accountId,
+    );
+    expect(stored).toBe(1);
+
+    const remaining = await db
+      .select({ payload: frameLogs.payload, sizeBytes: frameLogs.sizeBytes })
+      .from(frameLogs)
+      .where(eq(frameLogs.frameId, frame.id))
+      .orderBy(frameLogs.id);
+    const totalBytes = remaining.reduce((sum, row) => sum + row.sizeBytes, 0);
+    expect(totalBytes).toBeLessThanOrEqual(maxFrameLogBytesPerAccount);
+    const labels = remaining.map(
+      (row) => (row.payload as Record<string, unknown>).label ?? "fresh",
+    );
+    expect(labels).not.toContain("oldest");
+    expect(labels).toContain("newest");
+    expect(labels).toContain("fresh");
+  });
+
+  it("reports usage with limits on the grants poll", async () => {
+    const { accessToken, accountId } = await linkBackend();
+    await seedScene(accountId, "private", 1_234_567);
+
+    const response = await getGrants(
+      new NextRequest(new URL("/api/backends/grants", baseUrl), {
+        headers: { authorization: `Bearer ${accessToken}` },
+      }),
+    );
+    expect(response.status).toBe(200);
+    const payload = await readJson(response);
+    const usage = payload.usage as {
+      scenes: { private_bytes: number; private_max_bytes: number };
+    };
+    expect(usage.scenes.private_bytes).toBe(1_234_567);
+    expect(usage.scenes.private_max_bytes).toBe(maxPrivateSceneBytesPerAccount);
+  });
+});

--- a/cloud/apps/auth-web/src/test/integration/frame-scene-images.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frame-scene-images.integration.test.ts
@@ -9,6 +9,8 @@ import { zipSync } from "fflate";
 import { NextRequest } from "next/server";
 import {
   createDb,
+  frameAssetFiles,
+  frameCommands,
   frames,
   frameSceneAssignments,
   linkedClients,
@@ -19,6 +21,7 @@ import {
 } from "@frameos-cloud/db";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET as getSceneImage } from "../../../app/api/frames/[frameId]/scene_images/[sceneId]/route";
+import { sceneSnapshotAssetPath } from "../../lib/frame-asset-cache";
 import { resetRateLimitForTests } from "../../lib/rate-limit";
 import { resetSceneImageCacheForTests } from "../../lib/scene-images";
 import { hashSecret } from "../../lib/secrets";
@@ -352,5 +355,85 @@ describe("GET /api/frames/{id}/scene_images/{sceneId}", () => {
     expect(Buffer.from(await second.arrayBuffer()).toString()).toBe(
       "cached-bytes",
     );
+  });
+
+  it("prefers the device's cached snapshot over the store cover", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Snapshotted",
+      previewImage: Buffer.from("cover-bytes"),
+      previewImageType: "image/jpeg",
+      runtimeSceneIds: ["runtime-snap"],
+    });
+    await assignScene(frame.id, scene.id);
+    await db.insert(frameAssetFiles).values({
+      content: Buffer.from("device-render"),
+      contentType: "image/png",
+      frameId: frame.id,
+      path: sceneSnapshotAssetPath("runtime-snap"),
+      sizeBytes: "device-render".length,
+      thumb: false,
+    });
+
+    const response = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-snap`),
+      routeParams(frame.id, "runtime-snap"),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=60");
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "device-render",
+    );
+  });
+
+  it("queues an asset_get for the snapshot and serves the cover meanwhile", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Fetching",
+      previewImage: Buffer.from("cover-bytes"),
+      previewImageType: "image/jpeg",
+      runtimeSceneIds: ["runtime-fetch"],
+    });
+    await assignScene(frame.id, scene.id);
+
+    const response = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-fetch?thumb=1`),
+      routeParams(frame.id, "runtime-fetch"),
+    );
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "cover-bytes",
+    );
+    const queued = await db
+      .select({ payload: frameCommands.payload, type: frameCommands.type })
+      .from(frameCommands)
+      .where(eq(frameCommands.frameId, frame.id));
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.type).toBe("asset_get");
+    expect(queued[0]!.payload).toEqual({
+      path: sceneSnapshotAssetPath("runtime-fetch"),
+      thumb: true,
+    });
+  });
+
+  it("404s fast for an unmapped scene on a disconnected frame, still queueing the fetch", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+
+    const started = Date.now();
+    const response = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-unknown`),
+      routeParams(frame.id, "runtime-unknown"),
+    );
+    expect(response.status).toBe(404);
+    // No long poll: the frame is not connected, so waiting cannot help.
+    expect(Date.now() - started).toBeLessThan(5000);
+    const queued = await db
+      .select({ type: frameCommands.type })
+      .from(frameCommands)
+      .where(eq(frameCommands.frameId, frame.id));
+    expect(queued.map((row) => row.type)).toEqual(["asset_get"]);
   });
 });

--- a/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
@@ -293,11 +293,15 @@ describe("cloud-managed frame enrollment", () => {
     const payload = (await response.json()) as Record<string, unknown>;
     expect(payload.status).toBe("pending");
     expect(payload.token_type).toBe("Bearer");
-    expect(payload.scope).toBe("frame:managed");
+    // The FULL grant, not just frame:managed — the device stores this string
+    // as its local scope list and gates its telemetry push loops on it.
+    expect(payload.scope).toBe(
+      "frame:managed telemetry:logs telemetry:metrics",
+    );
     expect(payload.ws_path).toBe("/api/frames/ws");
     expect(typeof payload.access_token).toBe("string");
 
-    // The linked client is real and carries only the managed scope.
+    // The linked client is real and carries the claim-token grant.
     const [frame] = await db
       .select()
       .from(frames)

--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -727,7 +727,12 @@ export async function startFrameHub(
     }
     // storeFrameLogs enforces the per-frame retention cap and per-line size
     // limits in the same transaction as the insert.
-    const stored = await storeFrameLogs(db, session.frame.id, entries);
+    const stored = await storeFrameLogs(
+      db,
+      session.frame.id,
+      entries,
+      session.frame.accountId,
+    );
     if (stored === 0) {
       return;
     }

--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -524,6 +524,12 @@ export async function startFrameHub(
         JSON.stringify({
           id: randomUUID(),
           pending_commands: pendingCount,
+          // What this link is granted, so the device can enable the matching
+          // push loops. Load-bearing for older enrollments: their enroll
+          // response under-reported the scope string as just frame:managed,
+          // so without this a frame never learns it may send telemetry
+          // (docs/cloud-frames.md session start).
+          scopes: session.scopes,
           type: "ready",
         }),
       );

--- a/cloud/docs/cloud-workspace-gaps.md
+++ b/cloud/docs/cloud-workspace-gaps.md
@@ -1,5 +1,29 @@
 # Cloud workspace: the road to full frame control
 
+> Status (2026-08-05, cloud-workspace-fixes): item **2** got its long-term
+> half — `/scene_images/{sceneId}` now serves the DEVICE's own per-scene
+> snapshot first (the runner already writes
+> `{assets}/.frameos/scene_images/{name}-{md5}.png` on every scene switch;
+> the route fetches it through the existing `asset_get` verb +
+> `frame_asset_files` cache, `?thumb=1` riding the device's 320×320
+> thumbnailer) and falls back to store covers. Item **3** grew real
+> persistence: cloud Save & Deploy now saves edited scenes to the account
+> (new versions of assigned private scenes via `/api/account/scenes/{id}/
+> content`, brand-new scenes via the new `POST /api/account/scenes`
+> create-from-JSON route), updates the assignment list and pushes it — the
+> ad-hoc uploadScenes push is only the fallback when persistence fails. The
+> Assets panel is read-write on cloud: new wire verbs `asset_put` /
+> `asset_mkdir` / `asset_delete` / `asset_rename` (docs/cloud-frames.md;
+> dot-directories refused, 2.5 MiB single-frame upload cap) behind
+> backend-contract routes `/api/frames/{id}/assets/{upload,mkdir,delete,
+> rename}`. The wasm live preview proxies external fetches through
+> `/api/store/preview-proxy` on cloud (injected `preview_proxy_url` +
+> `isCloudMode()` fallback in livePreviewLogic — it used to resolve the
+> backend's project-scoped proxy path, fail, and leave every fetch to die on
+> CORS). Monaco + app sources work in the cloud workspace (bundled monaco +
+> workers in cloud-frontend, embedded builtin app sources), and the tab
+> title says FrameOS Cloud.
+
 > Status (2026-08-03, this branch): items **4** and **5** are done, item **8**
 > is done (tiles hydrate from the server), and asset browsing shipped as a new
 > surface: `assets_list`/`asset_get` wire verbs (docs/cloud-frames.md), hub

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -223,14 +223,22 @@ but not in this device's profile), `message_too_large`, `invalid_json`,
 | `assets_list` | `{}` | bare ack, then a separate `{"id", "type": "assets", "assets": [{"path", "size", "mtime", "is_dir"?}…], "truncated"?: true}` message with the same `id`. Paths are **relative to the device's assets directory** (`assets_path`, default `/srv/assets`) — never absolute. A device may bound the listing (the reference cap is 5000 entries) and must then say so with `"truncated": true` rather than silently stopping |
 | `image_get` | `{}` | the frame's current rendered image. Bare ack, then the same `asset_chunk` stream `asset_get` uses (same `id` correlation, same caps); the first chunk's `content_type` says what the device produces (the Linux runtime sends `image/png` of its last render, the ESP32 packs `image/bmp` from its framebuffer). `ok: false` ack with `no_image` when nothing has rendered yet, `busy` on a small device already streaming |
 | `asset_get` | `{"path": "…", "thumb"?: true}` | read one file from the assets directory. Failure is an ordinary `ok: false` ack: `invalid_path` (traversal, absolute, or outside the assets directory), `not_found`, `is_directory`, `too_large` (the reference cap is **8 MiB** raw), `busy` (a small device already streaming another file). Success is a bare ack followed by one or more `{"id", "type": "asset_chunk", "seq": 0…N, "data": "<base64>", "done": bool}` messages with the same `id`, in order; the first chunk also carries `"size"` (total raw bytes), `"mtime"` and `"content_type"`. A read that fails after the ack ends the stream with `{"type": "asset_chunk", "id", "error": "…", "done": true}` and the provider discards the partial file. With `thumb`, a device that can generate thumbnails (Linux) returns a small preview; a device that cannot (ESP32) returns the original bytes |
+| `asset_put` | `{"path": "…", "data": "<base64>"}` | store one file in the assets directory. The whole payload rides a single message, so the raw size is bounded well under the inbound frame cap (the reference device cap is **2.5 MiB** raw — `too_large` past it); the filename component is sanitized by the device exactly like a local admin upload, parent folders are created as needed, and an existing file at the path is replaced. Errors: `invalid_path` (traversal, absolute, outside the assets directory, or a dot-directory — see below), `invalid_data` (empty or undecodable base64), `too_large`, `write_failed`. The ack carries `"asset": {"path" (relative, as stored), "size", "mtime", "is_dir"}` |
+| `asset_mkdir` | `{"path": "…"}` | create a folder (and parents) in the assets directory. Errors: `invalid_path`, `write_failed` |
+| `asset_delete` | `{"path": "…"}` | delete a file or folder (recursively) in the assets directory. Errors: `invalid_path`, `not_found`, `write_failed` |
+| `asset_rename` | `{"src": "…", "dst": "…"}` | rename/move a file or folder within the assets directory (the destination's parent folders are created). Errors: `invalid_path`, `not_found`, `write_failed` |
 
 Explicitly absent, by design (see `cloud/docs/cloud-frames.md`): shell/exec,
 PTY, arbitrary file read/write, SSH anything, network/WiFi config, admin
 credentials, update URLs, agent/profile state, compiled scene deploys. The
-`assets_list`/`asset_get` verbs are deliberately not a file API: they are
-read-only, confined to the assets directory (the same user-content directory
-the local admin's Assets panel serves), and the device — not the provider —
-resolves and bounds every path.
+asset verbs are deliberately not a file API: they are confined to the assets
+directory (the same user-content directory the local admin's Assets panel
+serves), and the device — not the provider — resolves and bounds every path.
+Additionally, the write verbs (`asset_put`/`asset_mkdir`/`asset_delete`/
+`asset_rename`) refuse any path containing a dot-component: dot-directories
+(`.thumbs`, `.frameos`) are the device's own plumbing (thumbnail cache, scene
+snapshots) — readable via `asset_get` where the provider knows a specific
+path, but never writable from the wire.
 
 ### Device profiles
 
@@ -244,7 +252,7 @@ drains either way.
 | Profile | Implements | Answers `unsupported_verb` for |
 |---|---|---|
 | Full (Linux/Raspberry Pi FrameOS) | the whole table | — |
-| ESP32 (microcontroller firmware) | `set_scenes`, `set_current_scene`, `get_state`, `render`, `reboot`, `restart_runtime` (identical to `reboot`: on ESP32 the runtime *is* the firmware), `assets_list`, `asset_get` (both only while the SD card is mounted — otherwise an empty listing / `not_found`; `thumb` is ignored and the original bytes are returned), `image_get` (`image/bmp`) | `set_schedule`, `set_settings`, `get_logs`, `get_metrics`, `notify_update_available` |
+| ESP32 (microcontroller firmware) | `set_scenes`, `set_current_scene`, `get_state`, `render`, `reboot`, `restart_runtime` (identical to `reboot`: on ESP32 the runtime *is* the firmware), `assets_list`, `asset_get` (both only while the SD card is mounted — otherwise an empty listing / `not_found`; `thumb` is ignored and the original bytes are returned), `image_get` (`image/bmp`) | `set_schedule`, `set_settings`, `get_logs`, `get_metrics`, `notify_update_available`, `asset_put`, `asset_mkdir`, `asset_delete`, `asset_rename` |
 
 The ESP32 profile is a subset because the firmware has no scheduler, no log
 buffer and no metrics buffer to expose, and updates itself from its own

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -179,8 +179,13 @@ profile they target rather than relying on the cap.
    64-byte signature; the provider verifies the signature against the same
    decoded bytes it generated. (Signing the base64 text is the obvious
    mistake, and it fails silently — the socket simply closes.)
-4. Provider → frame: `{"type": "ready", "pending_commands": N}` — then drains
-   the durable per-frame command queue in order.
+4. Provider → frame: `{"type": "ready", "pending_commands": N,
+   "scopes"?: ["frame:managed", "telemetry:logs", …]}` — then drains the
+   durable per-frame command queue in order. The optional `scopes` array is
+   the link's currently granted scope list; a device should treat it as
+   additive truth and enable the matching push loops (telemetry above all) —
+   it is how a frame whose enrollment response under-reported the grant
+   learns it may send logs and metrics without re-enrolling.
 
 The provider must verify the signature against the enrolled public key and
 close the socket on mismatch, with WebSocket close code **4401** (also used

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -379,6 +379,26 @@ directly. Providers serve a session-gated streaming pass-through
 public release asset through without buffering it. Personalization stays in
 the browser, so no user data passes through it.
 
+**The self-hosted sibling: `/boot/frameos-setup.bin`.** Release images also
+ship a second, larger placeholder — **8 MiB**, first line
+`# FRAMEOS-SETUP-BLOB-V1`, canonical bytes from
+`app.tasks.setup_json_reset.render_setup_blob_placeholder` — for
+personalization by a self-hosted FrameOS backend, whose payload (the full
+`frameos-setup.json` with frame config and scenes, plus the
+hostname/WiFi/SSH-keys/root-password boot files) cannot fit 4096 bytes. A
+personalized region is `size=<bytes>` on line 2 followed by a gzipped POSIX
+tar of the allow-listed `/boot/frameos-*` files, padded with `#` to the
+fixed size; the first-boot script unpacks it with busybox `gunzip | tar`,
+installs the members, shreds the blob, and runs the normal first-boot
+handlers (display/boot config comes from `frameos setup` itself, so no
+partition surgery is needed anywhere). The backend patches the region
+in place in the raw image (`app.tasks.sd_image_blob_patch`) exactly like
+the browser patches the cloud region — same magic-scan, same pristine-region
+verification, same fixed-size overwrite — which means SD personalization
+for backend-managed frames needs no mtools, debugfs, docker or build host
+when the frame runs a precompiled FrameOS with interpreted scenes. While
+the second line is a comment the region is inert and the image generic.
+
 **Multi-use claim tokens.** A provider may mint claim tokens with a use
 budget (`max_uses` > 1) so one personalized image can be flashed to many
 cards: each boot enrolls a distinct frame (every device generates its own

--- a/docs/cloud-link.md
+++ b/docs/cloud-link.md
@@ -232,9 +232,20 @@ its own privileges silently.
   "grants": [
     { "account_id": "…", "account_email": "owner@example.com", "role": "owner", "updated_at": "…" }
   ],
-  "linked_client_id": "…"
+  "linked_client_id": "…",
+  "usage": {
+    "scenes": { "private_bytes": 0, "private_max_bytes": 209715200, "public_bytes": 0 },
+    "backups": { "bytes": 0, "max_bytes": 104857600 },
+    "frame_logs": { "bytes": 0, "max_bytes": 104857600 }
+  }
 }
 ```
+
+`usage` (optional) is the account's storage usage and quota snapshot —
+public store scenes are quota-free, hence the private/public split. The
+limits ride along so clients never hardcode them (a provider may raise them
+per account, e.g. for a paid tier). Clients should treat the whole block as
+informational display data.
 
 `account_email` is a display snapshot, not an identity key. FrameOS may cache
 grant state across short provider outages, but must honor revocation as soon

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -1355,7 +1355,9 @@ static void ws_handle_message(const char *data, size_t len)
         /* provider-side notices; nothing to do */
     } else if (strcmp(type, "set_schedule") == 0 || strcmp(type, "set_settings") == 0 ||
                strcmp(type, "get_logs") == 0 || strcmp(type, "get_metrics") == 0 ||
-               strcmp(type, "notify_update_available") == 0) {
+               strcmp(type, "notify_update_available") == 0 ||
+               strcmp(type, "asset_put") == 0 || strcmp(type, "asset_mkdir") == 0 ||
+               strcmp(type, "asset_delete") == 0 || strcmp(type, "asset_rename") == 0) {
         /* Documented verbs the esp32 profile does not implement. Answering
          * `unsupported_verb` (not `unknown_verb`) lets a provider tell "this
          * device profile is smaller" apart from "you sent something that is

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -222,6 +222,25 @@ proc persistScenesChecksum(checksum: string) {.gcsafe.} =
       state["scenes_checksum"] = %checksum
       saveCloudLinkState(state)
 
+proc persistProviderScopes(scopes: seq[string]): bool {.gcsafe.} =
+  ## Union the scopes the provider announced in its `ready` message into the
+  ## link state. Additive on purpose (removals arrive as a fresh enroll or a
+  ## link reset, never silently): older enroll responses under-reported the
+  ## grant as just frame:managed, so this is how an already-enrolled frame
+  ## learns it may send telemetry. Returns true when anything changed; the
+  ## save bumps the link generation, which the session loop already watches.
+  {.gcsafe.}:
+    if scopes.len == 0:
+      return false
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      let existing = state{"scope"}.getStr("")
+      let merged = unionScopeString(existing, scopes.join(" "))
+      if merged != existing:
+        state["scope"] = %merged
+        saveCloudLinkState(state)
+        result = true
+
 proc providerExemptHostPort(providerUrl: string): string =
   ## "host:port" for the provider's own API endpoint. The local admin linked
   ## this provider deliberately (possibly a dev provider on the LAN), so its
@@ -1131,9 +1150,11 @@ proc recvJsonWithin(socket: WebSocket, timeoutMs: int): Future[JsonNode] {.async
   except JsonParsingError:
     result = %*{}
 
-proc runHandshake(socket: WebSocket, ctx: CloudVerbContext) {.async.} =
+proc runHandshake(socket: WebSocket, ctx: CloudVerbContext): Future[JsonNode] {.async.} =
   ## hello → challenge → auth → ready. Raises CloudHubAuthError when the
-  ## provider rejects the signature or the handshake stalls.
+  ## provider rejects the signature or the handshake stalls. Returns the
+  ## `ready` message — it carries `pending_commands` and (newer hubs) the
+  ## link's granted `scopes`.
   var hello = helloStatePayload(ctx.frameConfig, ctx.scenesChecksum)
   hello["type"] = %"hello"
   await socket.send($hello)
@@ -1171,7 +1192,7 @@ proc runHandshake(socket: WebSocket, ctx: CloudVerbContext) {.async.} =
     let ready = await recvJsonWithin(socket, HubHandshakeTimeoutMs)
     let msgType = ready{"type"}.getStr("")
     if msgType == "ready":
-      break
+      return ready
     if msgType == "error":
       raise newException(CloudHubAuthError,
         "Provider rejected device authentication: " & ready{"error"}.getStr(""))
@@ -1253,8 +1274,28 @@ proc runHubSession(frameConfig: FrameConfig, link: HubLinkSnapshot):
   let pingInterval = min(HubPingIntervalSeconds, idleTimeout / 3)
   result = sessionDisconnected
   try:
-    await runHandshake(socket, ctx)
+    let ready = await runHandshake(socket, ctx)
     log(%*{"event": "cloud:hub:connected", "provider": link.providerUrl})
+    # The hub announces the link's granted scopes in `ready`. Merge anything
+    # new into the local link state — this is how frames whose enroll response
+    # under-reported the grant (older providers said only frame:managed)
+    # finally learn they may push telemetry. The generation-watch below picks
+    # up the persisted change; the in-memory flags update here so the very
+    # first session already forwards logs.
+    let readyScopes = ready{"scopes"}
+    if readyScopes != nil and readyScopes.kind == JArray:
+      var announced: seq[string] = @[]
+      for scope in readyScopes:
+        if scope.kind == JString and scope.getStr("").len > 0:
+          announced.add(scope.getStr(""))
+      if persistProviderScopes(announced):
+        generation = currentCloudLinkGeneration()
+        for scope in announced:
+          if scope notin ctx.scopes:
+            ctx.scopes.add(scope)
+        logsGranted = "telemetry:logs" in ctx.scopes
+        metricsGranted = "telemetry:metrics" in ctx.scopes
+        log(%*{"event": "cloud:hub:scopesUpdated", "scopes": ctx.scopes.join(" ")})
     if logsGranted:
       # Drop anything queued before this session so the provider only gets
       # lines from its own watch window.

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -10,11 +10,14 @@
 ## arbitrary file read/write verb, no SSH anything, no compiled-scene deploy —
 ## the code for those capabilities simply does not exist here, so no
 ## provider-side compromise or configuration flag can reach them. The only
-## file access is `assets_list`/`asset_get`: read-only, resolved and bounded
-## on-device inside the assets directory (admin_api_assets_routes'
-## resolveAssetPath — the same guard the local Assets panel uses). Anything
-## outside the verb table is answered with `unknown_verb` and audit-logged
-## through the normal log pipeline (`cloud:audit`).
+## file access is the asset verb family (`assets_list`/`asset_get` plus the
+## write verbs `asset_put`/`asset_mkdir`/`asset_delete`/`asset_rename`):
+## resolved and bounded on-device inside the assets directory
+## (admin_api_assets_routes' resolveAssetPath — the same guard the local
+## Assets panel uses), with writes additionally refused for dot-directories
+## (`.frameos`, `.thumbs` — the device's own plumbing). Anything outside the
+## verb table is answered with `unknown_verb` and audit-logged through the
+## normal log pipeline (`cloud:audit`).
 ##
 ## Frames keep working when the provider is down: this thread only ever pushes
 ## data out and reacts to messages; rendering, schedules and the local admin
@@ -96,6 +99,10 @@ const
   # folder. Over the cap the listing says `truncated: true` — never a silent
   # stop (a partial listing that looks complete is worse than none).
   HubMaxAssetListEntries* = 5000
+  # `asset_put` rides a single inbound frame (there is no cloud→device chunk
+  # stream), so the raw payload must survive base64 inflation plus envelope
+  # inside HubMaxInboundBytes. 2.5 MiB raw ≈ 3.4 MiB encoded.
+  HubMaxAssetUploadBytes* = 2_621_440
 
 # Declarative settings a provider may push; every key maps onto an existing
 # frame.json field through the same persist path the local admin uses. Must
@@ -157,6 +164,14 @@ type
     ## paths relative to the assets directory (docs/cloud-frames.md).
     listAssetsFn*: proc(): JsonNode {.gcsafe.}
     readAssetFn*: proc(path: string, thumb: bool): AssetReadResult {.gcsafe.}
+    ## Write verbs. writeAssetFn returns the stored entry as
+    ## {"path" (relative), "size", "mtime", "is_dir"}; all four raise
+    ## ValueError for a path the guard refuses and OSError for a filesystem
+    ## failure — the handlers translate those into wire errors.
+    writeAssetFn*: proc(path: string, data: string): JsonNode {.gcsafe.}
+    mkdirAssetFn*: proc(path: string) {.gcsafe.}
+    deleteAssetFn*: proc(path: string) {.gcsafe.}
+    renameAssetFn*: proc(src: string, dst: string) {.gcsafe.}
     ## The current rendered image for `image_get` (error "no_image" until the
     ## first render).
     getImageFn*: proc(): AssetReadResult {.gcsafe.}
@@ -352,6 +367,17 @@ proc defaultReadAsset(path: string, thumb: bool): AssetReadResult {.gcsafe.} =
       contentType: if thumb: "image/jpeg" else: contentTypeForFilePath(fullPath),
       mtime: getFileInfo(fullPath).lastWriteTime.toUnix())
 
+proc defaultWriteAsset(path: string, data: string): JsonNode {.gcsafe.} =
+  ## Store one uploaded file. resolveAssetUploadPath sanitizes the filename
+  ## component exactly like the local admin upload does, so the provider
+  ## cannot smuggle path tricks through the name; the returned path is the
+  ## relative path actually written.
+  {.gcsafe.}:
+    let (dir, name, ext) = splitFile(path)
+    var payload = saveAssetUploadPayload(dir, name & ext, data)
+    payload["path"] = %relativeAssetPath(payload{"path"}.getStr(""))
+    payload
+
 proc defaultCloudVerbContext*(frameConfig: FrameConfig, scopes: seq[string],
                               scenesChecksum: string): CloudVerbContext {.gcsafe.} =
   {.gcsafe.}:
@@ -385,6 +411,18 @@ proc defaultCloudVerbContext*(frameConfig: FrameConfig, scopes: seq[string],
       readAssetFn: proc(path: string, thumb: bool): AssetReadResult {.gcsafe.} =
         {.gcsafe.}:
           defaultReadAsset(path, thumb),
+      writeAssetFn: proc(path: string, data: string): JsonNode {.gcsafe.} =
+        {.gcsafe.}:
+          defaultWriteAsset(path, data),
+      mkdirAssetFn: proc(path: string) {.gcsafe.} =
+        {.gcsafe.}:
+          createAssetDirectory(path),
+      deleteAssetFn: proc(path: string) {.gcsafe.} =
+        {.gcsafe.}:
+          deleteAssetEntry(path),
+      renameAssetFn: proc(src: string, dst: string) {.gcsafe.} =
+        {.gcsafe.}:
+          renameAssetEntry(src, dst),
       getImageFn: proc(): AssetReadResult {.gcsafe.} =
         {.gcsafe.}:
           try:
@@ -698,6 +736,107 @@ proc handleImageGet(ctx: CloudVerbContext, id: JsonNode): CloudVerbReply =
   ctx.audit("image_get", true)
   CloudVerbReply(ack: ackOk(id), extra: assetChunkExtras(id, image))
 
+proc assetWriteError(error: ref CatchableError): string =
+  ## The write helpers raise ValueError for guard refusals and OSError for
+  ## filesystem trouble; "Asset not found" is the one OSError worth naming.
+  if error of ValueError:
+    "invalid_path"
+  elif error.msg == "Asset not found":
+    "not_found"
+  else:
+    "write_failed"
+
+proc refusedWritePath(path: string): bool =
+  ## Writes never touch dot-directories: `.thumbs` and `.frameos` (scene
+  ## snapshots) are the device's own plumbing. asset_get deliberately CAN
+  ## read them (that is how the provider fetches scene snapshots), but a
+  ## provider must not be able to plant or destroy files there.
+  hiddenAssetPath(path.strip())
+
+proc handleAssetPut(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.writeAssetFn.isNil:
+    ctx.audit("asset_put", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let path = msg{"path"}.getStr("")
+  if path.len == 0 or refusedWritePath(path):
+    ctx.audit("asset_put", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  let encoded = msg{"data"}.getStr("")
+  var data: string
+  try:
+    data = decode(encoded)
+  except CatchableError:
+    ctx.audit("asset_put", false, "invalid_data")
+    return CloudVerbReply(ack: ackError(id, "invalid_data"))
+  if data.len == 0:
+    ctx.audit("asset_put", false, "invalid_data")
+    return CloudVerbReply(ack: ackError(id, "invalid_data"))
+  if data.len > HubMaxAssetUploadBytes:
+    ctx.audit("asset_put", false, "too_large")
+    return CloudVerbReply(ack: ackError(id, "too_large"))
+  try:
+    let stored = ctx.writeAssetFn(path, data)
+    ctx.audit("asset_put", true)
+    var ack = ackOk(id)
+    ack["asset"] = stored
+    CloudVerbReply(ack: ack)
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_put", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
+proc handleAssetMkdir(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.mkdirAssetFn.isNil:
+    ctx.audit("asset_mkdir", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let path = msg{"path"}.getStr("")
+  if path.len == 0 or refusedWritePath(path):
+    ctx.audit("asset_mkdir", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  try:
+    ctx.mkdirAssetFn(path)
+    ctx.audit("asset_mkdir", true)
+    CloudVerbReply(ack: ackOk(id))
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_mkdir", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
+proc handleAssetDelete(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.deleteAssetFn.isNil:
+    ctx.audit("asset_delete", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let path = msg{"path"}.getStr("")
+  if path.len == 0 or refusedWritePath(path):
+    ctx.audit("asset_delete", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  try:
+    ctx.deleteAssetFn(path)
+    ctx.audit("asset_delete", true)
+    CloudVerbReply(ack: ackOk(id))
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_delete", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
+proc handleAssetRename(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
+  if ctx.renameAssetFn.isNil:
+    ctx.audit("asset_rename", false, "unsupported_verb")
+    return CloudVerbReply(ack: ackError(id, "unsupported_verb"))
+  let src = msg{"src"}.getStr("")
+  let dst = msg{"dst"}.getStr("")
+  if src.len == 0 or dst.len == 0 or refusedWritePath(src) or refusedWritePath(dst):
+    ctx.audit("asset_rename", false, "invalid_path")
+    return CloudVerbReply(ack: ackError(id, "invalid_path"))
+  try:
+    ctx.renameAssetFn(src, dst)
+    ctx.audit("asset_rename", true)
+    CloudVerbReply(ack: ackOk(id))
+  except CatchableError as error:
+    let wireError = assetWriteError(error)
+    ctx.audit("asset_rename", false, wireError)
+    CloudVerbReply(ack: ackError(id, wireError))
+
 proc handleGetLogs(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudVerbReply =
   if not ctx.hasScope("telemetry:logs"):
     ctx.audit("get_logs", false, "insufficient_scope")
@@ -761,6 +900,14 @@ proc handleCloudVerb*(ctx: CloudVerbContext, msg: JsonNode): CloudVerbReply {.gc
     result = handleAssetsList(ctx, id)
   of "asset_get":
     result = handleAssetGet(ctx, id, msg)
+  of "asset_put":
+    result = handleAssetPut(ctx, id, msg)
+  of "asset_mkdir":
+    result = handleAssetMkdir(ctx, id, msg)
+  of "asset_delete":
+    result = handleAssetDelete(ctx, id, msg)
+  of "asset_rename":
+    result = handleAssetRename(ctx, id, msg)
   of "image_get":
     result = handleImageGet(ctx, id)
   of "render":

--- a/frameos/src/frameos/cloud/tests/test_hub_verbs.nim
+++ b/frameos/src/frameos/cloud/tests/test_hub_verbs.nim
@@ -13,6 +13,10 @@ type
     dropEvents: bool ## simulates a full runtime event queue
     assetReads: seq[(string, bool)]
     assetData: string ## what readAssetFn serves for "photos/cat.jpg"
+    assetWrites: seq[(string, string)]
+    assetMkdirs: seq[string]
+    assetDeletes: seq[string]
+    assetRenames: seq[(string, string)]
 
 proc makeContext(recorded: Recorded, scopes: seq[string] = @[]): CloudVerbContext =
   CloudVerbContext(
@@ -56,6 +60,19 @@ proc makeContext(recorded: Recorded, scopes: seq[string] = @[]): CloudVerbContex
         AssetReadResult(error: "no_image")
       else:
         AssetReadResult(data: "png-bytes", contentType: "image/png", mtime: 1700000002),
+    writeAssetFn: proc(path: string, data: string): JsonNode {.gcsafe.} =
+      if path == "denied.bin":
+        raise newException(ValueError, "Invalid asset path")
+      recorded.assetWrites.add((path, data))
+      %*{"path": path, "size": data.len, "mtime": 1700000003, "is_dir": false},
+    mkdirAssetFn: proc(path: string) {.gcsafe.} =
+      recorded.assetMkdirs.add(path),
+    deleteAssetFn: proc(path: string) {.gcsafe.} =
+      if path == "missing.bin":
+        raise newException(OSError, "Asset not found")
+      recorded.assetDeletes.add(path),
+    renameAssetFn: proc(src: string, dst: string) {.gcsafe.} =
+      recorded.assetRenames.add((src, dst)),
     rebootFn: proc() {.gcsafe.} =
       recorded.reboots += 1,
     auditFn: proc(payload: JsonNode) {.gcsafe.} =
@@ -426,6 +443,73 @@ suite "cloud hub verb dispatcher":
     })
     check refused.ack{"error"}.getStr("") == "no_image"
     check refused.extra.len == 0
+
+  test "asset_put stores decoded bytes and acks the stored entry":
+    let recorded = Recorded()
+    let reply = handleCloudVerb(makeContext(recorded), %*{
+      "id": "p1", "type": "asset_put",
+      "path": "photos/new.jpg", "data": encode("fresh-bytes"),
+    })
+    check reply.ack{"ok"}.getBool(false) == true
+    check reply.ack{"asset"}{"path"}.getStr("") == "photos/new.jpg"
+    check reply.ack{"asset"}{"size"}.getInt(0) == "fresh-bytes".len
+    check recorded.assetWrites == @[("photos/new.jpg", "fresh-bytes")]
+
+  test "asset_put refuses bad payloads without touching the filesystem":
+    let recorded = Recorded()
+    let ctx = makeContext(recorded)
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "data": encode("x"),
+    }).ack{"error"}.getStr("") == "invalid_path"
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "path": "a.bin", "data": "",
+    }).ack{"error"}.getStr("") == "invalid_data"
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "path": "a.bin", "data": "not-base64!!!",
+    }).ack{"error"}.getStr("") == "invalid_data"
+    # Guard refusals from the write helper surface as invalid_path.
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_put", "path": "denied.bin", "data": encode("x"),
+    }).ack{"error"}.getStr("") == "invalid_path"
+    check recorded.assetWrites.len == 0
+
+  test "asset write verbs never touch dot-directories":
+    let recorded = Recorded()
+    let ctx = makeContext(recorded)
+    for message in [
+      %*{"type": "asset_put", "path": ".frameos/scene_images/x.png", "data": encode("x")},
+      %*{"type": "asset_mkdir", "path": ".thumbs/sub"},
+      %*{"type": "asset_delete", "path": ".frameos"},
+      %*{"type": "asset_rename", "src": "ok.bin", "dst": ".thumbs/ok.bin"},
+      %*{"type": "asset_rename", "src": ".thumbs/x.jpg", "dst": "ok.bin"},
+    ]:
+      check handleCloudVerb(ctx, message).ack{"error"}.getStr("") == "invalid_path"
+    check recorded.assetWrites.len == 0
+    check recorded.assetMkdirs.len == 0
+    check recorded.assetDeletes.len == 0
+    check recorded.assetRenames.len == 0
+
+  test "asset_mkdir, asset_delete and asset_rename dispatch and map errors":
+    let recorded = Recorded()
+    let ctx = makeContext(recorded)
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_mkdir", "path": "albums/summer",
+    }).ack{"ok"}.getBool(false) == true
+    check recorded.assetMkdirs == @["albums/summer"]
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_delete", "path": "photos/old.jpg",
+    }).ack{"ok"}.getBool(false) == true
+    check recorded.assetDeletes == @["photos/old.jpg"]
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_delete", "path": "missing.bin",
+    }).ack{"error"}.getStr("") == "not_found"
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_rename", "src": "photos/cat.jpg", "dst": "photos/dog.jpg",
+    }).ack{"ok"}.getBool(false) == true
+    check recorded.assetRenames == @[("photos/cat.jpg", "photos/dog.jpg")]
+    check handleCloudVerb(ctx, %*{
+      "type": "asset_rename", "src": "", "dst": "x.bin",
+    }).ack{"error"}.getStr("") == "invalid_path"
 
   test "reboot and restart_runtime use the injected implementations":
     let recorded = Recorded()

--- a/frameos/src/system/index/scene.nim
+++ b/frameos/src/system/index/scene.nim
@@ -1,16 +1,23 @@
 {.warning[UnusedImport]: off.}
 import pixie, json, strformat, strutils, sequtils, options, os, tables, algorithm
 import std/monotimes
+import std/uri
 import zippy
 
 import frameos/values
 import frameos/types
 import frameos/channels
+import frameos/cloud/link_state
 import frameos/utils/url
 import frameos/utils/time
 import apps/render/text/app as render_textApp
 import scenes/scenes as compiledScenes
 import system/options as sceneOptions
+
+# Sockets exist on the device runtimes only — the wasm/embedded builds render
+# this scene too, and there the address lines just say "unknown".
+when not defined(frameosWasm) and not defined(frameosEmbedded):
+  import std/net as system_net
 
 const DEBUG = true
 let PUBLIC_STATE_FIELDS*: seq[StateField] = @[]
@@ -71,18 +78,89 @@ proc buildSceneList*(self: Scene): seq[(string, string)] =
   ordered.sort(proc(a, b: (string, string)): int = cmpIgnoreCase(a[1], b[1]))
   return ordered
 
+proc defaultRouteInterface*(): string =
+  ## The interface carrying the default route ("wlan0", "eth0"), from
+  ## /proc/net/route — Linux only, empty anywhere else. Pure file read, no
+  ## child processes.
+  try:
+    if fileExists("/proc/net/route"):
+      for line in readFile("/proc/net/route").splitLines():
+        let cols = line.splitWhitespace()
+        if cols.len >= 2 and cols[1] == "00000000":
+          return cols[0]
+  except CatchableError:
+    discard
+  ""
+
+proc primaryIpAddress*(): string =
+  ## The local address the kernel would route external traffic through:
+  ## "connect" a UDP socket to a public address (no packet is sent) and read
+  ## the socket's own address back. Empty when there is no usable network.
+  when defined(frameosWasm) or defined(frameosEmbedded):
+    ""
+  else:
+    try:
+      let socket = system_net.newSocket(system_net.Domain.AF_INET,
+        system_net.SockType.SOCK_DGRAM, system_net.Protocol.IPPROTO_UDP)
+      defer: socket.close()
+      socket.connect("1.1.1.1", system_net.Port(53))
+      let (address, _) = socket.getLocalAddr()
+      if address.len > 0 and address != "0.0.0.0":
+        return address
+      ""
+    except CatchableError:
+      ""
+
+proc cloudProviderHostname(state: JsonNode): string =
+  let providerUrl = providerUrlFromState(state)
+  try:
+    let parsed = parseUri(providerUrl)
+    if parsed.hostname.len > 0:
+      return parsed.hostname
+  except CatchableError:
+    discard
+  providerUrl
+
+proc managementLine*(frameConfig: FrameConfig): string =
+  ## Who controls this frame: FrameOS Cloud (managed enrollment), a
+  ## self-hosted backend, or nobody (standalone). The old "Server:
+  ## not configured:8989" line lied on cloud-managed frames, whose
+  ## server_host is deliberately empty.
+  let linkState = loadCloudLinkState()
+  if linkState{"mode"}.getStr("") == "managed":
+    let host = cloudProviderHostname(linkState)
+    let status = linkState{"status"}.getStr("disconnected")
+    return &"Managed via: FrameOS Cloud ({host}, {status})"
+  let serverHost = frameConfig.serverHost
+  if serverHost.len > 0 and serverHost notin ["localhost", "127.0.0.1", "::1"]:
+    let serverPort = if frameConfig.serverPort > 0: $frameConfig.serverPort else: "?"
+    return &"Managed via: self-hosted backend ({serverHost}:{serverPort})"
+  "Managed via: standalone (no server configured)"
+
 proc buildSceneListText*(self: Scene): string =
   let entries = self.buildSceneList()
   let frameConfig = self.frameConfig
   let resolution = &"{frameConfig.width}x{frameConfig.height}"
   let deviceName = if frameConfig.name.len > 0: frameConfig.name else: "Unnamed frame"
   let deviceType = if frameConfig.device.len > 0: frameConfig.device else: "unknown device"
-  let serverHost = if frameConfig.serverHost.len > 0: frameConfig.serverHost else: "not configured"
-  let serverPort = if frameConfig.serverPort > 0: $frameConfig.serverPort else: "?"
-  let frameHost = if frameConfig.frameHost.len > 0: frameConfig.frameHost else: "0.0.0.0"
+  let ipAddress = primaryIpAddress()
+  let networkInterface = defaultRouteInterface()
+  let networkLine =
+    if ipAddress.len > 0 and networkInterface.len > 0:
+      &"Network: {ipAddress} ({networkInterface})"
+    elif ipAddress.len > 0:
+      &"Network: {ipAddress}"
+    else:
+      "Network: not connected"
+  # 0.0.0.0 means "listening everywhere" — as a URL it helps nobody, so show
+  # the address the network actually reaches this frame on when we know it.
+  let configuredFrameHost = if frameConfig.frameHost.len > 0: frameConfig.frameHost else: "0.0.0.0"
+  let frameHost =
+    if configuredFrameHost == "0.0.0.0" and ipAddress.len > 0: ipAddress
+    else: configuredFrameHost
   let framePort = if publicPort(frameConfig) > 0: $publicPort(frameConfig) else: "?"
   let frameScheme = publicScheme(frameConfig)
-  let agentAccess = if frameConfig.agent != nil and frameConfig.agent.agentEnabled: "enabled" else: "disabled"
+  let remoteControl = if frameConfig.agent != nil and frameConfig.agent.agentEnabled: "enabled" else: "disabled"
   var lines: seq[string] = @[
     "FrameOS System Info",
     "",
@@ -91,9 +169,10 @@ proc buildSceneListText*(self: Scene): string =
     &"Resolution: {resolution}",
     &"Rotation: {frameConfig.rotate}°",
     &"Time zone: {frameConfig.timeZone}",
-    &"Server: {serverHost}:{serverPort}",
+    networkLine,
+    managementLine(frameConfig),
     &"Frame: {frameScheme}://{frameHost}:{framePort}",
-    &"Agent access: {agentAccess}",
+    &"FrameOS Remote control: {remoteControl}",
     ""
   ]
   if entries.len == 0:

--- a/frameos/src/system/index/tests/test_scene.nim
+++ b/frameos/src/system/index/tests/test_scene.nim
@@ -81,8 +81,35 @@ suite "system/index scene":
       check "Resolution: 800x480" in text
       check "Rotation: 90" in text
       check "Time zone: Europe/Brussels" in text
-      check "Server: frameos.local:8989" in text
+      check "Network: " in text
+      check "Managed via: self-hosted backend (frameos.local:8989)" in text
       check "Frame: http://192.168.1.50:8787" in text
-      check "Agent access: disabled" in text
+      check "FrameOS Remote control: disabled" in text
       check "Installed Scenes" in text
       check "1. Default Scene" in text
+
+  test "management line prefers the cloud link and falls back to standalone":
+    # loadCloudLinkState reads ./state/cloud_link.json relative to the cwd, so
+    # run this from a scratch directory we control.
+    let previousDir = getCurrentDir()
+    let tempDir = getTempDir() / ("frameos-index-scene-link-" & $epochTime())
+    createDir(tempDir / "state")
+    setCurrentDir(tempDir)
+    try:
+      var config = testConfig()
+      config.serverHost = ""
+      check index_scene.managementLine(config) == "Managed via: standalone (no server configured)"
+
+      config.serverHost = "localhost"
+      check index_scene.managementLine(config) == "Managed via: standalone (no server configured)"
+
+      writeFile("state" / "cloud_link.json", $(%*{
+        "mode": "managed",
+        "status": "connected",
+        "provider_url": "https://cloud.frameos.net",
+      }))
+      check index_scene.managementLine(config) ==
+        "Managed via: FrameOS Cloud (cloud.frameos.net, connected)"
+    finally:
+      setCurrentDir(previousDir)
+      removeDir(tempDir)

--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -131,6 +131,19 @@ const cloudFrameSceneHydrationsInFlight = new Set<FrameId>()
 const cloudFrameScenesHydratedAt = new Map<FrameId, number>()
 const CLOUD_FRAME_SCENES_REFRESH_MS = 60_000
 
+/**
+ * Drop cached scenes.json bodies for one store scene (all pinned versions and
+ * 'latest'). A content save publishes a new version, and the '@latest' cache
+ * key would otherwise keep serving the pre-save body until a reload.
+ */
+export function clearCloudSceneJsonCache(storeSceneId: string): void {
+  for (const key of [...cloudSceneJsonCache.keys()]) {
+    if (key.startsWith(`${storeSceneId}@`)) {
+      cloudSceneJsonCache.delete(key)
+    }
+  }
+}
+
 async function fetchCloudFrameScenes(frameId: FrameId): Promise<FrameScene[]> {
   const rows = await listCloudFrameScenes(frameId)
   const scenes: FrameScene[] = []

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -25,6 +25,8 @@ import { duplicateScenes } from '../../utils/duplicateScenes'
 import { apiFetch } from '../../utils/apiFetch'
 import { isCloudMode } from '../../utils/cloudMode'
 import { pushCloudFrameSettings } from '../../utils/cloudFrameApi'
+import { persistAndPushCloudFrameScenes } from '../../utils/cloudFrameScenesSave'
+import { clearCloudSceneJsonCache } from '../../models/framesModel'
 import { getBasePath } from '../../utils/getBasePath'
 import { projectApiPath, projectApiPathFromCache } from '../../utils/projectApi'
 import { longRunningTasksModel } from '../../models/longRunningTasksModel'
@@ -2293,9 +2295,12 @@ export const frameLogic = kea<frameLogicType>([
     // push (the same call saveFrameForm makes) — but a form whose only
     // pending changes are scenes maps onto no settings at all, which
     // saveFrameForm treats as an error on a plain Save. Here it is fine: the
-    // scenes ARE the deploy, pushed by framesModel.deployFrame through the
-    // uploadScenes shim (set_scenes). So push what maps, ignore "nothing
-    // mapped", then hand over to the cloud deploy path.
+    // scenes are persisted separately — each edited scene becomes a new
+    // version of its private cloud scene (new scenes are created), the
+    // assignment list is updated, and POST /api/frames/{id}/scenes pushes the
+    // checksummed result to the device. That push IS the deploy; the ad-hoc
+    // uploadScenes shim stays as the fallback when persistence fails, so the
+    // frame still updates even if the cloud refuses a scene.
     const cloudSaveAndDeploy = async (): Promise<void> => {
       try {
         await pushCloudFrameSettings(props.frameId, normalizeFrameForSubmit(values.frameForm))
@@ -2316,7 +2321,49 @@ export const frameLogic = kea<frameLogicType>([
         longRunningTasksModel.actions.taskFailed({ frameId: props.frameId, kind: 'save', detail })
         throw error
       }
-      framesModel.actions.deployFrame(props.frameId, false)
+      const scenes = values.frameForm?.scenes ?? values.frame?.scenes ?? []
+      if (!scenes.length) {
+        framesModel.actions.deployFrame(props.frameId, false)
+        return
+      }
+      longRunningTasksModel.actions.startTask({
+        frameId: props.frameId,
+        kind: 'deploy',
+        title: 'Deploying scenes',
+        detail: 'Saving scenes to your cloud account',
+      })
+      try {
+        const outcome = await persistAndPushCloudFrameScenes(
+          props.frameId,
+          scenes,
+          values.frame?.active_scene_id
+        )
+        for (const storeSceneId of outcome.changedStoreSceneIds) {
+          clearCloudSceneJsonCache(storeSceneId)
+        }
+        framesModel.actions.hydrateCloudFrameScenes(props.frameId, true)
+        framesModel.actions.loadFrame(props.frameId)
+        longRunningTasksModel.actions.finishTask({
+          frameId: props.frameId,
+          kind: 'deploy',
+          status: 'success',
+          detail: [
+            'Saved to your cloud scenes — the frame applies them as soon as it syncs',
+            ...outcome.notes,
+          ].join('. '),
+        })
+      } catch (error) {
+        // Persistence failed (rate limit, moderation, offline store…) — the
+        // ad-hoc push still deploys the edited scenes to the device, it just
+        // cannot save them; deployFrame reports its own outcome.
+        const message = error instanceof Error ? error.message : String(error)
+        longRunningTasksModel.actions.taskFailed({
+          frameId: props.frameId,
+          kind: 'deploy',
+          detail: `Could not save the scenes to your cloud account (${message}) — pushing them straight to the frame instead`,
+        })
+        framesModel.actions.deployFrame(props.frameId, false)
+      }
     }
 
     return {

--- a/frontend/src/scenes/frame/panels/Assets/Assets.tsx
+++ b/frontend/src/scenes/frame/panels/Assets/Assets.tsx
@@ -597,9 +597,10 @@ export function Assets({ scrollContainer = true }: AssetsProps = {}): JSX.Elemen
   const { toggleShowSystemFolders } = useActions(assetsLogic(assetsLogicProps))
   const { setFrameAssetFolderExpanded } = useActions(workspaceLogic)
   // Font sync pulls from the backend's own store; the on-device panel and the
-  // cloud have nothing to sync from. Cloud is read-only wholesale — its wire
-  // contract is assets_list/asset_get and nothing else.
-  const readOnly = workspaceMode() === 'cloud'
+  // cloud have nothing to sync from. Everything else works on every control
+  // plane — the cloud speaks asset_put/asset_mkdir/asset_delete/asset_rename
+  // through /api/frames/{id}/assets/* since cloud-workspace-fixes.
+  const readOnly = false
   const showSyncAction = workspaceMode() === 'backend'
 
   // syncAssets registers a long-running task toast, so no need to open logs

--- a/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
@@ -447,9 +447,9 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
 
           <div className="frameos-muted shrink-0 text-xs">
             Runs the scene with the FrameOS interpreter compiled to WebAssembly, in your browser. Apps that fetch
-            external URLs are routed through the backend to get around browser CORS restrictions, so images and data
-            load — the device itself fetches them directly. Device-only apps (screenshots, camera snapshots) are
-            unavailable.
+            external URLs are routed through a same-origin proxy to get around browser CORS restrictions, so images
+            and data load — the device itself fetches them directly. Device-only apps (screenshots, camera snapshots)
+            are unavailable.
           </div>
         </div>
 

--- a/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
@@ -4,6 +4,8 @@ import { router } from 'kea-router'
 import { FrameScene, GPIOButton, RepositoryType, TemplateType, FrameId } from '../../../../types'
 import { apiFetch } from '../../../../utils/apiFetch'
 import { assetUrl } from '../../../../utils/assetUrl'
+import { isCloudMode } from '../../../../utils/cloudMode'
+import { isFrameControlMode } from '../../../../utils/frameControlMode'
 import { getBasePath } from '../../../../utils/getBasePath'
 import { projectApiPath } from '../../../../utils/projectApi'
 import { frameLogic } from '../../frameLogic'
@@ -291,16 +293,19 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
 
       // Fetch the frame's assembled settings (app API keys etc.) so data apps
       // that need secrets can run in the preview. Best-effort: a scene with no
-      // secret-using apps still previews fine if this fails.
+      // secret-using apps still previews fine if this fails. The cloud stores
+      // no backend settings and serves no such route, so don't ask it.
       let settings: Record<string, any> = {}
-      try {
-        const response = await apiFetch(`/api/frames/${frameId}/scene_preview_settings`)
-        if (response.ok) {
-          const data = await response.json()
-          settings = data?.settings ?? {}
+      if (!isCloudMode()) {
+        try {
+          const response = await apiFetch(`/api/frames/${frameId}/scene_preview_settings`)
+          if (response.ok) {
+            const data = await response.json()
+            settings = data?.settings ?? {}
+          }
+        } catch (error) {
+          // fall through with empty settings
         }
-      } catch (error) {
-        // fall through with empty settings
       }
       // User-entered keys (setPreviewSettings) win over the backend's, merged
       // per settings group.
@@ -309,7 +314,7 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       }
       const settingsJson = JSON.stringify(settings)
 
-      // Same-origin backend proxy so the runtime's HTTP requests (image apps,
+      // Same-origin proxy so the runtime's HTTP requests (image apps,
       // weather, ...) work despite CORS — the worker's sync XHR carries auth
       // cookies to it. Resolve the project-prefixed absolute path up front.
       // An embedding page (the standalone editor bundle) can supply its own
@@ -318,6 +323,14 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       const configuredProxyUrl = (window as any).FRAMEOS_APP_CONFIG?.preview_proxy_url
       if (typeof configuredProxyUrl === 'string' && configuredProxyUrl) {
         proxyUrl = configuredProxyUrl
+      } else if (isCloudMode()) {
+        // The cloud has no project-scoped backend proxy; it serves the same
+        // anonymous, rate-limited proxy the store's preview pages use. Also
+        // the fallback for a shell served without injected app config.
+        proxyUrl = getBasePath() + '/api/store/preview-proxy'
+      } else if (isFrameControlMode()) {
+        // The frame's own web server has no proxy endpoint — leave the
+        // preview direct-only rather than probing routes that don't exist.
       } else {
         try {
           proxyUrl = getBasePath() + (await projectApiPath(`/api/frames/${frameId}/scene_preview_proxy`))

--- a/frontend/src/scenes/settings/CloudSettings.tsx
+++ b/frontend/src/scenes/settings/CloudSettings.tsx
@@ -29,6 +29,16 @@ function pollErrorMessage(pollError: string): string {
   }
 }
 
+function formatCloudBytes(size: number): string {
+  const units = ['B', 'KB', 'MB', 'GB']
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex++
+  }
+  return `${unitIndex === 0 ? size : Number(size.toFixed(1))} ${units[unitIndex]}`
+}
+
 function expiresInLabel(expiresAt: string | null): string | null {
   if (!expiresAt) {
     return null
@@ -138,6 +148,26 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
                 </Button>
               </div>
             </div>
+            {link.usage ? (
+              <div className="space-y-1 @md:flex @md:items-start @md:gap-2">
+                <div className="@md:w-1/3 @md:shrink-0">
+                  <Label>Cloud storage</Label>
+                </div>
+                <div className="w-full space-y-1 text-sm">
+                  <div className="frameos-muted">
+                    Private scenes {formatCloudBytes(link.usage.scenes.private_bytes)} of{' '}
+                    {formatCloudBytes(link.usage.scenes.private_max_bytes)}
+                    {link.usage.scenes.public_bytes > 0
+                      ? ` · public scenes ${formatCloudBytes(link.usage.scenes.public_bytes)} (free)`
+                      : ''}
+                    {' · '}backups {formatCloudBytes(link.usage.backups.bytes)} of{' '}
+                    {formatCloudBytes(link.usage.backups.max_bytes)}
+                    {' · '}frame logs {formatCloudBytes(link.usage.frame_logs.bytes)} of{' '}
+                    {formatCloudBytes(link.usage.frame_logs.max_bytes)}
+                  </div>
+                </div>
+              </div>
+            ) : null}
             {!frameAdminMode ? (
               <div className="space-y-1 @md:flex @md:items-start @md:gap-2">
                 <div className="@md:w-1/3 @md:shrink-0">

--- a/frontend/src/scenes/workspace/FrameosShell.tsx
+++ b/frontend/src/scenes/workspace/FrameosShell.tsx
@@ -45,9 +45,12 @@ import { DeployToFrameIcon } from './FrameChangeStatusIcon'
 import { FrameRenameModal } from './FrameActionsMenu'
 import { isInFrameAdminMode } from '../../utils/frameAdmin'
 import { getFrameControlFrameId } from '../../utils/frameControlMode'
+import { isCloudMode } from '../../utils/cloudMode'
 import type { FrameId } from '../../types'
 
-const DEFAULT_BROWSER_TITLE = 'FrameOS Backend'
+// The tab title's suffix names the surface being used: the shared SPA also
+// serves cloud.frameos.net/frames, where "FrameOS Backend" is a lie.
+const DEFAULT_BROWSER_TITLE = isCloudMode() ? 'FrameOS Cloud' : 'FrameOS Backend'
 
 interface FrameosShellProps {
   mode: WorkspaceMode

--- a/frontend/src/scenes/workspace/systemAppSourceLogic.ts
+++ b/frontend/src/scenes/workspace/systemAppSourceLogic.ts
@@ -2,8 +2,8 @@ import { actions, afterMount, kea, key, path, props, propsChanged, reducers, sel
 import { loaders } from 'kea-loaders'
 
 import type { systemAppSourceLogicType } from './systemAppSourceLogicType'
-import { apiFetch } from '../../utils/apiFetch'
 import { buildAppTypeDeclarations } from '../../utils/appTypeDeclarations'
+import { loadAppSources } from '../../utils/sceneApps'
 
 export interface SystemAppSourceLogicProps {
   keyword: string | null
@@ -47,11 +47,10 @@ export const systemAppSourceLogic = kea<systemAppSourceLogicType>([
           }
 
           try {
-            const response = await apiFetch(`/api/apps/source?keyword=${encodeURIComponent(props.keyword)}`)
-            if (!response.ok) {
-              throw new Error('Failed to fetch app sources')
-            }
-            const sources = withoutGeneratedSources((await response.json()) as Record<string, string>)
+            // Embedded catalogs first, the backend API second (loadAppSources)
+            // — on control planes without /api/apps/source (the cloud, the
+            // on-device admin) the embedded sources are the only copy.
+            const sources = withoutGeneratedSources(await loadAppSources(props.keyword))
             actions.setActiveFile(firstSourceFile(sources))
             return sources
           } catch (error) {

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -846,6 +846,12 @@ export interface FrameOSSettings {
 }
 
 /** Mirrors GET /api/cloud/status (backend/app/api/cloud.py and the frame's cloud_api_routes.nim) */
+export interface CloudUsage {
+  scenes: { private_bytes: number; private_max_bytes: number; public_bytes: number }
+  backups: { bytes: number; max_bytes: number }
+  frame_logs: { bytes: number; max_bytes: number }
+}
+
 export interface CloudStatus {
   enabled: boolean
   provider_url: string | null
@@ -867,6 +873,9 @@ export interface CloudStatus {
     account_email: string | null
     connected_at: string | null
     last_inventory_sync_at: string | null
+    /** Storage usage + quota snapshot from the provider's grants poll.
+     * Public scenes are quota-free, hence the private/public split. */
+    usage?: CloudUsage | null
   } | null
   /** True unless cloud login is enforced (local passwords disabled). */
   local_fallback_enabled?: boolean

--- a/frontend/src/utils/cloudFrameApi.ts
+++ b/frontend/src/utils/cloudFrameApi.ts
@@ -159,6 +159,90 @@ export async function listCloudFrameScenes(frameId: FrameId): Promise<CloudFrame
 }
 
 /**
+ * Replace a cloud frame's assignment list outright and push it to the device
+ * (POST /api/frames/{id}/scenes enqueues the checksummed set_scenes). Pass
+ * `activeSceneId` (a RUNTIME scene id) to keep the current scene on screen —
+ * the device otherwise activates the first scene of the payload.
+ */
+export async function setCloudFrameScenes(
+  frameId: FrameId,
+  scenes: readonly { scene_id: string; scene_version?: number | null }[],
+  activeSceneId?: string
+): Promise<void> {
+  const response = await apiFetch(`/api/frames/${frameId}/scenes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      scenes: scenes.map((scene) => ({
+        scene_id: scene.scene_id,
+        ...(scene.scene_version ? { scene_version: scene.scene_version } : {}),
+      })),
+      ...(activeSceneId ? { scene_id: activeSceneId } : {}),
+    }),
+  })
+  await assertOk(response, 'Failed to update the frame scene list')
+}
+
+/**
+ * The scenes.json body of a store scene — the exact payload the device
+ * receives over set_scenes, carrying the runtime scene ids. Null when the
+ * scene is unreadable (pulled, network) so callers can leave it untouched.
+ */
+export async function fetchStoreSceneScenesJson(storeSceneId: string): Promise<FrameScene[] | null> {
+  try {
+    const response = await apiFetch(`/api/store/scenes/${storeSceneId}/scenes.json`)
+    if (!response.ok) {
+      return null
+    }
+    const json = await response.json()
+    return Array.isArray(json) && json.length > 0 ? (json as FrameScene[]) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Create a NEW private cloud scene from raw scenes JSON
+ * (POST /api/account/scenes — cloud only). Returns the store scene id.
+ */
+export async function createCloudAccountScene(
+  name: string,
+  scenes: readonly Partial<FrameScene>[],
+  description?: string
+): Promise<string> {
+  const response = await apiFetch(`/api/account/scenes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, scenes, ...(description ? { description } : {}) }),
+  })
+  await assertOk(response, `Failed to save "${name}" to your cloud scenes`)
+  const data = (await response.json()) as { scene?: { id?: string } }
+  if (!data.scene?.id) {
+    throw new Error(`Failed to save "${name}" to your cloud scenes (no scene id returned)`)
+  }
+  return data.scene.id
+}
+
+/**
+ * Replace a private cloud scene's contents with new scenes JSON, publishing a
+ * new immutable version (POST /api/account/scenes/{id}/content). Returns the
+ * new version number when the server reports one.
+ */
+export async function updateCloudAccountSceneContent(
+  storeSceneId: string,
+  scenes: readonly Partial<FrameScene>[]
+): Promise<number | undefined> {
+  const response = await apiFetch(`/api/account/scenes/${storeSceneId}/content`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ scenes }),
+  })
+  await assertOk(response, 'Failed to save the scene changes to your cloud scenes')
+  const data = (await response.json()) as { scene?: { version?: number } }
+  return typeof data.scene?.version === 'number' ? data.scene.version : undefined
+}
+
+/**
  * Assign a store scene to a cloud-managed frame. This is the cloud's actual
  * scene contract: POST /api/frames/{id}/scenes takes the full ordered list of
  * STORE scene ids, persists it server-side and enqueues a set_scenes push to

--- a/frontend/src/utils/cloudFrameScenesSave.ts
+++ b/frontend/src/utils/cloudFrameScenesSave.ts
@@ -1,0 +1,151 @@
+import type { FrameScene } from '../types'
+import {
+  cloudDeployActiveSceneId,
+  createCloudAccountScene,
+  fetchStoreSceneScenesJson,
+  listCloudFrameScenes,
+  setCloudFrameScenes,
+  updateCloudAccountSceneContent,
+} from './cloudFrameApi'
+import type { FrameId } from './frameId'
+
+// Cloud "Save & Deploy" persistence (cloud-workspace-fixes): the edited scene
+// graphs in the workspace form become durable server-side state instead of an
+// ad-hoc set_scenes push that only the device remembers.
+//
+//   * a form scene that came from an assigned store scene updates that store
+//     scene's contents (a new immutable version via /api/account/scenes/
+//     {id}/content) — multi-scene packs keep their other scenes;
+//   * a form scene with no owning assignment becomes a NEW private cloud
+//     scene (/api/account/scenes) and is appended to the assignment list;
+//   * assignments whose every runtime scene was removed from the form are
+//     dropped;
+//   * finally the full assignment list goes to POST /api/frames/{id}/scenes,
+//     which persists it and enqueues the checksummed set_scenes push — the
+//     deploy. The device's scenes_checksum then matches assigned_checksum,
+//     so the workspace shows in-sync and /scene_images resolves server truth.
+//
+// Editing a store scene the account does NOT own (a public install) cannot
+// update in place; the fallback forks the edited content into a new private
+// scene and swaps the assignment to it.
+
+export interface CloudScenePersistOutcome {
+  /** Store scene ids whose content changed or that were newly created. */
+  changedStoreSceneIds: string[]
+  /** Human-readable notes for non-fatal fallbacks (shown in the deploy toast). */
+  notes: string[]
+}
+
+interface AssignmentPlan {
+  scene_id: string
+  scene_version?: number | null
+}
+
+function sceneName(scene: Partial<FrameScene>): string {
+  return (scene.name ?? '').trim() || 'Untitled scene'
+}
+
+function scenesEqual(a: readonly Partial<FrameScene>[], b: readonly Partial<FrameScene>[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+/**
+ * Persist the workspace's edited scene list server-side, then push the
+ * resulting assignment list to the device. Throws only when the final push
+ * fails — per-scene persistence failures degrade to notes so one refused
+ * scene does not lose the rest of the save.
+ */
+export async function persistAndPushCloudFrameScenes(
+  frameId: FrameId,
+  formScenes: readonly FrameScene[],
+  activeSceneId?: string | null
+): Promise<CloudScenePersistOutcome> {
+  const rows = await listCloudFrameScenes(frameId)
+  const formById = new Map<string, FrameScene>()
+  for (const scene of formScenes) {
+    if (scene?.id) {
+      formById.set(scene.id, scene)
+    }
+  }
+
+  const changedStoreSceneIds: string[] = []
+  const notes: string[] = []
+  const assignments: AssignmentPlan[] = []
+  const claimedRuntimeIds = new Set<string>()
+
+  for (const row of rows) {
+    const stored = await fetchStoreSceneScenesJson(row.scene_id)
+    if (!stored) {
+      // Unreadable (pulled scene, transient error): keep the assignment
+      // untouched rather than guessing — its runtime scenes also stay
+      // unclaimed, which would duplicate them as new private scenes, so
+      // claim whatever the form still holds under this assignment's id.
+      assignments.push({ scene_id: row.scene_id, scene_version: row.scene_version ?? null })
+      if (formById.has(row.scene_id)) {
+        claimedRuntimeIds.add(row.scene_id)
+      }
+      continue
+    }
+
+    const storedIds = stored.map((scene) => scene.id).filter(Boolean)
+    const presentIds = storedIds.filter((id) => formById.has(id))
+    for (const id of presentIds) {
+      claimedRuntimeIds.add(id)
+    }
+    if (presentIds.length === 0) {
+      // Every runtime scene of this pack was removed from the frame.
+      continue
+    }
+
+    const updated = stored.map((scene) => formById.get(scene.id) ?? scene)
+    if (scenesEqual(stored, updated)) {
+      assignments.push({ scene_id: row.scene_id, scene_version: row.scene_version ?? null })
+      continue
+    }
+
+    try {
+      const version = await updateCloudAccountSceneContent(row.scene_id, updated)
+      changedStoreSceneIds.push(row.scene_id)
+      assignments.push({
+        scene_id: row.scene_id,
+        // A pinned assignment follows the edit it just made; an unpinned one
+        // keeps tracking latest (which now IS the edit).
+        scene_version: row.scene_version ? (version ?? null) : null,
+      })
+    } catch (error) {
+      // Not ours to edit (public install), name clash, moderation… — fork the
+      // edited content into a new private scene and swap the assignment.
+      try {
+        const name = row.name || sceneName(updated[0] ?? {})
+        const newSceneId = await createCloudAccountScene(name, updated)
+        changedStoreSceneIds.push(newSceneId)
+        assignments.push({ scene_id: newSceneId })
+        notes.push(`Saved the edited "${name}" as a new private cloud scene`)
+      } catch (forkError) {
+        const message = forkError instanceof Error ? forkError.message : String(forkError)
+        notes.push(`Kept "${row.name ?? row.scene_id}" unchanged in the cloud: ${message}`)
+        assignments.push({ scene_id: row.scene_id, scene_version: row.scene_version ?? null })
+      }
+    }
+  }
+
+  // Scenes with no owning assignment: newly created in the workspace (or
+  // deployed ad-hoc before this flow existed). Each becomes its own private
+  // cloud scene, in form order.
+  for (const scene of formScenes) {
+    if (!scene?.id || claimedRuntimeIds.has(scene.id)) {
+      continue
+    }
+    const name = sceneName(scene)
+    const newSceneId = await createCloudAccountScene(name, [scene])
+    changedStoreSceneIds.push(newSceneId)
+    assignments.push({ scene_id: newSceneId })
+  }
+
+  await setCloudFrameScenes(
+    frameId,
+    assignments,
+    cloudDeployActiveSceneId(activeSceneId, formScenes) ?? undefined
+  )
+  return { changedStoreSceneIds, notes }
+}

--- a/tools/buildroot-images/buildroot_images.py
+++ b/tools/buildroot-images/buildroot_images.py
@@ -76,9 +76,11 @@ from update_versions import (  # noqa: E402
 from app.utils.cross_compile import TargetMetadata  # noqa: E402
 from app.tasks.setup_json_reset import (  # noqa: E402
     BOOT_CLOUD_CONFIG_FILE,
+    BOOT_SETUP_BLOB_FILE,
     SETUP_JSON_RESET_SCRIPT_PATH,
     SETUP_JSON_RESET_SERVICE_NAME,
     render_cloud_config_placeholder,
+    render_setup_blob_placeholder,
     render_setup_json_reset_script,
     render_setup_json_reset_service,
 )
@@ -885,6 +887,15 @@ async def build_release_image(args: argparse.Namespace) -> None:
         # contiguity comment in backend/app/tasks/buildroot_image.py).
         (overlay_dir / "boot" / Path(BOOT_CLOUD_CONFIG_FILE).name).write_bytes(
             render_cloud_config_placeholder()
+        )
+        # And the big sibling: the 8 MiB frameos-setup.bin placeholder that
+        # lets a SELF-HOSTED backend personalize this image by pure in-place
+        # byte patching (backend/app/tasks/sd_image_blob_patch.py) — full
+        # frameos-setup.json payload plus the hostname/WiFi/SSH/root-password
+        # boot files, no mtools/debugfs anywhere. Same contiguity reasoning
+        # as above; a genimage-fresh FAT lays both out contiguously.
+        (overlay_dir / "boot" / Path(BOOT_SETUP_BLOB_FILE).name).write_bytes(
+            render_setup_blob_placeholder()
         )
 
         base_entry = await resolve_buildroot_base_entry(platform)


### PR DESCRIPTION
Stacked on #290 (base: `cloud-workspace-fixes`). Two work streams:

## Storage quotas (`src/lib/usage.ts` is the single meter)

- **Private scenes: 200 MiB — public scenes are free.** Publishing publicly costs the account nothing; the quota meters versions + gallery images + preview blobs of private scenes only. Display and enforcement finally share one definition (they used to disagree, from three drifting copies of the query).
- **Backups: 100 MiB** byte quota next to the old 500-item cap; replacements only count their size delta (`backup_storage_quota_exceeded`).
- **Frame logs: 100 MiB, culled not refused** — over budget the oldest lines across the account are deleted inside the ingestion transaction (a frame must never learn its logs bounced).
- Plugged write paths that minted bytes with no check: editor content saves, gallery image uploads, and the public→private visibility flip (which now re-meters the scene's bytes — including via a republish that changes visibility).
- **Usage surfaces**: the /account header shows per-category "X of Y"; `GET /api/backends/grants` carries the snapshot + limits (documented in `docs/cloud-link.md` — limits ride along so nothing hardcodes them, leaving room for paid tiers); the self-hosted backend caches it on `cloud_backend_link` (migration `e7a3b9c4d2f6`) via the 15-minute sync, `/api/cloud/status` exposes it, and the shared CloudSettings section renders it on backends and frame admins.

## SD images: backend personalizes prebuilt release images by pure byte patching

Release images now ship `/boot/frameos-setup.bin` — an 8 MiB all-comments placeholder (magic `# FRAMEOS-SETUP-BLOB-V1`) next to the 4 KB cloud one. A personalized region is a size header + gzipped tar of the `/boot/frameos-*` personalization files (full `frameos-setup.json` incl. scenes, hostname, WiFi keyfile, SSH keys, root password). First boot unpacks it with busybox `gunzip|tar`, installs the allow-listed members, shreds the blob, and the existing per-file handlers take over; display/boot config comes from `frameos setup` running `drivers.setup` on-device — the same trick the cloud flow relies on, so **no partition surgery anywhere**.

The backend's "Build SD card" prefers this for precompiled frames with interpreted scenes: download the same GitHub release `.img.gz` the cloud serves, gunzip, magic-scan for the pristine placeholder (decoy-safe, same verification as the in-browser cloud patcher), overwrite in place, re-gzip. **No mtools, debugfs, docker or build host** — and since it's pure byte surgery, the same personalization can move into a browser later. Fallbacks unchanged: older releases without the placeholder and oversized payloads use the existing local partition-patching; compile-from-source frames use the compose path. `sd_image` status metadata reports which mode produced the image.

Spec: `docs/cloud-frames.md` "The self-hosted sibling".

## Testing
- auth-web: typecheck, 331 unit, **185 integration** (6 new quota tests: visibility split, private-quota refusal, public-bytes exemption, backup byte quota + replacement delta, account-wide log culling, grants usage payload).
- backend: cloud sync tests extended for the usage snapshot (11/11), **36 first-boot/patcher tests** (blob placeholder layout, pristine no-op boot, real end-to-end sandbox extraction incl. shred verification via hard links, round-trip img patch, decoy-magic skipping, oversize refusal), full tasks suite 288 passed.
- Pre-existing ruff findings in `buildroot_image.py`/`buildroot_images.py` left untouched (verified against the clean tree).
- Not yet verified on hardware: a real first boot from a blob-personalized image (needs a release image built with the new placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)