### PR TITLE
Server-side scene rendering for ESP32 thin clients (wasm-sandboxed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -362,6 +362,15 @@ RUN set -eux; \
       > /etc/apt/sources.list.d/docker.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends docker-ce-cli docker-buildx-plugin; \
+    # Node hosts the wasm scene runtime for ESP32 thin-client renders
+    # (backend/tools/embedded_wasm_render.mjs); without it the render
+    # endpoint falls back to the diagnostic bitmap.
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends nodejs; \
     apt-get purge -y --auto-remove curl gnupg; \
     rm -rf /var/lib/apt/lists/*
 

--- a/backend/app/api/embedded_device.py
+++ b/backend/app/api/embedded_device.py
@@ -3,9 +3,13 @@
 The microcontroller authenticates with its ``server_api_key`` as a Bearer
 token (same scheme as ``/api/log``). Device endpoints:
 
-- ``GET /api/frames/{id}/embedded/render`` — a diagnostic thin-client bitmap.
-  Normal scenes render on-device via the Nim runtime; this route gives remote
-  render mode a simple end-to-end bitmap in the panel's wire format.
+- ``GET /api/frames/{id}/embedded/render`` — the thin-client bitmap in the
+  panel's wire format. When the frame has scenes and the wasm scene runtime
+  is available (node + the emscripten bundle, see
+  ``app/utils/embedded_render.py``), the active scene renders server-side —
+  sandboxed inside wasm, no outbound network. Otherwise (or on any render
+  failure) a diagnostic card is served so the device always gets a frame.
+  Boards with PSRAM normally render on-device via the Nim runtime instead.
 - ``GET /api/frames/{id}/embedded/ota/manifest`` — sha256/size of the latest
   OTA app image so the device can decide whether to update.
 - ``GET /api/frames/{id}/embedded/ota/download`` — the OTA app image
@@ -36,6 +40,8 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.drivers.devices import device_dimensions
 from app.models.frame import Frame, get_frame_json
+from app.redis import get_redis
+from app.utils.embedded_render import render_scene_rgba
 from app.tasks.embedded_firmware import (
     FOS_PIXEL_1BPP,
     FOS_PIXEL_2BPP_BWYR,
@@ -174,8 +180,9 @@ def _pack_palette(image, palette: list[tuple[int, int, int]], bits: int) -> byte
 def render_embedded_diagnostic_bitmap(frame: Frame, width: int, height: int, pixel_format: int) -> bytes:
     """Readable diagnostic card packed in the panel format.
 
-    Real scene rendering happens on-device in local mode. This exists so
-    thin-client mode has a deterministic bitmap to fetch end to end.
+    The fallback for thin-client mode: served when the frame has no scenes
+    or the wasm scene render is unavailable/fails, so the device always has
+    a deterministic bitmap to fetch end to end.
     """
     from PIL import Image, ImageDraw
 
@@ -202,6 +209,11 @@ def render_embedded_diagnostic_bitmap(frame: Frame, width: int, height: int, pix
     draw.text((32, height * 0.50), f"Backend diagnostic bitmap - {stamp}", fill=(0, 0, 0))
     draw.text((32, height * 0.60), "Scenes render on-device in local mode", fill=(0, 0, 0))
 
+    return pack_image_for_panel(image, pixel_format)
+
+
+def pack_image_for_panel(image, pixel_format: int) -> bytes:
+    """Pack an RGB(A) PIL image into the panel's FOSB payload format."""
     if pixel_format == FOS_PIXEL_1BPP:
         return _pack_1bpp(image)
     if pixel_format == FOS_PIXEL_DUAL_1BPP_RED:
@@ -226,16 +238,53 @@ def fosb_payload(width: int, height: int, pixel_format: int, packed: bytes) -> b
     return header + packed
 
 
+async def _active_scene_id(redis, frame: Frame) -> str | None:
+    """The workspace-activated scene, when one is cached; None lets the wasm
+    runtime fall back to the scene marked default (same choice the device
+    runtime makes)."""
+    if redis is None:
+        return None
+    try:
+        value = await redis.get(f"frame:{frame.id}:active_scene")
+    except Exception:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return value or None
+
+
 @api_public.get("/frames/{id:int}/embedded/render")
 async def api_embedded_device_render(
     id: int,
     db: Session = Depends(get_db),
+    redis=Depends(get_redis),
     authorization: str = Header(None),
 ):
     frame = _embedded_frame_from_bearer(db, id, authorization)
     width, height = embedded_render_dimensions(frame)
     pixel_format = embedded_pixel_format_for_panel(embedded_panel_for_frame(frame))
-    packed = render_embedded_diagnostic_bitmap(frame, width, height, pixel_format)
+
+    # Thin-client scene render: the frame's scenes run inside the wasm scene
+    # runtime (QuickJS sandboxed in wasm, no outbound network) in a bounded
+    # Node subprocess. Any failure — no scenes, no node/wasm toolchain, scene
+    # error, timeout — falls back to the diagnostic bitmap below, so the
+    # device always gets a valid frame.
+    packed: bytes | None = None
+    rgba = await render_scene_rgba(
+        frame,
+        width,
+        height,
+        scene_id=await _active_scene_id(redis, frame),
+        settings=embedded_settings_payload(db, frame),
+    )
+    if rgba is not None:
+        from PIL import Image
+
+        image = Image.frombytes("RGBA", (width, height), rgba).convert("RGB")
+        packed = pack_image_for_panel(image, pixel_format)
+
+    if packed is None:
+        packed = render_embedded_diagnostic_bitmap(frame, width, height, pixel_format)
     expected = embedded_buffer_size(width, height, pixel_format)
     if len(packed) != expected:
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/backend/app/api/tests/test_embedded_device.py
+++ b/backend/app/api/tests/test_embedded_device.py
@@ -100,6 +100,97 @@ async def test_render_returns_spectra6_fosb_bitmap(async_client, no_auth_client,
 
 
 @pytest.mark.asyncio
+async def test_render_uses_wasm_scene_render_when_available(async_client, no_auth_client, db, monkeypatch):
+    frame = await device_frame(async_client, db)
+    frame.scenes = [{'id': 'scene-1', 'name': 'Black', 'nodes': [], 'edges': []}]
+    db.add(frame)
+    db.commit()
+
+    async def fake_render(frame_arg, width, height, **kwargs):
+        # Solid black RGBA → the 1bpp packing must come out all zeros,
+        # which the (mostly white) diagnostic card never does.
+        return bytes([0, 0, 0, 255]) * (width * height)
+
+    monkeypatch.setattr('app.api.embedded_device.render_scene_rgba', fake_render)
+
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/embedded/render', headers=auth(frame))
+    assert response.status_code == 200, response.text
+    body = response.content
+    assert body[:4] == b'FOSB'
+    payload = body[12:]
+    assert payload == b'\x00' * len(payload)
+
+
+@pytest.mark.asyncio
+async def test_render_falls_back_to_diagnostic_when_scene_render_fails(
+    async_client, no_auth_client, db, monkeypatch
+):
+    frame = await device_frame(async_client, db)
+    frame.scenes = [{'id': 'scene-1', 'name': 'Broken', 'nodes': [], 'edges': []}]
+    db.add(frame)
+    db.commit()
+
+    async def failing_render(frame_arg, width, height, **kwargs):
+        return None
+
+    monkeypatch.setattr('app.api.embedded_device.render_scene_rgba', failing_render)
+
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/embedded/render', headers=auth(frame))
+    assert response.status_code == 200, response.text
+    body = response.content
+    assert body[:4] == b'FOSB'
+    # The diagnostic card has a white background: 1bpp packing is mostly 0xFF.
+    payload = body[12:]
+    assert payload.count(0xFF) > len(payload) // 2
+
+
+@pytest.mark.asyncio
+async def test_render_end_to_end_wasm_scene(async_client, no_auth_client, db):
+    """Full path: real Node subprocess hosting the wasm scene runtime.
+
+    Runs only where the toolchain exists (node on PATH + the emscripten
+    bundle built by frameos/tools/build_wasm.sh) — CI's docker images and
+    dev checkouts that ran build_wasm.sh.
+    """
+    import json as jsonlib
+    from pathlib import Path
+
+    from app.utils.embedded_render import thin_client_renderer_available
+
+    if not thin_client_renderer_available():
+        pytest.skip('node + wasm bundle not available')
+    fixture = Path(__file__).resolve().parents[4] / 'e2e' / 'generated' / 'scenes.json'
+    if not fixture.is_file():
+        pytest.skip('e2e scenes fixture not available')
+
+    scenes = jsonlib.loads(fixture.read_text())
+    gradient = [scene for scene in scenes if scene.get('id') == 'dataGradient_interpreted']
+    assert gradient, 'expected dataGradient_interpreted in the e2e fixture'
+
+    frame = await device_frame(async_client, db)
+    frame.scenes = gradient
+    db.add(frame)
+    db.commit()
+
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/embedded/render', headers=auth(frame))
+    assert response.status_code == 200, response.text
+    body = response.content
+    assert body[:4] == b'FOSB'
+    version, pixel_format, width, height, _ = struct.unpack('<BBHHH', body[4:12])
+    assert (width, height) == (800, 480)
+    payload = body[12:]
+    assert len(payload) == (width // 8) * height
+    # A gradient dithers to a genuine mix of black and white — nothing like
+    # the diagnostic card's near-uniform white field.
+    ones = sum(bin(byte).count('1') for byte in payload[:4800])
+    total_bits = 4800 * 8
+    assert 0.05 < ones / total_bits < 0.95
+
+
+@pytest.mark.asyncio
 async def test_scenes_requires_device_auth(async_client, no_auth_client, db):
     frame = await device_frame(async_client, db)
     response = await no_auth_client.get(f'/api/frames/{frame.id}/embedded/scenes')

--- a/backend/app/utils/embedded_render.py
+++ b/backend/app/utils/embedded_render.py
@@ -1,0 +1,120 @@
+"""Server-side scene rendering for ESP32 thin clients.
+
+PSRAM-less boards (ESP32-C3: TRMNL OG/BWRY, XTEINK X4) cannot run the
+on-device renderer, so the backend renders their scenes and the device blits
+the result. The rendering happens inside the same emscripten wasm bundle the
+browser live-preview uses (frameos/tools/build_wasm.sh), hosted by a short-
+lived Node subprocess (backend/tools/embedded_wasm_render.mjs).
+
+Sandbox posture: user scene code (QuickJS) executes inside the wasm module,
+never natively on the backend. The wasm runtime has no filesystem or socket
+access; its only HTTP hook is a browser-style synchronous XHR bridge, which
+does not exist under Node — so outbound requests from scene apps fail closed.
+The subprocess itself is bounded by a wall-clock timeout and a concurrency
+cap so render storms cannot pile up Node processes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+from pathlib import Path
+
+from app.models.frame import Frame
+from app.utils.timezone import frame_timezone
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RENDER_HARNESS = REPO_ROOT / "backend" / "tools" / "embedded_wasm_render.mjs"
+RENDER_TIMEOUT_SECONDS = 30
+# Renders are CPU-bound (a full QuickJS + pixie pass); two at a time keeps a
+# fleet of polling thin clients from forking a Node per request.
+_render_semaphore = asyncio.Semaphore(2)
+
+_WASM_ASSET_DIRS = (
+    # Built by frameos/tools/build_wasm.sh (dev checkouts and the Docker
+    # app-builder stage, which lands them in frontend/dist via Vite's public/).
+    REPO_ROOT / "frontend" / "public" / "frameos-wasm",
+    REPO_ROOT / "frontend" / "dist" / "frameos-wasm",
+    # npm-package layout (frameos/wasm `npm run build`).
+    REPO_ROOT / "frameos" / "wasm" / "dist" / "assets",
+)
+
+
+def wasm_assets_dir() -> Path | None:
+    override = os.environ.get("FRAMEOS_WASM_DIR")
+    candidates = ([Path(override)] if override else []) + list(_WASM_ASSET_DIRS)
+    for candidate in candidates:
+        if (candidate / "frameos.js").is_file() and (candidate / "frameos.wasm").is_file():
+            return candidate
+    return None
+
+
+def thin_client_renderer_available() -> bool:
+    return shutil.which("node") is not None and wasm_assets_dir() is not None and RENDER_HARNESS.is_file()
+
+
+async def render_scene_rgba(
+    frame: Frame,
+    width: int,
+    height: int,
+    *,
+    scene_id: str | None = None,
+    settings: dict | None = None,
+    timeout: float = RENDER_TIMEOUT_SECONDS,
+) -> bytes | None:
+    """One frame of the scene as width*height*4 RGBA bytes, or None.
+
+    None means "no render available" (no scenes, no toolchain, render error,
+    timeout) — the caller falls back to the diagnostic bitmap. Failures are
+    expected operational states here, not exceptions: the device keeps
+    polling, and a broken scene must not take the endpoint down with it.
+    """
+    scenes = [scene for scene in (frame.scenes or []) if isinstance(scene, dict)]
+    if not scenes:
+        return None
+    node = shutil.which("node")
+    assets = wasm_assets_dir()
+    if node is None or assets is None or not RENDER_HARNESS.is_file():
+        return None
+
+    request = {
+        "assetsDir": str(assets),
+        "width": int(width),
+        "height": int(height),
+        "name": frame.name or f"frame {frame.id}",
+        "timeZone": frame_timezone(frame.timezone),
+        "settingsJson": json.dumps(settings or {}),
+        "scenesJson": json.dumps(scenes, separators=(",", ":")),
+    }
+    if scene_id:
+        request["sceneId"] = scene_id
+
+    expected = int(width) * int(height) * 4
+    async with _render_semaphore:
+        process = await asyncio.create_subprocess_exec(
+            node,
+            str(RENDER_HARNESS),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(json.dumps(request).encode("utf-8")),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            return None
+
+    if process.returncode != 0 or len(stdout) != expected:
+        detail = stderr.decode("utf-8", errors="replace").strip().splitlines()
+        tail = detail[-1] if detail else f"exit {process.returncode}"
+        # Log through print (uvicorn stdout); the device-facing endpoint has
+        # no frame log context worth spamming on every poll.
+        print(f"embedded_render: frame {frame.id} scene render failed: {tail}")
+        return None
+    return stdout

--- a/backend/tools/embedded_wasm_render.mjs
+++ b/backend/tools/embedded_wasm_render.mjs
@@ -1,0 +1,104 @@
+// Render one FrameOS scene frame to raw RGBA, headless, under Node.
+//
+// Used by the backend's ESP32 thin-client endpoint
+// (app/utils/embedded_render.py): scenes for PSRAM-less boards render here —
+// inside the same emscripten wasm runtime the browser live-preview uses —
+// instead of on the device.
+//
+// Protocol: a single JSON object on stdin
+//   {assetsDir, width, height, name, timeZone, settingsJson, scenesJson, sceneId}
+// and exactly width*height*4 bytes of RGBA on stdout on success (exit 0).
+// All logs go to stderr; any failure exits non-zero with a message there.
+//
+// Sandbox posture: user scene code (QuickJS) runs inside the wasm module.
+// The runtime's only host hooks are logging and the synchronous-XHR HTTP
+// bridge (tools/wasm/frameos_library.js) — Node has no XMLHttpRequest, so
+// every outbound request from scene apps fails closed. Keep it that way:
+// no XHR polyfill, no Module.frameosProxyUrl here. The wasm module has no
+// filesystem or socket access of its own (plain MEMFS, no NODERAWFS).
+
+import { readFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+import { join } from 'node:path'
+
+// Defense in depth: the Python parent enforces the real timeout and kills
+// us; this backstop covers a detached/orphaned harness.
+const HARD_TIMEOUT_MS = 60_000
+const killTimer = setTimeout(() => {
+  process.stderr.write('embedded_wasm_render: hard timeout\n')
+  process.exit(3)
+}, HARD_TIMEOUT_MS)
+killTimer.unref()
+
+function fail(message) {
+  process.stderr.write(`embedded_wasm_render: ${message}\n`)
+  process.exit(1)
+}
+
+async function readStdin() {
+  const chunks = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString('utf-8')
+}
+
+const request = JSON.parse(await readStdin())
+const { assetsDir, width, height } = request
+if (!assetsDir || !Number.isInteger(width) || !Number.isInteger(height)) {
+  fail('assetsDir, width and height are required')
+}
+
+const wasmBinary = await readFile(join(assetsDir, 'frameos.wasm'))
+const { default: createFrameOS } = await import(
+  pathToFileURL(join(assetsDir, 'frameos.js')).href
+)
+
+const Module = await createFrameOS({
+  wasmBinary,
+  print: (line) => process.stderr.write(`[frameos] ${line}\n`),
+  printErr: (line) => process.stderr.write(`[frameos] ${line}\n`),
+  onFrameosLog: (line) => process.stderr.write(`[scene] ${line}\n`),
+})
+
+const call = (name, ret, argTypes, args) => Module.ccall(name, ret, argTypes, args)
+const lastError = () => {
+  try {
+    return call('frameos_wasm_last_error', 'string', [], [])
+  } catch (e) {
+    return String(e)
+  }
+}
+
+// Same init sequence as the live-preview worker (wasm/dist/assets/preview-worker.js).
+const ok = call(
+  'frameos_wasm_init',
+  'boolean',
+  ['number', 'number', 'string', 'string', 'string'],
+  [width, height, request.name || 'thin client', request.timeZone || 'UTC', request.settingsJson || '{}']
+)
+if (!ok) fail(`init failed: ${lastError()}`)
+
+const loaded = call('frameos_wasm_load_scenes', 'number', ['string'], [request.scenesJson || '[]'])
+if (!loaded) fail(`no scenes loaded: ${lastError()}`)
+
+if (request.sceneId) {
+  if (!call('frameos_wasm_select_scene', 'boolean', ['string'], [request.sceneId])) {
+    fail(`scene ${request.sceneId} not found: ${lastError()}`)
+  }
+}
+
+const rc = call('frameos_wasm_render', 'number', [], [])
+const outWidth = call('frameos_wasm_width', 'number', [], [])
+const outHeight = call('frameos_wasm_height', 'number', [], [])
+const ptr = call('frameos_wasm_buffer', 'number', [], [])
+const len = call('frameos_wasm_buffer_len', 'number', [], [])
+if (rc === 2 || !ptr || !len) fail(`render failed: ${lastError()}`)
+if (len !== outWidth * outHeight * 4) {
+  fail(`unexpected buffer size ${len} for ${outWidth}x${outHeight}`)
+}
+
+process.stdout.write(Buffer.from(Module.HEAPU8.buffer, ptr, len), (err) => {
+  if (err) fail(`stdout write failed: ${err}`)
+  process.exit(0)
+})

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -478,12 +478,15 @@ constructing them. (Transitional: the generic binary is published as
 image, `…-esp32-c3-generic.bin`, targets PSRAM-less ESP32-C3 boards
 (TRMNL OG/BWRY, XTEINK X4): same panel set and provisioning surface, but
 thin-client only — no on-device renderer. Backend-managed C3 frames pull
-rendered bitmaps over the existing `/api/frames/{id}/embedded/render`
-endpoint. Cloud-managed C3 frames can enroll, report state, and take
-settings/logs verbs today, but scene rendering needs a cloud-side render
-source (a push-image verb or server-rendered pulls) — not yet implemented;
-until then a C3 frame linked to the cloud shows its provisioning/status
-screen only.
+rendered bitmaps over `/api/frames/{id}/embedded/render`: the backend runs
+the frame's scenes inside the same emscripten wasm runtime the live preview
+uses (QuickJS sandboxed in wasm, no outbound network, bounded Node
+subprocess — `backend/app/utils/embedded_render.py`), falling back to a
+diagnostic card when scenes or the toolchain are missing. Cloud-managed C3
+frames can enroll, report state, and take settings/logs verbs today, but
+cloud-side scene rendering (the same wasm approach, or a push-image verb)
+is not yet implemented; until then a C3 frame linked to the cloud shows its
+provisioning/status screen only.
 
 Concretely, the firmware exposes these as allowlisted keys on the
 existing USB serial console (`set cloud_url …`, `set claim_token …`,

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -102,7 +102,9 @@ Two chip targets build from this project:
 - **ESP32-C3**: thin-client-only firmware for PSRAM-less boards
   (`FRAMEOS_ESP32_PLATFORM=esp32-c3 ./ci_build_image.sh`, or backend builds
   for a frame whose platform is `esp32-c3`). ~380 KB of usable SRAM rules out
-  the local renderer; the backend or cloud renders and the device blits.
+  the local renderer; the backend renders the frame's scenes server-side in
+  the wasm scene runtime (`backend/app/utils/embedded_render.py`) and the
+  device blits the packed bitmap.
   Built with the 4 MB no-OTA layout so one image fits every supported C3 board.
 
 Known boards ship as hardware presets (`set hardware <preset>` on the console,

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -129,7 +129,10 @@ nim c \
     --passL:"-sMODULARIZE=1" \
     --passL:"-sEXPORT_ES6=1" \
     --passL:"-sEXPORT_NAME=createFrameOS" \
-    --passL:"-sENVIRONMENT=web,worker" \
+    `# node: the backend's thin-client renderer runs this same bundle under` \
+    `# Node (backend/tools/embedded_wasm_render.mjs); web,worker keep the` \
+    `# browser live-preview working.` \
+    --passL:"-sENVIRONMENT=web,worker,node" \
     --passL:"-sALLOW_MEMORY_GROWTH=1" \
     `# Growable memory via resizable ArrayBuffers (GROWABLE_ARRAYBUFFERS=1,` \
     `# the default) makes wasmMemory.buffer resizable, and Chrome's` \


### PR DESCRIPTION
Follow-up to #296, branched off `esp32-new-boards`.

The PSRAM-less ESP32-C3 boards added in #296 run as thin clients — but `/api/frames/{id}/embedded/render` only served a diagnostic card, so they had no real content anywhere. This PR makes the backend render the frame's actual scenes for them, sandboxed the way we want it:

## How

- The **same emscripten wasm bundle the browser live-preview uses** now also runs under Node (`-sENVIRONMENT=web,worker,node` in `build_wasm.sh`; browser behavior unchanged).
- A short-lived Node harness (`backend/tools/embedded_wasm_render.mjs`) loads the bundle, runs the live-preview worker's exact init/render sequence, and writes raw RGBA to stdout.
- `backend/app/utils/embedded_render.py` drives it with a wall-clock timeout + kill, a 2-render concurrency cap, and treats every failure as "fall back to the diagnostic card".
- The endpoint packs the RGBA through the existing per-panel packers into FOSB. Active scene = the workspace's cached selection, else the scene marked default (same rule as the device runtime).

## Security posture

- User scene code (QuickJS) executes **inside wasm**, never natively on the backend.
- **No outbound network from scenes**: the runtime's only HTTP hook is a browser sync-XHR bridge; Node has no XMLHttpRequest, so requests fail closed. No polyfill, no proxy configured. (A brokered, SSRF-safe fetch proxy can be a later opt-in.)
- No filesystem/socket access from the wasm module (plain MEMFS, no NODERAWFS).
- Bounded subprocess: parent timeout + kill, concurrency cap, and a hard self-timeout in the harness as backstop.

## Tests

- Endpoint tests: mocked scene render (verifies the scene path replaces the diagnostic) and mocked failure (verifies fallback).
- Real end-to-end test: renders the e2e gradient scene through Node + wasm to a dithered 1bpp 800×480 payload; skips where node or the wasm bundle is absent.
- `test_embedded_device.py` + `test_embedded_firmware.py`: 73 passed.

## Deployment

- Runtime Docker image gains `nodejs` (the wasm assets already ship via `frontend/dist/frameos-wasm`).
- Without node/wasm assets the endpoint degrades to the previous diagnostic-card behavior — no hard dependency.

This is also the building block for cloud-side thin-client rendering (and re-adding the C3 boards to the cloud flasher): the same harness can run in the cloud stack later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)