### PR TITLE
Post-boot diagnostics on /boot, hotspot survives display driver init

### DIFF
--- a/backend/app/tasks/buildroot_image.py
+++ b/backend/app/tasks/buildroot_image.py
@@ -68,6 +68,11 @@ from app.tasks.buildroot_platforms import (
     get_buildroot_platform,
     normalize_buildroot_platform,
 )
+from app.tasks.postboot_log import (
+    POSTBOOT_LOG_SCRIPT_PATH,
+    POSTBOOT_LOG_SERVICE_NAME,
+    stage_postboot_log,
+)
 from app.tasks.utils import get_fresh_frame
 from app.tasks.prebuilt_deps import resolve_prebuilt_target
 from app.utils.build_environment import BuildEnvironmentProvider, selected_build_environment_provider
@@ -1618,6 +1623,7 @@ class BuildrootImageBuilder:
         ):
             directory.mkdir(parents=True, exist_ok=True)
         stage_buildroot_network_manager_state(overlay_dir)
+        stage_postboot_log(overlay_dir)
 
         if not frameos_build.binary_path:
             raise RuntimeError("FrameOS cross compilation did not produce a binary")
@@ -2533,6 +2539,7 @@ genimage --rootpath "$work_dir/empty-root" --tmppath "$work_dir/tmp" --inputpath
             shutil.rmtree(compose_dir)
         compose_dir.mkdir(parents=True, exist_ok=True)
         stage_buildroot_frameos_service(service_root, self.platform.uses_network_manager)
+        stage_postboot_log(service_root)
         (service_root / "etc" / "hostname").write_text(_hostname_for_frame(self.frame) + "\n", encoding="utf-8")
         # Refresh the first-boot setup script/unit and fstab on the root
         # partition so images composed from older cached base images pick up
@@ -2694,6 +2701,13 @@ rm /etc/systemd/system/multi-user.target.wants/{SETUP_JSON_RESET_SERVICE_NAME}
 symlink /etc/systemd/system/multi-user.target.wants/{SETUP_JSON_RESET_SERVICE_NAME} ../{SETUP_JSON_RESET_SERVICE_NAME}
 rm /etc/fstab
 write $service_root/etc/fstab /etc/fstab
+rm {POSTBOOT_LOG_SCRIPT_PATH}
+write $service_root{POSTBOOT_LOG_SCRIPT_PATH} {POSTBOOT_LOG_SCRIPT_PATH}
+sif {POSTBOOT_LOG_SCRIPT_PATH} mode 0100755
+rm /etc/systemd/system/{POSTBOOT_LOG_SERVICE_NAME}
+write $service_root/etc/systemd/system/{POSTBOOT_LOG_SERVICE_NAME} /etc/systemd/system/{POSTBOOT_LOG_SERVICE_NAME}
+rm /etc/systemd/system/multi-user.target.wants/{POSTBOOT_LOG_SERVICE_NAME}
+symlink /etc/systemd/system/multi-user.target.wants/{POSTBOOT_LOG_SERVICE_NAME} ../{POSTBOOT_LOG_SERVICE_NAME}
 EOF
 {zero_2_w_wifi_firmware_section}debugfs -w -f "$cmds" "$rootfs"
 python3 - "$disk" "$rootfs" {root_partition["start"]} <<'PY'

--- a/backend/app/tasks/postboot_log.py
+++ b/backend/app/tasks/postboot_log.py
@@ -2,14 +2,23 @@
 
 Buildroot images keep journald in RAM and frameos logs on the ext4 data
 partition — neither is readable when a user pulls the SD card and puts it in
-a laptop. This unit writes ONE bounded snapshot file to /boot (FAT, readable
-anywhere) shortly after every boot: did frameos start, what did it log, and
+a laptop. This unit keeps a bounded snapshot file on /boot (FAT, readable
+anywhere) continuously refreshed: did frameos start, what did it log, and
 what does the network stack look like. It exists to end the guessing game
 when a frame comes up with a blank screen and no connectivity.
 
-Wear/space budget: two writes per boot (an early marker right at startup, a
-full snapshot ~2 minutes in), the file is overwritten in place each boot and
-every section is size-capped, so the file stays under ~256 KB forever.
+Refresh cadence: immediately at boot, then every 20 s until uptime reaches
+two minutes, then one final refresh and stop. The user never has to guess
+how long to wait: within the two-minute window the file is at most 20 s
+stale, and after it the final snapshot (labelled as such) sits unchanged
+until the next boot. Boot problems show inside that window — the network
+check times out at 30 s and the boot hotspot's retries finish well before
+two minutes.
+
+Wear/space budget: the file is overwritten in place (staged in tmpfs, one
+FAT write per refresh) and every section is size-capped, so it stays under
+~256 KB forever and the writes stop entirely two minutes into every boot —
+at most ~8 writes per boot.
 """
 
 from __future__ import annotations
@@ -20,25 +29,29 @@ from pathlib import Path
 POSTBOOT_LOG_SCRIPT_NAME = "frameos-postboot-log.sh"
 POSTBOOT_LOG_SCRIPT_PATH = f"/usr/local/bin/{POSTBOOT_LOG_SCRIPT_NAME}"
 POSTBOOT_LOG_SERVICE_NAME = "frameos-postboot-log.service"
-# "2min" in the name on purpose: this is a snapshot taken about two minutes
-# after boot, not a full or live log. Full logs live in /srv/frameos/logs/.
+# "2min" in the name on purpose: this snapshot covers the first two minutes
+# after boot, it is not a full or live log. Full logs: /srv/frameos/logs/.
 POSTBOOT_LOG_FILE_NAME = "frameos-postboot-2min.log"
 BOOT_POSTBOOT_LOG_FILE = f"/boot/{POSTBOOT_LOG_FILE_NAME}"
 
 _POSTBOOT_LOG_SCRIPT = """#!/bin/sh
 # FrameOS post-boot diagnostics snapshot.
 #
-# Writes __LOG_NAME__ to the boot partition twice per boot: a small marker as
-# soon as multi-user boot is underway, then a full snapshot once uptime
-# reaches __CAPTURE_AT__ seconds. The file is a bounded SNAPSHOT for reading
-# the SD card on another computer - it is NOT a full log. Full frameos logs
-# are on the ext4 partition in /srv/frameos/logs/.
+# Refreshes __LOG_NAME__ on the boot partition every __REFRESH_INTERVAL__s
+# during the first __STOP_AFTER__s after boot, writes one final snapshot,
+# and then stops for good - the boot partition sees no further writes until
+# the next boot. Pull the power at any point: within the window the file is
+# at most __REFRESH_INTERVAL__s stale, after it the final snapshot is what
+# there is to read. It is a bounded SNAPSHOT for reading the SD card on
+# another computer - NOT a full log. Full frameos logs are on the ext4
+# partition in /srv/frameos/logs/.
 set -u
 
 BOOT_DIR="${FRAMEOS_BOOT_DIR:-/boot}"
 LOG_FILE="$BOOT_DIR/__LOG_NAME__"
 STAGE_FILE="${FRAMEOS_POSTBOOT_STAGE:-/run/frameos-postboot.tmp}"
-CAPTURE_AT_SECONDS=__CAPTURE_AT__
+REFRESH_INTERVAL_SECONDS=__REFRESH_INTERVAL__
+STOP_AFTER_SECONDS=__STOP_AFTER__
 SECTION_BYTES=49152
 
 uptime_seconds() {
@@ -70,7 +83,8 @@ grab() {
 write_header() {
   {
     printf '%s\\n' "FrameOS post-boot snapshot: $1"
-    printf '%s\\n' "This is a bounded snapshot written shortly after boot, NOT a full log."
+    printf '%s\\n' "Refreshed every ${REFRESH_INTERVAL_SECONDS}s during the first ${STOP_AFTER_SECONDS}s after boot, then final."
+    printf '%s\\n' "This is a bounded snapshot, NOT a full log."
     printf '%s\\n' "Full frameos logs: /srv/frameos/logs/ (ext4 data partition)."
     printf 'generated_at=%s uptime_seconds=%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null)" "$(uptime_seconds)"
     printf 'hostname=%s\\n' "$(hostname 2>/dev/null)"
@@ -145,25 +159,26 @@ snapshot() {
   publish
 }
 
-# Early marker: proves the boot reached multi-user and shows the initial
-# service states even if the frame dies before the full snapshot.
-snapshot "early (boot start)"
-
-while [ "$(uptime_seconds)" -lt "$CAPTURE_AT_SECONDS" ]; do
-  sleep 5
+# The first snapshot right away proves the boot reached multi-user even if
+# the frame dies moments later; every refresh replaces the file whole.
+while [ "$(uptime_seconds)" -lt "$STOP_AFTER_SECONDS" ]; do
+  snapshot "at $(uptime_seconds)s uptime (still refreshing)"
+  sleep "$REFRESH_INTERVAL_SECONDS"
 done
 
-snapshot "at ${CAPTURE_AT_SECONDS}s uptime"
+snapshot "final at $(uptime_seconds)s uptime - no further refreshes this boot"
 """
 
-POSTBOOT_LOG_CAPTURE_AT_SECONDS = 120
+POSTBOOT_LOG_REFRESH_INTERVAL_SECONDS = 20
+POSTBOOT_LOG_STOP_AFTER_SECONDS = 120
 
 
 def render_postboot_log_script() -> str:
     return (
         _POSTBOOT_LOG_SCRIPT
         .replace("__LOG_NAME__", POSTBOOT_LOG_FILE_NAME)
-        .replace("__CAPTURE_AT__", str(POSTBOOT_LOG_CAPTURE_AT_SECONDS))
+        .replace("__REFRESH_INTERVAL__", str(POSTBOOT_LOG_REFRESH_INTERVAL_SECONDS))
+        .replace("__STOP_AFTER__", str(POSTBOOT_LOG_STOP_AFTER_SECONDS))
     )
 
 

--- a/backend/app/tasks/postboot_log.py
+++ b/backend/app/tasks/postboot_log.py
@@ -1,0 +1,213 @@
+"""Post-boot diagnostics snapshot written to the FAT boot partition.
+
+Buildroot images keep journald in RAM and frameos logs on the ext4 data
+partition — neither is readable when a user pulls the SD card and puts it in
+a laptop. This unit writes ONE bounded snapshot file to /boot (FAT, readable
+anywhere) shortly after every boot: did frameos start, what did it log, and
+what does the network stack look like. It exists to end the guessing game
+when a frame comes up with a blank screen and no connectivity.
+
+Wear/space budget: two writes per boot (an early marker right at startup, a
+full snapshot ~2 minutes in), the file is overwritten in place each boot and
+every section is size-capped, so the file stays under ~256 KB forever.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+POSTBOOT_LOG_SCRIPT_NAME = "frameos-postboot-log.sh"
+POSTBOOT_LOG_SCRIPT_PATH = f"/usr/local/bin/{POSTBOOT_LOG_SCRIPT_NAME}"
+POSTBOOT_LOG_SERVICE_NAME = "frameos-postboot-log.service"
+# "2min" in the name on purpose: this is a snapshot taken about two minutes
+# after boot, not a full or live log. Full logs live in /srv/frameos/logs/.
+POSTBOOT_LOG_FILE_NAME = "frameos-postboot-2min.log"
+BOOT_POSTBOOT_LOG_FILE = f"/boot/{POSTBOOT_LOG_FILE_NAME}"
+
+_POSTBOOT_LOG_SCRIPT = """#!/bin/sh
+# FrameOS post-boot diagnostics snapshot.
+#
+# Writes __LOG_NAME__ to the boot partition twice per boot: a small marker as
+# soon as multi-user boot is underway, then a full snapshot once uptime
+# reaches __CAPTURE_AT__ seconds. The file is a bounded SNAPSHOT for reading
+# the SD card on another computer - it is NOT a full log. Full frameos logs
+# are on the ext4 partition in /srv/frameos/logs/.
+set -u
+
+BOOT_DIR="${FRAMEOS_BOOT_DIR:-/boot}"
+LOG_FILE="$BOOT_DIR/__LOG_NAME__"
+STAGE_FILE="${FRAMEOS_POSTBOOT_STAGE:-/run/frameos-postboot.tmp}"
+CAPTURE_AT_SECONDS=__CAPTURE_AT__
+SECTION_BYTES=49152
+
+uptime_seconds() {
+  cut -d. -f1 /proc/uptime 2>/dev/null || echo 0
+}
+
+# Everything is staged in $STAGE_FILE (tmpfs) and copied to FAT in one go, so
+# the boot partition sees a single write per snapshot.
+publish() {
+  [ -d "$BOOT_DIR" ] || return 0
+  cp "$STAGE_FILE" "$LOG_FILE" 2>/dev/null || return 0
+  sync
+}
+
+section() {
+  printf '\\n===== %s =====\\n' "$1" >> "$STAGE_FILE"
+}
+
+# Run a command with its output size-capped; never let a broken tool break
+# the snapshot.
+grab() {
+  if command -v "$1" >/dev/null 2>&1; then
+    "$@" 2>&1 | tail -c "$SECTION_BYTES" >> "$STAGE_FILE" || true
+  else
+    printf '(%s not available)\\n' "$1" >> "$STAGE_FILE"
+  fi
+}
+
+write_header() {
+  {
+    printf '%s\\n' "FrameOS post-boot snapshot: $1"
+    printf '%s\\n' "This is a bounded snapshot written shortly after boot, NOT a full log."
+    printf '%s\\n' "Full frameos logs: /srv/frameos/logs/ (ext4 data partition)."
+    printf 'generated_at=%s uptime_seconds=%s\\n' "$(date '+%Y-%m-%dT%H:%M:%S%z' 2>/dev/null)" "$(uptime_seconds)"
+    printf 'hostname=%s\\n' "$(hostname 2>/dev/null)"
+    printf 'current_release=%s\\n' "$(readlink /srv/frameos/current 2>/dev/null)"
+    cat /srv/frameos/current/versions.json 2>/dev/null || true
+  } > "$STAGE_FILE"
+}
+
+write_services() {
+  section "services"
+  for unit in frameos.service frameos-remote.service wpa_supplicant.service NetworkManager.service; do
+    printf '%s: %s\\n' "$unit" "$(systemctl is-active "$unit" 2>/dev/null)" >> "$STAGE_FILE"
+  done
+  grab systemctl --failed --no-pager --plain --no-legend
+}
+
+write_network() {
+  section "network"
+  grab ip addr
+  grab ip route
+  grab iw dev
+  grab iw dev wlan0 link
+  if command -v wpa_cli >/dev/null 2>&1; then
+    grab wpa_cli -p /var/run/wpa_supplicant -i wlan0 status
+  fi
+  if command -v rfkill >/dev/null 2>&1; then
+    grab rfkill list
+  fi
+  section "network daemons"
+  # busybox ps has no -a/-o flags, so keep this to the lowest common form.
+  ps 2>/dev/null | grep -E 'wpa_supplicant|hostapd|udhcpc|dnsmasq|NetworkManager' \\
+      | grep -v grep | tail -c "$SECTION_BYTES" >> "$STAGE_FILE" || true
+  # The wpa_supplicant config proves what the first-boot mirror wrote, but
+  # its secrets must never land on the FAT partition.
+  section "wpa_supplicant config (secrets redacted)"
+  sed -e 's/^\\([[:space:]]*psk=\\).*/\\1<redacted>/' \\
+      -e 's/^\\([[:space:]]*wep_key[0-9]*=\\).*/\\1<redacted>/' \\
+      -e 's/^\\([[:space:]]*password=\\).*/\\1<redacted>/' \\
+      /etc/wpa_supplicant/wpa_supplicant-wlan0.conf 2>/dev/null \\
+      | tail -c "$SECTION_BYTES" >> "$STAGE_FILE" || true
+}
+
+write_journal() {
+  section "journal: frameos.service (tail)"
+  grab journalctl -b -u frameos.service --no-pager -o short-iso
+  section "journal: frameos-remote.service (tail)"
+  grab journalctl -b -u frameos-remote.service --no-pager -o short-iso
+  section "journal: wpa_supplicant.service (tail)"
+  grab journalctl -b -u wpa_supplicant.service --no-pager -o short-iso
+  section "journal: full boot (tail)"
+  grab journalctl -b --no-pager -o short-iso
+}
+
+write_frameos_log() {
+  section "frameos file log (tail)"
+  latest_log="$(ls -1t /srv/frameos/logs/ 2>/dev/null | head -n 1)"
+  if [ -n "$latest_log" ]; then
+    printf 'file=/srv/frameos/logs/%s\\n' "$latest_log" >> "$STAGE_FILE"
+    tail -c "$SECTION_BYTES" "/srv/frameos/logs/$latest_log" >> "$STAGE_FILE" 2>/dev/null || true
+  else
+    printf '(no files in /srv/frameos/logs/)\\n' >> "$STAGE_FILE"
+  fi
+}
+
+snapshot() {
+  write_header "$1"
+  write_services
+  write_network
+  write_journal
+  write_frameos_log
+  section "end of snapshot ($1)"
+  publish
+}
+
+# Early marker: proves the boot reached multi-user and shows the initial
+# service states even if the frame dies before the full snapshot.
+snapshot "early (boot start)"
+
+while [ "$(uptime_seconds)" -lt "$CAPTURE_AT_SECONDS" ]; do
+  sleep 5
+done
+
+snapshot "at ${CAPTURE_AT_SECONDS}s uptime"
+"""
+
+POSTBOOT_LOG_CAPTURE_AT_SECONDS = 120
+
+
+def render_postboot_log_script() -> str:
+    return (
+        _POSTBOOT_LOG_SCRIPT
+        .replace("__LOG_NAME__", POSTBOOT_LOG_FILE_NAME)
+        .replace("__CAPTURE_AT__", str(POSTBOOT_LOG_CAPTURE_AT_SECONDS))
+    )
+
+
+def render_postboot_log_service(script_path: str = POSTBOOT_LOG_SCRIPT_PATH) -> str:
+    # Type=exec on purpose: the script keeps running until the two-minute
+    # snapshot is written, and a oneshot would hold multi-user.target hostage
+    # for that long.
+    return f"""[Unit]
+Description=FrameOS post-boot diagnostics snapshot on the boot partition
+After=frameos.service frameos-remote.service
+RequiresMountsFor=/boot /srv/frameos
+
+[Service]
+Type=exec
+ExecStart={script_path}
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def stage_postboot_log(root: Path) -> None:
+    """Stage the snapshot script and unit into a rootfs overlay/patch dir."""
+    script_path = root / POSTBOOT_LOG_SCRIPT_PATH.lstrip("/")
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text(render_postboot_log_script(), encoding="utf-8")
+    os.chmod(script_path, 0o755)
+
+    systemd_dir = root / "etc" / "systemd" / "system"
+    wants_dir = systemd_dir / "multi-user.target.wants"
+    wants_dir.mkdir(parents=True, exist_ok=True)
+    (systemd_dir / POSTBOOT_LOG_SERVICE_NAME).write_text(render_postboot_log_service(), encoding="utf-8")
+    link = wants_dir / POSTBOOT_LOG_SERVICE_NAME
+    if link.exists() or link.is_symlink():
+        link.unlink()
+    link.symlink_to(f"../{POSTBOOT_LOG_SERVICE_NAME}")
+
+
+__all__ = [
+    "BOOT_POSTBOOT_LOG_FILE",
+    "POSTBOOT_LOG_FILE_NAME",
+    "POSTBOOT_LOG_SCRIPT_PATH",
+    "POSTBOOT_LOG_SERVICE_NAME",
+    "render_postboot_log_script",
+    "render_postboot_log_service",
+    "stage_postboot_log",
+]

--- a/backend/app/tasks/tests/test_buildroot_image.py
+++ b/backend/app/tasks/tests/test_buildroot_image.py
@@ -1228,6 +1228,17 @@ async def test_precompiled_sd_image_shortcut_patches_root_and_boot_only(tmp_path
         "../frameos-firstboot-setup.service"
     ) in captured["root_patch_script"]
     assert "write $service_root/etc/fstab /etc/fstab" in captured["root_patch_script"]
+    # Older cached base images also get the post-boot diagnostics snapshot
+    # unit patched in, so every composed image writes /boot/frameos-postboot-2min.log.
+    assert (
+        "write $service_root/usr/local/bin/frameos-postboot-log.sh /usr/local/bin/frameos-postboot-log.sh"
+        in captured["root_patch_script"]
+    )
+    assert "sif /usr/local/bin/frameos-postboot-log.sh mode 0100755" in captured["root_patch_script"]
+    assert (
+        "symlink /etc/systemd/system/multi-user.target.wants/frameos-postboot-log.service "
+        "../frameos-postboot-log.service"
+    ) in captured["root_patch_script"]
     assert "brcmfmac43436-sdio.raspberrypi,model-zero-2-w.bin" in captured["root_patch_script"]
     assert "c91cd2804cf7463aab913e7247c176049f16bbd6" in captured["root_patch_script"]
     boot_root = temp_dir / "overlay" / "boot"

--- a/backend/app/tasks/tests/test_postboot_log.py
+++ b/backend/app/tasks/tests/test_postboot_log.py
@@ -36,7 +36,23 @@ def test_postboot_log_script_is_bounded_and_redacts_secrets():
     assert "/run/frameos-postboot.tmp" in script
     # No un-substituted template placeholders.
     assert "__LOG_NAME__" not in script
-    assert "__CAPTURE_AT__" not in script
+    assert "__REFRESH_INTERVAL__" not in script
+    assert "__STOP_AFTER__" not in script
+
+
+def test_postboot_log_script_refreshes_then_stops():
+    script = render_postboot_log_script()
+    # The user must never have to guess how long to wait: the file refreshes
+    # every 20 s during the first two minutes...
+    assert "REFRESH_INTERVAL_SECONDS=20" in script
+    assert "STOP_AFTER_SECONDS=120" in script
+    assert "still refreshing" in script
+    # ...and then the writes stop for good, so the boot partition sees a
+    # bounded number of writes per boot.
+    assert "final at" in script
+    assert "no further refreshes this boot" in script
+    # Snapshots label their own freshness in the header.
+    assert 'Refreshed every ${REFRESH_INTERVAL_SECONDS}s' in script
 
 
 def test_postboot_log_redaction_pattern_works(tmp_path: Path):

--- a/backend/app/tasks/tests/test_postboot_log.py
+++ b/backend/app/tasks/tests/test_postboot_log.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from app.tasks.postboot_log import (
+    POSTBOOT_LOG_FILE_NAME,
+    render_postboot_log_script,
+    render_postboot_log_service,
+    stage_postboot_log,
+)
+
+
+def test_postboot_log_script_is_posix_shell(tmp_path: Path):
+    # Runs under busybox ash on the armv6 image; a bashism would break it.
+    script_path = tmp_path / "postboot.sh"
+    script_path.write_text(render_postboot_log_script(), encoding="utf-8")
+    result = subprocess.run(["/bin/sh", "-n", str(script_path)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_postboot_log_script_is_bounded_and_redacts_secrets():
+    script = render_postboot_log_script()
+    # The filename itself must say this is a time-boxed snapshot, not a log.
+    assert POSTBOOT_LOG_FILE_NAME == "frameos-postboot-2min.log"
+    assert POSTBOOT_LOG_FILE_NAME in script
+    assert "NOT a full log" in script
+    # Every section is size-capped so the FAT partition can never fill up.
+    assert 'tail -c "$SECTION_BYTES"' in script
+    # Wi-Fi secrets must never land on the world-readable FAT partition.
+    assert "<redacted>" in script
+    assert "psk=" in script
+    # Content is staged in tmpfs and copied in one go: one FAT write per
+    # snapshot, minimal SD wear.
+    assert "/run/frameos-postboot.tmp" in script
+    # No un-substituted template placeholders.
+    assert "__LOG_NAME__" not in script
+    assert "__CAPTURE_AT__" not in script
+
+
+def test_postboot_log_redaction_pattern_works(tmp_path: Path):
+    conf = tmp_path / "wpa_supplicant-wlan0.conf"
+    conf.write_text(
+        'ctrl_interface=/var/run/wpa_supplicant\nnetwork={\n    ssid="Zebox"\n    psk="super-secret"\n}\n',
+        encoding="utf-8",
+    )
+    redacted = subprocess.run(
+        [
+            "sed",
+            "-e",
+            r"s/^\([[:space:]]*psk=\).*/\1<redacted>/",
+            str(conf),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "super-secret" not in redacted
+    assert "psk=<redacted>" in redacted
+    assert 'ssid="Zebox"' in redacted
+
+
+def test_postboot_log_service_does_not_block_boot():
+    service = render_postboot_log_service()
+    # A oneshot would hold multi-user.target hostage for the whole two-minute
+    # capture window; the unit must run alongside boot, not gate it.
+    assert "Type=exec" in service
+    assert "Type=oneshot" not in service
+    assert "WantedBy=multi-user.target" in service
+    assert "RequiresMountsFor=/boot /srv/frameos" in service
+
+
+def test_postboot_log_staging(tmp_path: Path):
+    stage_postboot_log(tmp_path)
+
+    script = tmp_path / "usr" / "local" / "bin" / "frameos-postboot-log.sh"
+    unit = tmp_path / "etc" / "systemd" / "system" / "frameos-postboot-log.service"
+    link = tmp_path / "etc" / "systemd" / "system" / "multi-user.target.wants" / "frameos-postboot-log.service"
+
+    assert script.is_file()
+    assert os.access(script, os.X_OK)
+    assert "frameos-postboot-2min.log" in script.read_text(encoding="utf-8")
+    assert unit.is_file()
+    assert link.is_symlink()
+    assert os.readlink(link) == "../frameos-postboot-log.service"
+
+    # Re-staging must be idempotent (the compose path can run repeatedly).
+    stage_postboot_log(tmp_path)
+    assert link.is_symlink()

--- a/cloud-frontend/src/components/AddFramePanel.tsx
+++ b/cloud-frontend/src/components/AddFramePanel.tsx
@@ -1,4 +1,6 @@
 import {
+  ArrowLeftIcon,
+  ChevronRightIcon,
   ClipboardDocumentIcon,
   CommandLineIcon,
   CpuChipIcon,
@@ -27,13 +29,15 @@ const mintErrorMessages: Record<string, string> = {
 }
 
 // "Add frame": four enrollment paths (install script, SD image, link code,
-// ESP32 USB flashing). Claim codes are plumbing, not UX: the install command
-// is ready to copy the moment the panel appears, minted once per opening (see
-// the mint site below for why that is safe now). The SD builder and the ESP32
-// flasher mint their own — multi-use and single-use respectively — on first
-// use, because those flows can take minutes and burn a code per attempt. The
-// server stores only hashes; every enrolled frame appears as pending until the
-// owner confirms it.
+// ESP32 USB flashing), presented in two stages — first a chooser with one
+// line per path, then the chosen path's full form. Claim codes are plumbing,
+// not UX: the install command is minted once per opening (see the mint site
+// below for why that is safe now), so it is ready to copy the moment the
+// script path is opened. The SD builder and the ESP32 flasher mint their own
+// — multi-use and single-use respectively — on first use, because those
+// flows can take minutes and burn a code per attempt. The server stores only
+// hashes; every enrolled frame appears as pending until the owner confirms
+// it.
 //
 // Ported from cloud/apps/auth-web/src/components/AddFramePanel.tsx, which owned
 // the only copy of this flow while /account/frames and /frames both showed
@@ -56,7 +60,45 @@ export interface AddFramePanelProps {
   onClose?: (() => void) | undefined
 }
 
+type AddFramePath = 'script' | 'sd' | 'link' | 'esp32'
+
+// Stage one: one button per enrollment path, each with a single line saying
+// what it is for. The chosen path's full form is stage two.
+const pathChoices: {
+  description: string
+  icon: typeof CommandLineIcon
+  key: AddFramePath
+  title: string
+}[] = [
+  {
+    description: 'Run one command on a device that already runs Linux — it installs FrameOS and links the frame here.',
+    icon: CommandLineIcon,
+    key: 'script',
+    title: 'Install script (any Pi / most Linux)',
+  },
+  {
+    description: 'Build a personalized image in this browser, flash it to a card, and the Pi enrolls on first boot.',
+    icon: DevicePhoneMobileIcon,
+    key: 'sd',
+    title: 'SD card image (Raspberry Pi)',
+  },
+  {
+    description: 'Already have FrameOS on your network? Approve the short code the frame shows to link it here.',
+    icon: QrCodeIcon,
+    key: 'link',
+    title: 'Link a frame that already runs',
+  },
+  {
+    description: 'Plug the board in over USB — this browser writes the firmware and enrolls the frame automatically.',
+    icon: CpuChipIcon,
+    key: 'esp32',
+    title: 'Flash an ESP32 from this browser',
+  },
+]
+
 export function AddFramePanel({ claimTokenTtlHours, cloudOrigin, onClose }: AddFramePanelProps): ReactElement {
+  // undefined = the chooser stage; a key = that path's form.
+  const [path, setPath] = useState<AddFramePath | undefined>()
   const [claimToken, setClaimToken] = useState<string | undefined>()
   const [error, setError] = useState<string | undefined>()
   const [installCopied, setInstallCopied] = useState(false)
@@ -249,6 +291,36 @@ export function AddFramePanel({ claimTokenTtlHours, cloudOrigin, onClose }: AddF
           </p>
         ) : null}
 
+        {path === undefined ? (
+          <div className="grid gap-2">
+            {pathChoices.map((choice) => (
+              <button
+                key={choice.key}
+                className="frameos-card flex items-center gap-3 rounded-2xl border border-white/90 p-4 text-left shadow-sm transition hover:border-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                onClick={() => setPath(choice.key)}
+                type="button"
+              >
+                <choice.icon aria-hidden className="frameos-strong h-6 w-6 shrink-0" />
+                <span className="min-w-0 flex-1">
+                  <span className="frameos-strong block text-sm font-semibold">{choice.title}</span>
+                  <span className="frameos-muted block text-xs">{choice.description}</span>
+                </span>
+                <ChevronRightIcon aria-hidden className="frameos-muted h-5 w-5 shrink-0" />
+              </button>
+            ))}
+          </div>
+        ) : (
+          <button
+            className="frameos-muted inline-flex items-center gap-1.5 text-xs font-semibold transition hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            onClick={() => setPath(undefined)}
+            type="button"
+          >
+            <ArrowLeftIcon aria-hidden className="h-4 w-4" />
+            All ways to add a frame
+          </button>
+        )}
+
+        {path === 'script' ? (
         <section className="frameos-card rounded-2xl border border-white/90 p-4 shadow-sm">
           <h3 className="frameos-strong mb-1 flex items-center gap-2 text-sm font-semibold">
             <CommandLineIcon aria-hidden className="h-5 w-5" />
@@ -281,7 +353,9 @@ export function AddFramePanel({ claimTokenTtlHours, cloudOrigin, onClose }: AddF
               : `Claim codes are single-use and expire within ${claimTokenTtlHours} hours.`}
           </p>
         </section>
+        ) : null}
 
+        {path === 'sd' ? (
         <section className="frameos-card rounded-2xl border border-white/90 p-4 shadow-sm">
           <h3 className="frameos-strong mb-1 flex items-center gap-2 text-sm font-semibold">
             <DevicePhoneMobileIcon aria-hidden className="h-5 w-5" />
@@ -294,7 +368,9 @@ export function AddFramePanel({ claimTokenTtlHours, cloudOrigin, onClose }: AddF
             mintClaimToken={mintClaimToken}
           />
         </section>
+        ) : null}
 
+        {path === 'link' ? (
         <section className="frameos-card rounded-2xl border border-white/90 p-4 shadow-sm">
           <h3 className="frameos-strong mb-1 flex items-center gap-2 text-sm font-semibold">
             <QrCodeIcon aria-hidden className="h-5 w-5" />
@@ -312,7 +388,9 @@ export function AddFramePanel({ claimTokenTtlHours, cloudOrigin, onClose }: AddF
             The frame asks and you approve — nothing to copy from here, and the code proves you can see the device.
           </p>
         </section>
+        ) : null}
 
+        {path === 'esp32' ? (
         <section className="frameos-card rounded-2xl border border-white/90 p-4 shadow-sm">
           <h3 className="frameos-strong mb-1 flex items-center gap-2 text-sm font-semibold">
             <CpuChipIcon aria-hidden className="h-5 w-5" />
@@ -320,6 +398,7 @@ export function AddFramePanel({ claimTokenTtlHours, cloudOrigin, onClose }: AddF
           </h3>
           <Esp32CloudFlasher cloudOrigin={cloudOrigin} />
         </section>
+        ) : null}
       </div>
     </div>
   )

--- a/cloud-frontend/src/components/Esp32CloudFlasher.tsx
+++ b/cloud-frontend/src/components/Esp32CloudFlasher.tsx
@@ -40,10 +40,12 @@ const genericFirmwareSuffix = '-esp32-s3-generic.bin'
 // pins in one shot (the preset table in fos_console.c, mirroring
 // EMBEDDED_HARDWARE_PRESETS in the backend). Everything else is a XIAO with
 // a bare panel wired to it — the full compiled-in panel table
-// (lib/generated-devices) is offered via `set panel`; the default (empty)
-// keeps the firmware's baked-in EPD_7in5_V2.
+// (lib/generated-devices) is offered via `set panel`. There is no implicit
+// default: nobody actually runs the firmware's baked-in EPD_7in5_V2 combo,
+// and silently provisioning any one bundle would misconfigure every other
+// board — so the picker starts on a placeholder and flashing requires a
+// choice.
 const boardChoices = [
-  { label: 'Seeed XIAO ESP32-S3 + Waveshare 7.5" V2 (default)', value: '' },
   { label: 'Waveshare PhotoPainter 7.3" (ESP32-S3 — buttons, SD card)', value: 'hw:waveshare_esp32_s3_photopainter' },
   { label: 'Waveshare PhotoPainter 13.3" (ESP32-S3 — SD card)', value: 'hw:waveshare_esp32_s3_epaper_13_3e6' },
 ] as const
@@ -75,6 +77,35 @@ export function pinsSpecError(spec: string): string | undefined {
 }
 const flashBaudrate = 460800
 const consoleBaudrate = 115200
+
+// The firmware's console REPL lives only on the ESP32-S3's built-in
+// USB-Serial/JTAG device (CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG in
+// embedded/esp32/sdkconfig.defaults) — the port the OS names
+// "USB JTAG/serial debug unit". Some boards (Waveshare PhotoPainter 13.3")
+// additionally expose an on-board USB-UART bridge on UART0, which shows up
+// as a second port ("USB Single Serial" for its CH343). The ROM bootloader
+// flashes fine through the bridge, but the console prompt can never appear
+// there, so provisioning would always time out after a successful-looking
+// flash. Known bridge vendors are refused before anything is written.
+const uartBridgeVendors: Record<number, string> = {
+  0x0403: 'FTDI',
+  0x067b: 'Prolific',
+  0x10c4: 'Silicon Labs CP210x',
+  0x1a86: 'WCH ("USB Single Serial")',
+}
+
+export function portSelectionError(info: { usbVendorId?: number } | undefined): string | undefined {
+  const bridge = info?.usbVendorId !== undefined ? uartBridgeVendors[info.usbVendorId] : undefined
+  if (!bridge) {
+    return undefined
+  }
+  return (
+    `The selected port is a ${bridge} USB-UART bridge. Flashing would work through it, ` +
+    'but the FrameOS console only answers on the chip\'s built-in USB port, so the frame could ' +
+    'never be provisioned. Click flash again and pick the port named "USB JTAG/serial debug unit" ' +
+    '(boards like the PhotoPainter 13.3" show both ports over one cable).'
+  )
+}
 
 // The console prompt has no trailing space (fos_console.c: `printf("frameos>")`).
 const consolePrompt = 'frameos>'
@@ -365,7 +396,10 @@ async function provisionOverSerial(
     log('Waiting for the FrameOS console…')
     if (!(await readUntil(consolePrompt, bootPromptTimeoutMs))) {
       throw new Error(
-        'The flashed firmware never showed its FrameOS console prompt, so nothing was provisioned. Unplug the board, plug it back in and try again.'
+        'The flashed firmware never showed its FrameOS console prompt, so nothing was provisioned. ' +
+          'If the board offers more than one serial port, the console only answers on ' +
+          '"USB JTAG/serial debug unit" — not on a "USB Single Serial" UART bridge. ' +
+          'Unplug the board, plug it back in and try again with that port.'
       )
     }
     for (const command of commands) {
@@ -500,7 +534,7 @@ export function Esp32CloudFlasher({
   // flash, provision it over serial, never show it to the user.
   async function mintEnrollmentCode(): Promise<string> {
     const response = await fetch('/api/frames/claim-tokens', {
-      body: JSON.stringify(frameName ? { name: frameName } : {}),
+      body: JSON.stringify({ name: frameName.trim() }),
       headers: { 'content-type': 'application/json' },
       method: 'POST',
     })
@@ -534,6 +568,16 @@ export function Esp32CloudFlasher({
       setPhase('error')
       return
     }
+    if (!frameName.trim()) {
+      setError('Name the frame first — that is how it shows up in this workspace.')
+      setPhase('error')
+      return
+    }
+    if (panelSelectable && !panelChoice) {
+      setError('Pick the frame hardware first — your board, or the e-paper panel wired to your ESP32.')
+      setPhase('error')
+      return
+    }
     if (rememberWifi && wifiSsid) {
       storeRememberedWifi(wifiSsid, wifiPassword)
     } else {
@@ -549,9 +593,15 @@ export function Esp32CloudFlasher({
       const firmware = await fetchGenericFirmware(log)
 
       setPhase('connecting')
-      log('Pick the USB serial port of your ESP32…')
+      log('Pick the USB serial port of your ESP32 — if several are listed, choose "USB JTAG/serial debug unit"…')
       const serial = (navigator as unknown as { serial: WebSerialLike }).serial
       const port = await serial.requestPort()
+      // Refuse a USB-UART bridge port before writing anything: the flash
+      // would succeed but provisioning could never find the console.
+      const portError = portSelectionError(port.getInfo?.())
+      if (portError) {
+        throw new Error(portError)
+      }
 
       setPhase('flashing')
       const { ESPLoader, Transport } = await loadEsptool()
@@ -749,16 +799,18 @@ export function Esp32CloudFlasher({
     <div className="space-y-2">
       <p className="frameos-muted text-xs">
         Plug the board in over USB and click flash — it writes the generic FrameOS firmware and links the frame to this
-        account automatically.
+        account automatically. If the port picker lists several ports, choose &ldquo;USB JTAG/serial debug unit&rdquo;
+        (a &ldquo;USB Single Serial&rdquo; port can flash but not provision).
       </p>
       <div className="grid gap-2">
         <input
-          aria-label="Frame name (optional)"
+          aria-label="Frame name"
           className={controlClassName}
           disabled={busy}
           maxLength={256}
           onChange={(event) => setFrameName(event.target.value)}
-          placeholder="Frame name (optional)"
+          placeholder="Frame name"
+          required
           value={frameName}
         />
         {!panelSelectable ? (
@@ -777,6 +829,9 @@ export function Esp32CloudFlasher({
               onChange={(event) => setPanelChoice(event.target.value)}
               value={panelChoice}
             >
+              <option disabled value="">
+                Choose your board or e-paper panel…
+              </option>
               <optgroup label="Integrated boards">
                 {boardChoices.map((choice) => (
                   <option key={choice.value} value={choice.value}>

--- a/cloud-frontend/src/components/SdImageBuilder.tsx
+++ b/cloud-frontend/src/components/SdImageBuilder.tsx
@@ -290,6 +290,11 @@ export function SdImageBuilder({
     let writable: WritableImageStream | undefined
     try {
       // Validate user input before opening the save dialog.
+      if (!frameName.trim()) {
+        failWith('Name the frame first — that is how its enrollments show up in this workspace.')
+        busyRef.current = false
+        return
+      }
       sanitizeConfigValue(frameName, 'Frame name')
       sanitizeConfigValue(wifiSsid, 'WiFi network name')
       sanitizeConfigValue(wifiPassword, 'WiFi password')
@@ -530,12 +535,13 @@ export function SdImageBuilder({
             ))}
           </select>
           <input
-            aria-label="Frame name (optional)"
+            aria-label="Frame name"
             className={controlClassName}
             disabled={building}
             maxLength={256}
             onChange={(event) => setFrameName(event.target.value)}
-            placeholder="Frame name (optional)"
+            placeholder="Frame name"
+            required
             value={frameName}
           />
           <select

--- a/cloud/apps/auth-web/app/account/installs/page.tsx
+++ b/cloud/apps/auth-web/app/account/installs/page.tsx
@@ -1,9 +1,10 @@
-import { desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, notExists, sql } from "drizzle-orm";
 import Link from "next/link";
 import {
   connectedBackends,
   createDb,
   deviceAuthorizationRequests,
+  frames,
   linkedClients,
 } from "@frameos-cloud/db";
 import { InstallRowMenu } from "../../../src/components/InstallRowMenu";
@@ -55,7 +56,23 @@ export default async function AccountInstallsPage({
             connectedBackends,
             eq(connectedBackends.linkedClientId, linkedClients.id),
           )
-          .where(eq(linkedClients.accountId, accountId))
+          .where(
+            and(
+              eq(linkedClients.accountId, accountId),
+              // Cloud-managed frames (claim-token or link-code enrollment)
+              // each carry a linkedClients row too, but they live on the
+              // Frames page — listing them here twice as "backends" was just
+              // confusing. What remains: self-managed backends and frames
+              // that link to the cloud for services (login, backups) without
+              // handing over management. Those have no `frames` row.
+              notExists(
+                db
+                  .select({ id: frames.id })
+                  .from(frames)
+                  .where(eq(frames.linkedClientId, linkedClients.id)),
+              ),
+            ),
+          )
           .orderBy(desc(linkedClients.createdAt))
       : [];
 
@@ -92,7 +109,9 @@ export default async function AccountInstallsPage({
         <div>
           <h2>Linked backends</h2>
           <p className="copy">
-            To manage frames and use cloud services, link a FrameOS backend.{" "}
+            Self-managed frames and backends that link to your account for
+            cloud services like login and backups. Cloud-managed frames live
+            under Frames.{" "}
             <a
               href="https://frameos.net/guide/"
               rel="noreferrer noopener"

--- a/cloud/apps/auth-web/app/account/layout.tsx
+++ b/cloud/apps/auth-web/app/account/layout.tsx
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, notExists, sql } from "drizzle-orm";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import {
@@ -11,9 +11,9 @@ import {
 } from "@frameos-cloud/db";
 import { AccountNav } from "../../src/components/AccountNav";
 import { AppShell } from "../../src/components/AppShell";
+import { StorageUsageMeters } from "../../src/components/StorageUsageMeters";
 import { UserIdentifier } from "../../src/components/UserIdentifier";
 import { getAccountUrl, getCloudBaseUrl } from "../../src/lib/env";
-import { formatBytes } from "../../src/lib/format";
 import { readSession } from "../../src/lib/session";
 import { accountUsage, type AccountUsage } from "../../src/lib/usage";
 
@@ -63,6 +63,15 @@ export default async function AccountLayout({
             and(
               eq(linkedClients.accountId, accountId),
               isNull(linkedClients.revokedAt),
+              // Same predicate as the installs page: cloud-managed frames
+              // carry a linkedClients row, but they are counted on the
+              // Frames tab, not here.
+              notExists(
+                db
+                  .select({ id: frames.id })
+                  .from(frames)
+                  .where(eq(frames.linkedClientId, linkedClients.id)),
+              ),
             ),
           ),
         db
@@ -92,13 +101,6 @@ export default async function AccountLayout({
     usage = usageSnapshot;
   }
 
-  const storageBytes = usage
-    ? usage.scenes.private_bytes +
-      usage.scenes.public_bytes +
-      usage.backups.bytes +
-      usage.frame_logs.bytes
-    : 0;
-
   return (
     <AppShell isSuperadmin={isSuperadmin} title="FrameOS Account">
       {session.accountId ? (
@@ -112,24 +114,8 @@ export default async function AccountLayout({
         <div>
           <h1>{session?.name ?? "FrameOS Cloud account"}</h1>
           <p className="copy">{session?.email}</p>
-          {session?.accountId && usage ? (
-            <p className="copy">
-              Storage used: {formatBytes(storageBytes)}
-              {" — "}
-              private scenes {formatBytes(usage.scenes.private_bytes)} of{" "}
-              {formatBytes(usage.scenes.private_max_bytes)}
-              {usage.scenes.public_bytes > 0
-                ? ` · public scenes ${formatBytes(usage.scenes.public_bytes)} (free)`
-                : ""}
-              {" · "}
-              backups {formatBytes(usage.backups.bytes)} of{" "}
-              {formatBytes(usage.backups.max_bytes)}
-              {" · "}
-              frame logs {formatBytes(usage.frame_logs.bytes)} of{" "}
-              {formatBytes(usage.frame_logs.max_bytes)}
-            </p>
-          ) : null}
         </div>
+        {session?.accountId && usage ? <StorageUsageMeters usage={usage} /> : null}
       </div>
       <AccountNav
         counts={{

--- a/cloud/apps/auth-web/app/api/frames/enroll/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/enroll/route.ts
@@ -217,7 +217,13 @@ async function enrollWithClaimToken(
         throw new QuotaExceededError();
       }
 
-      const name = displayName ?? token.name ?? "FrameOS frame";
+      // The claim token's name outranks the device's: the owner typed it at
+      // mint time (the ESP32 flasher's "Frame name" field), while the
+      // device's is self-asserted and usually just its default hostname —
+      // every stock ESP32 enrolls as "frameos", which used to shadow the
+      // chosen name. Multi-use tokens (SD images) carry no token name, so
+      // the device-sent name (baked into the image) still applies there.
+      const name = token.name ?? displayName ?? "FrameOS frame";
       const [linkedClient] = await tx
         .insert(linkedClients)
         .values({

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -276,6 +276,78 @@ html.theme-dark .button-primary {
   font-size: 30px;
 }
 
+/* The account header's storage meters (StorageUsageMeters.tsx): one thin
+   capacity bar per quota bucket, sitting to the right of the user's name.
+   Deliberately quiet — muted labels, 5px tracks, the accent fill shifting
+   to warning/danger only when a bucket actually fills up. */
+.storage-usage {
+  display: grid;
+  grid-template-columns: max-content minmax(72px, 120px) max-content;
+  gap: 5px 10px;
+  align-items: center;
+  font-size: 12px;
+  line-height: 1.2;
+  flex-shrink: 0;
+}
+
+.storage-usage__total {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 2px;
+}
+
+.storage-usage__total-label {
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+}
+
+.storage-usage__total-value {
+  font-weight: 600;
+}
+
+.storage-usage__label {
+  color: var(--muted);
+}
+
+.storage-usage__track {
+  display: block;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--line);
+  overflow: hidden;
+}
+
+.storage-usage__fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--primary);
+}
+
+.storage-usage__fill--warning {
+  background: var(--warning);
+}
+
+.storage-usage__fill--critical {
+  background: var(--danger);
+}
+
+.storage-usage__value {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  justify-self: end;
+}
+
+.storage-usage__row {
+  display: contents;
+}
+
 .compact-header {
   align-items: center;
   margin-bottom: 0;

--- a/cloud/apps/auth-web/src/components/StorageUsageMeters.tsx
+++ b/cloud/apps/auth-web/src/components/StorageUsageMeters.tsx
@@ -1,0 +1,87 @@
+import { formatBytes } from "../lib/format";
+import type { AccountUsage } from "../lib/usage";
+
+// The account header's storage summary: one small capacity meter per quota
+// bucket instead of the old single-line sentence. Server-rendered, no JS —
+// the bars are plain divs whose width is the fill percentage. Colors stay
+// on the shared tokens (globals.css .storage-usage rules), so they follow
+// the light/dark theme; the numbers next to each bar carry the exact state,
+// the color shift at 80%/95% is reinforcement, not the only signal.
+
+interface MeterBucket {
+  bytes: number;
+  label: string;
+  maxBytes: number;
+}
+
+function meterFill(bucket: MeterBucket) {
+  const percent = bucket.maxBytes > 0 ? (bucket.bytes / bucket.maxBytes) * 100 : 0;
+  return {
+    className:
+      percent >= 95
+        ? "storage-usage__fill storage-usage__fill--critical"
+        : percent >= 80
+          ? "storage-usage__fill storage-usage__fill--warning"
+          : "storage-usage__fill",
+    // A 200 MB quota with 3 KB used rounds to 0% — keep a visible sliver so
+    // "there is something here" still reads.
+    width: bucket.bytes > 0 ? `${Math.max(1.5, Math.min(100, percent))}%` : "0",
+  };
+}
+
+export function StorageUsageMeters({ usage }: { usage: AccountUsage }) {
+  const totalBytes =
+    usage.scenes.private_bytes +
+    usage.scenes.public_bytes +
+    usage.backups.bytes +
+    usage.frame_logs.bytes;
+  const meters: MeterBucket[] = [
+    {
+      bytes: usage.scenes.private_bytes,
+      label: "Private scenes",
+      maxBytes: usage.scenes.private_max_bytes,
+    },
+    { bytes: usage.backups.bytes, label: "Backups", maxBytes: usage.backups.max_bytes },
+    {
+      bytes: usage.frame_logs.bytes,
+      label: "Frame logs",
+      maxBytes: usage.frame_logs.max_bytes,
+    },
+  ];
+
+  return (
+    <div className="storage-usage">
+      <div className="storage-usage__total">
+        <span className="storage-usage__total-label">Storage used</span>
+        <span className="storage-usage__total-value">{formatBytes(totalBytes)}</span>
+      </div>
+      {meters.map((bucket) => {
+        const fill = meterFill(bucket);
+        return (
+          <div
+            className="storage-usage__row"
+            key={bucket.label}
+            title={`${bucket.label}: ${formatBytes(bucket.bytes)} of ${formatBytes(bucket.maxBytes)}`}
+          >
+            <span className="storage-usage__label">{bucket.label}</span>
+            <span className="storage-usage__track">
+              <span className={fill.className} style={{ width: fill.width }} />
+            </span>
+            <span className="storage-usage__value">
+              {formatBytes(bucket.bytes)} / {formatBytes(bucket.maxBytes)}
+            </span>
+          </div>
+        );
+      })}
+      {usage.scenes.public_bytes > 0 ? (
+        <div className="storage-usage__row" title="Published public scenes don't count against any quota">
+          <span className="storage-usage__label">Public scenes</span>
+          <span />
+          <span className="storage-usage__value">
+            {formatBytes(usage.scenes.public_bytes)} · free
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
@@ -288,7 +288,11 @@ describe("cloud-managed frame enrollment", () => {
     const claimToken = await mintToken("Kitchen frame");
     expect(claimToken.startsWith("FRCT_")).toBe(true);
 
-    const response = await enroll(claimToken, keys.publicKeyBase64);
+    // The device asserts its own name — a stock ESP32 always sends its
+    // default hostname "frameos" — and the owner's mint-time name must win.
+    const response = await enroll(claimToken, keys.publicKeyBase64, {
+      name: "frameos",
+    });
     expect(response.status).toBe(200);
     const payload = (await response.json()) as Record<string, unknown>;
     expect(payload.status).toBe("pending");
@@ -382,6 +386,28 @@ describe("cloud-managed frame enrollment", () => {
     const payload = (await response.json()) as Record<string, unknown>;
     expect(payload.ws_path).toBe("/api/frames/ws");
     expect("ws_url" in payload).toBe(false);
+  });
+
+  it("uses the device-sent name only when the claim token carries none", async () => {
+    // Install-script and SD-image tokens are minted without a name; there
+    // the device's own name (baked into the image, or its hostname) is the
+    // best available. With neither, the placeholder applies.
+    const accountId = await signIn();
+    const named = await enroll(await mintToken(), deviceKeypair().publicKeyBase64, {
+      name: "Hallway",
+    });
+    expect(named.status).toBe(200);
+    const anonymous = await enroll(await mintToken(), deviceKeypair().publicKeyBase64);
+    expect(anonymous.status).toBe(200);
+
+    const rows = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.accountId, accountId));
+    expect(rows.map((row) => row.name).sort()).toEqual([
+      "FrameOS frame",
+      "Hallway",
+    ]);
   });
 
   it("multi-use claim tokens enroll distinct frames until the budget is spent", async () => {

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-add-frame-panel.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-add-frame-panel.test.tsx
@@ -45,6 +45,12 @@ function mintCalls() {
   );
 }
 
+// The panel opens on a chooser stage — one button per enrollment path — and
+// the forms live behind them.
+function openPath(name: RegExp) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
 beforeEach(() => {
   onClose.mockReset();
   fetchMock.mockReset();
@@ -79,6 +85,10 @@ describe("AddFramePanel", () => {
     renderPanel();
 
     expect(screen.getByText("Add a frame")).toBeDefined();
+    // Minted at mount — before any path is chosen — so the command is ready
+    // the moment the script stage opens.
+    expect(mintCalls()).toHaveLength(1);
+    openPath(/install script/i);
     await screen.findByText(/FRAMEOS_CLAIM_TOKEN=FRCT_from_server/);
     expect(mintCalls()).toHaveLength(1);
     // Copyable straight away — no claim code to transcribe by hand, and no
@@ -94,6 +104,7 @@ describe("AddFramePanel", () => {
 
   it("mints once per opening, not once per render", async () => {
     const view = renderPanel();
+    openPath(/install script/i);
     await screen.findByText(/FRAMEOS_CLAIM_TOKEN=FRCT_from_server/);
 
     view.rerender(
@@ -132,6 +143,7 @@ describe("AddFramePanel", () => {
   it("shows the masked command while the code is still in flight", async () => {
     fetchMock.mockImplementation(() => new Promise<Response>(() => undefined));
     renderPanel();
+    openPath(/install script/i);
 
     await screen.findByText(/FRAMEOS_CLAIM_TOKEN=<claim code>/);
     expect(screen.getByText(/Creating a single-use claim code/)).toBeDefined();
@@ -146,6 +158,7 @@ describe("AddFramePanel", () => {
   // is whatever host the admin browsed through.
   it("builds the install command against the injected cloud origin", async () => {
     renderPanel();
+    openPath(/install script/i);
 
     await screen.findByText(
       /curl -fsSL https:\/\/account\.frameos\.net\/install\.sh/,
@@ -199,6 +212,7 @@ describe("AddFramePanel", () => {
     view.unmount();
     expect(pending[0]?.signal?.aborted).toBe(true);
     renderPanel();
+    openPath(/install script/i);
     await act(async () => {
       pending[0]?.deliver(Response.json({ claim_token: "FRCT_stale" }));
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -223,6 +237,36 @@ describe("AddFramePanel", () => {
 
     expect(screen.getByText("Add a frame")).toBeDefined();
     expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+  });
+
+  it("opens on a chooser stage and drills into one path at a time", async () => {
+    renderPanel();
+
+    // Stage one: all four paths as buttons, no forms yet.
+    expect(screen.getByRole("button", { name: /install script/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /sd card image/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /link a frame/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /flash an esp32/i })).toBeDefined();
+    expect(screen.queryByTestId("esp32-flasher")).toBeNull();
+    expect(screen.queryByTestId("sd-builder")).toBeNull();
+    expect(screen.queryByText(/FRAMEOS_CLAIM_TOKEN/)).toBeNull();
+
+    // Stage two: only the chosen path's form.
+    openPath(/flash an esp32/i);
+    expect(screen.getByTestId("esp32-flasher")).toBeDefined();
+    expect(screen.queryByTestId("sd-builder")).toBeNull();
+    expect(screen.queryByText(/FRAMEOS_CLAIM_TOKEN/)).toBeNull();
+
+    // Back to the chooser.
+    fireEvent.click(
+      screen.getByRole("button", { name: /all ways to add a frame/i }),
+    );
+    expect(screen.queryByTestId("esp32-flasher")).toBeNull();
+    expect(screen.getByRole("button", { name: /sd card image/i })).toBeDefined();
+
+    openPath(/sd card image/i);
+    expect(screen.getByTestId("sd-builder")).toBeDefined();
+    expect(screen.queryByTestId("esp32-flasher")).toBeNull();
   });
 
   it("closes through the drawer that owns its open state", () => {

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-esp32-flasher.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-esp32-flasher.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Esp32CloudFlasher,
   pinsSpecError,
+  portSelectionError,
   wifiInputError,
 } from "../../../../../../cloud-frontend/src/components/Esp32CloudFlasher";
 
@@ -212,6 +213,17 @@ function clickFlash() {
   fireEvent.click(screen.getByRole("button", { name: /connect & flash/i }));
 }
 
+// A frame name and a hardware choice are both required before flashing (there
+// is no default board any more). Fill them the way a real flash would.
+async function fillRequiredFields(hardware = "panel:EPD_7in5_V2") {
+  fireEvent.change(screen.getByLabelText("Frame name"), {
+    target: { value: "Kitchen" },
+  });
+  fireEvent.change(await screen.findByLabelText("Frame hardware"), {
+    target: { value: hardware },
+  });
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
 });
@@ -242,6 +254,24 @@ describe("wifiInputError", () => {
   it("enforces the 802.11 length limits", () => {
     expect(wifiInputError("x".repeat(33), "")).toMatch(/at most 32/);
     expect(wifiInputError("MyNet", "x".repeat(65))).toMatch(/at most 64/);
+  });
+});
+
+describe("portSelectionError", () => {
+  it("refuses known USB-UART bridge vendors — the console never answers there", () => {
+    // The PhotoPainter 13.3" exposes a CH343 ("USB Single Serial", WCH
+    // vendor id) next to the chip's own USB-Serial/JTAG port; flashing works
+    // over the bridge but the FrameOS console only exists on the JTAG port.
+    expect(portSelectionError({ usbVendorId: 0x1a86 })).toMatch(
+      /USB JTAG\/serial debug unit/,
+    );
+    expect(portSelectionError({ usbVendorId: 0x10c4 })).toMatch(/CP210x/);
+  });
+
+  it("accepts the Espressif built-in USB device and ports without USB info", () => {
+    expect(portSelectionError({ usbVendorId: 0x303a })).toBeUndefined();
+    expect(portSelectionError({})).toBeUndefined();
+    expect(portSelectionError(undefined)).toBeUndefined();
   });
 });
 
@@ -278,6 +308,47 @@ describe("Esp32CloudFlasher", () => {
     ).toHaveLength(0);
   });
 
+  it("requires a frame name before touching the network", async () => {
+    mockCloudApi();
+    stubSerial(createHealthyPort());
+    render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
+    fireEvent.change(await screen.findByLabelText("Frame hardware"), {
+      target: { value: "panel:EPD_7in5_V2" },
+    });
+    clickFlash();
+
+    expect(await screen.findByRole("alert")).toHaveProperty(
+      "textContent",
+      expect.stringMatching(/Name the frame/),
+    );
+    // Only the mount-time release probe may have fired.
+    expect(
+      fetchedUrls().filter((url) => url !== "/api/frames/firmware"),
+    ).toHaveLength(0);
+  });
+
+  it("requires a hardware choice — there is no default board any more", async () => {
+    // The old default ("XIAO + 7.5\" V2") was a combo nobody actually runs,
+    // and silently provisioning any one bundle would misconfigure every
+    // other board. The picker starts on a placeholder and flashing refuses
+    // until something real is chosen.
+    mockCloudApi();
+    stubSerial(createHealthyPort());
+    render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
+    await screen.findByLabelText("Frame hardware");
+    fireEvent.change(screen.getByLabelText("Frame name"), {
+      target: { value: "Kitchen" },
+    });
+    clickFlash();
+
+    expect(await screen.findByRole("alert")).toHaveProperty(
+      "textContent",
+      expect.stringMatching(/Pick the frame hardware/),
+    );
+    expect(esptool.calls.writeFlash).not.toHaveBeenCalled();
+    expect(fetchedUrls()).not.toContain("/api/frames/claim-tokens");
+  });
+
   it("flashes and provisions using only same-origin requests, quoting WiFi values", async () => {
     mockCloudApi();
     const port = createHealthyPort();
@@ -287,9 +358,7 @@ describe("Esp32CloudFlasher", () => {
 
     // The flasher owns its own name field (each enrollment path names its own
     // frame); the value must reach the claim-token mint.
-    fireEvent.change(screen.getByLabelText("Frame name (optional)"), {
-      target: { value: "Kitchen" },
-    });
+    await fillRequiredFields();
     fireEvent.change(screen.getByLabelText("WiFi network"), {
       target: { value: "My Home WiFi" },
     });
@@ -328,6 +397,7 @@ describe("Esp32CloudFlasher", () => {
     expect(port.writes).toEqual([
       `set cloud_url "${window.location.origin}"`,
       'set claim_token "FRCT_minted"',
+      'set panel "EPD_7in5_V2"',
       'wifi "My Home WiFi" "pa ss\\"word"',
     ]);
     // The claim token is minted once, and only after the flash succeeded.
@@ -362,7 +432,7 @@ describe("Esp32CloudFlasher", () => {
     });
     stubSerial(createHealthyPort());
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
     clickFlash();
 
     const done = await screen.findByTestId("esp32-flash-done", undefined, {
@@ -385,7 +455,7 @@ describe("Esp32CloudFlasher", () => {
     });
     stubSerial(createHealthyPort());
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
     clickFlash();
 
     const done = await screen.findByTestId("esp32-flash-done", undefined, {
@@ -401,9 +471,7 @@ describe("Esp32CloudFlasher", () => {
     stubSerial(port);
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
 
-    fireEvent.change(await screen.findByLabelText("Frame hardware"), {
-      target: { value: "panel:EPD_13in3e" },
-    });
+    await fillRequiredFields("panel:EPD_13in3e");
     clickFlash();
     await screen.findByTestId("esp32-flash-done", undefined, { timeout: 5000 });
 
@@ -419,7 +487,7 @@ describe("Esp32CloudFlasher", () => {
     mockCloudApi();
     stubSerial(createHealthyPort());
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
 
     fireEvent.change(screen.getByLabelText("WiFi network"), {
       target: { value: "MyNet" },
@@ -444,9 +512,7 @@ describe("Esp32CloudFlasher", () => {
     stubSerial(port);
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
 
-    fireEvent.change(await screen.findByLabelText("Frame hardware"), {
-      target: { value: "hw:waveshare_esp32_s3_photopainter" },
-    });
+    await fillRequiredFields("hw:waveshare_esp32_s3_photopainter");
     fireEvent.change(screen.getByLabelText("GPIO pins (optional)"), {
       target: { value: "rst=1,dc=2,cs=3,cs2=-1,busy=4,sck=5,mosi=6,pwr=-1" },
     });
@@ -489,9 +555,7 @@ describe("Esp32CloudFlasher", () => {
     stubSerial(port);
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
 
-    fireEvent.change(await screen.findByLabelText("Frame hardware"), {
-      target: { value: "hw:waveshare_esp32_s3_photopainter" },
-    });
+    await fillRequiredFields("hw:waveshare_esp32_s3_photopainter");
     clickFlash();
     await screen.findByTestId("esp32-flash-done", undefined, { timeout: 5000 });
 
@@ -509,6 +573,11 @@ describe("Esp32CloudFlasher", () => {
     await screen.findByRole("button", { name: /connect & flash/i });
 
     expect(screen.queryByLabelText("Frame hardware")).toBeNull();
+    // Only the name is required here — there is no hardware picker to choose
+    // from on a legacy release.
+    fireEvent.change(screen.getByLabelText("Frame name"), {
+      target: { value: "Kitchen" },
+    });
     clickFlash();
     await screen.findByTestId("esp32-flash-done", undefined, { timeout: 5000 });
     expect(fetchedUrls()).toContain(
@@ -522,7 +591,7 @@ describe("Esp32CloudFlasher", () => {
     const port = createHealthyPort();
     stubSerial(port);
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
 
     clickFlash();
 
@@ -538,7 +607,7 @@ describe("Esp32CloudFlasher", () => {
     );
     stubSerial(createHealthyPort());
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
 
     clickFlash();
 
@@ -552,6 +621,33 @@ describe("Esp32CloudFlasher", () => {
     expect(screen.queryByTestId("esp32-flash-done")).toBeNull();
   });
 
+  it("refuses a USB-UART bridge port before flashing anything", async () => {
+    // Picking the PhotoPainter 13.3"'s "USB Single Serial" (CH343) port used
+    // to flash 3 MB and then time out waiting for a console that only exists
+    // on the "USB JTAG/serial debug unit" port. The wrong port must fail
+    // up front, before the flash and before a claim token is spent.
+    mockCloudApi();
+    const port = createHealthyPort();
+    (port as FakePort & { getInfo(): { usbVendorId: number } }).getInfo = () => ({
+      usbVendorId: 0x1a86,
+    });
+    stubSerial(port);
+    render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
+    await fillRequiredFields();
+
+    clickFlash();
+
+    expect(
+      await screen.findByRole("alert", undefined, { timeout: 5000 }),
+    ).toHaveProperty(
+      "textContent",
+      expect.stringMatching(/USB JTAG\/serial debug unit/),
+    );
+    expect(esptool.calls.writeFlash).not.toHaveBeenCalled();
+    expect(fetchedUrls()).not.toContain("/api/frames/claim-tokens");
+    expect(port.writes).toHaveLength(0);
+  });
+
   it("fails loudly when the flashed firmware never shows a console prompt", async () => {
     mockCloudApi();
     // Device never speaks: the stream ends without a prompt.
@@ -563,7 +659,7 @@ describe("Esp32CloudFlasher", () => {
       }),
     );
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
 
     clickFlash();
 
@@ -584,7 +680,7 @@ describe("Esp32CloudFlasher", () => {
     esptool.calls.writeFlash.mockRejectedValueOnce(new Error("flash write failed"));
     stubSerial(createHealthyPort());
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
 
     clickFlash();
 
@@ -599,7 +695,7 @@ describe("Esp32CloudFlasher", () => {
     esptool.calls.writeFlash.mockRejectedValue(new Error("flash write failed"));
     stubSerial(createHealthyPort());
     render(<Esp32CloudFlasher cloudOrigin={window.location.origin} />);
-    await screen.findByRole("button", { name: /connect & flash/i });
+    await fillRequiredFields();
 
     clickFlash();
 

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-sd-image-builder.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-sd-image-builder.test.tsx
@@ -164,6 +164,13 @@ function savedBytes(saved: SavedFile): Uint8Array {
   return joined;
 }
 
+// The frame name is required now — every build path fills one first.
+function nameFrame(value = "Kitchen Frame") {
+  fireEvent.change(screen.getByPlaceholderText("Frame name"), {
+    target: { value },
+  });
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
 });
@@ -211,6 +218,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.change(
       screen.getByPlaceholderText(/WiFi network \(optional/),
       { target: { value: 'my "network"' } },
@@ -238,9 +246,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
-    fireEvent.change(screen.getByPlaceholderText("Frame name (optional)"), {
-      target: { value: "Kitchen Frame" },
-    });
+    nameFrame();
     fireEvent.change(
       screen.getByPlaceholderText(/WiFi network \(optional/),
       { target: { value: "MyNet" } },
@@ -299,6 +305,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.click(
       screen.getByRole("button", { name: /download sd image/i }),
     );
@@ -327,6 +334,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.change(screen.getByLabelText("Display"), {
       target: { value: "waveshare.EPD_13in3e" },
     });
@@ -367,6 +375,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.change(screen.getByLabelText("Display"), {
       target: { value: "waveshare.EPD_10in3" },
     });
@@ -391,6 +400,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.change(screen.getByLabelText("Display"), {
       target: { value: "http.upload" },
     });
@@ -415,6 +425,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.change(
       screen.getByPlaceholderText(/WiFi network \(optional/),
       { target: { value: "MyNet" } },
@@ -467,6 +478,7 @@ describe("SdImageBuilder", () => {
     // The in-memory caveat is stated up front.
     expect(screen.getByText(/assembled in memory/)).toBeDefined();
 
+    nameFrame();
     fireEvent.click(
       screen.getByRole("button", { name: /download sd image/i }),
     );
@@ -474,7 +486,7 @@ describe("SdImageBuilder", () => {
 
     expect(clicked).toHaveLength(1);
     expect(clicked[0]?.download).toBe(
-      "frameos-raspberry-pi-zero-2-w-cloud.img.gz",
+      "frameos-raspberry-pi-zero-2-w-kitchen-frame.img.gz",
     );
     expect(clicked[0]?.href).toBe("blob:mock-url");
     expect(blobs).toHaveLength(1);
@@ -509,6 +521,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     const button = screen.getByRole("button", { name: /download sd image/i });
     fireEvent.click(button);
 
@@ -529,9 +542,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
-    fireEvent.change(screen.getByPlaceholderText("Frame name (optional)"), {
-      target: { value: "x".repeat(5000) },
-    });
+    nameFrame("x".repeat(5000));
     fireEvent.click(
       screen.getByRole("button", { name: /download sd image/i }),
     );
@@ -562,6 +573,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W (v1.2.3)",
     });
 
+    nameFrame();
     fireEvent.click(
       screen.getByRole("button", { name: /download sd image/i }),
     );
@@ -571,5 +583,27 @@ describe("SdImageBuilder", () => {
       undefined,
       { timeout: 5000 },
     );
+  });
+
+  it("requires a frame name before opening the save dialog", async () => {
+    mockReleaseAndImage();
+    stubSaveFilePicker();
+    const mint = vi.fn(() => Promise.resolve("FRCT_multi"));
+    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    await screen.findByRole("option", {
+      name: "Raspberry Pi Zero 2 W (v1.2.3)",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /download sd image/i }),
+    );
+
+    await screen.findByText(/Name the frame first/);
+    expect(mint).not.toHaveBeenCalled();
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).startsWith("/api/frames/sd-image"),
+      ),
+    ).toHaveLength(0);
   });
 });

--- a/docs/boot-partition.md
+++ b/docs/boot-partition.md
@@ -1,0 +1,74 @@
+# The boot partition: what lives there and why
+
+The first partition of a FrameOS SD image (label `BOOT`, FAT32, mounted at
+`/boot`) is the only part of the image every computer can read and write —
+macOS, Windows, Linux, a browser flash tool. FrameOS therefore uses it for
+three jobs:
+
+1. **Raspberry Pi firmware configuration** (`config.txt`, `cmdline.txt`).
+2. **One-time provisioning**: personalization the frame consumes on first
+   boot and then destroys.
+3. **Diagnostics you can read by pulling the card**: two log files that
+   answer "what happened at boot" without a serial cable or SSH.
+
+The partition is mounted root-only (`umask=077`) because until first boot it
+carries secrets (Wi-Fi credentials, the root password, cloud claim tokens).
+
+## File reference
+
+### Firmware configuration (persistent)
+
+| File | What it is |
+| --- | --- |
+| `config.txt` | Raspberry Pi firmware config. FrameOS display driver setup appends what the panel needs (e.g. `dtoverlay=spi0-0cs` for manual dual-CS e-ink panels) and enables the memory cgroup marker line's counterpart below. Edits are made in place and require a reboot. |
+| `cmdline.txt` | Kernel command line (single line!). FrameOS setup adds `cgroup_enable=memory` so the memory clamps in `frameos.service` work. |
+
+### Provisioning (consumed on first boot, then destroyed)
+
+The first-boot service (`frameos-firstboot-setup.service` running
+`frameos-setup-reset.sh`) processes these. Secret-bearing files are
+**shredded, never renamed**: overwritten with zeros first, then removed, so
+no `setup-done-*.json` copies of credentials linger on the card.
+
+| File | What it is |
+| --- | --- |
+| `frameos-setup.bin` | The setup blob. Release images ship it as a fixed-size placeholder at a contiguous offset so personalization tools (backend, cloud, in-browser flasher) can patch credentials into a downloaded image **in place** without rebuilding it. On first boot it is unpacked into the individual files below, then shredded. |
+| `frameos-setup.json` | The full frame configuration (`frame.json` payload plus scenes). Applied by the setup run, then shredded. If setup fails it is left in place so the next boot retries. |
+| `frameos-cloud.txt` | Cloud personalization (claim token, provider URL). Release images carry a comment-only placeholder; if it contains no real keys it is left alone, otherwise it is consumed and shredded. |
+| `frameos-hostname` | Installed to `/etc/hostname`, then removed. |
+| `frameos-wifi.nmconnection` | Wi-Fi credentials as a NetworkManager keyfile. Installed into the NetworkManager state directory; on platforms without NetworkManager (armv6 / Pi Zero W) the credentials are additionally mirrored into `/srv/frameos/state/wpa_supplicant/wpa_supplicant-wlan0.conf`, because nothing on those images reads a keyfile. Shredded after install. |
+| `frameos-authorized_keys` | SSH keys for root. Installed, then shredded. |
+| `frameos-root-password` | Root password for `chpasswd`. Installed, then shredded. |
+
+### Diagnostics (written by the frame, safe to share)
+
+| File | What it is |
+| --- | --- |
+| `frameos-setup-reset.log` | Everything the first-boot setup printed, **appended** across runs (a retry after a failure adds a second block). This is the log to read when provisioning itself misbehaves. |
+| `frameos-postboot-2min.log` | A **bounded snapshot, not a full log** — the name says so on purpose. Written by `frameos-postboot-log.service` twice per boot: a small marker as soon as multi-user boot is underway, then the full snapshot once uptime reaches two minutes. Contents: service states (`frameos`, `frameos-remote`, `wpa_supplicant`, `NetworkManager`), a network snapshot (`ip addr`/`ip route`/`iw`, `wpa_cli status`, running network daemons, the wpa_supplicant config **with secrets redacted**), size-capped journal tails for the FrameOS units and the whole boot, and the tail of the newest frameos file log. It answers "did frameos start, what did it log, and what does the network look like" from any laptop with an SD reader. |
+
+## Space and SD-card wear
+
+`frameos-postboot-2min.log` is assembled in tmpfs and copied to the FAT
+partition in a single write per snapshot (two writes per boot, ~256 KB
+ceiling, overwritten in place every boot). It cannot grow unbounded and adds
+no steady-state write load. `frameos-setup-reset.log` only grows when the
+first-boot service actually runs, which is once per provisioning.
+
+## Where the full logs are
+
+The boot partition never carries complete logs. Persistent frameos logs live
+on the ext4 data partition at `/srv/frameos/logs/frameos-<date>.log`
+(buildroot images set `logToFile` by default because their journald storage
+is volatile). The journal itself is in RAM and lost on power-off — which is
+exactly why the post-boot snapshot copies its tail to `/boot`.
+
+## Debugging workflow
+
+1. Frame misbehaves → power off, pull the SD card, put it in any computer.
+2. Read `frameos-postboot-2min.log` first: it tells you whether frameos
+   started, what it logged, and the state of Wi-Fi/hotspot at two minutes.
+3. Read `frameos-setup-reset.log` if the problem looks like provisioning
+   (wrong hostname, Wi-Fi never configured, setup errors).
+4. If you need history beyond the snapshot, mount the ext4 partition
+   (Linux) and read `/srv/frameos/logs/`.

--- a/docs/boot-partition.md
+++ b/docs/boot-partition.md
@@ -45,15 +45,17 @@ no `setup-done-*.json` copies of credentials linger on the card.
 | File | What it is |
 | --- | --- |
 | `frameos-setup-reset.log` | Everything the first-boot setup printed, **appended** across runs (a retry after a failure adds a second block). This is the log to read when provisioning itself misbehaves. |
-| `frameos-postboot-2min.log` | A **bounded snapshot, not a full log** — the name says so on purpose. Written by `frameos-postboot-log.service` twice per boot: a small marker as soon as multi-user boot is underway, then the full snapshot once uptime reaches two minutes. Contents: service states (`frameos`, `frameos-remote`, `wpa_supplicant`, `NetworkManager`), a network snapshot (`ip addr`/`ip route`/`iw`, `wpa_cli status`, running network daemons, the wpa_supplicant config **with secrets redacted**), size-capped journal tails for the FrameOS units and the whole boot, and the tail of the newest frameos file log. It answers "did frameos start, what did it log, and what does the network look like" from any laptop with an SD reader. |
+| `frameos-postboot-2min.log` | A **bounded snapshot covering the first two minutes after boot, not a full log** — the name says so on purpose. `frameos-postboot-log.service` writes it immediately at boot, refreshes it every 20 seconds until uptime reaches two minutes, then writes one final snapshot (labelled `final … no further refreshes this boot`) and stops. Power off at any point: within the window the file is at most 20 seconds stale, after it the final snapshot is the complete picture. Contents: service states (`frameos`, `frameos-remote`, `wpa_supplicant`, `NetworkManager`), a network snapshot (`ip addr`/`ip route`/`iw`, `wpa_cli status`, running network daemons, the wpa_supplicant config **with secrets redacted**), size-capped journal tails for the FrameOS units and the whole boot, and the tail of the newest frameos file log. It answers "did frameos start, what did it log, and what does the network look like" from any laptop with an SD reader. |
 
 ## Space and SD-card wear
 
 `frameos-postboot-2min.log` is assembled in tmpfs and copied to the FAT
-partition in a single write per snapshot (two writes per boot, ~256 KB
-ceiling, overwritten in place every boot). It cannot grow unbounded and adds
-no steady-state write load. `frameos-setup-reset.log` only grows when the
-first-boot service actually runs, which is once per provisioning.
+partition in a single write per refresh — at most ~8 writes in the first two
+minutes of a boot, then nothing until the next boot. It is overwritten in
+place with every section size-capped (~256 KB ceiling), so it can neither
+grow unbounded nor fill the boot partition. `frameos-setup-reset.log` only
+grows when the first-boot service actually runs, which is once per
+provisioning.
 
 ## Where the full logs are
 

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -263,7 +263,11 @@ The ESP32 profile is a subset because the firmware has no scheduler, no log
 buffer and no metrics buffer to expose, and updates itself from its own
 configured archive. A provider should degrade gracefully — hide or disable
 those controls for a frame whose `hardware.platform` is `esp32`, rather than
-enqueueing commands that will come back refused.
+enqueueing commands that will come back refused. Logs still flow: `get_logs`
+stays unsupported (nothing buffered to replay), but the firmware pushes
+`log_batch` messages while the session is live and `telemetry:logs` is in
+the ready scopes — a tick coalescer only (up to one batch per second, ≤60
+lines), nothing retained across disconnects, and error acks are ignored.
 
 ### Frame → provider messages
 

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -443,7 +443,12 @@ keeps its prompts); every prompt can be pre-answered with the script's
 
 The provider's flasher page uses WebSerial + esptool-js to write a prebuilt
 firmware image, then provisions `cloud_url` + `claim_token` (+ optional
-WiFi) into the device's NVS config partition. Same enrollment flow A over the
+WiFi) into the device's NVS config partition. The port must be the chip's
+built-in USB-Serial/JTAG device ("USB JTAG/serial debug unit"): the console
+REPL only exists there (`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG`), and boards
+that also expose an on-board USB-UART bridge (PhotoPainter 13.3", CH343 →
+"USB Single Serial") can flash through the bridge but never provision, so
+the flasher refuses known bridge vendor ids before writing anything. Same enrollment flow A over the
 device's own network connection afterwards. The firmware binaries come from
 the release archive; the flasher never receives per-user builds.
 

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -505,10 +505,23 @@ static void queue_log_line(const char *msg)
     xSemaphoreGive(s_log_lock);
 }
 
+static void (*s_log_tap)(const char *line) = NULL;
+
+void frameos_nim_set_log_tap(void (*tap)(const char *line))
+{
+    s_log_tap = tap;
+}
+
 void frameos_nim_log_hook(const char *msg)
 {
     ESP_LOGI("nim", "%s", msg ? msg : "");
     queue_log_line(msg);
+    /* The tap runs on whatever task logged; the cloud client's tap only
+     * copies the line into its own queue (or drops it). */
+    void (*tap)(const char *) = s_log_tap;
+    if (tap != NULL && msg != NULL) {
+        tap(msg);
+    }
 }
 
 void frameos_nim_set_log_upload_enabled(bool enabled)

--- a/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
@@ -46,6 +46,7 @@ bool frameos_nim_send_event(const char *event, const char *payload_json)
     return false;
 }
 void frameos_nim_log_hook(const char *msg) { (void)msg; }
+void frameos_nim_set_log_tap(void (*tap)(const char *line)) { (void)tap; }
 void frameos_nim_set_log_upload_enabled(bool enabled) { (void)enabled; }
 void frameos_nim_flush_logs(void) {}
 uint8_t *fos_nim_http_request(const char *method, const char *url,

--- a/embedded/esp32/components/frameos_nim/include/frameos_nim.h
+++ b/embedded/esp32/components/frameos_nim/include/frameos_nim.h
@@ -56,6 +56,10 @@ bool frameos_nim_send_event(const char *event, const char *payload_json);
 
 /* Provided by the firmware for the Nim side (logging hook). */
 void frameos_nim_log_hook(const char *msg);
+/* Optional tap invoked with every structured log line (on the logging
+ * task!). Used by the cloud client to forward logs over its WebSocket; the
+ * tap must be cheap and never block. Pass NULL to remove. */
+void frameos_nim_set_log_tap(void (*tap)(const char *line));
 /* Enable/disable backend log upload after network state changes. The baked
  * config still gates this; passing true has no effect when logs are disabled. */
 void frameos_nim_set_log_upload_enabled(bool enabled);

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
@@ -80,6 +81,18 @@ static const char *NVS_NS = "frameos";
 #define FOS_CLOUD_ASSET_LIST_MAX_DEPTH 8
 #define FOS_CLOUD_ASSET_PATH_MAX 256
 #define FOS_CLOUD_ASSET_JOB_QUEUE_DEPTH 8
+/* Log forwarding: every structured log line (frameos_nim_log_hook) is teed
+ * into a small queue while the WS session is live AND the provider granted
+ * telemetry:logs, then the cloud task coalesces the queue into one
+ * `log_batch` per 1 s tick. This is a tick coalescer, not a store: nothing
+ * is kept across disconnects, a full queue drops the line, and a failed or
+ * refused send is simply forgotten (the hub's error acks — rate_limited,
+ * insufficient_scope — are documented as non-fatal notices). One batch per
+ * second also stays far under the hub's 120 batches/min cap, which a
+ * per-line send would trip during a render burst. */
+#define FOS_CLOUD_LOG_QUEUE_DEPTH 64
+#define FOS_CLOUD_LOG_BATCH_MAX 60
+#define FOS_CLOUD_LOG_LINE_MAX 2048
 
 static fos_cloud_state_t s_state = FOS_CLOUD_NONE;
 static char s_last_error[96] = "";
@@ -607,6 +620,12 @@ static uint32_t s_scene_ack_generation = 0;
 static int64_t s_scene_ack_deadline_us = 0;
 static volatile bool s_scene_ack_pending = false;
 
+/* telemetry:logs granted by the provider — parsed from the ready message's
+ * scopes array, cleared with the session. Read from the logging tasks (the
+ * tap), written by the WS task; a stale read costs at most one line. */
+static volatile bool s_logs_granted = false;
+static QueueHandle_t s_log_queue = NULL;
+
 static void ws_backoff_reset(void);
 
 static void ws_send_json(cJSON *msg)
@@ -616,6 +635,109 @@ static void ws_send_json(cJSON *msg)
     esp_websocket_client_send_text(s_ws_client, text, strlen(text),
                                    pdMS_TO_TICKS(10000));
     cJSON_free(text);
+}
+
+/* Runs on whatever task produced the log line (render, HTTP, Nim): copy the
+ * line into the queue and get out. Anything that cannot be taken right now
+ * — session down, scope missing, queue full, allocation failure — drops the
+ * line; the serial console still carries everything. */
+static void cloud_log_tap(const char *line)
+{
+    if (!s_ws_ready || !s_logs_granted || s_log_queue == NULL) return;
+    size_t len = strnlen(line, FOS_CLOUD_LOG_LINE_MAX);
+    char *copy = malloc(len + 1);
+    if (!copy) return;
+    memcpy(copy, line, len);
+    copy[len] = '\0';
+    if (xQueueSend(s_log_queue, &copy, 0) != pdTRUE) {
+        free(copy);
+    }
+}
+
+static void ws_logs_init(void)
+{
+    if (s_log_queue == NULL) {
+        s_log_queue = xQueueCreate(FOS_CLOUD_LOG_QUEUE_DEPTH, sizeof(char *));
+    }
+    if (s_log_queue != NULL) {
+        frameos_nim_set_log_tap(cloud_log_tap);
+    }
+}
+
+static void ws_drain_log_queue(void)
+{
+    char *line = NULL;
+    while (s_log_queue != NULL && xQueueReceive(s_log_queue, &line, 0) == pdTRUE) {
+        free(line);
+    }
+}
+
+/* Cloud task, once per tick: coalesce whatever the tap queued into a single
+ * log_batch. The hub sends no ack on success and its two error acks
+ * (insufficient_scope, rate_limited) are non-fatal notices the verb
+ * dispatcher already ignores, so there is nothing to wait for here. */
+static void ws_poll_logs(void)
+{
+    if (s_log_queue == NULL) return;
+    if (!s_ws_client || !s_ws_ready || !s_logs_granted) {
+        /* Lines that raced in around a disconnect are not deliverable. */
+        ws_drain_log_queue();
+        return;
+    }
+    cJSON *logs = NULL;
+    int count = 0;
+    bool have_time = fos_wifi_time_synced();
+    double now = have_time ? (double)time(NULL) : 0;
+    char *line = NULL;
+    while (count < FOS_CLOUD_LOG_BATCH_MAX &&
+           xQueueReceive(s_log_queue, &line, 0) == pdTRUE) {
+        if (logs == NULL) logs = cJSON_CreateArray();
+        if (logs == NULL) {
+            free(line);
+            return;
+        }
+        cJSON *payload = cJSON_Parse(line);
+        if (payload != NULL && !cJSON_IsObject(payload)) {
+            cJSON_Delete(payload);
+            payload = NULL;
+        }
+        if (payload == NULL) {
+            /* Same wrapping the backend uploader applies to plain lines. */
+            payload = cJSON_CreateObject();
+            if (payload != NULL) {
+                cJSON_AddStringToObject(payload, "event", "log");
+                cJSON_AddStringToObject(payload, "source", "esp32");
+                cJSON_AddStringToObject(payload, "message", line);
+            }
+        }
+        free(line);
+        if (payload == NULL) continue;
+        cJSON *entry = cJSON_CreateObject();
+        if (entry == NULL) {
+            cJSON_Delete(payload);
+            continue;
+        }
+        /* Without SNTP the entry carries no timestamp and the hub stamps
+         * its own arrival time — better than a 1970 date. */
+        if (have_time) cJSON_AddNumberToObject(entry, "timestamp", now);
+        cJSON_AddItemToObject(entry, "payload", payload);
+        cJSON_AddItemToArray(logs, entry);
+        count++;
+    }
+    if (logs == NULL) return;
+    if (count == 0) {
+        cJSON_Delete(logs);
+        return;
+    }
+    cJSON *msg = cJSON_CreateObject();
+    if (msg == NULL) {
+        cJSON_Delete(logs);
+        return;
+    }
+    cJSON_AddStringToObject(msg, "type", "log_batch");
+    cJSON_AddItemToObject(msg, "logs", logs);
+    ws_send_json(msg);
+    cJSON_Delete(msg);
 }
 
 /* Attach the hello-shaped state fields to msg. */
@@ -1320,10 +1442,25 @@ static void ws_handle_message(const char *data, size_t len)
     if (strcmp(type, "challenge") == 0) {
         ws_send_auth(root);
     } else if (strcmp(type, "ready") == 0) {
+        /* The ready message is authoritative for what this session may do:
+         * its scopes array reflects the provider's current grant, including
+         * revocations since enrollment. */
+        bool logs_granted = false;
+        const cJSON *scopes = cJSON_GetObjectItem(root, "scopes");
+        const cJSON *scope = NULL;
+        cJSON_ArrayForEach(scope, scopes) {
+            if (cJSON_IsString(scope) && scope->valuestring &&
+                strcmp(scope->valuestring, "telemetry:logs") == 0) {
+                logs_granted = true;
+                break;
+            }
+        }
+        s_logs_granted = logs_granted;
         s_ws_ready = true;
         s_ws_auth_failures = 0; /* a completed handshake clears the streak */
         ws_backoff_reset();
-        ESP_LOGI(TAG, "ws: session ready");
+        ESP_LOGI(TAG, "ws: session ready (logs %s)",
+                 logs_granted ? "granted" : "not granted");
     } else if (strcmp(type, "get_state") == 0) {
         ws_ack(id, true, NULL);
         ws_send_state(id);
@@ -1430,6 +1567,7 @@ static void ws_event_handler(void *arg, esp_event_base_t base, int32_t event_id,
     switch (event_id) {
         case WEBSOCKET_EVENT_CONNECTED:
             s_ws_ready = false;
+            s_logs_granted = false; /* re-derived from this session's ready */
             s_ws_backoff_advanced = false; /* a new attempt got this far */
             ESP_LOGI(TAG, "ws: connected, sending hello");
             ws_send_hello();
@@ -1446,6 +1584,7 @@ static void ws_event_handler(void *arg, esp_event_base_t base, int32_t event_id,
         case WEBSOCKET_EVENT_DISCONNECTED:
         case WEBSOCKET_EVENT_CLOSED:
             s_ws_ready = false;
+            s_logs_granted = false;
             /* 4401: the provider closed an established socket because the
              * signature failed, the auth timed out, or the frame was revoked. */
             if (data && data->close_status_code == FOS_CLOUD_WS_AUTH_CLOSE_CODE) {
@@ -1599,8 +1738,11 @@ static void ws_start(void)
         ESP_LOGI(TAG, "ws: dialing %s://…%s", wss ? "wss" : "ws",
                  dial_path ? dial_path : "");
     }
-    /* TODO(cloud-frames): ship log batches under telemetry:logs; apply
-     * set_settings/set_schedule for the declarative allowlist. */
+    /* Tee runtime log lines toward this session (flushed by ws_poll_logs on
+     * the cloud task once telemetry:logs is confirmed by `ready`). */
+    ws_logs_init();
+    /* TODO(cloud-frames): apply set_settings/set_schedule for the
+     * declarative allowlist. */
 }
 
 /* Cloud task only: the websocket task must not be torn down from inside its
@@ -1612,6 +1754,8 @@ static void ws_stop(void)
     esp_websocket_client_destroy(s_ws_client);
     s_ws_client = NULL;
     s_ws_ready = false;
+    s_logs_granted = false;
+    ws_drain_log_queue();
     s_scene_ack_pending = false;
     free(s_ws_rx); /* the ws task is gone; nothing else touches this */
     s_ws_rx = NULL;
@@ -1640,6 +1784,7 @@ static void ws_start(void)
 
 static void ws_stop(void) {}
 static void ws_poll_scene_ack(void) {}
+static void ws_poll_logs(void) {}
 static bool ws_process_asset_jobs(void) { return false; }
 static bool ws_demote_requested(void) { return false; }
 static void ws_clear_demote_request(void) {}
@@ -1713,8 +1858,9 @@ static void cloud_task(void *arg)
                 ws_started = true;
             }
             ws_poll_scene_ack();
+            ws_poll_logs();
             /* Streamed asset replies run here, off the WS task. A 1 s idle
-             * tick keeps browse-the-SD latency humane; both polls are cheap
+             * tick keeps browse-the-SD latency humane; the polls are cheap
              * flag/queue checks. */
             ws_process_asset_jobs();
             vTaskDelay(pdMS_TO_TICKS(1000));

--- a/frameos/src/frameos/frameos.nim
+++ b/frameos/src/frameos/frameos.nim
@@ -135,7 +135,11 @@ proc newFrameOS*(): FrameOS =
       hotspotStatus: HotspotStatus.disabled,
     ),
   )
-  drivers.init(result)
+  # Display drivers are initialized later, in start(): first the network
+  # check and boot hotspot get their chance to run, so a display driver that
+  # crashes or hangs during init (bad SPI overlay, wrong pins, unvalidated
+  # panel) cannot leave the frame both blank AND unreachable. A frame with a
+  # broken display but a live hotspot/network can still be debugged.
   result.runner = newRunner(frameConfig)
   result.server = newServer(result)
   startScheduler(result)
@@ -208,6 +212,11 @@ proc start*(self: FrameOS) {.async.} =
   if applyBootGuardStartupFallback(firstSceneId, bootCrashCount):
     self.logger.log(%*{"event": "boot:guard:fallback", "sceneId": bootGuardFallbackSceneId(),
       "crashesWithoutRender": bootCrashCount, "threshold": BOOT_GUARD_CRASH_LIMIT})
+
+  # Deliberately after the network check, boot hotspot and boot-crash
+  # accounting: a driver that dies here leaves a reachable frame, and the
+  # crash is counted by the boot guard on the next attempt.
+  drivers.init(self)
 
   self.runner.start(firstSceneId)
 

--- a/frameos/src/frameos/setup.nim
+++ b/frameos/src/frameos/setup.nim
@@ -383,7 +383,14 @@ proc setupSystemHardening*(liveApply = true): SetupResult =
   # Wifi power save is a notorious source of dropouts and firmware wedges on
   # the Pi Zero 2 W's brcmfmac chip. Persist the NetworkManager setting and
   # also switch it off on the running interfaces right away.
-  if dirExists("/etc/NetworkManager"):
+  #
+  # /etc/NetworkManager exists even on images that have no NetworkManager at
+  # all (buildroot stages it as a bind-mount point on every platform), so also
+  # require the systemd unit before writing config for — and reloading — a
+  # service that is not there. The `iw` fallback below still disables power
+  # save on those images.
+  if dirExists("/etc/NetworkManager") and
+      commandSucceeds("systemctl cat NetworkManager.service >/dev/null 2>&1"):
     try:
       const powersaveConfPath = "/etc/NetworkManager/conf.d/wifi-powersave-off.conf"
       const powersaveConf = "[connection]\n# 2 = disable wifi power saving\nwifi.powersave = 2\n"

--- a/frameos/src/frameos/tests/test_setup.nim
+++ b/frameos/src/frameos/tests/test_setup.nim
@@ -232,6 +232,26 @@ block test_system_hardening_defers_live_changes_when_not_live_applying:
   finally:
     resetSetupCommandRunnerForTest()
 
+block test_system_hardening_skips_networkmanager_config_without_the_unit:
+  # /etc/NetworkManager exists even on images without NetworkManager (it is a
+  # bind-mount point on buildroot), so the powersave config must additionally
+  # be gated on the systemd unit being present.
+  var commands: seq[string] = @[]
+  setSetupCommandRunnerForTest(proc(command: string): SetupCommandResult =
+    commands.add(command)
+    if command.contains("systemctl cat NetworkManager.service"):
+      ("", 1)
+    else:
+      ("", 0)
+  )
+  try:
+    discard setupSystemHardening(liveApply = true)
+
+    doAssert not commands.anyIt(it.contains("wifi-powersave-off"))
+    doAssert not commands.anyIt(it.contains("reload NetworkManager"))
+  finally:
+    resetSetupCommandRunnerForTest()
+
 block test_write_frame_config_dimensions_persists_detected_size:
   let path = getTempDir() / ("frameos-dimensions-" & $epochTime().int64 & ".json")
   writeFile(path, pretty(%*{

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -1523,10 +1523,20 @@ async function saveFrameForm(frame: Partial<FrameType>, frameId: FrameId, nextAc
     // Cloud frames have no POST /api/frames/{id} — the control plane only
     // accepts the declarative settings allowlist, and applies it on the
     // device immediately (which is why Save stays visible with no deploy
-    // step). Scene assignment is a separate, store-scene-only endpoint
-    // (/api/frames/{id}/scenes) that takes published store scene ids, not
-    // the frame's edited scene graphs, so Save deliberately never touches it.
-    if (!(await pushCloudFrameSettings(frameId, normalizedFrame))) {
+    // step). Edited scene graphs go through the same store-scene persistence
+    // Deploy uses (new immutable versions of assigned scenes, new private
+    // scenes for unclaimed ones, then the checksummed assignment push).
+    // Save used to skip scenes entirely, which silently dropped a newly
+    // added scene while still reporting success because the name pushed.
+    const settingsPushed = await pushCloudFrameSettings(frameId, normalizedFrame)
+    const scenes = normalizedFrame.scenes ?? []
+    if (scenes.length > 0) {
+      const outcome = await persistAndPushCloudFrameScenes(frameId, scenes, normalizedFrame.active_scene_id)
+      for (const storeSceneId of outcome.changedStoreSceneIds) {
+        clearCloudSceneJsonCache(storeSceneId)
+      }
+      framesModel.actions.hydrateCloudFrameScenes(frameId, true)
+    } else if (!settingsPushed) {
       throw new Error('Nothing in these settings can be pushed to a cloud-managed frame')
     }
     return

--- a/frontend/src/scenes/workspace/FrameSceneSidebarCard.tsx
+++ b/frontend/src/scenes/workspace/FrameSceneSidebarCard.tsx
@@ -1,14 +1,15 @@
 import { useActions, useValues } from 'kea'
 import clsx from 'clsx'
-import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
+import { ArrowsRightLeftIcon, CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
 
+import { embeddedUsbLogsModel, isEmbeddedUsbLogStreamOpen } from '../../models/embeddedUsbLogsModel'
 import type { FrameType } from '../../types'
 import { isInFrameAdminMode } from '../../utils/frameAdmin'
 import { frameLogic } from '../frame/frameLogic'
 import { DeployToFrameIcon } from './FrameChangeStatusIcon'
 import { FrameLocalDeployMenu } from './FrameLocalDeployMenu'
 import { workspaceLogic } from './workspaceLogic'
-import { frameMenuActionIsAllowed, workspaceMode } from './workspaceSurfaces'
+import { frameMenuActionIsAllowed, frameSupportsUsbSerialConsole, workspaceMode } from './workspaceSurfaces'
 
 interface FrameSceneSidebarCardProps {
   frame: FrameType
@@ -26,7 +27,9 @@ export function FrameSceneSidebarCard({
   const { hideDeployPlanModal, saveFrame, saveAndDeployFrame } = useActions(frameLogic({ frameId: frame.id }))
   const { hasFrameSyncChanges } = useValues(frameLogic({ frameId: frame.id }))
   const { frameChangeDrawerSelection } = useValues(workspaceLogic)
-  const { closeChatDrawer, closeFrameChangeDrawer, openFrameChangeDrawer } = useActions(workspaceLogic)
+  const { closeChatDrawer, closeFrameChangeDrawer, openFrameChangeDrawer, openFrameTool } = useActions(workspaceLogic)
+  const { usbLogStreamStatesByFrameId } = useValues(embeddedUsbLogsModel)
+  const { startUsbLogStream, stopUsbLogStream } = useActions(embeddedUsbLogsModel)
   const deployDrawerIsOpen =
     frameChangeDrawerSelection?.frameId === frame.id && frameChangeDrawerSelection.kind === 'deploy'
   const inFrameAdminMode = isInFrameAdminMode()
@@ -54,10 +57,55 @@ export function FrameSceneSidebarCard({
   const canLocalDeploy = frameMenuActionIsAllowed(mode, 'localDeploy')
   const cloudDeploy = mode === 'cloud'
 
+  // Cloud-managed ESP32 frames don't push logs to the cloud yet, so their
+  // USB serial console is the primary debugging channel — surface it up here
+  // with Save/Deploy rather than only inside the Logs toolbar. Connecting
+  // also opens the Logs tool, where the stream lands.
+  const showUsbButton =
+    frameSupportsUsbSerialConsole(frame, mode) && typeof navigator !== 'undefined' && 'serial' in navigator
+  const usbLogStreamState = usbLogStreamStatesByFrameId[frame.id]
+  const usbLogStreamOpen = isEmbeddedUsbLogStreamOpen(usbLogStreamState)
+  const usbLogStreamBusy =
+    usbLogStreamState?.status === 'selecting' ||
+    usbLogStreamState?.status === 'connecting' ||
+    usbLogStreamState?.status === 'stopping'
+  const connectUsb = (): void => {
+    if (usbLogStreamOpen) {
+      stopUsbLogStream(frame.id)
+      return
+    }
+    openFrameTool(frame.id, 'logs')
+    startUsbLogStream(frame.id)
+  }
+
   return (
     <div
       className={clsx('grid gap-2', canDeploy || canLocalDeploy || cloudDeploy ? 'grid-cols-2' : 'grid-cols-1', className)}
     >
+      {showUsbButton ? (
+        <button
+          type="button"
+          title="Stream this board's USB serial console into the Logs panel"
+          onClick={connectUsb}
+          disabled={usbLogStreamBusy}
+          className="frameos-secondary-button col-span-full inline-flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40"
+        >
+          {usbLogStreamOpen || usbLogStreamBusy ? (
+            <StopCircleIcon className="h-4 w-4 shrink-0" />
+          ) : (
+            <CommandLineIcon className="h-4 w-4 shrink-0" />
+          )}
+          {usbLogStreamState?.status === 'selecting'
+            ? 'Select USB port'
+            : usbLogStreamState?.status === 'connecting'
+            ? 'Connecting USB'
+            : usbLogStreamState?.status === 'stopping'
+            ? 'Disconnecting USB'
+            : usbLogStreamOpen
+            ? 'Disconnect USB'
+            : 'Connect USB'}
+        </button>
+      ) : null}
       <SaveFrameButton onSave={saveFrame} unsavedChanges={unsavedChanges} />
       {canLocalDeploy && inFrameAdminMode ? (
         <FrameLocalDeployMenu


### PR DESCRIPTION
## Why

A user's Pi Zero W (13.3e panel, buildroot image) came up with no Wi-Fi and no hotspot, and diagnosing it from the single readable artifact — `/boot/frameos-setup-reset.log` — was a guessing game. Root-causing that exposed three gaps.

## What

**1. The boot hotspot could be killed by a broken display driver.** On armv6 images, station DHCP (`udhcpc`) and the setup hotspot both live inside the frameos process — but `drivers.init()` ran in `newFrameOS()`, *before* the network check and `startAp()` in `start()`. A display driver that crashes or hangs during init (bad SPI overlay, wrong pins, unvalidated panel) left the frame blank **and** unreachable. Driver init now runs after the network check, boot hotspot, and boot-crash accounting: a frame with a broken display but a live hotspot can still be debugged.

**2. armv6 setup ran `systemctl reload NetworkManager` on images that have no NetworkManager.** The hardening step gated the wifi-powersave config on `dirExists("/etc/NetworkManager")` — but that directory is a bind-mount point staged on every buildroot image, including armv6. Every armv6 setup run logged a confusing `Failed to reload NetworkManager.service: Unit NetworkManager.service not found`. The gate now also requires the systemd unit to exist; the `iw` fallback still disables wifi power save on those images.

**3. Nothing readable on the SD card said whether frameos even started.** Buildroot journald is in RAM, frameos logs are on ext4 — a frame that dies before joining the network leaves nothing a user with a card reader can inspect. New `frameos-postboot-log.service` maintains **`/boot/frameos-postboot-2min.log`**: written immediately at boot, refreshed every 20 s until uptime reaches two minutes, then one final snapshot (labelled `final … no further refreshes this boot`) and no further writes that boot. The user never has to guess how long to wait — pull power at any point and the file is at most 20 s stale within the window, or the complete final picture after it.

Contents: service states, a network snapshot (`ip`/`iw`/`wpa_cli`, running daemons, wpa_supplicant config with **secrets redacted**), size-capped journal tails, and the tail of the newest frameos file log. Wear/space design: staged in tmpfs (one FAT write per refresh, ~8 writes per boot total), overwritten in place, every section size-capped (~256 KB ceiling). `Type=exec` so the capture window never blocks `multi-user.target`.

Staged into full image builds and patched (debugfs) into images composed from older cached bases, same as the first-boot unit.

**Docs:** `docs/boot-partition.md` — every file on the boot partition, its lifecycle (placeholder → consumed → shredded), space/wear guarantees, and the pull-the-card debugging workflow.

## Verification

- Backend: 84 buildroot/postboot tests + 30 setup-json-reset tests pass; new tests cover script POSIX-ness, secret redaction, single-write staging, the refresh-then-stop cadence, unit non-blocking type, staging idempotency, and the debugfs patch lines.
- Nim: `test_setup` (incl. new no-NetworkManager gate test), `test_portal`, `test_network_backend`, `test_upgrade` all pass; `frameos.nim` compiles with the reordered startup.
- Postboot script smoke-run locally against a fake `/boot`: snapshot published immediately with the cadence header, graceful degradation when tools are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)