### PR TITLE
Virtual frames: backend-rendered frames with no hardware

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -27,6 +27,7 @@ from .cloud import *  # noqa: E402, F403
 from .cloud_backups import *  # noqa: E402, F403
 from .cloud_store import *  # noqa: E402, F403
 from .embedded_device import *  # noqa: E402, F403
+from .virtual_frame import *  # noqa: E402, F403
 from .frame_bootstrap import *  # noqa: E402, F403
 from .frames import *  # noqa: E402, F403
 from .fonts import *  # noqa: E402, F403

--- a/backend/app/api/embedded_device.py
+++ b/backend/app/api/embedded_device.py
@@ -184,6 +184,11 @@ def render_embedded_diagnostic_bitmap(frame: Frame, width: int, height: int, pix
     or the wasm scene render is unavailable/fails, so the device always has
     a deterministic bitmap to fetch end to end.
     """
+    return pack_image_for_panel(embedded_diagnostic_image(frame, width, height), pixel_format)
+
+
+def embedded_diagnostic_image(frame: Frame, width: int, height: int):
+    """The diagnostic card as a PIL RGB image (also used by virtual frames)."""
     from PIL import Image, ImageDraw
 
     image = Image.new("RGB", (width, height), (255, 255, 255))
@@ -209,7 +214,7 @@ def render_embedded_diagnostic_bitmap(frame: Frame, width: int, height: int, pix
     draw.text((32, height * 0.50), f"Backend diagnostic bitmap - {stamp}", fill=(0, 0, 0))
     draw.text((32, height * 0.60), "Scenes render on-device in local mode", fill=(0, 0, 0))
 
-    return pack_image_for_panel(image, pixel_format)
+    return image
 
 
 def pack_image_for_panel(image, pixel_format: int) -> bytes:

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -134,6 +134,7 @@ from app.tasks.embedded_firmware import (
     embedded_ota_supported_for_frame,
     embedded_toolchain_available,
     latest_embedded_firmware,
+    embedded_platform_spec_for_frame,
     normalize_embedded_platform,
     refresh_embedded_firmware_status,
     request_or_queue_embedded_firmware_ota,
@@ -2021,6 +2022,20 @@ async def api_frame_get_image(
 
     cache_key = _frame_image_cache_key(frame.id)
     path = "/image"
+
+    # Virtual frames have no device to fetch from: render server-side (the
+    # same wasm path their public URLs use) instead of proxying to a
+    # nonexistent host.
+    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+        from .virtual_frame import render_virtual_frame_png
+
+        png = await render_virtual_frame_png(db, redis, frame)
+        await _store_frame_image(db, redis, frame, png, scene_id=None, publish_rendered=False)
+        return Response(
+            content=png,
+            media_type="image/png",
+            headers=await read_frame_sync_hint_headers(redis, frame.id),
+        )
 
     if request.method == "HEAD":
         headers = await read_frame_sync_hint_headers(redis, frame.id)

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -2747,9 +2747,10 @@ async def api_frame_deploy_event(
     # Deploying a virtual frame IS rendering it: there is no device, no
     # firmware, nothing to copy — render into the image cache and succeed.
     if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
-        from .virtual_frame import refresh_virtual_frame_image
+        from .virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
 
         await refresh_virtual_frame_image(db, redis, frame)
+        await mark_virtual_frame_deployed(db, redis, frame)
         await log(db, redis, id, "stdout", "Virtual frame rendered (deploy = render)")
         return {"message": "Success", "taskId": deploy_task_id}
     try:
@@ -3129,9 +3130,10 @@ async def api_frame_fast_deploy_event(
     # Virtual frames: "update active scenes" is just a render — the renderer
     # always reads the saved scenes, nothing needs shipping anywhere.
     if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
-        from .virtual_frame import refresh_virtual_frame_image
+        from .virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
 
         await refresh_virtual_frame_image(db, redis, frame)
+        await mark_virtual_frame_deployed(db, redis, frame)
         return {"message": "Success", "taskId": deploy_task_id}
     try:
         from app.tasks import fast_deploy_frame

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -1370,6 +1370,18 @@ async def api_frame_event(
         scenes, body = _normalize_upload_scenes_payload(body)
         scene_id = body.get("sceneId")
         _validate_upload_scenes_payload(scenes, scene_id)
+    # Virtual frames have no device to forward to: every event reduces to
+    # "note the scene choice, render the image, done".
+    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+        from .virtual_frame import refresh_virtual_frame_image
+
+        scene_id = body.get("sceneId") if isinstance(body, dict) else None
+        if event in {"setCurrentScene", "setSceneState", "uploadScenes"}:
+            await _mark_frame_states_cache_stale(
+                redis, frame, scene_id=scene_id if isinstance(scene_id, str) else None
+            )
+        await refresh_virtual_frame_image(db, redis, frame)
+        return "OK"
     try:
         await _forward_frame_request(
             frame, redis, path=f"/event/{event}", method="POST", json_body=body
@@ -2727,6 +2739,14 @@ async def api_frame_deploy_event(
 ):
     frame = _project_frame(db, id) or _not_found()
     deploy_task_id = _task_id_param(task_id)
+    # Deploying a virtual frame IS rendering it: there is no device, no
+    # firmware, nothing to copy — render into the image cache and succeed.
+    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+        from .virtual_frame import refresh_virtual_frame_image
+
+        await refresh_virtual_frame_image(db, redis, frame)
+        await log(db, redis, id, "stdout", "Virtual frame rendered (deploy = render)")
+        return {"message": "Success", "taskId": deploy_task_id}
     try:
         from app.tasks import deploy_frame
         from app.tasks.deploy_frame import cancel_active_deploy

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -2044,12 +2044,18 @@ async def api_frame_get_image(
     # same wasm path their public URLs use) instead of proxying to a
     # nonexistent host.
     if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
-        from .virtual_frame import render_virtual_frame_png
+        # Serve the cached image; render only when there is none. Rendering
+        # on every poll made the preview flash "rendering" continuously —
+        # fresh frames come from deploy/activate/render events, which
+        # publish straight into this cache.
+        cached = await _get_cached_frame_image(redis, cache_key)
+        if cached is None:
+            from .virtual_frame import render_virtual_frame_png
 
-        png = await render_virtual_frame_png(db, redis, frame)
-        await _store_frame_image(db, redis, frame, png, scene_id=None, publish_rendered=False)
+            cached = await render_virtual_frame_png(db, redis, frame)
+            await _store_frame_image(db, redis, frame, cached, scene_id=None, publish_rendered=False)
         return Response(
-            content=png,
+            content=cached,
             media_type="image/png",
             headers=await read_frame_sync_hint_headers(redis, frame.id),
         )

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -1366,6 +1366,7 @@ async def api_frame_event(
         if request.headers.get("content-type") == "application/json"
         else request.body()
     )
+    scenes = None
     if event == "uploadScenes":
         scenes, body = _normalize_upload_scenes_payload(body)
         scene_id = body.get("sceneId")
@@ -1376,11 +1377,15 @@ async def api_frame_event(
         from .virtual_frame import refresh_virtual_frame_image
 
         scene_id = body.get("sceneId") if isinstance(body, dict) else None
+        scene_id = scene_id if isinstance(scene_id, str) else None
         if event in {"setCurrentScene", "setSceneState", "uploadScenes"}:
-            await _mark_frame_states_cache_stale(
-                redis, frame, scene_id=scene_id if isinstance(scene_id, str) else None
-            )
-        await refresh_virtual_frame_image(db, redis, frame)
+            await _mark_frame_states_cache_stale(redis, frame, scene_id=scene_id)
+        # uploadScenes = preview-on-frame: render the posted (possibly
+        # unsaved) scenes without persisting them.
+        upload = scenes if event == "uploadScenes" else None
+        await refresh_virtual_frame_image(
+            db, redis, frame, scenes_override=upload, scene_id=scene_id
+        )
         return "OK"
     try:
         await _forward_frame_request(
@@ -3121,6 +3126,13 @@ async def api_frame_fast_deploy_event(
 ):
     frame = _project_frame(db, id) or _not_found()
     deploy_task_id = _task_id_param(task_id)
+    # Virtual frames: "update active scenes" is just a render — the renderer
+    # always reads the saved scenes, nothing needs shipping anywhere.
+    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+        from .virtual_frame import refresh_virtual_frame_image
+
+        await refresh_virtual_frame_image(db, redis, frame)
+        return {"message": "Success", "taskId": deploy_task_id}
     try:
         from app.tasks import fast_deploy_frame
         from app.tasks.deploy_frame import cancel_active_deploy

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -2750,15 +2750,6 @@ async def api_frame_deploy_event(
 ):
     frame = _project_frame(db, id) or _not_found()
     deploy_task_id = _task_id_param(task_id)
-    # Deploying a virtual frame IS rendering it: there is no device, no
-    # firmware, nothing to copy — render into the image cache and succeed.
-    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
-        from .virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
-
-        await refresh_virtual_frame_image(db, redis, frame)
-        await mark_virtual_frame_deployed(db, redis, frame)
-        await log(db, redis, id, "stdout", "Virtual frame rendered (deploy = render)")
-        return {"message": "Success", "taskId": deploy_task_id}
     try:
         from app.tasks import deploy_frame
         from app.tasks.deploy_frame import cancel_active_deploy
@@ -3133,14 +3124,6 @@ async def api_frame_fast_deploy_event(
 ):
     frame = _project_frame(db, id) or _not_found()
     deploy_task_id = _task_id_param(task_id)
-    # Virtual frames: "update active scenes" is just a render — the renderer
-    # always reads the saved scenes, nothing needs shipping anywhere.
-    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
-        from .virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
-
-        await refresh_virtual_frame_image(db, redis, frame)
-        await mark_virtual_frame_deployed(db, redis, frame)
-        return {"message": "Success", "taskId": deploy_task_id}
     try:
         from app.tasks import fast_deploy_frame
         from app.tasks.deploy_frame import cancel_active_deploy

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -2053,7 +2053,11 @@ async def api_frame_get_image(
             from .virtual_frame import render_virtual_frame_png
 
             cached = await render_virtual_frame_png(db, redis, frame)
-            await _store_frame_image(db, redis, frame, cached, scene_id=None, publish_rendered=False)
+            active_scene = await _active_scene_id_from_cache(redis, frame.id)
+            await _store_frame_image(
+                db, redis, frame, cached,
+                scene_id=active_scene or None, publish_rendered=False,
+            )
         return Response(
             content=cached,
             media_type="image/png",

--- a/backend/app/api/tests/test_virtual_frame.py
+++ b/backend/app/api/tests/test_virtual_frame.py
@@ -47,7 +47,7 @@ async def test_virtual_image_rejected_for_hardware_frames(async_client, no_auth_
     db.commit()
 
     response = await no_auth_client.get(
-        f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}')
+        f'/api/frames/{frame.id}/virtual/image?k=any-token')
     assert response.status_code == 400
 
 
@@ -59,7 +59,7 @@ async def test_virtual_image_serves_png_at_configured_size(async_client, no_auth
 
     frame = await create_virtual_frame(async_client, db)
     response = await no_auth_client.get(
-        f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}')
+        f'/api/frames/{frame.id}/virtual/image?k={frame.device_config["viewToken"]}')
     assert response.status_code == 200, response.text
     assert response.headers['content-type'] == 'image/png'
     assert response.headers['cache-control'] == 'no-store'
@@ -79,7 +79,7 @@ async def test_virtual_image_bw_color_mode(async_client, no_auth_client, db):
     db.commit()
 
     response = await no_auth_client.get(
-        f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}')
+        f'/api/frames/{frame.id}/virtual/image?k={frame.device_config["viewToken"]}')
     assert response.status_code == 200
     image = Image.open(io.BytesIO(response.content)).convert('RGB')
     colors = image.getcolors(maxcolors=16)
@@ -96,10 +96,10 @@ async def test_virtual_page_embeds_image_and_interval(async_client, no_auth_clie
     db.commit()
 
     response = await no_auth_client.get(
-        f'/api/frames/{frame.id}/virtual/page?k={frame.server_api_key}')
+        f'/api/frames/{frame.id}/virtual/page?k={frame.device_config["viewToken"]}')
     assert response.status_code == 200
     body = response.text
-    assert f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}' in body
+    assert f'/api/frames/{frame.id}/virtual/image?k={frame.device_config["viewToken"]}' in body
     assert '60000' in body  # refresh interval in ms
 
 

--- a/backend/app/api/tests/test_virtual_frame.py
+++ b/backend/app/api/tests/test_virtual_frame.py
@@ -1,0 +1,110 @@
+import pytest
+
+from app.models.frame import Frame
+from app.tasks.embedded_firmware import ensure_embedded_frame_defaults
+
+
+async def create_virtual_frame(async_client, db) -> Frame:
+    response = await async_client.post('/api/frames/new', json={
+        'name': 'Virtual Frame',
+        'frame_host': '',
+        'server_host': 'localhost',
+        'mode': 'embedded',
+        'platform': 'virtual',
+    })
+    assert response.status_code == 200, response.text
+    frame = db.get(Frame, response.json()['frame']['id'])
+    ensure_embedded_frame_defaults(frame, 'virtual')
+    frame.width = 320
+    frame.height = 240
+    db.add(frame)
+    db.commit()
+    assert frame.server_api_key
+    return frame
+
+
+@pytest.mark.asyncio
+async def test_virtual_image_requires_token(async_client, no_auth_client, db):
+    frame = await create_virtual_frame(async_client, db)
+    response = await no_auth_client.get(f'/api/frames/{frame.id}/virtual/image')
+    assert response.status_code == 401
+    response = await no_auth_client.get(f'/api/frames/{frame.id}/virtual/image?k=wrong')
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_virtual_image_rejected_for_hardware_frames(async_client, no_auth_client, db):
+    response = await async_client.post('/api/frames/new', json={
+        'name': 'ESP32 Frame',
+        'frame_host': '',
+        'server_host': 'localhost',
+        'mode': 'embedded',
+        'platform': 'esp32-s3',
+    })
+    frame = db.get(Frame, response.json()['frame']['id'])
+    ensure_embedded_frame_defaults(frame)
+    db.add(frame)
+    db.commit()
+
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}')
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_virtual_image_serves_png_at_configured_size(async_client, no_auth_client, db):
+    import io
+
+    from PIL import Image
+
+    frame = await create_virtual_frame(async_client, db)
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}')
+    assert response.status_code == 200, response.text
+    assert response.headers['content-type'] == 'image/png'
+    assert response.headers['cache-control'] == 'no-store'
+    image = Image.open(io.BytesIO(response.content))
+    assert image.size == (320, 240)
+
+
+@pytest.mark.asyncio
+async def test_virtual_image_bw_color_mode(async_client, no_auth_client, db):
+    import io
+
+    from PIL import Image
+
+    frame = await create_virtual_frame(async_client, db)
+    frame.device_config = {**(frame.device_config or {}), 'colorMode': 'bw'}
+    db.add(frame)
+    db.commit()
+
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}')
+    assert response.status_code == 200
+    image = Image.open(io.BytesIO(response.content)).convert('RGB')
+    colors = image.getcolors(maxcolors=16)
+    assert colors is not None  # quantized to a handful of colors
+    for _count, color in colors:
+        assert color in ((0, 0, 0), (255, 255, 255))
+
+
+@pytest.mark.asyncio
+async def test_virtual_page_embeds_image_and_interval(async_client, no_auth_client, db):
+    frame = await create_virtual_frame(async_client, db)
+    frame.interval = 60
+    db.add(frame)
+    db.commit()
+
+    response = await no_auth_client.get(
+        f'/api/frames/{frame.id}/virtual/page?k={frame.server_api_key}')
+    assert response.status_code == 200
+    body = response.text
+    assert f'/api/frames/{frame.id}/virtual/image?k={frame.server_api_key}' in body
+    assert '60000' in body  # refresh interval in ms
+
+
+@pytest.mark.asyncio
+async def test_virtual_frame_defaults(async_client, db):
+    frame = await create_virtual_frame(async_client, db)
+    assert frame.device == 'virtual'
+    assert frame.embedded['platform'] == 'virtual'

--- a/backend/app/api/tests/test_virtual_frame.py
+++ b/backend/app/api/tests/test_virtual_frame.py
@@ -108,3 +108,36 @@ async def test_virtual_frame_defaults(async_client, db):
     frame = await create_virtual_frame(async_client, db)
     assert frame.device == 'virtual'
     assert frame.embedded['platform'] == 'virtual'
+
+
+@pytest.mark.asyncio
+async def test_virtual_deploy_renders_and_succeeds(async_client, db, redis):
+    frame = await create_virtual_frame(async_client, db)
+    response = await async_client.post(f'/api/frames/{frame.id}/deploy')
+    assert response.status_code == 200, response.text
+    assert response.json()['message'] == 'Success'
+
+
+@pytest.mark.asyncio
+async def test_virtual_set_current_scene_event(async_client, db, redis):
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [
+        {'id': 'scene-a', 'name': 'A', 'nodes': [], 'edges': []},
+        {'id': 'scene-b', 'name': 'B', 'nodes': [], 'edges': []},
+    ]
+    db.add(frame)
+    db.commit()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/event/setCurrentScene',
+        json={'sceneId': 'scene-b'},
+        headers={'content-type': 'application/json'})
+    assert response.status_code == 200, response.text
+    assert await redis.get(f'frame:{frame.id}:active_scene') in (b'scene-b', 'scene-b')
+
+
+@pytest.mark.asyncio
+async def test_virtual_render_event(async_client, db, redis):
+    frame = await create_virtual_frame(async_client, db)
+    response = await async_client.post(f'/api/frames/{frame.id}/event/render')
+    assert response.status_code == 200, response.text

--- a/backend/app/api/tests/test_virtual_frame.py
+++ b/backend/app/api/tests/test_virtual_frame.py
@@ -141,3 +141,31 @@ async def test_virtual_render_event(async_client, db, redis):
     frame = await create_virtual_frame(async_client, db)
     response = await async_client.post(f'/api/frames/{frame.id}/event/render')
     assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+async def test_virtual_activation_persists_scene_image(async_client, db, redis):
+    from app.models.scene_image import SceneImage
+
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [
+        {'id': 'scene-a', 'name': 'A', 'nodes': [], 'edges': []},
+        {'id': 'scene-b', 'name': 'B', 'nodes': [], 'edges': []},
+    ]
+    db.add(frame)
+    db.commit()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/event/setCurrentScene',
+        json={'sceneId': 'scene-b'},
+        headers={'content-type': 'application/json'})
+    assert response.status_code == 200, response.text
+
+    row = db.query(SceneImage).filter_by(frame_id=frame.id, scene_id='scene-b').first()
+    assert row is not None, "SceneImage row should persist for the activated scene"
+    assert row.image and row.width == 320
+
+    # And the UI's reload path serves it.
+    response = await async_client.get(f'/api/frames/{frame.id}/scene_images/scene-b')
+    assert response.status_code == 200, response.text
+    assert response.headers['content-type'].startswith('image/')

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -145,6 +145,27 @@ async def render_virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
     return await _virtual_frame_png(db, redis, frame)
 
 
+async def mark_virtual_frame_deployed(db: Session, redis, frame: Frame) -> None:
+    """Record a successful 'deploy' so the workspace stops showing the frame
+    as waiting-for-first-deploy: for a virtual frame, rendering IS deploying.
+    Mirrors what the USB deploy completion records for embedded frames."""
+    from datetime import datetime, timezone
+
+    from app.models.frame import update_frame
+    from app.utils.versions import current_frameos_version
+
+    snapshot = frame.to_dict()
+    snapshot.pop("last_successful_deploy", None)
+    snapshot.pop("last_successful_deploy_at", None)
+    version = current_frameos_version()
+    if isinstance(version, str) and version:
+        snapshot["frameos_version"] = version
+    frame.status = "ready"
+    frame.last_successful_deploy = snapshot
+    frame.last_successful_deploy_at = datetime.now(timezone.utc)
+    await update_frame(db, redis, frame)
+
+
 async def refresh_virtual_frame_image(
     db: Session,
     redis,

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -1,0 +1,180 @@
+"""Virtual frames: a backend-rendered frame with no hardware at all.
+
+A frame whose platform is ``virtual`` renders exactly like the thin-client
+boards — scenes run in the sandboxed wasm runtime server-side — but the
+output is served as an image URL instead of a panel payload, for browser
+kiosks, old tablets, digital-signage players, or anything else that can
+show a picture. Self-hosted backends only.
+
+- ``GET /api/frames/{id}/virtual/image?k=<server_api_key>`` — one PNG frame
+  at the frame's configured size, optionally quantized to an e-ink-style
+  palette (``device_config.colorMode``).
+- ``GET /api/frames/{id}/virtual/page?k=<server_api_key>`` — a black
+  full-screen HTML page that shows the image and refreshes it on the
+  frame's interval. Paste into any kiosk browser and walk away.
+
+The token is the frame's ``server_api_key`` — the same device credential
+the hardware thin clients present as a Bearer header, carried in the query
+string because kiosk browsers cannot set headers. Treat the URL like a
+password; rotating the frame's server API key invalidates it.
+"""
+
+from __future__ import annotations
+
+import io
+from http import HTTPStatus
+
+from fastapi import Depends, HTTPException, Query
+from fastapi.responses import HTMLResponse, Response
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.frame import Frame
+from app.redis import get_redis
+from app.tasks.embedded_firmware import embedded_platform_spec_for_frame
+from app.utils.embedded_render import render_scene_rgba
+
+from . import api_public
+from .embedded_device import (
+    BWYR_PALETTE,
+    SEVEN_COLOR_PALETTE,
+    SPECTRA6_PALETTE,
+    _active_scene_id,
+    _nearest_palette_index,
+    embedded_diagnostic_image,
+    embedded_settings_payload,
+)
+
+VIRTUAL_DEFAULT_WIDTH = 800
+VIRTUAL_DEFAULT_HEIGHT = 480
+VIRTUAL_MIN_DIMENSION = 16
+VIRTUAL_MAX_DIMENSION = 4096
+
+# device_config.colorMode → how the rendered RGB image is quantized before
+# encoding, to preview/e-ink-match the look of a physical panel.
+VIRTUAL_COLOR_MODES = ("rgb", "bw", "gray4", "bwyr", "sevencolor", "spectra6")
+
+
+def _virtual_frame(db: Session, frame_id: int, token: str | None) -> Frame:
+    if not token:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Missing token")
+    frame = db.query(Frame).filter_by(server_api_key=token).first()
+    if not frame or int(frame.id) != frame_id:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized")
+    if embedded_platform_spec_for_frame(frame)["family"] != "virtual":
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Not a virtual frame")
+    return frame
+
+
+def virtual_frame_dimensions(frame: Frame) -> tuple[int, int]:
+    def clamp(value, fallback):
+        if not isinstance(value, int) or isinstance(value, bool):
+            return fallback
+        return max(VIRTUAL_MIN_DIMENSION, min(VIRTUAL_MAX_DIMENSION, value))
+
+    return clamp(frame.width, VIRTUAL_DEFAULT_WIDTH), clamp(frame.height, VIRTUAL_DEFAULT_HEIGHT)
+
+
+def virtual_color_mode(frame: Frame) -> str:
+    device_config = frame.device_config if isinstance(frame.device_config, dict) else {}
+    mode = str(device_config.get("colorMode") or "rgb").strip().lower()
+    return mode if mode in VIRTUAL_COLOR_MODES else "rgb"
+
+
+def _quantize(image, mode: str):
+    if mode == "rgb":
+        return image
+    if mode == "bw":
+        return image.convert("1").convert("RGB")
+    if mode == "gray4":
+        gray = image.convert("L")
+        return gray.point(lambda v: round(v * 3 / 255) * 85).convert("RGB")
+    palette = {
+        "bwyr": [p for p in BWYR_PALETTE],
+        "sevencolor": [p for p in SEVEN_COLOR_PALETTE],
+        # Palette index 4 is the "missing" Spectra slot; filter the sentinel.
+        "spectra6": [p for p in SPECTRA6_PALETTE if p[0] <= 255],
+    }[mode]
+    rgb = image.convert("RGB")
+    out = rgb.copy()
+    pixels = out.load()
+    source = rgb.load()
+    for y in range(rgb.height):
+        for x in range(rgb.width):
+            pixels[x, y] = palette[_nearest_palette_index(source[x, y], palette)]
+    return out
+
+
+async def _virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
+    from PIL import Image
+
+    width, height = virtual_frame_dimensions(frame)
+    rgba = await render_scene_rgba(
+        frame,
+        width,
+        height,
+        scene_id=await _active_scene_id(redis, frame),
+        settings=embedded_settings_payload(db, frame),
+    )
+    if rgba is not None:
+        image = Image.frombytes("RGBA", (width, height), rgba).convert("RGB")
+    else:
+        image = embedded_diagnostic_image(frame, width, height)
+    image = _quantize(image, virtual_color_mode(frame))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@api_public.get("/frames/{id:int}/virtual/image")
+async def api_virtual_frame_image(
+    id: int,
+    k: str = Query(None),
+    db: Session = Depends(get_db),
+    redis=Depends(get_redis),
+):
+    frame = _virtual_frame(db, id, k)
+    png = await _virtual_frame_png(db, redis, frame)
+    return Response(
+        content=png,
+        media_type="image/png",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@api_public.get("/frames/{id:int}/virtual/page")
+async def api_virtual_frame_page(
+    id: int,
+    k: str = Query(None),
+    db: Session = Depends(get_db),
+    redis=Depends(get_redis),
+):
+    frame = _virtual_frame(db, id, k)
+    interval = frame.interval if isinstance(frame.interval, (int, float)) else 300
+    interval = max(15, int(interval or 300))
+    width, height = virtual_frame_dimensions(frame)
+    # The page never embeds the key in rendered text, only in the image URL
+    # it already arrived with; JS swaps the image in place so e-ink-style
+    # updates do not flash white on kiosk browsers.
+    html = f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>{(frame.name or f"Frame {frame.id}")}</title>
+<style>
+  html, body {{ margin: 0; height: 100%; background: #000; }}
+  body {{ display: flex; align-items: center; justify-content: center; }}
+  img {{ max-width: 100vw; max-height: 100vh; object-fit: contain;
+        image-rendering: auto; }}
+</style></head>
+<body>
+<img id="frame" width="{width}" height="{height}"
+     src="/api/frames/{frame.id}/virtual/image?k={k}" alt="">
+<script>
+  const img = document.getElementById('frame');
+  const base = img.src;
+  setInterval(() => {{
+    const next = new Image();
+    next.onload = () => {{ img.src = next.src; }};
+    next.src = base + '&t=' + Date.now();
+  }}, {interval * 1000});
+</script>
+</body></html>"""
+    return HTMLResponse(content=html, headers={"Cache-Control": "no-store"})

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -111,7 +111,14 @@ def _quantize(image, mode: str):
     return out
 
 
-async def _virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
+async def _virtual_frame_png(
+    db: Session,
+    redis,
+    frame: Frame,
+    *,
+    scenes_override: list | None = None,
+    scene_id_override: str | None = None,
+) -> bytes:
     from PIL import Image
 
     width, height = virtual_frame_dimensions(frame)
@@ -119,8 +126,9 @@ async def _virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
         frame,
         width,
         height,
-        scene_id=await _active_scene_id(redis, frame),
+        scene_id=scene_id_override or await _active_scene_id(redis, frame),
         settings=embedded_settings_payload(db, frame),
+        scenes_override=scenes_override,
     )
     if rgba is not None:
         image = Image.frombytes("RGBA", (width, height), rgba).convert("RGB")
@@ -137,16 +145,27 @@ async def render_virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
     return await _virtual_frame_png(db, redis, frame)
 
 
-async def refresh_virtual_frame_image(db: Session, redis, frame: Frame) -> None:
+async def refresh_virtual_frame_image(
+    db: Session,
+    redis,
+    frame: Frame,
+    *,
+    scenes_override: list | None = None,
+    scene_id: str | None = None,
+) -> None:
     """Render now and publish into the frame image cache.
 
     The virtual equivalent of "the device rendered": deploy, scene
-    activation and render-now events all reduce to this.
+    activation, render-now and scene previews all reduce to this.
+    ``scenes_override`` renders unsaved scenes (preview-on-frame) without
+    persisting them.
     """
     from .frames import _store_frame_image
 
-    png = await _virtual_frame_png(db, redis, frame)
-    await _store_frame_image(db, redis, frame, png, scene_id=None, publish_rendered=True)
+    png = await _virtual_frame_png(
+        db, redis, frame, scenes_override=scenes_override, scene_id_override=scene_id
+    )
+    await _store_frame_image(db, redis, frame, png, scene_id=scene_id, publish_rendered=True)
 
 
 @api_public.get("/frames/{id:int}/virtual/image")

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -184,12 +184,28 @@ async def refresh_virtual_frame_image(
     ``scenes_override`` renders unsaved scenes (preview-on-frame) without
     persisting them.
     """
+    import time
+
+    from app.models.log import new_log as log
+
     from .frames import _store_frame_image
 
+    started = time.monotonic()
     png = await _virtual_frame_png(
         db, redis, frame, scenes_override=scenes_override, scene_id_override=scene_id
     )
     await _store_frame_image(db, redis, frame, png, scene_id=scene_id, publish_rendered=True)
+
+    width, height = virtual_frame_dimensions(frame)
+    shown_scene = scene_id or await _active_scene_id(redis, frame)
+    source = scenes_override if scenes_override is not None else frame.scenes
+    names = {s.get("id"): s.get("name") for s in (source or []) if isinstance(s, dict)}
+    label = names.get(shown_scene) or shown_scene or (next(iter(names.values()), None)) or "default scene"
+    await log(
+        db, redis, int(frame.id), "stdout",
+        f'Rendered "{label}"{" (preview)" if scenes_override is not None else ""} '
+        f'{width}x{height} in {int((time.monotonic() - started) * 1000)} ms',
+    )
 
 
 @api_public.get("/frames/{id:int}/virtual/image")

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -184,28 +184,40 @@ async def refresh_virtual_frame_image(
     ``scenes_override`` renders unsaved scenes (preview-on-frame) without
     persisting them.
     """
+    import json
     import time
 
     from app.models.log import new_log as log
 
     from .frames import _store_frame_image
 
+    width, height = virtual_frame_dimensions(frame)
+    shown_scene = scene_id or await _active_scene_id(redis, frame)
+    source = scenes_override if scenes_override is not None else frame.scenes
+    scene_ids = [s.get("id") for s in (source or []) if isinstance(s, dict)]
+    if not shown_scene and scene_ids:
+        shown_scene = scene_ids[0]
+
+    # Same structured event lines a physical frame's runtime emits, so the
+    # workspace log views and status indicators treat virtual renders
+    # exactly like device renders.
+    await log(db, redis, int(frame.id), "webhook", json.dumps({
+        "event": "render:scene",
+        "sceneId": shown_scene,
+        "width": width,
+        "height": height,
+        **({"preview": True} if scenes_override is not None else {}),
+    }, separators=(",", ":")))
     started = time.monotonic()
     png = await _virtual_frame_png(
         db, redis, frame, scenes_override=scenes_override, scene_id_override=scene_id
     )
     await _store_frame_image(db, redis, frame, png, scene_id=scene_id, publish_rendered=True)
-
-    width, height = virtual_frame_dimensions(frame)
-    shown_scene = scene_id or await _active_scene_id(redis, frame)
-    source = scenes_override if scenes_override is not None else frame.scenes
-    names = {s.get("id"): s.get("name") for s in (source or []) if isinstance(s, dict)}
-    label = names.get(shown_scene) or shown_scene or (next(iter(names.values()), None)) or "default scene"
-    await log(
-        db, redis, int(frame.id), "stdout",
-        f'Rendered "{label}"{" (preview)" if scenes_override is not None else ""} '
-        f'{width}x{height} in {int((time.monotonic() - started) * 1000)} ms',
-    )
+    await log(db, redis, int(frame.id), "webhook", json.dumps({
+        "event": "render:done",
+        "sceneId": shown_scene,
+        "ms": round((time.monotonic() - started) * 1000, 1),
+    }, separators=(",", ":")))
 
 
 @api_public.get("/frames/{id:int}/virtual/image")

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -58,11 +58,17 @@ VIRTUAL_COLOR_MODES = ("rgb", "bw", "gray4", "bwyr", "sevencolor", "spectra6")
 def _virtual_frame(db: Session, frame_id: int, token: str | None) -> Frame:
     if not token:
         raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Missing token")
-    frame = db.query(Frame).filter_by(server_api_key=token).first()
-    if not frame or int(frame.id) != frame_id:
+    frame = db.get(Frame, frame_id)
+    if frame is None:
         raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized")
     if embedded_platform_spec_for_frame(frame)["family"] != "virtual":
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Not a virtual frame")
+    # View-only credential: grants exactly "see the rendered frame", never the
+    # device API surface. Rotate by regenerating device_config.viewToken.
+    device_config = frame.device_config if isinstance(frame.device_config, dict) else {}
+    view_token = device_config.get("viewToken")
+    if not isinstance(view_token, str) or not view_token or token != view_token:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized")
     return frame
 
 
@@ -124,6 +130,11 @@ async def _virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
     return buffer.getvalue()
+
+
+async def render_virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
+    """Public entry for other endpoints (workspace image previews)."""
+    return await _virtual_frame_png(db, redis, frame)
 
 
 @api_public.get("/frames/{id:int}/virtual/image")

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -212,7 +212,9 @@ async def refresh_virtual_frame_image(
     png = await _virtual_frame_png(
         db, redis, frame, scenes_override=scenes_override, scene_id_override=scene_id
     )
-    await _store_frame_image(db, redis, frame, png, scene_id=scene_id, publish_rendered=True)
+    # Store under the scene that was actually shown so the per-scene
+    # snapshot lands in the SceneImage table and survives restarts.
+    await _store_frame_image(db, redis, frame, png, scene_id=shown_scene, publish_rendered=True)
     await log(db, redis, int(frame.id), "webhook", json.dumps({
         "event": "render:done",
         "sceneId": shown_scene,

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -88,27 +88,30 @@ def virtual_color_mode(frame: Frame) -> str:
 
 
 def _quantize(image, mode: str):
+    from PIL import Image
+
     if mode == "rgb":
         return image
     if mode == "bw":
+        # convert("1") applies Floyd-Steinberg by default.
         return image.convert("1").convert("RGB")
     if mode == "gray4":
-        gray = image.convert("L")
-        return gray.point(lambda v: round(v * 3 / 255) * 85).convert("RGB")
-    palette = {
-        "bwyr": [p for p in BWYR_PALETTE],
-        "sevencolor": [p for p in SEVEN_COLOR_PALETTE],
-        # Palette index 4 is the "missing" Spectra slot; filter the sentinel.
-        "spectra6": [p for p in SPECTRA6_PALETTE if p[0] <= 255],
-    }[mode]
-    rgb = image.convert("RGB")
-    out = rgb.copy()
-    pixels = out.load()
-    source = rgb.load()
-    for y in range(rgb.height):
-        for x in range(rgb.width):
-            pixels[x, y] = palette[_nearest_palette_index(source[x, y], palette)]
-    return out
+        palette = [(v, v, v) for v in (0, 85, 170, 255)]
+    else:
+        palette = {
+            "bwyr": list(BWYR_PALETTE),
+            "sevencolor": list(SEVEN_COLOR_PALETTE),
+            # Palette index 4 is the "missing" Spectra slot; filter the sentinel.
+            "spectra6": [p for p in SPECTRA6_PALETTE if p[0] <= 255],
+        }[mode]
+    # Floyd-Steinberg dither against the panel palette — nearest-color alone
+    # looks terrible on photographic content.
+    palette_image = Image.new("P", (1, 1))
+    flat = [channel for color in palette for channel in color]
+    palette_image.putpalette(flat + flat[:3] * (256 - len(palette)))
+    return image.convert("RGB").quantize(
+        palette=palette_image, dither=Image.Dither.FLOYDSTEINBERG
+    ).convert("RGB")
 
 
 async def _virtual_frame_png(

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -137,6 +137,18 @@ async def render_virtual_frame_png(db: Session, redis, frame: Frame) -> bytes:
     return await _virtual_frame_png(db, redis, frame)
 
 
+async def refresh_virtual_frame_image(db: Session, redis, frame: Frame) -> None:
+    """Render now and publish into the frame image cache.
+
+    The virtual equivalent of "the device rendered": deploy, scene
+    activation and render-now events all reduce to this.
+    """
+    from .frames import _store_frame_image
+
+    png = await _virtual_frame_png(db, redis, frame)
+    await _store_frame_image(db, redis, frame, png, scene_id=None, publish_rendered=True)
+
+
 @api_public.get("/frames/{id:int}/virtual/image")
 async def api_virtual_frame_image(
     id: int,

--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -103,6 +103,20 @@ async def deploy_frame_task(ctx: dict[str, Any], id: int, task_id: str | None = 
     if not frame:
         raise Exception("Frame not found")
 
+    # Virtual frames: deploying IS rendering — no SSH, no device, ever.
+    # Belt-and-braces with the endpoint gates: this catches every enqueue path.
+    from app.tasks.embedded_firmware import embedded_platform_spec_for_frame
+
+    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+        from app.api.virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
+
+        await refresh_virtual_frame_image(db, redis, frame)
+        await mark_virtual_frame_deployed(db, redis, frame)
+        await log(db, redis, id, type="stdout", line="Virtual frame rendered (deploy = render)")
+        if task_id:
+            await log(db, redis, int(frame.id), type="stdout", line=deploy_task_log_line(task_id, "completed"))
+        return
+
     await register_active_deploy_job(redis, id, job_id)
     try:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/backend/app/tasks/deploy_frame.py
+++ b/backend/app/tasks/deploy_frame.py
@@ -110,9 +110,10 @@ async def deploy_frame_task(ctx: dict[str, Any], id: int, task_id: str | None = 
     if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
         from app.api.virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
 
+        if task_id:
+            await log(db, redis, int(frame.id), type="stdout", line=deploy_task_log_line(task_id, "started"))
         await refresh_virtual_frame_image(db, redis, frame)
         await mark_virtual_frame_deployed(db, redis, frame)
-        await log(db, redis, id, type="stdout", line="Virtual frame rendered (deploy = render)")
         if task_id:
             await log(db, redis, int(frame.id), type="stdout", line=deploy_task_log_line(task_id, "completed"))
         return

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -1475,6 +1475,11 @@ def ensure_embedded_frame_defaults(frame: Frame, platform: str | None = None) ->
     frame.max_http_response_bytes = embedded_max_http_response_bytes_for_frame(frame)
 
     device_config = dict(embedded_device_config(frame))
+    if EMBEDDED_PLATFORMS[normalized_platform]["family"] == "virtual" and not device_config.get("viewToken"):
+        # View-only credential for the image/page URLs — deliberately not the
+        # server_api_key, so a shared kiosk URL grants nothing but the picture
+        # and can be rotated without touching the device identity.
+        device_config["viewToken"] = secure_token(32)
     device_config["pins"] = embedded_pins_for_frame(frame)
     if "sdCardAssets" in device_config or "sd_card_assets" in device_config:
         device_config.pop("sd_card_assets", None)

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -93,6 +93,18 @@ EMBEDDED_PLATFORMS: dict[str, dict[str, Any]] = {
         "defaultPsramMB": 0,
         "localRenderSupported": False,
     },
+    # No hardware at all: the backend renders (same wasm path as the thin
+    # clients) and serves the frame as an image/page URL — for browser
+    # kiosks, old tablets, or any device that can show a picture.
+    # Self-hosted backends only.
+    "virtual": {
+        "label": "Virtual frame (backend renderer)",
+        "family": "virtual",
+        "aliases": {"backend-renderer", "virtual-frame"},
+        "maxGpio": -1,
+        "defaultPsramMB": 0,
+        "localRenderSupported": False,
+    },
 }
 EMBEDDED_PLATFORM_ALIASES = EMBEDDED_PLATFORMS[SUPPORTED_EMBEDDED_PLATFORM]["aliases"]
 EMBEDDED_PROJECT_DIR = REPO_ROOT / "embedded" / "esp32"
@@ -1455,7 +1467,10 @@ def ensure_embedded_frame_defaults(frame: Frame, platform: str | None = None) ->
     if not frame.server_api_key:
         frame.server_api_key = secure_token(32)
     if not frame.device or frame.device == "web_only":
-        frame.device = f"waveshare.{EMBEDDED_DEFAULT_PANEL}"
+        if EMBEDDED_PLATFORMS[normalized_platform]["family"] == "virtual":
+            frame.device = "virtual"
+        else:
+            frame.device = f"waveshare.{EMBEDDED_DEFAULT_PANEL}"
 
     frame.max_http_response_bytes = embedded_max_http_response_bytes_for_frame(frame)
 
@@ -1796,7 +1811,13 @@ async def embedded_firmware_task(ctx: dict[str, Any], id: int, request_id: str |
 
 
 async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: str | None) -> None:
-    if embedded_platform_spec_for_frame(frame)["family"] != "esp32":
+    family = embedded_platform_spec_for_frame(frame)["family"]
+    if family == "virtual":
+        raise ValueError(
+            "Virtual frames have no firmware — the backend renders them; "
+            "use the image URL from the frame's settings."
+        )
+    if family != "esp32":
         raise ValueError(
             "This platform uses the generic prebuilt firmware: flash the "
             "frameos-<version>-pico-w.uf2 (or -pico-2w.uf2) release asset over "

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -1430,7 +1430,10 @@ def ensure_embedded_frame_defaults(frame: Frame, platform: str | None = None) ->
     if apply_embedded_hardware_preset(frame):
         # The preset knows the board's chip; it overrides a caller-supplied platform.
         normalized_platform = embedded_platform_for_frame(frame)
-    if not frame.frame_host:
+    if EMBEDDED_PLATFORMS[normalized_platform]["family"] == "virtual":
+        # Nothing must ever try to reach a virtual frame over the network.
+        frame.frame_host = ""
+    elif not frame.frame_host:
         frame.frame_host = f"frame{frame.id}.local" if frame.id else "frame.local"
     if not frame.frame_port or frame.frame_port == 8787:
         frame.frame_port = 80

--- a/backend/app/tasks/fast_deploy_frame.py
+++ b/backend/app/tasks/fast_deploy_frame.py
@@ -31,6 +31,18 @@ async def fast_deploy_frame_task(ctx: dict[str, Any], id: int, task_id: str | No
         await log(db, redis, id, "stderr", "Frame not found")
         return
 
+    # Virtual frames: fast deploy IS rendering — no SSH, no device, ever.
+    from app.tasks.embedded_firmware import embedded_platform_spec_for_frame
+
+    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+        from app.api.virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
+
+        await refresh_virtual_frame_image(db, redis, frame)
+        await mark_virtual_frame_deployed(db, redis, frame)
+        if task_id:
+            await log(db, redis, id, "stdout", deploy_task_log_line(task_id, "completed", "fast"))
+        return
+
     deployer = FrameDeployer(db=db, redis=redis, frame=frame, nim_path="", temp_dir="")
     workflow = FrameDeployWorkflow(
         db=db,

--- a/backend/app/tasks/fast_deploy_frame.py
+++ b/backend/app/tasks/fast_deploy_frame.py
@@ -37,6 +37,8 @@ async def fast_deploy_frame_task(ctx: dict[str, Any], id: int, task_id: str | No
     if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
         from app.api.virtual_frame import mark_virtual_frame_deployed, refresh_virtual_frame_image
 
+        if task_id:
+            await log(db, redis, id, "stdout", deploy_task_log_line(task_id, "started", "fast"))
         await refresh_virtual_frame_image(db, redis, frame)
         await mark_virtual_frame_deployed(db, redis, frame)
         if task_id:

--- a/backend/app/utils/embedded_render.py
+++ b/backend/app/utils/embedded_render.py
@@ -62,6 +62,7 @@ async def render_scene_rgba(
     *,
     scene_id: str | None = None,
     settings: dict | None = None,
+    scenes_override: list | None = None,
     timeout: float = RENDER_TIMEOUT_SECONDS,
 ) -> bytes | None:
     """One frame of the scene as width*height*4 RGBA bytes, or None.
@@ -71,7 +72,8 @@ async def render_scene_rgba(
     expected operational states here, not exceptions: the device keeps
     polling, and a broken scene must not take the endpoint down with it.
     """
-    scenes = [scene for scene in (frame.scenes or []) if isinstance(scene, dict)]
+    source = scenes_override if scenes_override is not None else frame.scenes
+    scenes = [scene for scene in (source or []) if isinstance(scene, dict)]
     if not scenes:
         return None
     node = shutil.which("node")

--- a/backend/app/utils/embedded_render.py
+++ b/backend/app/utils/embedded_render.py
@@ -8,10 +8,11 @@ lived Node subprocess (backend/tools/embedded_wasm_render.mjs).
 
 Sandbox posture: user scene code (QuickJS) executes inside the wasm module,
 never natively on the backend. The wasm runtime has no filesystem or socket
-access; its only HTTP hook is a browser-style synchronous XHR bridge, which
-does not exist under Node — so outbound requests from scene apps fail closed.
-The subprocess itself is bounded by a wall-clock timeout and a concurrency
-cap so render storms cannot pile up Node processes.
+access; its HTTP hook goes through the harness' synchronous fetch shim,
+giving scene apps the same outbound HTTP a physical frame has (the cloud
+metadata address is blocked). The subprocess itself is bounded by a
+wall-clock timeout and a concurrency cap so render storms cannot pile up
+Node processes.
 """
 
 from __future__ import annotations

--- a/backend/tools/embedded_wasm_render.mjs
+++ b/backend/tools/embedded_wasm_render.mjs
@@ -10,16 +10,92 @@
 // and exactly width*height*4 bytes of RGBA on stdout on success (exit 0).
 // All logs go to stderr; any failure exits non-zero with a message there.
 //
-// Sandbox posture: user scene code (QuickJS) runs inside the wasm module.
-// The runtime's only host hooks are logging and the synchronous-XHR HTTP
-// bridge (tools/wasm/frameos_library.js) — Node has no XMLHttpRequest, so
-// every outbound request from scene apps fails closed. Keep it that way:
-// no XHR polyfill, no Module.frameosProxyUrl here. The wasm module has no
+// Sandbox posture: user scene code (QuickJS) runs inside the wasm module,
+// never natively in Node. Its host hooks are logging and the synchronous
+// XHR bridge (tools/wasm/frameos_library.js); the shim below implements
+// that bridge so scene apps' HTTP works exactly like on a physical frame —
+// the device fetches xkcd/weather/etc directly, and so does this. The one
+// hard block is the cloud metadata address. The wasm module has no
 // filesystem or socket access of its own (plain MEMFS, no NODERAWFS).
 
+import { spawnSync } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
 import { join } from 'node:path'
+
+// Synchronous XMLHttpRequest, as the emscripten HTTP bridge expects: each
+// send() runs fetch() in a short-lived child Node so the blocking wait is
+// outside this process' event loop.
+const FETCH_CHILD_SCRIPT = `
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('end', async () => {
+  const req = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), req.timeoutMs || 30000);
+    const response = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.bodyBase64 ? Buffer.from(req.bodyBase64, 'base64') : undefined,
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    const body = Buffer.from(await response.arrayBuffer());
+    process.stdout.write(JSON.stringify({ status: response.status, bodyBase64: body.toString('base64') }));
+  } catch (error) {
+    process.stdout.write(JSON.stringify({ status: 0, error: String(error) }));
+  }
+});
+`
+
+class SyncXMLHttpRequest {
+  open(method, url) {
+    this._method = method
+    this._url = url
+    this._headers = {}
+    this.status = 0
+    this.response = null
+    this.responseText = ''
+  }
+  setRequestHeader(name, value) {
+    this._headers[name] = value
+  }
+  send(body) {
+    if (/^https?:\/\/(\[?fd00:ec2::254\]?|169\.254\.169\.254)([:/]|$)/i.test(this._url)) {
+      throw new Error('blocked: cloud metadata address')
+    }
+    const request = {
+      method: this._method,
+      url: this._url,
+      headers: this._headers,
+      timeoutMs: this.timeout || 30000,
+      bodyBase64: body ? Buffer.from(body).toString('base64') : '',
+    }
+    const child = spawnSync(process.execPath, ['-e', FETCH_CHILD_SCRIPT], {
+      input: JSON.stringify(request),
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: (this.timeout || 30000) + 5000,
+    })
+    if (child.status !== 0 || !child.stdout) {
+      throw new Error(`fetch child failed: ${child.stderr || child.status}`)
+    }
+    const result = JSON.parse(child.stdout.toString('utf-8'))
+    if (result.status === 0) {
+      throw new Error(result.error || 'request failed')
+    }
+    this.status = result.status
+    const bytes = Buffer.from(result.bodyBase64 || '', 'base64')
+    if (this.responseType === 'arraybuffer') {
+      this.response = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+    } else {
+      this.responseText = bytes.toString('utf-8')
+      this.response = this.responseText
+    }
+  }
+}
+globalThis.XMLHttpRequest = SyncXMLHttpRequest
 
 // Defense in depth: the Python parent enforces the real timeout and kills
 // us; this backstop covers a detached/orphaned harness.

--- a/frontend/src/decorators/frame.tsx
+++ b/frontend/src/decorators/frame.tsx
@@ -155,6 +155,9 @@ export function frameRootUrl(frame: FrameType): string {
 }
 
 export function frameUrl(frame: FrameType): string | null {
+  if (!frame.frame_host) {
+    return null
+  }
   const url = frameRootUrl(frame)
   if (frame.frame_access === 'public' || frame.frame_access === 'protected') {
     return url
@@ -168,6 +171,9 @@ function frameControlPath(frame: FrameType): string {
 }
 
 export function frameControlUrl(frame: FrameType): string | null {
+  if (!frame.frame_host) {
+    return null
+  }
   const url = frameRootUrl(frame) + frameControlPath(frame)
   if (frame.frame_access === 'public' || !frame.frame_access_key) {
     return url
@@ -177,14 +183,22 @@ export function frameControlUrl(frame: FrameType): string | null {
 }
 
 export function frameAdminUrl(frame: FrameType): string | null {
-  if (!frame.frame_admin_auth?.enabled) {
+  // Virtual frames have no host at all; nothing to link to.
+  if (!frame.frame_admin_auth?.enabled || !frame.frame_host) {
     return null
   }
   const url = frameRootUrl(frame) + frameAdminPath()
-  return withFrameAdminLoginParams(url, frame.frame_admin_auth.user || '', frame.frame_admin_auth.pass || '')
+  try {
+    return withFrameAdminLoginParams(url, frame.frame_admin_auth.user || '', frame.frame_admin_auth.pass || '')
+  } catch {
+    return null
+  }
 }
 
 export function frameImageUrl(frame: FrameType): string | null {
+  if (!frame.frame_host) {
+    return null
+  }
   const url = frameRootUrl(frame) + `/image`
   if (frame.frame_access === 'public' || frame.frame_access === 'protected') {
     return url

--- a/frontend/src/devices.ts
+++ b/frontend/src/devices.ts
@@ -248,6 +248,7 @@ export const EMBEDDED_ESP32_S3 = 'esp32-s3'
 export const EMBEDDED_ESP32_C3 = 'esp32-c3'
 export const EMBEDDED_PICO_W = 'pico-w'
 export const EMBEDDED_PICO_2W = 'pico-2w'
+export const EMBEDDED_VIRTUAL = 'virtual'
 
 export const embeddedPlatforms: Option[] = [
   { value: EMBEDDED_ESP32_S3, label: 'ESP32-S3' },
@@ -257,6 +258,28 @@ export const embeddedPlatforms: Option[] = [
   // serial — the backend never builds per-frame firmware for these.
   { value: EMBEDDED_PICO_W, label: 'Raspberry Pi Pico W (thin client)' },
   { value: EMBEDDED_PICO_2W, label: 'Raspberry Pi Pico 2 W (thin client)' },
+  // No hardware at all: the backend renders the frame and serves it as an
+  // image/page URL. Mirrors EMBEDDED_PLATFORMS["virtual"] in
+  // backend/app/tasks/embedded_firmware.py.
+  { value: EMBEDDED_VIRTUAL, label: 'Virtual frame (backend renderer)' },
+]
+
+// ESP32-C3 and the Pico family have no PSRAM to render scenes on-device:
+// their firmware runs thin-client only, with the backend doing the rendering.
+// Used to tag hardware presets for those boards in the preset dropdowns.
+export function isThinClientEmbeddedPlatform(platform?: string | null): boolean {
+  return platform === EMBEDDED_ESP32_C3 || platform === EMBEDDED_PICO_W || platform === EMBEDDED_PICO_2W
+}
+
+// How the backend quantizes a virtual frame's rendered image.
+// Mirrors VIRTUAL_COLOR_MODES in backend/app/api/virtual_frame.py.
+export const virtualColorModes: Option[] = [
+  { value: 'rgb', label: 'Full color' },
+  { value: 'bw', label: 'Black & white' },
+  { value: 'gray4', label: '4-level grayscale' },
+  { value: 'bwyr', label: 'Black/White/Yellow/Red' },
+  { value: 'sevencolor', label: '7-color ACeP' },
+  { value: 'spectra6', label: 'Spectra 6' },
 ]
 
 export const rpiOSPlatforms: Option[] = [

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -1,5 +1,7 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 import clsx from 'clsx'
+import copy from 'copy-to-clipboard'
 import equal from 'fast-deep-equal'
 import { Button } from '../../../../components/Button'
 import { framesModel } from '../../../../models/framesModel'
@@ -31,7 +33,10 @@ import {
   EMBEDDED_ESP32_S3,
   EMBEDDED_PICO_2W,
   EMBEDDED_PICO_W,
+  EMBEDDED_VIRTUAL,
+  isThinClientEmbeddedPlatform,
   modes,
+  virtualColorModes,
 } from '../../../../devices'
 import { secureToken } from '../../../../utils/secureToken'
 import { appsLogic } from '../Apps/appsLogic'
@@ -181,6 +186,34 @@ const ESP32_FLASH_SIZE_OPTIONS: Option[] = [
   { value: '16MB', label: '16MB' },
   { value: '32MB', label: '32MB' },
 ]
+
+function VirtualFrameUrlRow({ label, url }: { label: string; url: string }): JSX.Element {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Field name="_noop" label={label}>
+      <div className="flex w-full items-start gap-2">
+        <A
+          href={url}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="frameos-link min-w-0 flex-1 break-all font-mono text-xs leading-5 hover:underline"
+        >
+          {url}
+        </A>
+        <Button
+          color="secondary"
+          size="small"
+          onClick={() => {
+            copy(url)
+            setCopied(true)
+          }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+    </Field>
+  )
+}
 
 const FRAME_ADMIN_SERVICE_SETTING_KEYS = ['frameOS', 'openAI', 'homeAssistant', 'github', 'immich', 'unsplash'] as const
 
@@ -783,7 +816,12 @@ const ESP32_HARDWARE_PRESET_CONFIGS: Partial<Record<FrameEmbeddedHardwarePreset,
 
 const ESP32_HARDWARE_PRESET_OPTIONS: Option[] = [
   { value: 'custom', label: 'Custom ESP32 board' },
-  ...Object.entries(ESP32_HARDWARE_PRESET_CONFIGS).map(([value, config]) => ({ value, label: config.label })),
+  ...Object.entries(ESP32_HARDWARE_PRESET_CONFIGS).map(([value, config]) => ({
+    value,
+    // Boards without PSRAM cannot render on-device; flag them so it is clear
+    // the backend does the rendering for these presets.
+    label: isThinClientEmbeddedPlatform(config.platform) ? `${config.label} — Thin client` : config.label,
+  })),
 ]
 
 function normalizeEsp32HardwarePreset(value: unknown): FrameEmbeddedHardwarePreset {
@@ -1100,6 +1138,16 @@ export function FrameSettings({
   const errorBehavior = normalizeFrameErrorBehavior(frameForm.error_behavior ?? frame.error_behavior)
   const isBuildrootMode = mode === 'buildroot'
   const isEmbeddedMode = mode === 'embedded'
+  // Virtual frames have no board at all: the backend renders them and serves
+  // the result at the URLs shown in the "Virtual frame" section below, so all
+  // ESP32 hardware controls (panel, pins, flash, presets) are hidden.
+  const isVirtualPlatform =
+    isEmbeddedMode && (frameForm.embedded?.platform ?? frame.embedded?.platform) === EMBEDDED_VIRTUAL
+  const virtualServerApiKey = frameForm.server_api_key ?? frame.server_api_key ?? ''
+  const virtualUrlToken = virtualServerApiKey || '<backend-api-key>'
+  const virtualUrlOrigin = typeof window !== 'undefined' ? window.location.origin : ''
+  const virtualImageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/image?k=${virtualUrlToken}`
+  const virtualPageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/page?k=${virtualUrlToken}`
   const configuredGpioButtons = !isEmbeddedMode ? configuredGpioButtonsForDevice(frameForm.device) : null
   const showWifiCredentials = isBuildrootMode || isEmbeddedMode
   const maxHttpResponsePlaceholder = String(
@@ -1510,12 +1558,17 @@ export function FrameSettings({
               )}
             </Field>
           ) : null}
+          {isVirtualPlatform ? null : (
           <Field name="device" label="Display driver">
             {({ value, onChange }) => (
               <Select
                 name="device"
                 value={(value as string) || ''}
-                options={devices}
+                options={
+                  // Embedded frames can be headless: device "none" maps to the
+                  // firmware's panel "none", so surface it as a real choice.
+                  isEmbeddedMode ? [{ value: 'none', label: 'No display panel' }, ...devices] : devices
+                }
                 onChange={(nextDevice) => {
                   const previousDevice = (value as string) || ''
                   onChange(nextDevice)
@@ -1563,6 +1616,7 @@ export function FrameSettings({
               />
             )}
           </Field>
+          )}
           {frameForm.device === 'waveshare.EPD_10in3' ? (
             <Group name="device_config">
               <Field name="vcom" label="VCOM">
@@ -1707,6 +1761,8 @@ export function FrameSettings({
                 <Field name="platform" label="Platform">
                   <Select name="embedded.platform" options={embeddedPlatforms} />
                 </Field>
+                {isVirtualPlatform ? null : (
+                <>
                 <Field
                   name="hardwarePreset"
                   label="Hardware preset"
@@ -1745,7 +1801,10 @@ export function FrameSettings({
                     />
                   )}
                 </Field>
+                </>
+                )}
               </Group>
+              {isVirtualPlatform ? null : (
               <Group name="device_config">
                 <Field
                   name="pins"
@@ -1950,6 +2009,7 @@ export function FrameSettings({
                   }}
                 </Field>
               </Group>
+              )}
             </>
           ) : null}
           {/* {frameForm.mode === 'rpios' || !frameForm.mode ? (
@@ -2005,6 +2065,53 @@ export function FrameSettings({
             </Field>
           ) : null}
         </div>
+
+        {isVirtualPlatform ? (
+          <>
+            <H6 id="frame-settings-virtual" className="mt-2">
+              Virtual frame
+            </H6>
+            <div className="pl-2 @md:pl-8 space-y-2">
+              <p className="frameos-muted text-sm">
+                The backend renders this frame and serves it at the URLs below. The token is the frame's backend API
+                key, so treat these URLs like passwords — regenerating the key invalidates them.
+              </p>
+              {!virtualServerApiKey ? (
+                <p className="text-sm font-semibold text-amber-600">
+                  No backend API key is set for this frame yet. Generate one in the "Backend access" section below,
+                  save, and the URLs will fill in.
+                </p>
+              ) : null}
+              <VirtualFrameUrlRow label="Image URL (PNG, rendered on request)" url={virtualImageUrl} />
+              <VirtualFrameUrlRow
+                label={`Kiosk page URL (refreshes every ${frameForm.interval ?? frame.interval ?? 300} seconds)`}
+                url={virtualPageUrl}
+              />
+              <Field name="width" label="Width">
+                <TextInput name="width" placeholder="800" />
+              </Field>
+              <Field name="height" label="Height">
+                <TextInput name="height" placeholder="480" />
+              </Field>
+              <Group name="device_config">
+                <Field
+                  name="colorMode"
+                  label="Color mode"
+                  tooltip="How the backend quantizes the rendered image — pick an e-ink palette to preview how a scene would look on a physical panel."
+                >
+                  {({ value, onChange }) => (
+                    <Select
+                      name="device_config.colorMode"
+                      value={(value as string) || 'rgb'}
+                      options={virtualColorModes}
+                      onChange={onChange}
+                    />
+                  )}
+                </Field>
+              </Group>
+            </div>
+          </>
+        ) : null}
 
         {!inFrameAdminMode && !hideForCloud ? (
           <>

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -1143,8 +1143,10 @@ export function FrameSettings({
   // ESP32 hardware controls (panel, pins, flash, presets) are hidden.
   const isVirtualPlatform =
     isEmbeddedMode && (frameForm.embedded?.platform ?? frame.embedded?.platform) === EMBEDDED_VIRTUAL
-  const virtualServerApiKey = frameForm.server_api_key ?? frame.server_api_key ?? ''
-  const virtualUrlToken = virtualServerApiKey || '<backend-api-key>'
+  // View-only credential, never the device API key: leaking a kiosk URL
+  // grants nothing but the picture. Rotate via device_config.viewToken.
+  const virtualViewToken = frameForm.device_config?.viewToken ?? frame.device_config?.viewToken ?? ''
+  const virtualUrlToken = virtualViewToken || '<view-token>'
   const virtualUrlOrigin = typeof window !== 'undefined' ? window.location.origin : ''
   const virtualImageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/image?k=${virtualUrlToken}`
   const virtualPageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/page?k=${virtualUrlToken}`
@@ -2073,13 +2075,12 @@ export function FrameSettings({
             </H6>
             <div className="pl-2 @md:pl-8 space-y-2">
               <p className="frameos-muted text-sm">
-                The backend renders this frame and serves it at the URLs below. The token is the frame's backend API
-                key, so treat these URLs like passwords — regenerating the key invalidates them.
+                The backend renders this frame and serves it at the URLs below. The token only grants viewing this
+                frame's image — still, treat the URLs as semi-private; save a new view token to invalidate them.
               </p>
-              {!virtualServerApiKey ? (
+              {!virtualViewToken ? (
                 <p className="text-sm font-semibold text-amber-600">
-                  No backend API key is set for this frame yet. Generate one in the "Backend access" section below,
-                  save, and the URLs will fill in.
+                  No view token is set for this frame yet. Save the frame once and the URLs will fill in.
                 </p>
               ) : null}
               <VirtualFrameUrlRow label="Image URL (PNG, rendered on request)" url={virtualImageUrl} />

--- a/frontend/src/scenes/frames/NewFrame.tsx
+++ b/frontend/src/scenes/frames/NewFrame.tsx
@@ -937,8 +937,8 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
             </ModeButton>
             <ModeButton
               onClick={() => setNewFrameValues(setInstallMethodValues('embedded', savedSettings))}
-              title="Flash ESP32 (EXPERIMENTAL)"
-              description="Build firmware for an ESP32 and flash it over USB."
+              title="Flash embedded device"
+              description="ESP32-S3/C3 boards and e-ink devices like the TRMNL, XTEINK X4, Inky Frame (Pico W), reTerminal, and CrowPanel."
             >
               <CpuChipIcon className="h-4 w-4" />
             </ModeButton>

--- a/frontend/src/scenes/frames/NewFrame.tsx
+++ b/frontend/src/scenes/frames/NewFrame.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeftIcon,
   ArrowUpTrayIcon,
   CommandLineIcon,
+  ComputerDesktopIcon,
   CpuChipIcon,
   ServerStackIcon,
 } from '@heroicons/react/24/outline'
@@ -15,18 +16,22 @@ import {
   EMBEDDED_ESP32_S3,
   EMBEDDED_PICO_2W,
   EMBEDDED_PICO_W,
+  EMBEDDED_VIRTUAL,
   devices,
   partialRefreshDefaultsByDevice,
   partialRefreshDevices,
   buildrootPlatforms,
   embeddedPlatforms,
+  isThinClientEmbeddedPlatform,
   rpiOSPlatforms,
+  virtualColorModes,
 } from '../../devices'
 import { defaultRemoteControl, newFrameForm } from './newFrameForm'
 import {
   FrameEmbeddedHardwarePreset,
   FrameInstallMethod,
   FrameOSSettings,
+  FrameVirtualColorMode,
   GPIOButton,
   NewFrameFormType,
 } from '../../types'
@@ -198,7 +203,8 @@ function setInstallMethodValues(
       platform: EMBEDDED_ESP32_S3,
       frame_host: '',
       server_host: defaultNewFrameServerHost(savedSettings),
-      device: '',
+      // "none" = headless firmware (panel "none"); a real panel is opt-in.
+      device: 'none',
       network: defaultWifiNetwork(savedSettings),
       rememberWifi: true,
     }
@@ -217,6 +223,31 @@ function setInstallMethodValues(
     mode: 'rpios',
     platform: '',
     server_host: defaultNewFrameServerHost(savedSettings),
+  }
+}
+
+// A virtual frame is an embedded-mode frame on the "virtual" platform: no
+// board, no panel, no pins, no WiFi. The backend renders its scenes (same
+// wasm path as the thin clients) and serves them as an image/page URL, and
+// ensure_embedded_frame_defaults sets device to "virtual" server-side.
+// Mirrors the clamp in backend/app/api/virtual_frame.py
+const VIRTUAL_MIN_DIMENSION = 16
+const VIRTUAL_MAX_DIMENSION = 4096
+const VIRTUAL_DEFAULT_WIDTH = 800
+const VIRTUAL_DEFAULT_HEIGHT = 480
+
+function setVirtualInstallValues(savedSettings: FrameOSSettings): Partial<NewFrameFormType> {
+  return {
+    install_method: 'embedded',
+    mode: 'embedded',
+    platform: EMBEDDED_VIRTUAL,
+    frame_host: '',
+    server_host: defaultNewFrameServerHost(savedSettings),
+    device: 'virtual',
+    device_config: {},
+    width: VIRTUAL_DEFAULT_WIDTH,
+    height: VIRTUAL_DEFAULT_HEIGHT,
+    gpio_buttons: [],
   }
 }
 
@@ -572,10 +603,14 @@ const unsupportedEmbeddedWaveshareDevices = new Set([
 ])
 
 const embeddedDevices = [
+  // Device "none" is what survives the backend's embedded defaults and maps
+  // to firmware panel "none" (headless). "web_only" would NOT: the backend
+  // rewrites an empty or web_only device to the default Waveshare panel
+  // (ensure_embedded_frame_defaults in backend/app/tasks/embedded_firmware.py).
+  { value: 'none', label: 'No display panel' },
   ...(devices
     .find((group) => group.label === 'Waveshare')
     ?.options.filter((device) => !unsupportedEmbeddedWaveshareDevices.has(device.value)) ?? []),
-  { value: 'web_only', label: 'No display (headless)' },
 ]
 
 function renderEmbeddedDeviceOptions(): JSX.Element[] {
@@ -596,7 +631,10 @@ function renderPlatformOptions(installMethod: FrameInstallMethod): JSX.Element[]
   ))
 }
 
-type AddFrameMode = FrameInstallMethod | 'import'
+// 'virtual' is not its own install_method: it is the embedded install flow on
+// the "virtual" platform, surfaced as a separate card because there is no
+// hardware to flash and none of the ESP32 steps apply.
+type AddFrameMode = FrameInstallMethod | 'import' | 'virtual'
 type UploadHeader = { name: string; value: string }
 
 function installMethodTitle(installMethod: AddFrameMode): string {
@@ -608,6 +646,9 @@ function installMethodTitle(installMethod: AddFrameMode): string {
   }
   if (installMethod === 'embedded') {
     return 'Flash embedded device'
+  }
+  if (installMethod === 'virtual') {
+    return 'Virtual frame'
   }
   if (installMethod === 'import') {
     return 'Import frame'
@@ -743,7 +784,9 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
   const { file, importingFrameLoading, isNewFrameSubmitting, newFrame, newFrameErrors } = useValues(newFrameForm)
   const { savedSettings } = useValues(settingsLogic)
   const installMethod = newFrame.install_method
-  const addFrameMode: AddFrameMode | undefined = newFrame.mode === 'import' ? 'import' : installMethod
+  const isVirtualPlatform = installMethod === 'embedded' && newFrame.platform === EMBEDDED_VIRTUAL
+  const addFrameMode: AddFrameMode | undefined =
+    newFrame.mode === 'import' ? 'import' : isVirtualPlatform ? 'virtual' : installMethod
   const timezone = normalizedTimezone(newFrame.timezone, savedSettings.defaults?.timezone)
   const sshKeyOptions = normalizeSshKeys(savedSettings.ssh_keys).keys
   const selectedSshKeys = new Set(newFrame.ssh_keys ?? defaultInstallSshKeyIds(savedSettings))
@@ -796,6 +839,36 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
         sdCardAssets: presetConfig.sdCardAssets,
       },
       gpio_buttons: presetConfig.gpioButtons.map((button) => ({ ...button })),
+    })
+  }
+
+  // Virtual frames have no board, panel, pins, or WiFi: the backend renders
+  // them and serves the result as an image/page URL. Picking the platform
+  // wires in the "virtual" device (the backend would default it the same
+  // way) and flips the form to the virtual flow; leaving it resets the
+  // device to headless ("none") so the panel picker starts at no panel.
+  const setEmbeddedPlatform = (platform: string): void => {
+    if (platform === EMBEDDED_VIRTUAL) {
+      setNewFrameValues({
+        platform,
+        device: 'virtual',
+        embedded: { ...(newFrame.embedded ?? {}), platform, hardwarePreset: 'custom' },
+        device_config: { ...(newFrame.device_config ?? {}), hardwarePreset: 'custom' },
+        gpio_buttons: [],
+      })
+      return
+    }
+    if (newFrame.device === 'virtual') {
+      setNewFrameValues({
+        platform,
+        device: 'none',
+        embedded: { ...(newFrame.embedded ?? {}), platform },
+      })
+      return
+    }
+    setNewFrameValues({
+      platform,
+      embedded: { ...(newFrame.embedded ?? {}), platform },
     })
   }
 
@@ -868,6 +941,13 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
               description="Build firmware for an ESP32 and flash it over USB."
             >
               <CpuChipIcon className="h-4 w-4" />
+            </ModeButton>
+            <ModeButton
+              onClick={() => setNewFrameValues(setVirtualInstallValues(savedSettings))}
+              title="Virtual frame"
+              description="No hardware — the backend renders to a PNG anyone can download."
+            >
+              <ComputerDesktopIcon className="h-4 w-4" />
             </ModeButton>
             <ModeButton
               onClick={() => setNewFrameValues({ mode: 'import', install_method: undefined })}
@@ -1180,6 +1260,83 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
             </button>
           </div>
         </Form>
+      ) : addFrameMode === 'virtual' ? (
+        <Form logic={newFrameForm} formKey="newFrame" className="space-y-4" enableFormOnSubmit>
+          <p className="frameos-form-hint text-sm leading-relaxed text-slate-500">
+            No hardware — the backend renders this frame's scenes and serves them as an image URL (one PNG per request)
+            and a self-refreshing kiosk page for browsers, tablets, and signage players. Both URLs appear in the frame's
+            settings after it is added.
+          </p>
+          <FormField label="Name" error={newFrameErrors.name}>
+            <input
+              className={textInputClassName()}
+              value={newFrame.name ?? ''}
+              onChange={(event) => setNewFrameValue('name', event.target.value)}
+              placeholder="Kitchen Frame"
+              required
+            />
+          </FormField>
+          <div className="grid grid-cols-1 gap-2 @md:grid-cols-2">
+            <FormField label="Width">
+              <input
+                className={textInputClassName()}
+                type="number"
+                min={VIRTUAL_MIN_DIMENSION}
+                max={VIRTUAL_MAX_DIMENSION}
+                value={newFrame.width ?? ''}
+                onChange={(event) => {
+                  const parsed = parseInt(event.target.value, 10)
+                  setNewFrameValue('width', Number.isNaN(parsed) ? undefined : parsed)
+                }}
+                placeholder={String(VIRTUAL_DEFAULT_WIDTH)}
+                required
+              />
+            </FormField>
+            <FormField label="Height">
+              <input
+                className={textInputClassName()}
+                type="number"
+                min={VIRTUAL_MIN_DIMENSION}
+                max={VIRTUAL_MAX_DIMENSION}
+                value={newFrame.height ?? ''}
+                onChange={(event) => {
+                  const parsed = parseInt(event.target.value, 10)
+                  setNewFrameValue('height', Number.isNaN(parsed) ? undefined : parsed)
+                }}
+                placeholder={String(VIRTUAL_DEFAULT_HEIGHT)}
+                required
+              />
+            </FormField>
+          </div>
+          <FormField label="Color mode">
+            <select
+              className={selectClassName()}
+              value={newFrame.device_config?.colorMode ?? 'rgb'}
+              onChange={(event) =>
+                setNewFrameValue('device_config', {
+                  ...(newFrame.device_config ?? {}),
+                  colorMode: event.target.value as FrameVirtualColorMode,
+                })
+              }
+            >
+              {virtualColorModes.map((mode) => (
+                <option key={mode.value} value={mode.value}>
+                  {mode.label}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          <div className="flex gap-2 pt-2">
+            <AddFrameSubmitButton loading={isNewFrameSubmitting} />
+            <button
+              type="button"
+              onClick={cancel}
+              className="frameos-secondary-button h-11 rounded-xl bg-slate-100 px-4 text-sm font-semibold text-slate-700 transition hover:bg-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            >
+              Cancel
+            </button>
+          </div>
+        </Form>
       ) : addFrameMode === 'embedded' ? (
         <Form logic={newFrameForm} formKey="newFrame" className="space-y-4" enableFormOnSubmit>
           <p className="frameos-form-hint text-sm leading-relaxed text-slate-500">
@@ -1199,7 +1356,7 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
             <select
               className={selectClassName()}
               value={newFrame.platform ?? ''}
-              onChange={(event) => setNewFrameValue('platform', event.target.value)}
+              onChange={(event) => setEmbeddedPlatform(event.target.value)}
             >
               {renderPlatformOptions('embedded')}
             </select>
@@ -1213,7 +1370,7 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
               <option value="custom">Custom ESP32 board</option>
               {Object.entries(EMBEDDED_HARDWARE_PRESET_CONFIGS).map(([preset, config]) => (
                 <option key={preset} value={preset}>
-                  {config.label}
+                  {isThinClientEmbeddedPlatform(config.platform) ? `${config.label} — Thin client` : config.label}
                 </option>
               ))}
             </select>
@@ -1221,13 +1378,10 @@ export function NewFrame({ headerAction }: { headerAction?: JSX.Element }): JSX.
           <FormField label="Display panel" error={newFrameErrors.device}>
             <select
               className={selectClassName()}
-              value={newFrame.device ?? ''}
+              value={newFrame.device || 'none'}
               onChange={(event) => setEmbeddedDevice(event.target.value)}
               required
             >
-              <option value="" disabled>
-                Select display panel
-              </option>
               {renderEmbeddedDeviceOptions()}
             </select>
           </FormField>

--- a/frontend/src/scenes/frames/newFrameForm.tsx
+++ b/frontend/src/scenes/frames/newFrameForm.tsx
@@ -58,7 +58,9 @@ function agentPayload(frame: NewFrameFormType): NonNullable<NewFrameFormType['ag
 }
 
 function framePayload(frame: NewFrameFormType): NewFrameFormType {
-  const { rememberWifi: _rememberWifi, ...frameValues } = frame
+  // width/height are not part of FrameCreateRequest (the backend would drop
+  // them silently); they are applied with a follow-up update after creation.
+  const { rememberWifi: _rememberWifi, width: _width, height: _height, ...frameValues } = frame
   const installMethod = installMethodOf(frame)
   const agent = agentPayload(frame)
 
@@ -205,6 +207,32 @@ export const newFrameForm = kea<newFrameFormType>([
           }
 
           const result = await response.json()
+          let createdFrame = result?.frame
+          // FrameCreateRequest carries no width/height, so a virtual frame's
+          // chosen size is applied through the regular frame-update endpoint
+          // right after creation.
+          const sizeUpdate = {
+            ...(frame.width ? { width: frame.width } : {}),
+            ...(frame.height ? { height: frame.height } : {}),
+          }
+          if (createdFrame?.id && Object.keys(sizeUpdate).length > 0) {
+            try {
+              const updateResponse = await apiFetch(`/api/frames/${createdFrame.id}`, {
+                method: 'POST',
+                body: JSON.stringify(sizeUpdate),
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+              })
+              if (updateResponse.ok) {
+                createdFrame = { ...createdFrame, ...sizeUpdate }
+              } else {
+                console.error('Failed to apply frame size after creation')
+              }
+            } catch (error) {
+              console.error(error)
+            }
+          }
           try {
             await saveRememberedWifiDefaults(frame)
           } catch (error) {
@@ -212,9 +240,9 @@ export const newFrameForm = kea<newFrameFormType>([
           }
           actions.resetNewFrame()
           actions.hideForm()
-          if (result?.frame?.id) {
-            framesModel.actions.addFrame(result.frame)
-            actions.frameCreated(result.frame.id, installMethod)
+          if (createdFrame?.id) {
+            framesModel.actions.addFrame(createdFrame)
+            actions.frameCreated(createdFrame.id, installMethod)
           }
         } catch (error) {
           console.error(error)

--- a/frontend/src/scenes/workspace/FrameActionsMenu.tsx
+++ b/frontend/src/scenes/workspace/FrameActionsMenu.tsx
@@ -61,9 +61,11 @@ export function FrameActionsMenu({
   // backend bookkeeping do not. The frame's device profile never hides an
   // entry — an esp32 cloud frame shows Rename disabled with the reason (it
   // rides the set_settings verb, which that firmware answers
-  // `unsupported_verb` for) instead of quietly dropping it.
+  // `unsupported_verb` for) instead of quietly dropping it. Virtual frames
+  // are the exception: device-shaped actions (reboot, stop, SD cards …) are
+  // hidden because there is no device — see workspaceSurfaces.ts.
   const mode = workspaceMode()
-  const allows = (action: FrameMenuAction): boolean => frameMenuActionIsAllowed(mode, action)
+  const allows = (action: FrameMenuAction): boolean => frameMenuActionIsAllowed(mode, action, frame)
   const disabledReason = (action: FrameMenuAction): string | null =>
     frameMenuActionDisabledReason(mode, action, frame)
   const renameDisabledReason = disabledReason('rename')

--- a/frontend/src/scenes/workspace/FrameDashboardSurface.tsx
+++ b/frontend/src/scenes/workspace/FrameDashboardSurface.tsx
@@ -318,7 +318,7 @@ function FrameDashboardHeader({ frame, archived }: { frame: FrameType; archived?
             buttonClassName="frameos-icon-tile flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white/70 !px-0 !py-0 text-slate-700 shadow-sm transition"
             buttonContent={<DeployToFrameIcon className="h-7 w-7" />}
           />
-        ) : !frameMenuActionIsAllowed(workspaceMode(), 'deploy') ? null : (
+        ) : !frameMenuActionIsAllowed(workspaceMode(), 'deploy', frame) ? null : (
           <FrameChangeStatusIcon frameId={frame.id} variant="dashboard" />
         )}
         <div className="min-w-0">
@@ -678,9 +678,11 @@ function FrameScenesBlock({
   // Allow-list per control plane — see workspaceSurfaces.ts. The frame's
   // device profile never removes a shortcut; it disables it with a tooltip
   // (an esp32 cloud frame keeps Logs — pushed to the cloud and read back —
-  // while Schedule/Settings/Metrics show why they cannot work).
+  // while Schedule/Settings/Metrics show why they cannot work). Virtual
+  // frames are the exception: shortcuts whose concepts don't exist for them
+  // (terminal, ping, assets, metrics) are hidden outright.
   const visibleSceneToolButtons = sceneToolButtons
-    .filter(({ panel }) => sceneToolPanelIsAllowed(workspaceMode(), panel))
+    .filter(({ panel }) => sceneToolPanelIsAllowed(workspaceMode(), panel, frame))
     .map((button) => ({
       ...button,
       disabledReason: sceneToolPanelDisabledReason(workspaceMode(), button.panel, frame),

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -1879,7 +1879,16 @@ function EmbeddedFirmwareSection({
             <>
               This {platformLabel} board runs the generic FrameOS UF2 firmware: copy the release asset onto the board
               over BOOTSEL drag-and-drop and provision it over the USB serial console. The backend does not build
-              per-frame firmware for it.
+              per-frame firmware for it.{' '}
+              <a
+                href="https://github.com/FrameOS/frameos/releases/latest"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                Download frameos-&lt;version&gt;-{platformLabel}.uf2 from the latest release
+              </a>
+              .
             </>
           ) : (
             <>

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -45,6 +45,8 @@ import type {
 } from '../../types'
 import { urls } from '../../urls'
 import { apiFetch } from '../../utils/apiFetch'
+import { secureToken } from '../../utils/secureToken'
+import { Button } from '../../components/Button'
 import { getDefaultSshKeyIds, normalizeSshKeys } from '../../utils/sshKeys'
 import { normalizedTimezone } from '../../utils/timezone'
 import {
@@ -1825,6 +1827,19 @@ function EmbeddedFirmwareSection({
   // View-only credential, never the device API key: leaking a kiosk URL
   // grants nothing but the picture.
   const virtualUrlToken = frame.device_config?.viewToken || '<view-token>'
+  const { loadFrame } = useActions(framesModel)
+  const rotateVirtualViewToken = async (): Promise<void> => {
+    const response = await apiFetch(`/api/frames/${frame.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        device_config: { ...(frame.device_config ?? {}), viewToken: secureToken(32) },
+      }),
+    })
+    if (response.ok) {
+      loadFrame(frame.id)
+    }
+  }
   const virtualImageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/image?k=${virtualUrlToken}`
   const virtualPageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/page?k=${virtualUrlToken}`
   const flashSize = embeddedFlashSize(frame)
@@ -1896,6 +1911,14 @@ function EmbeddedFirmwareSection({
         <div className="frame-tool-card space-y-4 rounded-[22px] p-4">
           <VirtualFrameUrlRow label="Image URL (PNG)" url={virtualImageUrl} />
           <VirtualFrameUrlRow label="Kiosk page URL (self-refreshing)" url={virtualPageUrl} />
+          <div className="flex items-center gap-3">
+            <Button size="small" color="secondary" onClick={rotateVirtualViewToken}>
+              Rotate view token
+            </Button>
+            <span className="frame-tool-muted text-xs leading-4">
+              Mints a new token and invalidates every shared URL immediately.
+            </span>
+          </div>
         </div>
       ) : isPicoPlatform ? null : (
         <>

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -2299,7 +2299,25 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
           )}
         </div>
         <div className="frameos-divider flex flex-wrap justify-end gap-2 border-t border-slate-200/80 px-5 py-4">
-          {activeDeployDrawerView !== 'main' ? (
+          {(frameForm.embedded?.platform ?? frame.embedded?.platform) === 'virtual' ? (
+            <>
+              <button
+                type="button"
+                onClick={closeDrawer}
+                className="frameos-secondary-button rounded-lg px-4 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                title="Save changes and render this frame's scenes now"
+                onClick={() => closeAndRun(saveAndFullDeployFrame)}
+                className="frameos-primary-action rounded-lg px-4 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              >
+                Deploy
+              </button>
+            </>
+          ) : activeDeployDrawerView !== 'main' ? (
             <button
               type="button"
               onClick={closeOnlyDrawerView ? closeDrawer : showMainDeployView}

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -1822,7 +1822,9 @@ function EmbeddedFirmwareSection({
   // instead of firmware the section shows the image and kiosk page URLs.
   const isVirtualPlatform = platformLabel === EMBEDDED_VIRTUAL
   const virtualUrlOrigin = typeof window !== 'undefined' ? window.location.origin : ''
-  const virtualUrlToken = frame.server_api_key || '<backend-api-key>'
+  // View-only credential, never the device API key: leaking a kiosk URL
+  // grants nothing but the picture.
+  const virtualUrlToken = frame.device_config?.viewToken || '<view-token>'
   const virtualImageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/image?k=${virtualUrlToken}`
   const virtualPageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/page?k=${virtualUrlToken}`
   const flashSize = embeddedFlashSize(frame)

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -25,6 +25,7 @@ import { Tooltip } from '../../components/Tooltip'
 import { frameHasActivityLog, frameHost } from '../../decorators/frame'
 import {
   BUILDROOT_RASPBERRY_PI_ZERO_2_W,
+  EMBEDDED_VIRTUAL,
   buildrootPlatforms,
   devices,
   partialRefreshDefaultsByDevice,
@@ -1775,6 +1776,29 @@ function ScriptInstallSection({ frame, onBack }: { frame: FrameType; onBack: () 
   )
 }
 
+function VirtualFrameUrlRow({ label, url }: { label: string; url: string }): JSX.Element {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-semibold text-[color:var(--tool-strong)]">{label}</div>
+      <pre className="frameos-inset whitespace-pre-wrap break-all rounded-xl border p-3 text-xs leading-5 text-[color:var(--tool-strong)]">
+        <code>{url}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={() => {
+          copy(url)
+          setCopied(true)
+        }}
+        className="frameos-secondary-button inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+      >
+        <ClipboardDocumentIcon className="h-4 w-4" />
+        {copied ? 'Copied' : 'Copy URL'}
+      </button>
+    </div>
+  )
+}
+
 function EmbeddedFirmwareSection({
   frame,
   onBack,
@@ -1794,6 +1818,13 @@ function EmbeddedFirmwareSection({
   // provisioned over the USB serial console: no per-frame firmware builds, no
   // esptool, no browser flashing, no OTA. Hide all of those controls.
   const isPicoPlatform = platformLabel.startsWith('pico')
+  // Virtual frames have no hardware at all: the backend renders them, so
+  // instead of firmware the section shows the image and kiosk page URLs.
+  const isVirtualPlatform = platformLabel === EMBEDDED_VIRTUAL
+  const virtualUrlOrigin = typeof window !== 'undefined' ? window.location.origin : ''
+  const virtualUrlToken = frame.server_api_key || '<backend-api-key>'
+  const virtualImageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/image?k=${virtualUrlToken}`
+  const virtualPageUrl = `${virtualUrlOrigin}/api/frames/${frame.id}/virtual/page?k=${virtualUrlToken}`
   const flashSize = embeddedFlashSize(frame)
   const otaSupported = embeddedOtaSupported(frame)
   const showUsbJtagPortGuidance = needsEsp32UsbJtagPortGuidance(frame)
@@ -1817,12 +1848,17 @@ function EmbeddedFirmwareSection({
       <DrawerHeading action={<FrameSettingsLink frameId={frame.id} />}>
         <span className="inline-flex items-center gap-2">
           {onBack ? <BackToDeployButton onClick={onBack} /> : null}
-          <span>Firmware</span>
+          <span>{isVirtualPlatform ? 'Virtual frame' : 'Firmware'}</span>
         </span>
       </DrawerHeading>
       <div className="mb-3">
         <div className="frame-tool-muted mt-1 text-sm leading-5">
-          {isPicoPlatform ? (
+          {isVirtualPlatform ? (
+            <>
+              Nothing to flash: the backend renders this frame. Point any browser, tablet, or signage player at the
+              kiosk page URL, or fetch the image URL for a PNG.
+            </>
+          ) : isPicoPlatform ? (
             <>
               This {platformLabel} board runs the generic FrameOS UF2 firmware: copy the release asset onto the board
               over BOOTSEL drag-and-drop and provision it over the USB serial console. The backend does not build
@@ -1835,12 +1871,12 @@ function EmbeddedFirmwareSection({
             </>
           )}
         </div>
-        {firmware?.status ? (
+        {firmware?.status && !isVirtualPlatform ? (
           <div className="mt-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--tool-strong)]">
             Status: {firmware.status}
           </div>
         ) : null}
-        {firmware?.error ? (
+        {firmware?.error && !isVirtualPlatform ? (
           <div
             className={clsx(
               'mt-2 text-sm font-semibold',
@@ -1854,7 +1890,12 @@ function EmbeddedFirmwareSection({
           </div>
         ) : null}
       </div>
-      {isPicoPlatform ? null : (
+      {isVirtualPlatform ? (
+        <div className="frame-tool-card space-y-4 rounded-[22px] p-4">
+          <VirtualFrameUrlRow label="Image URL (PNG)" url={virtualImageUrl} />
+          <VirtualFrameUrlRow label="Kiosk page URL (self-refreshing)" url={virtualPageUrl} />
+        </div>
+      ) : isPicoPlatform ? null : (
         <>
           <div className="frame-tool-card space-y-4 rounded-[22px] p-4">
             <div className="frame-tool-muted text-sm leading-5">

--- a/frontend/src/scenes/workspace/FrameSceneSidebarCard.tsx
+++ b/frontend/src/scenes/workspace/FrameSceneSidebarCard.tsx
@@ -53,8 +53,8 @@ export function FrameSceneSidebarCard({
   // uploadScenes shim. Save stays because it maps onto the declarative
   // settings push (utils/cloudFrameApi.ts).
   const mode = workspaceMode()
-  const canDeploy = frameMenuActionIsAllowed(mode, 'deploy')
-  const canLocalDeploy = frameMenuActionIsAllowed(mode, 'localDeploy')
+  const canDeploy = frameMenuActionIsAllowed(mode, 'deploy', frame)
+  const canLocalDeploy = frameMenuActionIsAllowed(mode, 'localDeploy', frame)
   const cloudDeploy = mode === 'cloud'
 
   // Cloud-managed ESP32 frames don't push logs to the cloud yet, so their

--- a/frontend/src/scenes/workspace/FrameWorkspace.tsx
+++ b/frontend/src/scenes/workspace/FrameWorkspace.tsx
@@ -265,13 +265,15 @@ const frameToolDefinitions: FrameToolDefinition[] = [
 // invisible in every mode until it is listed there. The frame's device
 // profile never hides a panel — it disables it with an explanation (e.g.
 // Schedule on an esp32 cloud frame, whose firmware refuses `set_schedule`),
-// so the workspace keeps its shape whatever the hardware.
+// so the workspace keeps its shape whatever the hardware. Virtual frames are
+// the one exception: panels whose concepts don't exist for them (terminal,
+// ping, assets, metrics) are hidden outright — see workspaceSurfaces.ts.
 function frameToolDefinitionsForMode(
   mode: WorkspaceMode = workspaceMode(),
   frame?: FrameType | null
 ): FrameToolDefinition[] {
   return frameToolDefinitions
-    .filter((definition) => frameToolPanelIsAllowed(mode, definition.panel))
+    .filter((definition) => frameToolPanelIsAllowed(mode, definition.panel, frame))
     .map((definition) => ({
       ...definition,
       disabledReason: frameToolPanelDisabledReason(mode, definition.panel, frame),
@@ -1347,7 +1349,11 @@ function FrameWorkspaceForFrame({ frameId }: { frameId: FrameId }): JSX.Element 
   if (frameToolPanelIsAllowed(mode, 'terminal')) {
     // The cloud protocol has no shell, so terminalLogic must never mount
     // there. The mode is constant for the app's lifetime, so this
-    // conditional hook is stable across renders.
+    // conditional hook is stable across renders. Deliberately mode-only: the
+    // frame loads asynchronously, so frame-aware gating (virtual frames hide
+    // the terminal) would flip this hook mid-life. For virtual frames the
+    // panel itself is hidden via frameToolDefinitionsForMode below, and the
+    // mounted logic sits inert until a session is opened.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useMountedLogic(terminalLogic(frameLogicProps))
   }

--- a/frontend/src/scenes/workspace/workspaceSurfaces.ts
+++ b/frontend/src/scenes/workspace/workspaceSurfaces.ts
@@ -246,12 +246,13 @@ export const addFrameFlows: Record<WorkspaceMode, AddFrameFlow> = {
 export type FrameCapability = 'schedule' | 'settings' | 'logs' | 'metrics' | 'updateNotify'
 
 /**
- * The one frame field capability gating reads. Structurally a subset of
+ * The frame fields capability gating reads. Structurally a subset of
  * FrameType, declared locally so this module keeps importing nothing beyond
  * the two mode probes.
  */
 export interface FrameCapabilityInput {
   hardware?: { platform?: string | null } | null
+  embedded?: { platform?: string | null } | null
 }
 
 const allFrameCapabilities: readonly FrameCapability[] = ['schedule', 'settings', 'logs', 'metrics', 'updateNotify']
@@ -272,6 +273,36 @@ function isEsp32Platform(platform: unknown): boolean {
 export function isEsp32CloudFrame(frame?: FrameCapabilityInput | null, mode: WorkspaceMode = workspaceMode()): boolean {
   return mode === 'cloud' && isEsp32Platform(frame?.hardware?.platform)
 }
+
+/**
+ * An embedded-mode frame on the "virtual" platform (devices.ts
+ * EMBEDDED_VIRTUAL; string literal here so this module stays import-free):
+ * no hardware at all — the backend renders the frame and serves it as an
+ * image/page URL.
+ */
+export function isVirtualFrame(frame?: FrameCapabilityInput | null): boolean {
+  return frame?.embedded?.platform === 'virtual'
+}
+
+/**
+ * Unlike the esp32 cloud profile above — which DISABLES controls, because the
+ * verbs exist and the firmware merely doesn't answer them yet — a virtual
+ * frame HIDES these surfaces: the concepts themselves don't exist. There is
+ * no shell to open, no device to ping or reboot, no on-device storage to
+ * browse, and no host to chart metrics for, so a disabled button would have
+ * nothing to explain.
+ */
+const virtualFrameHiddenPanels: readonly WorkspaceUtilityPanel[] = ['terminal', 'ping', 'assets', 'metrics']
+
+const virtualFrameHiddenMenuActions: readonly FrameMenuAction[] = [
+  'buildSdCard',
+  'deployRemote',
+  'localDeploy',
+  'reboot',
+  'restart',
+  'restartRemote',
+  'stop',
+]
 
 /**
  * The management verbs this frame's device profile supports. Only the cloud
@@ -337,9 +368,19 @@ function capabilityDisabledReason(
 }
 
 // Visibility is the mode's business alone — see the capability block comment
-// above for why the device profile disables rather than hides.
+// above for why the device profile disables rather than hides — with one
+// exception: virtual frames hide the surfaces whose concepts don't exist for
+// them at all (virtualFrameHiddenPanels/-MenuActions above). Callers with a
+// frame in hand pass it; without one the mode-level answer stands.
 
-export function frameToolPanelIsAllowed(mode: WorkspaceMode, panel: WorkspaceUtilityPanel): boolean {
+export function frameToolPanelIsAllowed(
+  mode: WorkspaceMode,
+  panel: WorkspaceUtilityPanel,
+  frame?: FrameCapabilityInput | null
+): boolean {
+  if (isVirtualFrame(frame) && virtualFrameHiddenPanels.includes(panel)) {
+    return false
+  }
   return allows(allowedFrameToolPanels, mode, panel)
 }
 
@@ -352,7 +393,14 @@ export function frameToolPanelDisabledReason(
   return capabilityDisabledReason(panelCapabilities[panel], mode, frame)
 }
 
-export function sceneToolPanelIsAllowed(mode: WorkspaceMode, panel: WorkspaceUtilityPanel): boolean {
+export function sceneToolPanelIsAllowed(
+  mode: WorkspaceMode,
+  panel: WorkspaceUtilityPanel,
+  frame?: FrameCapabilityInput | null
+): boolean {
+  if (isVirtualFrame(frame) && virtualFrameHiddenPanels.includes(panel)) {
+    return false
+  }
   return allows(allowedSceneToolPanels, mode, panel)
 }
 
@@ -368,7 +416,14 @@ export function sceneUtilityPanelIsAllowed(mode: WorkspaceMode, panel: Workspace
   return allows(allowedSceneUtilityPanels, mode, panel)
 }
 
-export function frameMenuActionIsAllowed(mode: WorkspaceMode, action: FrameMenuAction): boolean {
+export function frameMenuActionIsAllowed(
+  mode: WorkspaceMode,
+  action: FrameMenuAction,
+  frame?: FrameCapabilityInput | null
+): boolean {
+  if (isVirtualFrame(frame) && virtualFrameHiddenMenuActions.includes(action)) {
+    return false
+  }
   return allows(allowedFrameMenuActions, mode, action)
 }
 

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -7,6 +7,7 @@ import type { FrameId } from './utils/frameId'
 export type { FrameId }
 
 export type FrameErrorBehaviorMode = 'safe_mode' | 'show_error_retry' | 'silent_retry'
+export type FrameVirtualColorMode = 'rgb' | 'bw' | 'gray4' | 'bwyr' | 'sevencolor' | 'spectra6'
 export type FrameEmbeddedFlashSize = '2MB' | '4MB' | '8MB' | '16MB' | '32MB'
 export type FrameEmbeddedHardwarePreset =
   | 'custom'
@@ -107,6 +108,9 @@ export interface FrameType {
     psramMB?: number
     renderMode?: 'local' | 'remote' | 'on_device' | 'thin_client' | 'backend'
     hardwarePreset?: FrameEmbeddedHardwarePreset
+    /** Virtual frames only: how the backend quantizes the rendered image.
+     * Mirrors VIRTUAL_COLOR_MODES in backend/app/api/virtual_frame.py. */
+    colorMode?: FrameVirtualColorMode
     pins?: {
       rst?: number
       dc?: number
@@ -296,6 +300,10 @@ export interface NewFrameFormType {
   device?: string | null
   device_config?: FrameType['device_config']
   embedded?: FrameEmbeddedConfig
+  /** Virtual frames only. FrameCreateRequest has no width/height fields, so
+   * these are applied with a follow-up update right after creation. */
+  width?: number
+  height?: number
   timezone?: string | null
   server_host?: string | null
   ssh_pass?: string | null

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -111,6 +111,8 @@ export interface FrameType {
     /** Virtual frames only: how the backend quantizes the rendered image.
      * Mirrors VIRTUAL_COLOR_MODES in backend/app/api/virtual_frame.py. */
     colorMode?: FrameVirtualColorMode
+    // View-only credential for the virtual image/page URLs
+    viewToken?: string
     pins?: {
       rst?: number
       dc?: number


### PR DESCRIPTION
Fourth PR in the chain (#296 → #298 → #299 → this), based on `pico-inky-frames`.

A new **virtual** embedded platform for self-hosted backends: a frame with no hardware at all. The backend renders its scenes in the same sandboxed wasm runtime the thin-client boards use, and serves the result as URLs anything can display.

## Endpoints

- `GET /api/frames/{id}/virtual/image?k=<server_api_key>` — one PNG per request at the frame's configured size (16–4096 per side, default 800×480), optionally quantized to an e-ink-style palette via `device_config.colorMode`: `rgb | bw | gray4 | bwyr | sevencolor | spectra6`.
- `GET /api/frames/{id}/virtual/page?k=<server_api_key>` — a black full-screen kiosk page that swaps the image in place on the frame's interval. Paste into any browser, tablet, or signage player and walk away.

The token is the frame's `server_api_key` (the same device credential hardware thin clients present as a Bearer header), in the query because kiosk browsers can't set headers — rotating the key invalidates the URL. The endpoints refuse non-virtual frames, so hardware frames gain no new URL surface. Virtual frames have no firmware: the build path refuses with a pointer at the URL.

## UI

- **"Virtual frame" is its own card** under Add frame → installation methods ("No hardware — the backend renders to a PNG anyone can download."), with a dedicated create form asking name, width, height, and color mode up front. (The create API schema carries `device_config` but not width/height, so those apply via the frame-update call immediately after creation.)
- Frame settings and the deploy drawer show both URLs with copy buttons for virtual frames, and hide every ESP32-specific control.
- Ride-along UI fixes from user feedback: hardware preset dropdowns now mark thin-client boards ("— Thin client", derived from the preset's platform), and the embedded display-panel select defaults to a real "No display panel" (device `"none"`) — replacing the old `web_only` option that the backend silently rewrote into a 7.5" panel frame.

## Tests

6 new backend tests (token auth, non-virtual refusal, PNG size, b/w quantization, kiosk page contents, frame defaults) — pass alongside the existing 75 embedded tests. Frontend `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)