### PR TITLE
Hotfix: C3 release link error, cloud/backend scene fights, version-bump revert

### DIFF
--- a/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
@@ -48,6 +48,11 @@ bool frameos_nim_send_event(const char *event, const char *payload_json)
     return false;
 }
 void frameos_nim_log_hook(const char *msg) { (void)msg; }
+size_t frameos_nim_log_recent(frameos_log_entry_t *out, size_t max)
+{
+    (void)out; (void)max;
+    return 0;
+}
 void frameos_nim_set_log_tap(void (*tap)(const char *line)) { (void)tap; }
 void frameos_nim_set_log_upload_enabled(bool enabled) { (void)enabled; }
 void frameos_nim_flush_logs(void) {}

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -1659,6 +1659,26 @@ static void ws_handle_message(const char *data, size_t len)
     const cJSON *id = cJSON_GetObjectItem(root, "id");
     const char *type = cJSON_IsString(type_item) ? type_item->valuestring : "";
 
+    /* One control plane owns the content (docs/cloud-frames.md): enrollment
+     * is refused while a backend is configured, but a device that gained a
+     * backend AFTER enrolling (bench/dev setups) must not let the provider's
+     * stale scene assignment overwrite the backend's set on every reconnect
+     * — the hub re-pushes whenever its assigned checksum differs. Content
+     * mutations defer to the backend; telemetry, assets and OTA still work. */
+    static const char *backend_owned_verbs[] = {
+        "set_scenes", "set_current_scene", "set_settings", "set_schedule",
+    };
+    if (fos_config()->backend_url[0] != '\0') {
+        for (size_t i = 0; i < sizeof(backend_owned_verbs) / sizeof(backend_owned_verbs[0]); i++) {
+            if (strcmp(type, backend_owned_verbs[i]) == 0) {
+                ESP_LOGW(TAG, "ws: refusing %s — this frame is backend-managed", type);
+                ws_ack(id, false, "backend_managed");
+                cJSON_Delete(root);
+                return;
+            }
+        }
+    }
+
     if (strcmp(type, "challenge") == 0) {
         ws_send_auth(root);
     } else if (strcmp(type, "ready") == 0) {

--- a/frameos/editor/package.json
+++ b/frameos/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frameos-editor",
-  "version": "2026.8.10",
+  "version": "2026.8.9",
   "description": "The FrameOS visual scene editor as an embeddable static bundle: serve it from any host, embed it in an iframe, and exchange scenes JSON over postMessage.",
   "keywords": [
     "frameos",

--- a/frameos/wasm/package.json
+++ b/frameos/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frameos-wasm",
-  "version": "2026.8.10",
+  "version": "2026.8.8",
   "description": "Run FrameOS scenes in the browser via WebAssembly: a typed live-preview runtime plus a minimal showIf-aware management interface.",
   "keywords": [
     "frameos",

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
-  "frameos": "2026.8.10+5881ab45448b26501d748fbe75d4e7a5d8bf3667",
-  "editor": "2026.8.10+90b1b66c5461db3cba35f753bd197cd70f92d155",
+  "frameos": "2026.8.8+e9566fc0565ce6112fc957a5e2dfbdee87aea373",
+  "editor": "2026.8.9+6a3bcfdb31045ca4dc2c42aeddf66e38403ada07",
   "remote": "2026.8.2+d31a5be89a229f1132bf4a4a6cd31aa73665c368",
-  "docker": "2026.8.10+c1b38d62b2ba2e506162db3d83c55095a1400f08"
+  "docker": "2026.8.9+ae17e86940fc2c32b7ed4e47ccaa3430c730d7f7"
 }


### PR DESCRIPTION
Three things to unbreak the release and the bench frame:

1. **C3 release build fix** — the log ring (#301) added `frameos_nim_log_recent` to the glue but not to `frameos_nim_stub.c`, which is what thin-client ESP32-C3 builds link. The release workflow's C3 job died on the undefined reference (the S3 CI job always compiles the real glue, so PR CI never saw it). The stub returns an empty ring — the honest answer for a thin client. Verified locally with the C3 `ci_build_image.sh` (links + all layout assertions pass).

2. **"After an OTA we lose all scenes"** — a frame enrolled to a cloud *and* configured with a backend served two masters: the hub re-pushes its assigned scenes on every reconnect (checksum mismatch), clobbering the backend set after each reboot, and the local-etag rule then blocked the backend sync from restoring them. Content verbs (`set_scenes`/`set_current_scene`/`set_settings`/`set_schedule`) are now refused with `backend_managed` while a backend URL is configured — the runtime enforcement of the "one control plane" rule that enrollment already applies. Telemetry, assets and cloud OTA still work. Verified on the bench frame: re-push refused, 12 scenes restored and surviving reboots.

3. **Reverts `chore: version 2026.8.10`** — the failed run's version bump, so re-dispatching "Release FrameOS" starts clean (no tag was pushed).

After merging: re-run the Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)