### PR TITLE
Add debian-trixie-armv6 release target, fix armv6l SIGILL traps

### DIFF
--- a/backend/app/tasks/tests/test_precompiled_frameos.py
+++ b/backend/app/tasks/tests/test_precompiled_frameos.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.tasks.prebuilt_deps import resolve_prebuilt_target
 from app.tasks.precompiled_frameos import download_precompiled_frameos_release, frame_compiled_scene_count
 
 
@@ -74,6 +75,15 @@ async def test_download_precompiled_frameos_release_extracts_required_files(
     assert Path(result.archive_path).is_file()
     assert result.cache_hit is False
     assert any("Downloading precompiled FrameOS release" in message for _level, message in logs)
+
+
+def test_resolve_prebuilt_target_armv6():
+    # armv6 must never fall back to armhf (ARMv7 artifacts SIGILL on ARM1176)
+    # and resolves per-release like every other arch.
+    assert resolve_prebuilt_target("debian", "trixie", "armv6l") == "debian-trixie-armv6"
+    assert resolve_prebuilt_target("raspios", "trixie", "armv6l") == "debian-trixie-armv6"
+    assert resolve_prebuilt_target("debian", "bookworm", "armv6l") == "debian-bookworm-armv6"
+    assert resolve_prebuilt_target("debian", "trixie", "aarch64") == "debian-trixie-arm64"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tasks/tests/test_real_buildroot_sd_image_e2e.py
+++ b/backend/app/tasks/tests/test_real_buildroot_sd_image_e2e.py
@@ -157,7 +157,12 @@ async def test_real_buildroot_sd_image_generation_from_precompiled_release(
 
     logs = "\n".join(_log_lines(db, frame))
     if metadata.get("precompiledSdImage"):
-        assert "Customizing full precompiled Buildroot SD image" in logs
+        # Release images since 2026.8.6 carry a setup-blob placeholder and are
+        # personalized in place; older ones go through full customization.
+        assert (
+            "Personalizing precompiled SD image" in logs
+            or "Customizing full precompiled Buildroot SD image" in logs
+        )
         assert "Building FrameOS binary for Raspberry Pi Zero 2 W" not in logs
         assert "Building FrameOS Remote for Raspberry Pi Zero 2 W" not in logs
     else:

--- a/backend/app/utils/cross_compile.py
+++ b/backend/app/utils/cross_compile.py
@@ -364,7 +364,16 @@ class CrossCompiler:
         extra_cflags = (
             shlex.quote(" ".join(extra_cflags_parts)) if extra_cflags_parts else "''"
         )
-        extra_libs = shlex.quote(" ".join(f"-L{path}" for path in lib_dirs)) if lib_dirs else "''"
+        lib_flags = [f"-L{path}" for path in lib_dirs]
+        if target_cross_toolchain and target_cross_toolchain.tarball_url:
+            # ld resolves transitive DT_NEEDED deps of Debian link stubs (e.g.
+            # trixie's libcrypto.so needs libz.so.1 and libzstd.so.1) through
+            # -rpath-link search paths, not -L, so point it at the mirror too.
+            lib_flags.append(
+                "-Wl,-rpath-link,"
+                f"{TARBALL_TOOLCHAIN_DEBIAN_MIRROR}/lib/{target_cross_toolchain.triplet}"
+            )
+        extra_libs = shlex.quote(" ".join(lib_flags)) if lib_flags else "''"
         target_toolchain_script = indent(
             self._target_cross_toolchain_setup_script(target_cross_toolchain),
             " " * 16,

--- a/backend/bin/cross
+++ b/backend/bin/cross
@@ -74,6 +74,11 @@ TARGETS: tuple[TargetDefinition, ...] = (
     TargetDefinition("debian", "trixie", "armhf", "linux/arm/v7", "debian:trixie", runner=ARMHF_RUNNER),
     TargetDefinition("debian", "trixie", "arm64", "linux/arm64", "debian:trixie", runner="depot-ubuntu-24.04-arm-16"),
     TargetDefinition("debian", "trixie", "amd64", "linux/amd64", "debian:trixie"),
+    # Same Bootlin-toolchain build as bookworm armv6 (Raspberry Pi OS trixie
+    # still supports the Pi Zero W / Pi 1). Trixie's OpenSSL stubs pull
+    # libz/libzstd transitively at link time — needs the -rpath-link mirror
+    # flag in cross_compile.py.
+    TargetDefinition("debian", "trixie", "armv6", "linux/arm/v6", "debian:trixie"),
     TargetDefinition("ubuntu", "24.04", "arm64", "linux/arm64", "ubuntu:24.04", runner="depot-ubuntu-24.04-arm-16"),
     TargetDefinition("ubuntu", "24.04", "amd64", "linux/amd64", "ubuntu:24.04"),
     TargetDefinition("ubuntu", "26.04", "arm64", "linux/arm64", "ubuntu:26.04", runner="depot-ubuntu-24.04-arm-16"),

--- a/frameos/src/frameos/tests/test_upgrade.nim
+++ b/frameos/src/frameos/tests/test_upgrade.nim
@@ -24,6 +24,16 @@ suite "FrameOS upgrade helpers":
       "VERSION_CODENAME": "noble",
     }.toTable) == (distro: "ubuntu", release: "24.04")
 
+  test "uname arch mapping keeps armv6 separate from armhf":
+    check archForUname("aarch64") == "arm64"
+    check archForUname("armv7l") == "armhf"
+    # Pi Zero W / Pi 1: armhf release artifacts are ARMv7 and SIGILL on the
+    # ARM1176, so armv6l must map to its own target.
+    check archForUname("armv6l") == "armv6"
+    check archForUname("x86_64") == "amd64"
+    expect ValueError:
+      discard archForUname("riscv64")
+
   test "release payload selects stable target asset":
     let release = releaseInfoFromPayload(
       %*{

--- a/frameos/src/frameos/upgrade.nim
+++ b/frameos/src/frameos/upgrade.nim
@@ -20,7 +20,7 @@ const
     "ubuntu-24.04",
     "ubuntu-26.04",
   ]
-  SupportedArches = ["arm64", "armhf", "amd64"]
+  SupportedArches = ["arm64", "armhf", "armv6", "amd64"]
   MaxReleaseArchiveBytes = 512 * 1024 * 1024
 
 type
@@ -126,20 +126,28 @@ proc parseOsRelease(path = "/etc/os-release"): Table[string, string] =
       value = value[1 .. ^2]
     result[parts[0]] = value
 
+proc archForUname*(uname: string): string =
+  case uname
+  of "aarch64", "arm64", "armv8":
+    "arm64"
+  of "armv8l", "armv7l", "armhf":
+    "armhf"
+  # ARMv6 (Pi Zero W / Pi 1) must never fall back to armhf: those release
+  # artifacts are built for ARMv7 and SIGILL on the ARM1176. Mirrors the
+  # mapping in backend app/tasks/prebuilt_deps.py:resolve_prebuilt_target.
+  of "armv6l", "armv6":
+    "armv6"
+  of "x86_64", "amd64":
+    "amd64"
+  else:
+    raise newException(ValueError, "Unsupported CPU architecture: " & uname & ". Supported architectures: " & SupportedArches.join(", "))
+
 proc detectArch(): string =
   let overrideArch = getEnv("FRAMEOS_ARCH_OVERRIDE").strip()
   if overrideArch.len > 0:
     return overrideArch
   let uname = runShellCapture("uname -m", timeoutMs = 5000, maxOutputBytes = 4096).output.strip().splitLines()[0]
-  case uname
-  of "aarch64", "arm64", "armv8":
-    "arm64"
-  of "armv8l", "armv7l", "armv6l", "armhf":
-    "armhf"
-  of "x86_64", "amd64":
-    "amd64"
-  else:
-    raise newException(ValueError, "Unsupported CPU architecture: " & uname & ". Supported architectures: " & SupportedArches.join(", "))
+  archForUname(uname)
 
 proc normalizeDistroRelease*(values: Table[string, string]): tuple[distro, release: string] =
   result.distro = getEnv("FRAMEOS_DISTRO_OVERRIDE", values.getOrDefault("ID", "")).strip()

--- a/scripts/frameos-setup.sh
+++ b/scripts/frameos-setup.sh
@@ -29,7 +29,7 @@ FRAMEOS_CLAIM_TOKEN="${FRAMEOS_CLAIM_TOKEN:-}"
 FRAMEOS_CLOUD_URL_DEFAULT="https://cloud.frameos.net" # __FRAMEOS_CLOUD_URL_DEFAULT__
 FRAMEOS_CLOUD_URL="${FRAMEOS_CLOUD_URL:-$FRAMEOS_CLOUD_URL_DEFAULT}"
 SUPPORTED_RELEASES="debian:buster debian:bullseye debian:bookworm debian:trixie ubuntu:22.04 ubuntu:24.04 ubuntu:26.04"
-SUPPORTED_ARCHES="arm64 armhf amd64"
+SUPPORTED_ARCHES="arm64 armhf armv6 amd64"
 TTY="/dev/tty"
 GENERATED_ADMIN_PASSWORD=""
 
@@ -296,7 +296,11 @@ download_file() {
 detect_arch() {
   case "$(uname -m)" in
     aarch64|arm64|armv8) echo arm64 ;;
-    armv8l|armv7l|armv6l|armhf) echo armhf ;;
+    armv8l|armv7l|armhf) echo armhf ;;
+    # ARMv6 (Pi Zero W / Pi 1) must never fall back to armhf: those release
+    # artifacts are built for ARMv7 and SIGILL on the ARM1176. Mirrors the
+    # mapping in backend app/tasks/prebuilt_deps.py:resolve_prebuilt_target.
+    armv6l|armv6) echo armv6 ;;
     x86_64|amd64) echo amd64 ;;
     *) die "Unsupported CPU architecture: $(uname -m). Supported architectures: $SUPPORTED_ARCHES" ;;
   esac

--- a/tools/prebuilt-deps/README.md
+++ b/tools/prebuilt-deps/README.md
@@ -9,8 +9,8 @@ matching one of the following releases and architectures:
 - Ubuntu **26.04** LTS
 - **armhf** (32‑bit ARMv7), **arm64** (AArch64) and **amd64** (x86_64)
 - **armv6** (32‑bit ARMv6 hard-float, Raspberry Pi Zero W / 1): no distro
-  publishes `linux/arm/v6` containers, so `debian-bookworm-armv6` builds in an
-  amd64 container with the Bootlin `armv6-eabihf` toolchain (pinned in
+  publishes `linux/arm/v6` containers, so the `debian-*-armv6` targets build in
+  an amd64 container with the Bootlin `armv6-eabihf` toolchain (pinned in
   `build.sh`, keep in sync with `backend/app/utils/cross_toolchain_packages.py`)
   and verifies the produced objects are `Tag_CPU_arch: v6` hard-float. This
   target ships **quickjs only** — nim tarballs bootstrap CI runners and dev

--- a/tools/prebuilt-deps/build.sh
+++ b/tools/prebuilt-deps/build.sh
@@ -29,6 +29,7 @@ TARGET_MATRIX=(
   "debian|trixie|armhf|linux/arm/v7|debian:trixie"
   "debian|trixie|arm64|linux/arm64|debian:trixie"
   "debian|trixie|amd64|linux/amd64|debian:trixie"
+  "debian|trixie|armv6|linux/amd64|debian:trixie"
   "ubuntu|24.04|arm64|linux/arm64|ubuntu:24.04"
   "ubuntu|24.04|amd64|linux/amd64|ubuntu:24.04"
   "ubuntu|26.04|arm64|linux/arm64|ubuntu:26.04"

--- a/tools/prebuilt-deps/manifest.json
+++ b/tools/prebuilt-deps/manifest.json
@@ -234,6 +234,20 @@
       "component_md5sums": {
         "quickjs": "73958f663dbe5ea19c21b86cbdd70989"
       }
+    },
+    {
+      "target": "debian-trixie-armv6",
+      "versions": {
+        "quickjs": "2026-06-04"
+      },
+      "object_key": null,
+      "updated_at": "2026-08-05T20:33:53.601367+00:00",
+      "component_keys": {
+        "quickjs": "prebuilt-deps/debian-trixie-armv6/quickjs-2026-06-04.tar.gz"
+      },
+      "component_md5sums": {
+        "quickjs": "8dd9fe8a7e757ddff9fe8311a3e3de14"
+      }
     }
   ]
 }

--- a/tools/prebuilt-deps/r2_sync.py
+++ b/tools/prebuilt-deps/r2_sync.py
@@ -91,6 +91,7 @@ DEFAULT_TARGETS = [
     "debian-trixie-armhf",
     "debian-trixie-arm64",
     "debian-trixie-amd64",
+    "debian-trixie-armv6",
     "ubuntu-24.04-arm64",
     "ubuntu-24.04-amd64",
     "ubuntu-26.04-arm64",


### PR DESCRIPTION
## Why

Installing FrameOS on Raspberry Pi OS **trixie** on a Pi Zero W / Pi 1 fails with a 404:

```
deploy failed Client error '404 Not Found' for url
'https://github.com/FrameOS/frameos/releases/download/v2026.8.6/frameos-2026.8.6-debian-trixie-armv6.tar.gz'
```

`debian-trixie-armv6` was never in the release matrix — only `debian-bookworm-armv6` existed (added originally for the Pi Zero W Buildroot image). Raspberry Pi OS trixie still supports ARMv6 boards, so the target is real.

## What

- **New release target `debian-trixie-armv6`** in `backend/bin/cross` (picked up by both the PR cross-compile CI and the release workflow via `cross matrix`), plus matching rows in the prebuilt-deps matrices (`tools/prebuilt-deps/build.sh`, `r2_sync.py`, local manifest). The QuickJS prebuilt for it is already published to R2.
- **Linker fix that trixie exposed** (`cross_compile.py`): trixie's OpenSSL 3.5 armhf link stubs pull `libz.so.1`/`libzstd.so.1` transitively, and `ld` resolves transitive `DT_NEEDED` deps through `-rpath-link`, not `-L`. Standalone-tarball toolchains (Bootlin armv6) now also pass `-Wl,-rpath-link,<debian mirror>/lib/<triplet>`.
- **armv6l → armhf SIGILL fixes**: `upgrade.nim` (on-device self-upgrade) and `scripts/frameos-setup.sh` mapped `armv6l` to `armhf`, which downloads ARMv7 binaries that SIGILL on the ARM1176. Both now resolve `armv6`, mirroring the backend's `resolve_prebuilt_target` (which already had this right, comment and all).
- **Buildroot SD image e2e test fix** (pre-existing main breakage, same failure on `f49ca941`'s run): the 2026.8.6 release published the first SD images carrying the setup-blob placeholder from #291, so CI now takes the in-place "Personalizing precompiled SD image" path and never logs "Customizing full precompiled Buildroot SD image". The test accepts either path now.

## Verification

- `make release-debian-trixie-armv6` completes locally; the produced binary is `Tag_CPU_arch: v6KZ`, VFP hard-float, linking only `libc/libm/libssl.so.3/libcrypto.so.3` (sonames present on trixie).
- Backend: 57 tests across precompiled/deploy/cross suites pass; bootstrap API tests pass.
- Nim: `test_upgrade` suite passes, including new `archForUname` coverage.
- Setup script: 13 container tests pass; `sh -n` clean (install.template.sh is the build-time copy and stays identical).

## Backfill (done)

`frameos-2026.8.6-debian-trixie-armv6.tar.gz` (built from this branch — includes the `upgrade.nim` armv6 fix so those frames self-upgrade to the correct target) has been uploaded to the existing v2026.8.6 release, so already-shipped backends and install scripts stop 404ing immediately:
https://github.com/FrameOS/frameos/releases/download/v2026.8.6/frameos-2026.8.6-debian-trixie-armv6.tar.gz

🤖 Generated with [Claude Code](https://claude.com/claude-code)