### PR TITLE
ESP32: spill validation on hardware, scene cadence fixes, per-profile build dirs

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -349,10 +349,11 @@ jobs:
   # in and the active panel is chosen at runtime (`set panel <key>` on the
   # serial console or the setup portal dropdown); FRAMEOS_SELECTED_PANEL only
   # sets the boot-time default, kept at EPD_7in5_V2 for backward compat.
-  # The binary is published as -generic.bin; an identical copy keeps the old
-  # -epd7in5v2.bin name for one release cycle so cloud deployments that still
-  # reference it keep working — drop the copy after the cloud side reads
-  # -generic.bin from release metadata.
+  # The binary is published as -generic.bin only. The transitional
+  # -epd7in5v2.bin duplicate is gone: the cloud firmware route has read
+  # -generic.bin from release metadata since the same release cycle, no
+  # shipped firmware ever requested the old name for OTA, and old releases
+  # keep the asset they were published with.
   build-esp32-generic-firmware:
     name: Build ESP32 firmware (generic, all panels)
     needs: [update-versions]
@@ -408,10 +409,6 @@ jobs:
               bash embedded/esp32/ci_build_image.sh
               cp embedded/esp32/build-ci/merged-binary.bin \
                 "/release-assets/frameos-$DOCKER_VERSION-esp32-s3-generic.bin"
-              # Transitional copy under the pre-runtime-panel-selection name;
-              # remove once no deployed cloud references it.
-              cp embedded/esp32/build-ci/merged-binary.bin \
-                "/release-assets/frameos-$DOCKER_VERSION-esp32-s3-epd7in5v2.bin"
               # ESP32-C3 thin-client firmware (TRMNL OG/BWRY, XTEINK X4):
               # 4MB no-OTA layout, no on-device Nim renderer.
               FRAMEOS_ESP32_PLATFORM=esp32-c3 \
@@ -470,8 +467,6 @@ jobs:
           path: |
             release-assets/*-esp32-s3-generic.bin
             release-assets/*-esp32-s3-generic.bin.minisig
-            release-assets/*-esp32-s3-epd7in5v2.bin
-            release-assets/*-esp32-s3-epd7in5v2.bin.minisig
             release-assets/*-esp32-c3-generic.bin
             release-assets/*-esp32-c3-generic.bin.minisig
           if-no-files-found: error

--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -1217,37 +1217,32 @@ def test_ready_4mb_firmware_does_not_require_ota_artifact(tmp_path):
 
 
 def test_reset_stale_embedded_sdkconfig_removes_generated_files(tmp_path):
-    sdkconfig = tmp_path / "sdkconfig"
-    sdkconfig.write_text("CONFIG_ESP_MAIN_TASK_STACK_SIZE=3584\n", encoding="utf-8")
-    sdkconfig_old = tmp_path / "sdkconfig.old"
-    sdkconfig_old.write_text("CONFIG_ESP_MAIN_TASK_STACK_SIZE=3584\n", encoding="utf-8")
-    build_dir = tmp_path / "build"
+    build_dir = tmp_path / "build-esp32-s3-8mb"
     build_dir.mkdir()
+    sdkconfig = build_dir / "sdkconfig"
+    sdkconfig.write_text("CONFIG_ESP_MAIN_TASK_STACK_SIZE=3584\n", encoding="utf-8")
     (build_dir / "stale.o").write_text("old", encoding="utf-8")
 
-    with patch("app.tasks.embedded_firmware.EMBEDDED_PROJECT_DIR", tmp_path):
-        missing = _reset_stale_embedded_sdkconfig(build_dir)
+    missing = _reset_stale_embedded_sdkconfig(build_dir)
 
     assert missing == {
         "CONFIG_ESP_ERR_TO_NAME_LOOKUP": "y",
         "CONFIG_ESP_MAIN_TASK_STACK_SIZE": "8192",
     }
     assert not sdkconfig.exists()
-    assert not sdkconfig_old.exists()
     assert not build_dir.exists()
 
 
 def test_reset_stale_embedded_sdkconfig_keeps_current_config(tmp_path):
-    sdkconfig = tmp_path / "sdkconfig"
+    build_dir = tmp_path / "build-esp32-s3-8mb"
+    build_dir.mkdir()
+    sdkconfig = build_dir / "sdkconfig"
     sdkconfig.write_text(
         "CONFIG_ESP_ERR_TO_NAME_LOOKUP=y\nCONFIG_ESP_MAIN_TASK_STACK_SIZE=8192\n",
         encoding="utf-8",
     )
-    build_dir = tmp_path / "build"
-    build_dir.mkdir()
 
-    with patch("app.tasks.embedded_firmware.EMBEDDED_PROJECT_DIR", tmp_path):
-        missing = _reset_stale_embedded_sdkconfig(build_dir)
+    missing = _reset_stale_embedded_sdkconfig(build_dir)
 
     assert missing == {}
     assert sdkconfig.exists()
@@ -1255,7 +1250,9 @@ def test_reset_stale_embedded_sdkconfig_keeps_current_config(tmp_path):
 
 
 def test_reset_stale_embedded_sdkconfig_detects_flash_profile_switch(tmp_path):
-    sdkconfig = tmp_path / "sdkconfig"
+    build_dir = tmp_path / "build-esp32-s3-8mb"
+    build_dir.mkdir()
+    sdkconfig = build_dir / "sdkconfig"
     sdkconfig.write_text(
         '\n'.join([
             'CONFIG_ESP_ERR_TO_NAME_LOOKUP=y',
@@ -1267,12 +1264,9 @@ def test_reset_stale_embedded_sdkconfig_detects_flash_profile_switch(tmp_path):
         ]),
         encoding="utf-8",
     )
-    build_dir = tmp_path / "build"
-    build_dir.mkdir()
 
     required = embedded_required_sdkconfig_for_frame(Frame(embedded={"flashSize": "32MB"}))
-    with patch("app.tasks.embedded_firmware.EMBEDDED_PROJECT_DIR", tmp_path):
-        missing = _reset_stale_embedded_sdkconfig(build_dir, required)
+    missing = _reset_stale_embedded_sdkconfig(build_dir, required)
 
     assert missing == {
         "CONFIG_ESPTOOLPY_FLASHSIZE": '"32MB"',

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -741,15 +741,21 @@ def _missing_required_sdkconfig(path: Path, required: dict[str, str] | None = No
     }
 
 
+def embedded_build_dir(platform: str, flash_profile: dict[str, Any]) -> Path:
+    """Backend builds get a build dir per platform + flash profile (matching
+    ci_build_image.sh's -B convention), with the generated sdkconfig inside
+    it. Chip-target or flash-size switches then land in separate directories
+    instead of wiping one shared CMake cache, and backend builds never
+    clobber the in-tree build/ + sdkconfig a manual idf.py workflow uses.
+    The build-* prefix keeps these out of the source fingerprint."""
+    return EMBEDDED_PROJECT_DIR / f"build-{platform}-{str(flash_profile['flashSize']).lower()}"
+
+
 def _reset_stale_embedded_sdkconfig(build_dir: Path, required: dict[str, str] | None = None) -> dict[str, str]:
-    sdkconfig_path = EMBEDDED_PROJECT_DIR / "sdkconfig"
+    sdkconfig_path = build_dir / "sdkconfig"
     missing = _missing_required_sdkconfig(sdkconfig_path, required)
     if not missing or not sdkconfig_path.exists():
         return {}
-    sdkconfig_path.unlink()
-    sdkconfig_old_path = EMBEDDED_PROJECT_DIR / "sdkconfig.old"
-    if sdkconfig_old_path.exists():
-        sdkconfig_old_path.unlink()
     if build_dir.exists():
         shutil.rmtree(build_dir)
     return missing
@@ -1926,7 +1932,7 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
               f"Building {platform_spec['label']} firmware with ESP-IDF at {idf_path} "
               f"(panel={selected_panel}, flash={flash_profile['flashSize']})")
 
-    build_dir = EMBEDDED_PROJECT_DIR / "build"
+    build_dir = embedded_build_dir(platform, flash_profile)
     # export.sh refuses to run inside a foreign Python venv; scrub venv vars and
     # let it activate the ESP-IDF Python environment itself.
     env = {k: v for k, v in os.environ.items() if k not in {"VIRTUAL_ENV", "IDF_PYTHON_ENV_PATH"}}
@@ -1984,9 +1990,11 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
                   "nim not found on the worker; building firmware without the on-device Nim runtime")
     # generated_config.h and a fresh nimcache require a CMake reconfigure: the
     # component globs nimcache/*.c at configure time.
+    idf_base = (f'idf.py -B {shlex.quote(str(build_dir))} '
+                f'-D SDKCONFIG={shlex.quote(str(build_dir / "sdkconfig"))}')
     command = (f'source "$IDF_PATH/export.sh" >/dev/null 2>&1 && {nim_step}'
-               f'idf.py -D SDKCONFIG_DEFAULTS={shlex.quote(sdkconfig_defaults)} '
-               'reconfigure >/dev/null && idf.py build merge-bin')
+               f'{idf_base} -D SDKCONFIG_DEFAULTS={shlex.quote(sdkconfig_defaults)} '
+               f'reconfigure >/dev/null && {idf_base} build merge-bin')
 
     build_lock_token = await _acquire_embedded_build_lock(redis)
     try:
@@ -2031,7 +2039,7 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
         tail = "\n".join(output_tail[-20:])
         raise ValueError(f"idf.py build failed with exit code {returncode}:\n{tail}")
 
-    missing_sdkconfig = _missing_required_sdkconfig(EMBEDDED_PROJECT_DIR / "sdkconfig", required_sdkconfig)
+    missing_sdkconfig = _missing_required_sdkconfig(build_dir / "sdkconfig", required_sdkconfig)
     if missing_sdkconfig:
         missing = ", ".join(f"{key}={value}" for key, value in sorted(missing_sdkconfig.items()))
         raise ValueError(f"ESP32 sdkconfig is missing required defaults after build: {missing}")

--- a/docs/esp32-photopainter-todo.md
+++ b/docs/esp32-photopainter-todo.md
@@ -1,130 +1,42 @@
-# ESP32 13.3" PhotoPainter (ESP32-S3-ePaper-13.3E6) — full-support TODO
+# ESP32 13.3" (ESP32-S3-ePaper-13.3E6) — remaining TODO
 
 Goal: the 13.3E6 frame works standalone over Wi-Fi with OTA, against both the
-self-hosted backend and FrameOS Cloud; fast deploy (scenes + reload) and full
-deploy (firmware rebuild + upgrade) both work; assets and logs work; and when
-connected over USB serial, every control/upload/download has a serial path.
+self-hosted backend and FrameOS Cloud; fast deploy and full deploy both work;
+assets and logs work; and when connected over USB serial, every
+control/upload/download has a serial path.
 
 Hardware facts (Waveshare docs): 32 MB flash, 16 MB PSRAM, ETA6098 charge IC
 (not an I2C PMIC — no telemetry), MX1.25 battery header, no RTC chip, no user
 buttons (BOOT/Reset only), TF slot on SPI3. The existing
 `waveshare_esp32_s3_epaper_13_3e6` preset is correct; no new preset needed.
 
-## Already works (verified on device / in code)
+## Status 2026-08-08
 
-- Standalone: captive-portal + serial provisioning, offline render from cached
-  `/state/scenes.json`, APSTA fallback, SNTP.
-- Local rendering: Nim + pixie + QuickJS interpreter on-device (~14.5 s/render).
-- Fast deploy (backend): push `POST /uploadScenes` + `/reload` over LAN, pull
-  `GET /embedded/scenes` with ETag; USB `usb_api upload-scenes`; cloud
-  `set_scenes` push with `scene_ack`. Hot reload, no reboot.
-- OTA (backend): manifest + resumable download, rollback-protected early-boot
-  updater, 24 h periodic check, `POST /api/action/ota` poke.
-- Cloud: enrollment (FRCT_ claim token / device flow), Ed25519 WS auth,
-  verbs `get_state render reboot restart_runtime set_current_scene set_scenes
-  set_settings assets_list asset_get image_get`, scope-gated log streaming,
-  browser flasher.
-- Logs (live): `POST /api/log` to backend, WS `log_batch` to cloud, serial
-  console stream into the Logs panel.
-- Browser flash over WebSerial (esptool-js, watchdog reset, SPIFFS preserved).
+The parity push is essentially done, all hardware-verified on the bench
+13.3E6: assets over HTTP/cloud-WS/USB, full deploy (backend build → OTA),
+restart/reboot, logs + metrics, live `/embedded/settings`, USB provisioning
+UI, on-device scene scheduler (#301–#302); signed cloud OTA (#303); C3
+thin-client stub parity + dual-control-plane fix (#304); file-backed
+streaming decode for spilled PNGs (pixie `17512ae`), forced-spill validation
+(`set spill_force <bytes>`), scene refreshInterval/nextSleep cadence fixes,
+and per-profile backend build dirs (#305).
 
-## Status 2026-08-07 (branch esp32-photopainter)
+## Remaining
 
-P0 items 1-6 are DONE and hardware-verified on the bench 13.3E6 against a
-live local backend: assets round-trip over HTTP/cloud-WS/USB, full deploy
-delivered a backend-built image over OTA (device booted from ota_1),
-restart/reboot work from backend tasks, logs+metrics ingest within seconds
-(two silent-failure bugs found and fixed on the way: the 48K TLS-sized
-heap floor muting plain-http log upload, and metrics queued past the last
-flush), and /embedded/settings serves the ETag'd frame object the firmware
-applies live. P1: usb_api provisioning verbs + structured wifi-scan are
-in (with a pre-existing scan-vs-reconnect race fixed); spill dir is wired
-(forced-spill render validation pending); 32MB layout is CI-validated.
-Remaining: forced-spill render validation, image_get e2e check. Cloud OTA
-+ signed OTA landed on branch cloud-ota (verified live: hub verb →
-manifest → streamed download → Ed25519 verify → slot switch → reboot);
-the USB provisioning UI and set_schedule landed in #302.
-
-## P0 — core gaps (this effort)
-
-1. **Land `fix/cloud-frames-ws-watchdog`** (4 unmerged commits: cloud WS
-   watchdog in `fos_cloud.c`, readable cloud device logs, ESP32 `set_settings`
-   + compact settings surface, USB image hardening, e2e fix). PR + merge first;
-   everything below builds on top.
-
-2. **Assets end-to-end** (biggest hole — today the SD card must be moved by
-   hand):
-   - Firmware: real HTTP asset API on the device (`GET /api/frames/{id}/assets`
-     list, file get/upload/mkdir/delete/rename against the SD/`/state` paths).
-     `fos_http.c:1735` currently returns hardcoded `{"assets":[]}`.
-   - Backend: asset routes (`frames.py:2368-2600`) are SSH/agent-only — add an
-     embedded branch that proxies to the device HTTP API instead.
-   - Cloud: implement `asset_put/asset_mkdir/asset_delete/asset_rename` verbs
-     (currently `unsupported_verb`, `fos_cloud.c:1569`), sharing the same
-     firmware asset layer.
-   - USB: `usb_api upload-asset` / `list-assets` so photos load over serial.
-   - Enable FAT long filenames (8.3 names today).
-
-3. **Full deploy = rebuild + OTA over Wi-Fi**:
-   - `_plan_full()` (`frame_deploy_workflow.py:593`) has no embedded branch —
-     `POST /frames/{id}/deploy` on an ESP32 dies in SSH. Make full deploy for
-     embedded: build firmware (existing `embedded_firmware_task`) → wait ready
-     → trigger OTA → confirm via bootup log. Surface as the normal Deploy
-     button.
-   - Fix firmware-build hygiene while in there: platform metadata hardcodes
-     `esp32-s3` (`embedded_firmware.py:1627,1983-1998,2029`), `configHash`
-     omits the IDF target so S3↔C3 switches can serve stale images, shared
-     in-tree build dir races concurrent builds.
-
-4. **Restart/reboot + control parity (backend mode)**:
-   - Firmware: add `POST /api/action/restart` (runtime reload) — reboot exists
-     via cloud only; expose both over LAN HTTP and `usb_api`.
-   - Backend: `restart_frame_task`/`reboot_frame_task` are systemd-over-SSH
-     (`tasks/restart_frame.py`) — add embedded branches; gate `/reset`,
-     `/stop`, `/deploy_remote`, `/restart_remote`, `/clear_build_cache` with
-     400s for embedded.
-   - Frontend: `workspaceSurfaces.ts` only gates panels for `virtual` and
-     cloud-ESP32 — extend to backend-mode ESP32 (hide Terminal/Ping, keep
-     Assets/Metrics once they work, wire Restart/Reboot to the new endpoints).
-
-5. **Logs at rest + metrics**:
-   - Firmware: PSRAM ring buffer of recent log lines → serve
-     `GET /api/frames/{id}/logs` (hardcoded empty today, `fos_http.c:1727`),
-     cloud `get_logs`, and `usb_api logs`.
-   - Firmware: emit a periodic `metrics` log event (heap, PSRAM, RSSI, uptime,
-     render ms) → backend `new_metrics` ingests it as-is → Metrics panel and
-     cloud `get_metrics` come alive.
-
-6. **Settings without reflash**: firmware pulls
-   `GET /embedded/settings` (endpoint exists, never consumed) during scene
-   sync; extend the payload beyond HA/immich/openAI/unsplash to
-   interval/deep_sleep/render_mode/name so backend saves apply live.
-
-## P1 — cloud + serial completeness
-
-7. **USB serial parity**: `usb_api` lacks machine-framed
-   `set`/`wifi`/`wifi-scan`/`restart`/`factory-reset` (browser must scrape
-   REPL text); frontend exposes no Wi-Fi re-provisioning over USB and never
-   calls existing `reload/scenes-sync/ota/scene-state`. Add subcommands +
-   a small USB provisioning UI; prefer USB transport for controls when serial
-   is connected.
-8. **Cloud OTA**: implement the `ota`/`notify_update_available` verb pulling
-   the published generic image; signed OTA (minisign over release assets,
-   verify in `fos_ota.c` and `upgrade.nim`) is the named blocker — may split
-   into its own effort.
-9. **Large-image spill**: wire `fos_nim_http_set_spill_dir()` in `main.c`
-   (+ boot sweep of `http-spill-*.tmp`), validate with a ~3 MB gallery JPEG on
-   this frame; PNG full-decode OOM on 13.3E6 is the named repro.
-10. **Cloud verb stragglers**: `set_schedule` (TODO at `fos_cloud.c:1817`),
-    `image_get` end-to-end verification.
-11. **CI: validate the 32 MB layout** (`ci_build_image.sh` only checks
-    8 MB/4 MB; this board is 32 MB and nobody build-tests that profile).
+1. **`image_get` cloud verb**: end-to-end verification (the verb exists and
+   is wired; nobody has confirmed the full path against a live frame).
 
 ## P2 — later / nice-to-have
 
 - Battery: 13.3E6 has a battery header but no telemetry IC; check the
   schematic for a voltage-divider ADC pin and set `battery_pin` if present.
-- Deep-sleep improvements (GPIO wake is moot — no buttons), portal Wi-Fi scan
-  list in the HTML form, portal AP password, mDNS advertisement, log
-  persistence across offline periods, firmware artifact GC, API-key rotation
-  without reflash, per-frame build dirs.
+- Deep-sleep improvements (GPIO wake is moot — no buttons).
+- Portal: Wi-Fi scan list in the HTML form, AP password.
+- mDNS advertisement.
+- Log persistence across offline periods.
+- Firmware artifact GC.
+- API-key rotation without reflash (the bench unit's stuck NVS `api_key` is
+  the live example — `set api_key` cannot unset a value).
+- Parallel firmware builds: build dirs are per-profile now, but
+  `main/generated_config.h` and the Nim `nimcache` are still shared in-tree,
+  so builds serialize under the global build lock.

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -51,6 +51,7 @@ extern bool fos_nim_set_scene_impl(const char *scene_id);
 extern int fos_nim_load_scenes_impl(const char *json);
 extern void fos_nim_invalidate_settings_impl(void);
 extern double fos_nim_scene_interval_impl(void);
+extern double fos_nim_next_sleep_impl(void);
 extern bool fos_nim_render_requested_impl(void);
 extern bool fos_nim_send_event_impl(const char *event, const char *payload_json);
 
@@ -424,6 +425,15 @@ double frameos_nim_scene_interval(void)
     double interval = fos_nim_scene_interval_impl();
     nim_lock_give();
     return interval;
+}
+
+double frameos_nim_next_sleep(void)
+{
+    if (!s_nim_ready) return -1;
+    if (!nim_lock_take()) return -1;
+    double next_sleep = fos_nim_next_sleep_impl();
+    nim_lock_give();
+    return next_sleep;
 }
 
 bool frameos_nim_render_requested(void)
@@ -881,6 +891,7 @@ static const char *TAG = "fos_nim_http";
 static char s_http_spill_dir[128] = "";
 static size_t s_http_spill_max_bytes = 0;
 static uint32_t s_http_spill_seq = 0;
+static size_t s_http_spill_force_bytes = 0;
 
 void fos_nim_http_set_spill_dir(const char *dir, size_t max_spill_bytes)
 {
@@ -891,6 +902,11 @@ void fos_nim_http_set_spill_dir(const char *dir, size_t max_spill_bytes)
     }
     snprintf(s_http_spill_dir, sizeof(s_http_spill_dir), "%s", dir);
     s_http_spill_max_bytes = max_spill_bytes;
+}
+
+void fos_nim_http_set_spill_force_bytes(size_t threshold)
+{
+    s_http_spill_force_bytes = threshold;
 }
 
 typedef enum {
@@ -1052,7 +1068,10 @@ static fos_nim_body_status_t http_spill_remaining(
         fos_nim_http_free_chunks(chunks, chunk_count);
         return FOS_NIM_BODY_SPILL_FAILED;
     }
-    ESP_LOGI(TAG, "%s: PSRAM exhausted after %u buffered bytes; spilling body to %s",
+    /* WARN: spilling is a memory-pressure event (or the spill_force debug
+     * knob) and the only runtime evidence the spill path ran — the 32MB
+     * profile compiles ESP_LOGI out (CONFIG_LOG_DEFAULT_LEVEL=WARN). */
+    ESP_LOGW(TAG, "%s: PSRAM exhausted after %u buffered bytes; spilling body to %s",
              url, (unsigned)buffered, path);
 
     bool ok = true;
@@ -1113,7 +1132,7 @@ static fos_nim_body_status_t http_spill_remaining(
     }
     *out_path = dup;
     *out_total = total;
-    ESP_LOGI(TAG, "%s: spilled %u-byte body to %s", url, (unsigned)total, path);
+    ESP_LOGW(TAG, "%s: spilled %u-byte body to %s", url, (unsigned)total, path);
     return FOS_NIM_BODY_OK;
 }
 
@@ -1257,15 +1276,23 @@ fos_nim_http_chunk *fos_nim_http_request_chunked_spill(
             if (want > limit - total) want = limit - total;
             if (want < 1) want = 1;
             uint8_t *buf = NULL;
-            while (true) {
-                size_t free_spiram =
-                    heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-                if (free_spiram >= want + 1 + FOS_NIM_HTTP_PSRAM_RESERVE) {
-                    buf = heap_caps_malloc(want + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+            /* Debug knob (`set spill_force <bytes>`): pretend PSRAM ran out
+             * once this many bytes are buffered, so the spill path can be
+             * exercised on a frame with memory to spare. Small bodies
+             * (scene JSON, API calls) keep buffering normally. */
+            bool force_spill = s_http_spill_force_bytes > 0 && spill_allowed &&
+                               total >= s_http_spill_force_bytes;
+            if (!force_spill) {
+                while (true) {
+                    size_t free_spiram =
+                        heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                    if (free_spiram >= want + 1 + FOS_NIM_HTTP_PSRAM_RESERVE) {
+                        buf = heap_caps_malloc(want + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                    }
+                    if (buf != NULL) break;
+                    if (want <= FOS_NIM_HTTP_CHUNK_MIN_BYTES) break;
+                    want /= 2;
                 }
-                if (buf != NULL) break;
-                if (want <= FOS_NIM_HTTP_CHUNK_MIN_BYTES) break;
-                want /= 2;
             }
             if (buf == NULL) {
                 if (spill_allowed) {

--- a/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
@@ -41,6 +41,7 @@ int frameos_nim_load_scenes(const char *json)
     return 0;
 }
 double frameos_nim_scene_interval(void) { return 0; }
+double frameos_nim_next_sleep(void) { return -1; }
 bool frameos_nim_render_requested(void) { return false; }
 bool frameos_nim_send_event(const char *event, const char *payload_json)
 {
@@ -74,3 +75,4 @@ void fos_nim_http_set_spill_dir(const char *dir, size_t max_spill_bytes)
 {
     (void)dir; (void)max_spill_bytes;
 }
+void fos_nim_http_set_spill_force_bytes(size_t threshold) { (void)threshold; }

--- a/embedded/esp32/components/frameos_nim/include/frameos_nim.h
+++ b/embedded/esp32/components/frameos_nim/include/frameos_nim.h
@@ -52,6 +52,9 @@ int frameos_nim_load_scenes(const char *json);
 void frameos_nim_invalidate_settings(void);
 /* Refresh interval requested by the active scene, seconds; 0 = no opinion. */
 double frameos_nim_scene_interval(void);
+/* Sleep override from the scene's last render (logic/nextSleepDuration);
+ * negative = no override. Consult only right after a successful render. */
+double frameos_nim_next_sleep(void);
 /* True once when a scene event requested a redraw (clears the flag). */
 bool frameos_nim_render_requested(void);
 /* Deliver a JSON event payload to the current interpreted scene. */
@@ -135,6 +138,10 @@ fos_nim_http_chunk *fos_nim_http_request_chunked_spill(
  * before renders start; leftover http-spill-*.tmp files from a crash should
  * be swept at boot. */
 void fos_nim_http_set_spill_dir(const char *dir, size_t max_spill_bytes);
+/* Debug knob: force bodies to spill once `threshold` bytes are buffered,
+ * even with PSRAM free (0 = off). Lets the spill decode path be validated
+ * on frames that would otherwise never hit real memory pressure. */
+void fos_nim_http_set_spill_force_bytes(size_t threshold);
 
 #ifdef __cplusplus
 }

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -805,11 +805,15 @@ static void client_task(void *arg)
          * changes without a rebuild. ETag'd, so steady state is a 304. */
         fos_settings_sync(false);
 
+        /* A console `set spill_force` may have changed it since last pass. */
+        fos_nim_http_set_spill_force_bytes(config->http_spill_force_bytes);
+
         /* Battery guardrail: when the cell is nearly empty, skip the (costly)
          * render + panel refresh and sleep long so a low battery can't keep
          * cycling the display down to a damaging voltage. */
         int battery_pct = fos_battery_present() ? fos_battery_percent() : -1;
         bool battery_critical = battery_pct >= 0 && battery_pct <= FOS_BATTERY_CRITICAL_PCT;
+        bool rendered = false;
         if (battery_critical) {
             ESP_LOGW(TAG, "battery critical (%d%%); skipping render to protect the cell", battery_pct);
             log_render_skipped("battery", battery_pct);
@@ -819,21 +823,41 @@ static void client_task(void *arg)
                 log_render_skipped("ota", -1);
             } else {
                 render_once();
+                rendered = true;
             }
         }
         log_metrics_sample();
         frameos_nim_flush_logs(); /* the sample must not wait for next pass */
 
+        /* The scene's refreshInterval is authoritative when a scene is
+         * loaded and has an opinion (>= 1), matching the Pi runner where
+         * the frame-level interval is only the no-scene fallback. Clamped
+         * like the settings-pulled interval: a bad value must not park the
+         * frame for months. */
         uint32_t interval = config->interval_sec ? config->interval_sec : 300;
         double scene_interval = frameos_nim_scene_interval();
-        if (scene_interval >= 1.0 && scene_interval < interval) {
+        if (scene_interval >= 1.0) {
+            if (scene_interval > 7 * 86400.0) scene_interval = 7 * 86400.0;
             interval = (uint32_t)scene_interval;
+        }
+        /* A per-render override from logic/nextSleepDuration beats both
+         * intervals, like context.nextSleep on the Pi runner. Only valid
+         * right after a render actually ran. */
+        if (rendered) {
+            double next_sleep = frameos_nim_next_sleep();
+            if (next_sleep >= 0.0) {
+                if (next_sleep > 7 * 86400.0) next_sleep = 7 * 86400.0;
+                if (next_sleep < 1.0) next_sleep = 1.0;
+                interval = (uint32_t)next_sleep;
+            }
         }
         if (battery_critical && interval < FOS_BATTERY_CRITICAL_SLEEP_SEC) {
             interval = FOS_BATTERY_CRITICAL_SLEEP_SEC;
         }
 
         uint32_t sleep_s = compute_sleep_seconds(interval, cycle_start);
+        ESP_LOGI(TAG, "next render in %lu s (interval %lu s)",
+                 (unsigned long)sleep_s, (unsigned long)interval);
         uint32_t keep_awake_s = keep_awake_remaining_seconds();
         if (config->deep_sleep && fos_display_present() && keep_awake_s == 0) {
             ESP_LOGI(TAG, "deep sleeping for %lu s%s", (unsigned long)sleep_s,

--- a/embedded/esp32/main/fos_config.c
+++ b/embedded/esp32/main/fos_config.c
@@ -124,6 +124,7 @@ esp_err_t fos_config_init(void)
     uint32_t u32;
     if (nvs_get_u32(nvs, "frame_id", &u32) == ESP_OK) s_config.frame_id = u32;
     if (nvs_get_u32(nvs, "interval", &u32) == ESP_OK) s_config.interval_sec = u32;
+    if (nvs_get_u32(nvs, "spill_force", &u32) == ESP_OK) s_config.http_spill_force_bytes = u32;
     uint16_t rotate_u16 = 0;
     if (nvs_get_u16(nvs, "rotate", &rotate_u16) == ESP_OK &&
         (rotate_u16 == 0 || rotate_u16 == 90 || rotate_u16 == 180 || rotate_u16 == 270)) {
@@ -199,6 +200,7 @@ esp_err_t fos_config_save(void)
     nvs_set_u32(nvs, "interval", s_config.interval_sec);
     nvs_set_u16(nvs, "rotate", s_config.rotate);
     nvs_set_u32(nvs, "max_http", s_config.max_http_response_bytes);
+    nvs_set_u32(nvs, "spill_force", s_config.http_spill_force_bytes);
     nvs_set_u8(nvs, "render_mode", (uint8_t)s_config.render_mode);
     nvs_set_u8(nvs, "send_logs", s_config.server_send_logs ? 1 : 0);
     nvs_set_u8(nvs, "tls_enable", s_config.tls_enable ? 1 : 0);

--- a/embedded/esp32/main/fos_config.h
+++ b/embedded/esp32/main/fos_config.h
@@ -71,6 +71,9 @@ typedef struct {
     uint32_t interval_sec;         /* refresh interval */
     uint16_t rotate;               /* 0/90/180/270 — scenes render rotated, packers map to panel */
     uint32_t max_http_response_bytes;
+    uint32_t http_spill_force_bytes; /* debug: HTTP bodies over this many buffered
+                                      * bytes spill to storage even with PSRAM
+                                      * free (0 = off, spill on pressure only) */
     bool server_send_logs;         /* upload runtime/render logs to backend */
     bool tls_enable;               /* serve the frame HTTP API over HTTPS too */
     uint16_t tls_port;             /* HTTPS port, default mirrors Pi Caddy proxy */

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -139,7 +139,7 @@ static int cmd_set(int argc, char **argv)
     if (argc < 3) {
         printf("usage: set <wifi_ssid|wifi_pass|backend|api_key|cloud_url|claim_token|frame_id|"
                "hardware|panel|render_mode|rotate|"
-               "interval|server_send_logs|assets_path|assets_sd|assets_sd_pins|assets_sd_freq|"
+               "interval|spill_force|server_send_logs|assets_path|assets_sd|assets_sd_pins|assets_sd_freq|"
                "deep_sleep|wake_schedule|battery_pin|battery_divider|pins|gpio_buttons> <value...>\n");
         return 1;
     }
@@ -296,6 +296,7 @@ static int cmd_set(int argc, char **argv)
         config->render_mode = (strcmp(value, "remote") == 0 || strcmp(value, "1") == 0)
             ? FOS_RENDER_REMOTE : FOS_RENDER_LOCAL;
     else if (strcmp(key, "interval") == 0) config->interval_sec = strtoul(value, NULL, 10);
+    else if (strcmp(key, "spill_force") == 0) config->http_spill_force_bytes = strtoul(value, NULL, 10);
     else if (strcmp(key, "rotate") == 0) {
         unsigned long rot = strtoul(value, NULL, 10) % 360;
         if (rot != 0 && rot != 90 && rot != 180 && rot != 270) {

--- a/embedded/esp32/main/fos_scenes.c
+++ b/embedded/esp32/main/fos_scenes.c
@@ -18,6 +18,7 @@
 #include "fos_mem.h"
 #include "fos_wifi.h"
 #include "frameos_nim.h"
+#include "nvs.h"
 
 static const char *TAG = "fos_scenes";
 
@@ -348,6 +349,59 @@ static void save_etag(const char *etag)
 
 /* --------------------------------------------------------------- apply */
 
+/* Last explicitly selected scene, persisted so a reboot or power cut comes
+ * back on the scene that was showing — not the first scene in the payload.
+ * Same NVS namespace as fos_config; factory-reset clears it with the rest. */
+#define LAST_SCENE_NVS_KEY "last_scene"
+
+static void persist_last_scene(const char *scene_id)
+{
+    if (scene_id == NULL || scene_id[0] == '\0') return;
+    nvs_handle_t nvs;
+    if (nvs_open("frameos", NVS_READWRITE, &nvs) != ESP_OK) return;
+    char current[SCENE_ID_LEN] = "";
+    size_t len = sizeof(current);
+    if (nvs_get_str(nvs, LAST_SCENE_NVS_KEY, current, &len) != ESP_OK ||
+        strcmp(current, scene_id) != 0) {
+        nvs_set_str(nvs, LAST_SCENE_NVS_KEY, scene_id);
+        nvs_commit(nvs);
+    }
+    nvs_close(nvs);
+}
+
+/* True once the boot-time restore succeeded or an explicit selection made
+ * it moot. Until then every scene load retries: the first payload after
+ * boot can be the baked single-scene default (fresh /state), and the
+ * persisted scene only appears when the cached or backend payload lands. */
+static bool s_last_scene_settled = false;
+
+static void restore_last_scene(void)
+{
+    if (s_last_scene_settled) return;
+
+    char scene_id[SCENE_ID_LEN] = "";
+    size_t len = sizeof(scene_id);
+    nvs_handle_t nvs;
+    if (nvs_open("frameos", NVS_READONLY, &nvs) != ESP_OK) return;
+    esp_err_t err = nvs_get_str(nvs, LAST_SCENE_NVS_KEY, scene_id, &len);
+    nvs_close(nvs);
+    if (err != ESP_OK || scene_id[0] == '\0') {
+        s_last_scene_settled = true; /* nothing persisted */
+        return;
+    }
+
+    /* A scene missing from this payload keeps the payload's first scene
+     * active (the previous behavior) and retries on the next load. */
+    if (frameos_nim_set_scene(scene_id)) {
+        s_last_scene_settled = true;
+        ESP_LOGI(TAG, "restored last scene: %s", scene_id);
+        log_scene_event("scenes:restore", "ok", "nvs", scene_id, "restored",
+                        0, 0, 0, ESP_OK);
+    } else {
+        ESP_LOGW(TAG, "last scene %s not in payload; keeping default", scene_id);
+    }
+}
+
 static bool load_into_nim(const char *json, size_t len, const char *origin)
 {
     if (!frameos_nim_available()) {
@@ -367,6 +421,7 @@ static bool load_into_nim(const char *json, size_t len, const char *origin)
     ESP_LOGI(TAG, "%d scene(s) live", count);
     log_scene_event("scenes:load", "ok", origin, "", "runtime-loaded",
                     len, count, 0, ESP_OK);
+    restore_last_scene();
     return true;
 }
 
@@ -439,6 +494,8 @@ bool fos_scenes_apply_pending_selection(void)
                         "apply-failed", 0, 0, 0, ESP_FAIL);
         return false;
     }
+    persist_last_scene(scene_id);
+    s_last_scene_settled = true; /* explicit selection makes the boot restore moot */
     ESP_LOGI(TAG, "scene selected: %s", scene_id);
     printf("scene changed: %s\n", scene_id); /* visible on the USB serial stream */
     log_scene_event("event:setCurrentScene", "ok", "queued", scene_id,

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -252,7 +252,9 @@ void app_main(void)
                 closedir(dir);
             }
             fos_nim_http_set_spill_dir(spill_dir, 8 * 1024 * 1024);
-            ESP_LOGI(TAG, "http spill dir: %s", spill_dir);
+            fos_nim_http_set_spill_force_bytes(config->http_spill_force_bytes);
+            ESP_LOGI(TAG, "http spill dir: %s%s", spill_dir,
+                     config->http_spill_force_bytes ? " (forced)" : "");
         }
     }
 

--- a/frameos/src/embedded/embedded_main.nim
+++ b/frameos/src/embedded/embedded_main.nim
@@ -542,6 +542,18 @@ proc fos_nim_scene_interval_impl(): cdouble {.exportc, cdecl.} =
     log("scene interval failed: " & e.msg)
     0.cdouble
 
+proc fos_nim_next_sleep_impl(): cdouble {.exportc, cdecl.} =
+  ## Sleep override set by the just-finished render (logic/nextSleepDuration);
+  ## negative means "no override" and the interval logic applies.
+  try:
+    sceneNextSleepSeconds().cdouble
+  except Defect as e:
+    log("next sleep failed (defect): " & e.msg)
+    -1.cdouble
+  except CatchableError as e:
+    log("next sleep failed: " & e.msg)
+    -1.cdouble
+
 proc fos_nim_render_requested_impl(): bool {.exportc, cdecl.} =
   ## True once when a scene event (e.g. dispatched "render") asked for a
   ## redraw; clears the flag.

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -272,9 +272,18 @@ proc sceneRefreshSeconds*(): float =
     return currentExported.refreshInterval
   0.0
 
+var lastNextSleep: float = -1
+
+proc sceneNextSleepSeconds*(): float =
+  ## Per-render sleep override the scene's last render set through
+  ## logic/nextSleepDuration (context.nextSleep on the Pi runner);
+  ## negative = no override, use the interval logic.
+  lastNextSleep
+
 proc renderCurrentScene*(): Option[Image] =
   ## Render the active interpreted scene; none() when no scenes are loaded
   ## (the caller falls back to the baked demo scene).
+  lastNextSleep = -1
   if not ensureScene():
     return none(Image)
   let context = ExecutionContext(
@@ -283,10 +292,12 @@ proc renderCurrentScene*(): Option[Image] =
     payload: %*{},
     hasImage: false,
     loopIndex: 0,
-    loopKey: "."
+    loopKey: ".",
+    nextSleep: -1
   )
   let image = interpreter.render(currentScene, context)
   if image.isNil:
     log("render returned no image")
     return none(Image)
+  lastNextSleep = context.nextSleep
   some(image)


### PR DESCRIPTION
## What

Closes out the remaining P1 items from the ESP32 parity push, plus two bugs found along the way. Everything hardware-validated on the bench 13.3E6 (frame 59).

### Forced-spill render validation (the last named P1)
- New debug knob: `set spill_force <bytes>` (serial console, NVS-persisted). HTTP bodies spill to storage once that many bytes are buffered even with PSRAM free, so the spill decode path can be exercised on a 16MB-PSRAM frame that never hits real memory pressure. Small bodies (scene JSON, API calls) buffer normally.
- Spill events now log at **WARN** — the 32MB profile compiles `ESP_LOGI` out (`CONFIG_LOG_DEFAULT_LEVEL=WARN`), so WARN is the only runtime evidence of the path in production builds.
- **Validated:** with `spill_force=1MB`, a 4.1MB gallery PNG spilled to SD (`/srv/assets/.cache/http-spill-0.tmp`) and streamed row-by-row through pixie `17512ae`'s file-backed PNG decoder into the 1200×1600 canvas — render + EPD refresh in 137s, no `"no file-backed streaming decoder"` error.

### Scene cadence fixes (found while validating: "Seconds to show one image = 3600" was ignored)
- `fos_client.c` applied the scene's `refreshInterval` as `min()` against the frame interval — a scene could shorten the cadence but never lengthen it, so `frame.interval=300` silently beat any longer scene setting. The scene value is now authoritative when a scene is loaded, matching the Pi runner.
- `context.nextSleep` (`logic/nextSleepDuration` — what gallery scenes' "Seconds to show one image" feeds) was never read on embedded. The render context now initializes it to `-1` (Pi semantics), reads it back after each render, and exposes it via `frameos_nim_next_sleep()` (stub returns `-1`). A per-render override beats both intervals, exactly like the Pi.
- **Validated:** device logs "Set sleep duration between renders to 3600.0 seconds" and then stays quiet — no re-render for 10+ minutes where the old firmware fired at 300s.

### Build hygiene
- Backend firmware builds move from the shared in-tree `build/` + root `sdkconfig` to per-platform+flash-profile dirs (`build-esp32-s3-32mb`, …) with the generated sdkconfig inside — same `-B` convention as `ci_build_image.sh`. S3↔C3 or 8MB↔32MB switches no longer wipe each other's CMake caches, and backend builds no longer clobber a developer's manual sdkconfig.
- Release workflow: dropped the transitional `-esp32-s3-epd7in5v2.bin` asset (byte-identical copy of `-generic.bin`). The cloud firmware route has read `-generic.bin` from release metadata since the same cycle, and no shipped firmware ever requested the old name for OTA.

### Last-scene persistence (added after review of bench behavior)
- Scene selection persists to NVS and is restored on boot; validated on the 7.3" PhotoPainter — select non-first scene, restart, device comes back on it.

## Tests
- `backend`: `pytest app/api/tests/test_embedded_firmware.py` — 66 passed (sdkconfig-reset tests updated for per-profile dirs).
- Firmware built twice through the new path (cold + warm cache) and flashed to the bench frame over USB-JTAG.
- Builds on main's `51de82a9` (pixie file-backed PNG streaming, pinned `17512ae`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)