### PR TITLE
Assets and scene state for virtual frames

### DIFF
--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -2612,36 +2612,177 @@ async def api_frame_assets_upload_image(
     }
 
 
-@api_project.post("/frames/{id:int}/assets/upload")
-async def api_frame_assets_upload(
-    id: int,
-    path: Optional[str] = Form(
-        None,
-        description="Sub-folder inside the frame's assets directory (optional)",
-    ),
-    file: UploadFile = File(...),
-    db: Session = Depends(get_db),
-    redis: Redis = Depends(get_redis),
-):
-    frame = _project_frame(db, id) or _not_found()
-
-    subdir = (path or "").lstrip("/")
+def _asset_upload_combined_path(frame: Frame, subdir: str, filename: str) -> tuple[str, str]:
+    """Validate subdir + filename against the frame's assets root; returns
+    (assets_path, combined_path)."""
+    subdir = (subdir or "").lstrip("/")
     if "*" in subdir or ".." in subdir or os.path.isabs(subdir):
         _bad_request("Invalid character * in path")
-
     assets_path = frame.assets_path or "/srv/assets"
     combined_path = os.path.normpath(
-        os.path.join(assets_path, subdir, file.filename or "uploaded_file")
+        os.path.join(assets_path, subdir, filename or "uploaded_file")
     )
     if not combined_path.startswith(os.path.normpath(assets_path) + os.sep):
         _bad_request("Invalid asset path")
+    return assets_path, combined_path
 
-    data = await file.read()
 
+async def _asset_upload_store(
+    db: Session, redis: Redis, frame: Frame, combined_path: str, data: bytes
+) -> None:
     if _is_embedded_frame(frame):
         await _device_assets(frame).upload_asset(frame, redis, combined_path, data)
     else:
         await upload_file(db, redis, frame, combined_path, data)
+
+
+_UPLOAD_CHUNK_DIR = os.path.join(tempfile.gettempdir(), "frameos-upload-chunks")
+_UPLOAD_CHUNK_STALE_SECONDS = 24 * 3600
+
+
+def _upload_chunk_part_path(frame_id: int, upload_id: str) -> str:
+    return os.path.join(_UPLOAD_CHUNK_DIR, f"{frame_id}-{upload_id}.part")
+
+
+def _cleanup_stale_upload_parts() -> None:
+    try:
+        cutoff = time.time() - _UPLOAD_CHUNK_STALE_SECONDS
+        for name in os.listdir(_UPLOAD_CHUNK_DIR):
+            part = os.path.join(_UPLOAD_CHUNK_DIR, name)
+            try:
+                if os.path.getmtime(part) < cutoff:
+                    os.unlink(part)
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+async def _chunked_asset_upload(
+    request: Request, frame: Frame, db: Session, redis: Redis
+) -> dict[str, Any]:
+    """One chunk of a client-driven chunked upload (raw body + query params,
+    same protocol as the on-device admin API). Real embedded devices get each
+    chunk forwarded immediately — a completed chunk is on the device, so
+    client progress is device progress. Virtual/SSH frames (and embedded
+    devices on legacy firmware) accumulate locally and store on complete."""
+    qp = request.query_params
+    upload_id = qp.get("upload_id") or ""
+    if not embedded_assets.valid_upload_id(upload_id):
+        _bad_request("Invalid upload id")
+    filename = os.path.basename((qp.get("filename") or "").strip()) or "uploaded_file"
+    try:
+        chunk_index = int(qp.get("chunk_index") or "0")
+        offset = int(qp.get("offset") or "-1")
+    except ValueError:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid chunk parameters")
+    if chunk_index < 0:
+        _bad_request("Invalid chunk parameters")
+    if chunk_index == 0 and offset < 0:
+        offset = 0
+    complete = (qp.get("complete") or "1") == "1"
+    chunk = await request.body()
+    if not chunk and not complete:
+        _bad_request("Empty chunk")
+
+    assets_path, combined_path = _asset_upload_combined_path(frame, qp.get("path") or "", filename)
+
+    part_path = _upload_chunk_part_path(frame.id, upload_id)
+    accumulate = os.path.exists(part_path)
+
+    if _is_embedded_frame(frame) and not is_virtual_frame(frame) and not accumulate:
+        if offset < 0:
+            _bad_request("Missing offset")
+        payload = await embedded_assets.upload_asset_chunk(
+            frame,
+            redis,
+            combined_path,
+            chunk,
+            upload_id=upload_id,
+            chunk_index=chunk_index,
+            offset=offset,
+            complete=complete,
+        )
+        if payload is not None:
+            if not complete:
+                return {"pending": True, "received": payload.get("received", offset + len(chunk))}
+            await _invalidate_frame_assets_cache(redis, frame, assets_path)
+            rel = os.path.relpath(combined_path, assets_path)
+            return {
+                "path": rel,
+                "size": payload.get("size", offset + len(chunk)),
+                "mtime": payload.get("mtime", int(datetime.now().timestamp())),
+                "is_dir": False,
+            }
+        # Legacy firmware without chunk support: accumulate locally instead
+        # and deliver the whole file on the final chunk.
+        accumulate = True
+
+    if chunk_index > 0 and not accumulate:
+        # The part vanished (backend restart, stale cleanup): client restarts.
+        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="chunk_gap")
+
+    os.makedirs(_UPLOAD_CHUNK_DIR, exist_ok=True)
+    _cleanup_stale_upload_parts()
+    if chunk_index == 0:
+        with open(part_path, "wb") as fh:
+            fh.write(chunk)
+    else:
+        part_size = os.path.getsize(part_path)
+        seek_to = offset if offset >= 0 else part_size
+        if seek_to > part_size:
+            raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="chunk_gap")
+        with open(part_path, "r+b") as fh:
+            fh.seek(seek_to)
+            fh.write(chunk)
+
+    if not complete:
+        return {"pending": True, "received": os.path.getsize(part_path)}
+
+    with open(part_path, "rb") as fh:
+        data = fh.read()
+    os.unlink(part_path)
+    await _asset_upload_store(db, redis, frame, combined_path, data)
+    await _invalidate_frame_assets_cache(redis, frame, assets_path)
+    rel = os.path.relpath(combined_path, assets_path)
+    return {
+        "path": rel,
+        "size": len(data),
+        "mtime": int(datetime.now().timestamp()),
+        "is_dir": False,
+    }
+
+
+@api_project.post("/frames/{id:int}/assets/upload")
+async def api_frame_assets_upload(
+    id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    redis: Redis = Depends(get_redis),
+):
+    """Upload an asset. Two request shapes share this route:
+
+    * multipart form (``file`` + optional ``path``) — the whole file at once;
+    * chunked (query params ``upload_id``/``filename``/``chunk_index``/
+      ``offset``/``complete`` + raw body) — the protocol the on-device admin
+      API already speaks; used by the frontend for embedded frames so a slow
+      device link never has to survive one giant request.
+    """
+    frame = _project_frame(db, id) or _not_found()
+
+    if "upload_id" in request.query_params:
+        return await _chunked_asset_upload(request, frame, db, redis)
+
+    form = await request.form()
+    upload = form.get("file")
+    if upload is None or isinstance(upload, str):
+        _bad_request("Missing file")
+    assets_path, combined_path = _asset_upload_combined_path(
+        frame, str(form.get("path") or ""), upload.filename or ""
+    )
+
+    data = await upload.read()
+    await _asset_upload_store(db, redis, frame, combined_path, data)
     await _invalidate_frame_assets_cache(redis, frame, assets_path)
 
     rel = os.path.relpath(combined_path, assets_path)

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -100,7 +100,7 @@ from app.utils.frame_http import (
     _frame_scheme_port,
     _is_embedded_frame,
 )
-from app.utils import embedded_assets
+from app.utils import embedded_assets, virtual_assets
 from app.api.frame_sync import (
     apply_frame_sync,
     get_frame_sync_status,
@@ -137,6 +137,7 @@ from app.tasks.embedded_firmware import (
     embedded_toolchain_available,
     latest_embedded_firmware,
     embedded_platform_spec_for_frame,
+    is_virtual_frame,
     normalize_embedded_platform,
     refresh_embedded_firmware_status,
     request_or_queue_embedded_firmware_ota,
@@ -914,6 +915,12 @@ async def _forward_frame_request(
 
 
 async def _load_frame_states(redis: Redis, frame: Frame) -> dict[str, Any]:
+    if is_virtual_frame(frame):
+        from .virtual_frame import virtual_frame_states_payload
+
+        return _normalise_frame_states_payload(
+            await virtual_frame_states_payload(redis, frame)
+        )
     try:
         return _normalise_frame_states_payload(
             await _forward_frame_request(frame, redis, path="/states")
@@ -1192,6 +1199,12 @@ async def api_frame_get_state(
     id: int, db: Session = Depends(get_db), redis: Redis = Depends(get_redis)
 ):
     frame = _project_frame(db, id) or _not_found()
+    if is_virtual_frame(frame):
+        from .virtual_frame import virtual_frame_states_payload
+
+        payload = await virtual_frame_states_payload(redis, frame)
+        scene_id = payload["sceneId"]
+        return {"sceneId": scene_id, "state": payload["states"].get(scene_id) or {}}
     state = await _forward_frame_request(
         frame,
         redis,
@@ -1211,6 +1224,18 @@ async def api_frame_get_states(
     redis: Redis = Depends(get_redis),
 ):
     frame = _project_frame(db, id) or _not_found()
+    # Virtual frames answer from the backend's own state store — nothing to
+    # poll, so no cache/background-refresh dance.
+    if is_virtual_frame(frame):
+        state_record = await _load_frame_states(redis, frame)
+        return {
+            **state_record,
+            "cache": _frame_states_cache_meta(
+                cached=False,
+                refreshing=False,
+                fetched_at=time.time(),
+            ),
+        }
     cache_key = _frame_states_cache_key(frame.id)
     lock_key = _frame_states_cache_lock_key(frame.id)
     cached = await _read_frame_states_cache(redis, cache_key)
@@ -1374,12 +1399,21 @@ async def api_frame_event(
         scene_id = body.get("sceneId")
         _validate_upload_scenes_payload(scenes, scene_id)
     # Virtual frames have no device to forward to: every event reduces to
-    # "note the scene choice, render the image, done".
-    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
-        from .virtual_frame import refresh_virtual_frame_image
+    # "note the scene choice and state, render the image, done".
+    if is_virtual_frame(frame):
+        from .virtual_frame import (
+            apply_virtual_scene_state,
+            refresh_virtual_frame_image,
+            resolve_virtual_scene_id,
+        )
 
         scene_id = body.get("sceneId") if isinstance(body, dict) else None
         scene_id = scene_id if isinstance(scene_id, str) else None
+        if event in {"setCurrentScene", "setSceneState"}:
+            state = body.get("state") if isinstance(body, dict) else None
+            if isinstance(state, dict) and state:
+                target_scene = await resolve_virtual_scene_id(redis, frame, scene_id)
+                await apply_virtual_scene_state(redis, frame, target_scene, state)
         if event in {"setCurrentScene", "setSceneState", "uploadScenes"}:
             await _mark_frame_states_cache_stale(redis, frame, scene_id=scene_id)
         # uploadScenes = preview-on-frame: render the posted (possibly
@@ -1667,6 +1701,13 @@ async def api_frame_local_binary_zip(
     return StreamingResponse(sender(), headers=headers, media_type="application/zip")
 
 
+def _device_assets(frame: Frame):
+    """Asset backend for frames without SSH: virtual frames keep assets on the
+    backend disk, embedded frames proxy to the device HTTP API. Both modules
+    share the same function signatures."""
+    return virtual_assets if is_virtual_frame(frame) else embedded_assets
+
+
 async def _embedded_asset_file_response(
     redis: Redis,
     frame: Frame,
@@ -1683,7 +1724,7 @@ async def _embedded_asset_file_response(
     cached in redis keyed by the md5 of the original bytes, mirroring the
     SSH/agent code path's `asset:thumb:{md5}` cache."""
     try:
-        data, _device_content_type = await embedded_assets.download_asset(frame, redis, full_path)
+        data, _device_content_type = await _device_assets(frame).download_asset(frame, redis, full_path)
     except HTTPException as exc:
         if exc.status_code == HTTPStatus.NOT_FOUND:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Asset not found")
@@ -2114,7 +2155,7 @@ async def api_frame_get_image(
     # Virtual frames have no device to fetch from: render server-side (the
     # same wasm path their public URLs use) instead of proxying to a
     # nonexistent host.
-    if frame.mode == "embedded" and embedded_platform_spec_for_frame(frame)["family"] == "virtual":
+    if is_virtual_frame(frame):
         # Serve the cached image; render only when there is none. Rendering
         # on every poll made the preview flash "rendering" continuously —
         # fresh frames come from deploy/activate/render events, which
@@ -2321,7 +2362,7 @@ async def _load_frame_assets(
     assets_path: str,
 ) -> list[dict[str, Any]]:
     if _is_embedded_frame(frame):
-        return await embedded_assets.list_assets(frame, redis)
+        return await _device_assets(frame).list_assets(frame, redis)
 
     if await _use_remote(frame, redis):
         assets = await assets_list_on_frame(frame.id, assets_path, redis=redis)
@@ -2495,10 +2536,12 @@ async def api_frame_assets_sync(
     if frame is None:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Frame not found")
     if _is_embedded_frame(frame):
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail="Asset sync is not supported for embedded frames — fonts are compiled into the firmware",
+        detail = (
+            "Asset sync is not supported for virtual frames — fonts are bundled with the renderer"
+            if is_virtual_frame(frame)
+            else "Asset sync is not supported for embedded frames — fonts are compiled into the firmware"
         )
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=detail)
     try:
         from app.models.assets import sync_assets
 
@@ -2539,7 +2582,7 @@ async def api_frame_assets_upload_image(
     if _is_embedded_frame(frame):
         # The device API creates parent dirs and replaces in place; the
         # md5-derived filename keeps re-uploads of identical bytes idempotent.
-        await embedded_assets.upload_asset(frame, redis, combined_path, data)
+        await _device_assets(frame).upload_asset(frame, redis, combined_path, data)
         uploaded = True
     else:
         await make_dir(db, redis, frame, upload_dir)
@@ -2596,7 +2639,7 @@ async def api_frame_assets_upload(
     data = await file.read()
 
     if _is_embedded_frame(frame):
-        await embedded_assets.upload_asset(frame, redis, combined_path, data)
+        await _device_assets(frame).upload_asset(frame, redis, combined_path, data)
     else:
         await upload_file(db, redis, frame, combined_path, data)
     await _invalidate_frame_assets_cache(redis, frame, assets_path)
@@ -2632,7 +2675,7 @@ async def api_frame_assets_mkdir(
         _bad_request("Invalid asset path")
 
     if _is_embedded_frame(frame):
-        await embedded_assets.make_dir(frame, redis, full_path)
+        await _device_assets(frame).make_dir(frame, redis, full_path)
     else:
         await make_dir(db, redis, frame, full_path)
     await _invalidate_frame_assets_cache(redis, frame, assets_path)
@@ -2661,7 +2704,7 @@ async def api_frame_assets_delete(
         _bad_request("Invalid asset path")
 
     if _is_embedded_frame(frame):
-        await embedded_assets.delete_path(frame, redis, full_path)
+        await _device_assets(frame).delete_path(frame, redis, full_path)
     else:
         await delete_path(db, redis, frame, full_path)
     await _invalidate_frame_assets_cache(redis, frame, assets_path)
@@ -2694,7 +2737,7 @@ async def api_frame_assets_rename(
         _bad_request("Invalid asset path")
 
     if _is_embedded_frame(frame):
-        await embedded_assets.rename_path(frame, redis, src_full, dst_full)
+        await _device_assets(frame).rename_path(frame, redis, src_full, dst_full)
     else:
         await rename_path(db, redis, frame, src_full, dst_full)
     await _invalidate_frame_assets_cache(redis, frame, assets_path)
@@ -3658,7 +3701,9 @@ async def api_frame_import(
 async def api_frame_delete(
     frame_id: int, db: Session = Depends(get_db), redis: Redis = Depends(get_redis)
 ):
-    _project_frame(db, frame_id)
+    frame = _project_frame(db, frame_id)
+    if frame is not None and is_virtual_frame(frame):
+        virtual_assets.delete_frame_assets(frame)
     success = await delete_frame(db, redis, frame_id, current_project_id())
     if success:
         return {"message": "Frame deleted successfully"}

--- a/backend/app/api/tests/test_embedded_assets.py
+++ b/backend/app/api/tests/test_embedded_assets.py
@@ -38,7 +38,7 @@ class FakeDevice:
         self.responses = list(responses)
         self.calls = []
 
-    async def __call__(self, frame, redis, *, path, method="GET", body=None, headers=None):
+    async def __call__(self, frame, redis, *, path, method="GET", body=None, headers=None, timeout=None):
         self.calls.append({"path": path, "method": method, "body": body, "headers": headers})
         if not self.responses:
             raise AssertionError(f"Unexpected device request: {method} {path}")
@@ -468,3 +468,178 @@ async def test_write_operations_invalidate_assets_cache(async_client, db, redis)
 
     assert response.status_code == 200
     assert await redis.get(cache_key) is None
+
+
+# ---------------------------------------------------------------------------
+# chunked upload
+# ---------------------------------------------------------------------------
+
+
+def _chunk_url(frame_id, upload_id, filename, chunk_index, offset, complete, path=""):
+    from urllib.parse import urlencode
+
+    params = {
+        "upload_id": upload_id,
+        "filename": filename,
+        "chunk_index": chunk_index,
+        "offset": offset,
+        "complete": "1" if complete else "0",
+    }
+    if path:
+        params["path"] = path
+    return f"/api/frames/{frame_id}/assets/upload?{urlencode(params)}"
+
+
+def _device_query(call):
+    from urllib.parse import urlsplit
+
+    split = urlsplit(call["path"])
+    return {k: v[0] for k, v in parse_qs(split.query).items()}
+
+
+@pytest.mark.asyncio
+async def test_chunked_upload_forwards_each_chunk_to_device(async_client, db, redis):
+    frame = await create_embedded_frame(async_client, db)
+    chunks = [b"aaaa", b"bbbb", b"cc"]
+    device = FakeDevice([
+        json_response({"pending": True, "received": 4}),
+        json_response({"pending": True, "received": 8}),
+        json_response({"path": "sub/big.bin", "size": 10, "mtime": 1712345678, "is_dir": False}),
+    ])
+
+    with patch(FETCH, new=device):
+        for index, chunk in enumerate(chunks):
+            response = await async_client.post(
+                _chunk_url(frame.id, "chunky1", "big.bin", index, index * 4,
+                           index == len(chunks) - 1, path="sub"),
+                content=chunk,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            assert response.status_code == 200, response.text
+            if index < len(chunks) - 1:
+                assert response.json() == {"pending": True, "received": (index + 1) * 4}
+
+    final = response.json()
+    assert final["path"] == "sub/big.bin"
+    assert final["size"] == 10
+    assert final["is_dir"] is False
+
+    assert [call["body"] for call in device.calls] == chunks
+    queries = [_device_query(call) for call in device.calls]
+    assert [q["offset"] for q in queries] == ["0", "4", "8"]
+    assert [q["complete"] for q in queries] == ["0", "0", "1"]
+    assert all(q["upload_id"] == "chunky1" for q in queries)
+    assert all(q["path"] == "sub/big.bin" for q in queries)
+
+
+@pytest.mark.asyncio
+async def test_chunked_upload_legacy_firmware_accumulates_and_sends_whole_file(
+    async_client, db, redis
+):
+    frame = await create_embedded_frame(async_client, db)
+    chunks = [b"aaaa", b"bbbb", b"cc"]
+    device = FakeDevice([
+        # Legacy firmware ignores chunk params: replies with a stat dict (no
+        # "pending") for the probe chunk...
+        json_response({"path": "big.bin", "size": 4, "mtime": 1, "is_dir": False}),
+        # ...and receives one whole-file upload at the end.
+        json_response({"path": "big.bin", "size": 10, "mtime": 2, "is_dir": False}),
+    ])
+
+    with patch(FETCH, new=device):
+        for index, chunk in enumerate(chunks):
+            response = await async_client.post(
+                _chunk_url(frame.id, "legacy1", "big.bin", index, index * 4,
+                           index == len(chunks) - 1),
+                content=chunk,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            assert response.status_code == 200, response.text
+
+    final = response.json()
+    assert final["path"] == "big.bin"
+    assert final["size"] == 10
+
+    assert len(device.calls) == 2
+    assert device.calls[0]["body"] == b"aaaa"          # the chunked probe
+    assert "upload_id" in _device_query(device.calls[0])
+    assert device.calls[1]["body"] == b"aaaabbbbcc"    # the whole file
+    assert "upload_id" not in _device_query(device.calls[1])
+
+
+@pytest.mark.asyncio
+async def test_chunked_upload_device_gap_maps_to_conflict(async_client, db, redis):
+    frame = await create_embedded_frame(async_client, db)
+    device = FakeDevice([(409, b'{"error":"chunk_gap"}', {})])
+
+    with patch(FETCH, new=device):
+        response = await async_client.post(
+            _chunk_url(frame.id, "gappy1", "big.bin", 3, 12, False),
+            content=b"dddd",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_chunked_upload_rejects_bad_upload_id(async_client, db, redis):
+    frame = await create_embedded_frame(async_client, db)
+    device = FakeDevice([])
+
+    with patch(FETCH, new=device):
+        response = await async_client.post(
+            f"/api/frames/{frame.id}/assets/upload?upload_id=..%2Fevil&filename=x.bin",
+            content=b"x",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+    assert response.status_code == 400
+    assert device.calls == []
+
+
+@pytest.mark.asyncio
+async def test_upload_asset_splits_large_payload_into_chunks(async_client, db, redis, monkeypatch):
+    from app.utils import embedded_assets
+
+    frame = await create_embedded_frame(async_client, db)
+    monkeypatch.setattr(embedded_assets, "EMBEDDED_UPLOAD_CHUNK_BYTES", 4)
+    data = b"aaaabbbbcc"
+    device = FakeDevice([
+        json_response({"pending": True, "received": 4}),
+        json_response({"pending": True, "received": 8}),
+        json_response({"path": "big.bin", "size": 10, "mtime": 1, "is_dir": False}),
+    ])
+
+    with patch(FETCH, new=device):
+        payload = await embedded_assets.upload_asset(frame, redis, "/srv/assets/big.bin", data)
+
+    assert payload["size"] == 10
+    assert [call["body"] for call in device.calls] == [b"aaaa", b"bbbb", b"cc"]
+    queries = [_device_query(call) for call in device.calls]
+    assert [q["offset"] for q in queries] == ["0", "4", "8"]
+    assert [q["complete"] for q in queries] == ["0", "0", "1"]
+    assert len({q["upload_id"] for q in queries}) == 1
+
+
+@pytest.mark.asyncio
+async def test_upload_asset_legacy_firmware_falls_back_to_single_shot(
+    async_client, db, redis, monkeypatch
+):
+    from app.utils import embedded_assets
+
+    frame = await create_embedded_frame(async_client, db)
+    monkeypatch.setattr(embedded_assets, "EMBEDDED_UPLOAD_CHUNK_BYTES", 4)
+    data = b"aaaabbbbcc"
+    device = FakeDevice([
+        json_response({"path": "big.bin", "size": 4, "mtime": 1, "is_dir": False}),
+        json_response({"path": "big.bin", "size": 10, "mtime": 2, "is_dir": False}),
+    ])
+
+    with patch(FETCH, new=device):
+        payload = await embedded_assets.upload_asset(frame, redis, "/srv/assets/big.bin", data)
+
+    assert payload["size"] == 10
+    assert len(device.calls) == 2
+    assert device.calls[1]["body"] == data
+    assert "upload_id" not in _device_query(device.calls[1])

--- a/backend/app/api/tests/test_virtual_frame.py
+++ b/backend/app/api/tests/test_virtual_frame.py
@@ -283,6 +283,18 @@ async def test_virtual_assets_quota(async_client, db, redis, virtual_assets_dir)
     assert response.status_code == 200, response.text
 
 
+def test_virtual_assets_quota_parsing():
+    from app.utils.virtual_assets import DEFAULT_QUOTA_MB, quota_bytes
+
+    mb = 1024 * 1024
+    assert quota_bytes(Frame(device_config={'assetsQuotaMb': 250})) == 250 * mb
+    # Settings forms may deliver numbers as strings.
+    assert quota_bytes(Frame(device_config={'assetsQuotaMb': '250'})) == 250 * mb
+    for bad in (None, 0, -5, 'lots', True, {}):
+        assert quota_bytes(Frame(device_config={'assetsQuotaMb': bad})) == DEFAULT_QUOTA_MB * mb
+    assert quota_bytes(Frame(device_config=None)) == DEFAULT_QUOTA_MB * mb
+
+
 # -------------------------------------------------------------------- state
 
 
@@ -380,3 +392,53 @@ async def test_virtual_state_rejects_oversized_payload(async_client, db, redis):
               'state': {'word': 'x' * (VIRTUAL_STATE_QUOTA_BYTES + 1)}},
         headers={'content-type': 'application/json'})
     assert response.status_code == 413
+
+
+# ------------------------------------------------------- asset write-back
+
+
+@pytest.mark.asyncio
+async def test_virtual_render_passes_save_assets_and_budget(
+    async_client, db, redis, virtual_assets_dir, monkeypatch
+):
+    """The render pipeline forwards the frame's saveAssets config and the
+    remaining quota, and a reported write-back invalidates the asset cache."""
+    from app.api import virtual_frame as vf
+
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [{'id': 'scene-a', 'name': 'A', 'nodes': [], 'edges': []}]
+    frame.save_assets = True
+    frame.device_config = {**(frame.device_config or {}), 'assetsQuotaMb': 1}
+    db.add(frame)
+    db.commit()
+
+    # Prime the asset list cache so we can observe the invalidation.
+    response = await async_client.get(f'/api/frames/{frame.id}/assets')
+    assert response.status_code == 200
+    assert response.json()['assets'] == []
+
+    captured = {}
+
+    async def fake_render(frame_arg, width, height, **kwargs):
+        captured.update(kwargs)
+        # Simulate the harness writing a scene-saved asset back to disk.
+        target = virtual_assets_dir / f'frame_{frame_arg.id}' / 'wikicommons' / 'img.abc123.jpg'
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b'jpeg-bytes')
+        rgba = b'\x00' * (width * height * 4)
+        return rgba, None, {'files': ['wikicommons/img.abc123.jpg'], 'skippedOverBudget': 0}
+
+    monkeypatch.setattr(vf, 'render_scene_rgba_and_state', fake_render)
+
+    response = await async_client.post(f'/api/frames/{frame.id}/event/render')
+    assert response.status_code == 200, response.text
+
+    assert captured['save_assets'] is True
+    assert captured['assets_write_budget'] == 1024 * 1024  # empty store: full quota
+    assert captured['assets_dir'].endswith(f'frame_{frame.id}')
+
+    # The write-back invalidated the cached (empty) listing.
+    response = await async_client.get(f'/api/frames/{frame.id}/assets')
+    assert response.status_code == 200
+    paths = [a['path'] for a in response.json()['assets']]
+    assert '/srv/assets/wikicommons/img.abc123.jpg' in paths

--- a/backend/app/api/tests/test_virtual_frame.py
+++ b/backend/app/api/tests/test_virtual_frame.py
@@ -4,6 +4,13 @@ from app.models.frame import Frame
 from app.tasks.embedded_firmware import ensure_embedded_frame_defaults
 
 
+@pytest.fixture
+def virtual_assets_dir(tmp_path, monkeypatch):
+    root = tmp_path / "virtual_assets"
+    monkeypatch.setenv("FRAMEOS_VIRTUAL_ASSETS_DIR", str(root))
+    return root
+
+
 async def create_virtual_frame(async_client, db) -> Frame:
     response = await async_client.post('/api/frames/new', json={
         'name': 'Virtual Frame',
@@ -169,3 +176,207 @@ async def test_virtual_activation_persists_scene_image(async_client, db, redis):
     response = await async_client.get(f'/api/frames/{frame.id}/scene_images/scene-b')
     assert response.status_code == 200, response.text
     assert response.headers['content-type'].startswith('image/')
+
+
+# ------------------------------------------------------------------- assets
+
+
+@pytest.mark.asyncio
+async def test_virtual_assets_upload_list_download(async_client, db, redis, virtual_assets_dir):
+    frame = await create_virtual_frame(async_client, db)
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/upload',
+        data={'path': 'photos'},
+        files={'file': ('hello.txt', b'hello world')})
+    assert response.status_code == 200, response.text
+    assert response.json()['path'] == 'photos/hello.txt'
+    assert (virtual_assets_dir / f'frame_{frame.id}' / 'photos' / 'hello.txt').read_bytes() == b'hello world'
+
+    response = await async_client.get(f'/api/frames/{frame.id}/assets')
+    assert response.status_code == 200, response.text
+    assets = response.json()['assets']
+    paths = {a['path']: a for a in assets}
+    assert '/srv/assets/photos' in paths and paths['/srv/assets/photos']['is_dir']
+    entry = paths['/srv/assets/photos/hello.txt']
+    assert entry['size'] == len(b'hello world')
+    assert not entry['is_dir']
+
+    response = await async_client.get(
+        f'/api/projects/{async_client.project_id}/frames/{frame.id}/asset'
+        '?path=photos/hello.txt&mode=download')
+    assert response.status_code == 200, response.text
+    assert response.content == b'hello world'
+
+
+@pytest.mark.asyncio
+async def test_virtual_assets_mkdir_rename_delete(async_client, db, redis, virtual_assets_dir):
+    frame = await create_virtual_frame(async_client, db)
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/mkdir', data={'path': 'a/b'})
+    assert response.status_code == 200, response.text
+    assert (virtual_assets_dir / f'frame_{frame.id}' / 'a' / 'b').is_dir()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/upload',
+        data={'path': 'a/b'},
+        files={'file': ('one.txt', b'one')})
+    assert response.status_code == 200, response.text
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/rename',
+        data={'src': 'a/b/one.txt', 'dst': 'a/two.txt'})
+    assert response.status_code == 200, response.text
+    root = virtual_assets_dir / f'frame_{frame.id}'
+    assert not (root / 'a' / 'b' / 'one.txt').exists()
+    assert (root / 'a' / 'two.txt').read_bytes() == b'one'
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/delete', data={'path': 'a'})
+    assert response.status_code == 200, response.text
+    assert not (root / 'a').exists()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/delete', data={'path': 'a/two.txt'})
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_virtual_assets_missing_download_404(async_client, db, redis, virtual_assets_dir):
+    frame = await create_virtual_frame(async_client, db)
+    response = await async_client.get(
+        f'/api/projects/{async_client.project_id}/frames/{frame.id}/asset'
+        '?path=nope.txt&mode=download')
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_virtual_assets_quota(async_client, db, redis, virtual_assets_dir):
+    frame = await create_virtual_frame(async_client, db)
+    # ~1 KB quota via the per-frame override.
+    frame.device_config = {**(frame.device_config or {}), 'assetsQuotaMb': 0.001}
+    db.add(frame)
+    db.commit()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/upload',
+        files={'file': ('big.bin', b'x' * 2000)})
+    assert response.status_code == 507, response.text
+    assert 'quota' in response.json()['detail'].lower()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/upload',
+        files={'file': ('small.bin', b'x' * 600)})
+    assert response.status_code == 200, response.text
+
+    # The second small file pushes the total over the quota.
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/upload',
+        files={'file': ('small2.bin', b'x' * 600)})
+    assert response.status_code == 507
+
+    # Replacing the existing file does not double-count its old bytes.
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/assets/upload',
+        files={'file': ('small.bin', b'y' * 700)})
+    assert response.status_code == 200, response.text
+
+
+# -------------------------------------------------------------------- state
+
+
+def _stateful_scene(scene_id='scene-a'):
+    return {
+        'id': scene_id,
+        'name': 'Stateful',
+        'nodes': [],
+        'edges': [],
+        'fields': [
+            {'name': 'word', 'type': 'string', 'access': 'public', 'value': 'hi'},
+            {'name': 'config', 'type': 'json', 'access': 'public'},
+            {'name': 'secret', 'type': 'string', 'access': 'private'},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_virtual_set_scene_state_roundtrip(async_client, db, redis):
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [_stateful_scene()]
+    db.add(frame)
+    db.commit()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/event/setSceneState',
+        json={'sceneId': 'scene-a', 'render': True,
+              'state': {'word': 'hello', 'secret': 'nope', 'unknown': 'dropped'}},
+        headers={'content-type': 'application/json'})
+    assert response.status_code == 200, response.text
+
+    response = await async_client.get(f'/api/frames/{frame.id}/states')
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload['sceneId'] == 'scene-a'
+    # Only declared public fields survive the filter.
+    assert payload['states']['scene-a'] == {'word': 'hello'}
+
+    response = await async_client.get(f'/api/frames/{frame.id}/state')
+    assert response.status_code == 200, response.text
+    assert response.json() == {'sceneId': 'scene-a', 'state': {'word': 'hello'}}
+
+
+@pytest.mark.asyncio
+async def test_virtual_state_merges_and_parses_json_fields(async_client, db, redis):
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [_stateful_scene()]
+    db.add(frame)
+    db.commit()
+
+    for state in ({'word': 'first'}, {'config': '{"a": 1}'}):
+        response = await async_client.post(
+            f'/api/frames/{frame.id}/event/setSceneState',
+            json={'sceneId': 'scene-a', 'state': state},
+            headers={'content-type': 'application/json'})
+        assert response.status_code == 200, response.text
+
+    response = await async_client.get(f'/api/frames/{frame.id}/states')
+    states = response.json()['states']
+    # Merged across events; json-typed strings parsed like the device does.
+    assert states['scene-a'] == {'word': 'first', 'config': {'a': 1}}
+
+
+@pytest.mark.asyncio
+async def test_virtual_set_current_scene_applies_state(async_client, db, redis):
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [_stateful_scene('scene-a'), _stateful_scene('scene-b')]
+    db.add(frame)
+    db.commit()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/event/setCurrentScene',
+        json={'sceneId': 'scene-b', 'state': {'word': 'switched'}},
+        headers={'content-type': 'application/json'})
+    assert response.status_code == 200, response.text
+
+    response = await async_client.get(f'/api/frames/{frame.id}/states')
+    payload = response.json()
+    assert payload['sceneId'] == 'scene-b'
+    assert payload['states']['scene-b'] == {'word': 'switched'}
+
+
+@pytest.mark.asyncio
+async def test_virtual_state_rejects_oversized_payload(async_client, db, redis):
+    from app.api.virtual_frame import VIRTUAL_STATE_QUOTA_BYTES
+
+    frame = await create_virtual_frame(async_client, db)
+    frame.scenes = [_stateful_scene()]
+    db.add(frame)
+    db.commit()
+
+    response = await async_client.post(
+        f'/api/frames/{frame.id}/event/setSceneState',
+        json={'sceneId': 'scene-a',
+              'state': {'word': 'x' * (VIRTUAL_STATE_QUOTA_BYTES + 1)}},
+        headers={'content-type': 'application/json'})
+    assert response.status_code == 413

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -22,6 +22,7 @@ password; rotating the frame's server API key invalidates it.
 from __future__ import annotations
 
 import io
+import json
 from http import HTTPStatus
 
 from fastapi import Depends, HTTPException, Query
@@ -32,7 +33,8 @@ from app.database import get_db
 from app.models.frame import Frame
 from app.redis import get_redis
 from app.tasks.embedded_firmware import embedded_platform_spec_for_frame
-from app.utils.embedded_render import render_scene_rgba
+from app.utils import virtual_assets
+from app.utils.embedded_render import render_scene_rgba_and_state
 
 from . import api_public
 from .embedded_device import (
@@ -44,6 +46,8 @@ from .embedded_device import (
     embedded_diagnostic_image,
     embedded_settings_payload,
 )
+
+VIRTUAL_STATE_QUOTA_BYTES = 256 * 1024  # per frame, across all scenes
 
 VIRTUAL_DEFAULT_WIDTH = 800
 VIRTUAL_DEFAULT_HEIGHT = 480
@@ -70,6 +74,144 @@ def _virtual_frame(db: Session, frame_id: int, token: str | None) -> Frame:
     if not isinstance(view_token, str) or not view_token or token != view_token:
         raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized")
     return frame
+
+
+# --------------------------------------------------------------- scene state
+#
+# A device keeps scene state in the running process and persists chosen
+# fields to disk; a virtual frame's renderer is a fresh wasm process every
+# time, so the backend is the memory: per-scene state lives in redis (no
+# TTL, same as frame:{id}:active_scene) and is injected into the renderer on
+# every pass, then read back after the render so state the scene itself
+# changed sticks too.
+
+
+def _virtual_states_key(frame_id: int) -> str:
+    return f"frame:{frame_id}:virtual:scene_states"
+
+
+def _scene_by_id(frame: Frame, scene_id: str | None) -> dict | None:
+    if not scene_id:
+        return None
+    for scene in frame.scenes or []:
+        if isinstance(scene, dict) and scene.get("id") == scene_id:
+            return scene
+    return None
+
+
+def _scene_fields(scene: dict) -> list[dict]:
+    fields = scene.get("fields")
+    return [f for f in fields if isinstance(f, dict) and f.get("name")] if isinstance(fields, list) else []
+
+
+def _settable_field_names(scene: dict) -> set[str]:
+    # Mirrors the interpreter's publicStateFields: fields without an explicit
+    # access default to public.
+    return {f["name"] for f in _scene_fields(scene) if f.get("access") != "private"}
+
+
+def _storable_field_names(scene: dict) -> set[str]:
+    # What survives between renders: everything settable plus fields the
+    # scene marked persist=disk (the device's across-restarts contract).
+    return _settable_field_names(scene) | {
+        f["name"] for f in _scene_fields(scene) if f.get("persist") == "disk"
+    }
+
+
+async def get_virtual_scene_states(redis, frame: Frame) -> dict[str, dict]:
+    raw = await redis.get(_virtual_states_key(frame.id))
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+    except (ValueError, UnicodeDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        scene_id: state
+        for scene_id, state in payload.items()
+        if isinstance(scene_id, str) and isinstance(state, dict)
+    }
+
+
+async def _save_virtual_scene_states(redis, frame: Frame, states: dict[str, dict]) -> None:
+    serialized = json.dumps(states, separators=(",", ":"))
+    if len(serialized) > VIRTUAL_STATE_QUOTA_BYTES:
+        raise HTTPException(
+            status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Scene state exceeds {VIRTUAL_STATE_QUOTA_BYTES} bytes",
+        )
+    await redis.set(_virtual_states_key(frame.id), serialized)
+
+
+async def resolve_virtual_scene_id(redis, frame: Frame, scene_id: str | None = None) -> str | None:
+    """The scene an event or render targets: explicit id, else the
+    workspace-activated scene, else the frame's first scene."""
+    if scene_id:
+        return scene_id
+    active = await _active_scene_id(redis, frame)
+    if active:
+        return active
+    for scene in frame.scenes or []:
+        if isinstance(scene, dict) and scene.get("id"):
+            return scene["id"]
+    return None
+
+
+async def apply_virtual_scene_state(redis, frame: Frame, scene_id: str | None, state: dict) -> None:
+    """Merge a setSceneState/setCurrentScene state payload, keeping only the
+    scene's public fields — the same filter the device runtime applies."""
+    scene = _scene_by_id(frame, scene_id)
+    if scene is None or not isinstance(state, dict):
+        return
+    allowed = _settable_field_names(scene)
+    field_types = {f["name"]: f.get("type") for f in _scene_fields(scene)}
+    accepted = {}
+    for key, value in state.items():
+        if key not in allowed:
+            continue
+        # Control forms deliver json fields as strings; parse them like
+        # applyPublicStateFromPayload does on the device.
+        if field_types.get(key) == "json" and isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except ValueError:
+                pass
+        accepted[key] = value
+    if not accepted:
+        return
+    states = await get_virtual_scene_states(redis, frame)
+    states[scene_id] = {**states.get(scene_id, {}), **accepted}
+    await _save_virtual_scene_states(redis, frame, states)
+
+
+async def store_rendered_scene_state(redis, frame: Frame, scene_id: str | None, state: dict) -> None:
+    """Persist the state the renderer reported after a pass (defaults now
+    evaluated, plus anything the scene's own logic changed)."""
+    scene = _scene_by_id(frame, scene_id)
+    if scene is None or not isinstance(state, dict):
+        return
+    storable = _storable_field_names(scene)
+    filtered = {key: value for key, value in state.items() if key in storable}
+    states = await get_virtual_scene_states(redis, frame)
+    if states.get(scene_id) == filtered:
+        return
+    states[scene_id] = filtered
+    try:
+        await _save_virtual_scene_states(redis, frame, states)
+    except HTTPException:
+        # An oversized render-produced state must not fail the image request;
+        # the previous stored state simply stays.
+        pass
+
+
+async def virtual_frame_states_payload(redis, frame: Frame) -> dict:
+    """The `/states` shape a physical frame serves: current scene + per-scene
+    public state, straight from the backend store."""
+    states = await get_virtual_scene_states(redis, frame)
+    scene_id = await resolve_virtual_scene_id(redis, frame)
+    return {"sceneId": scene_id or "", "states": states}
 
 
 def virtual_frame_dimensions(frame: Frame) -> tuple[int, int]:
@@ -125,14 +267,29 @@ async def _virtual_frame_png(
     from PIL import Image
 
     width, height = virtual_frame_dimensions(frame)
-    rgba = await render_scene_rgba(
+    scene_states = await get_virtual_scene_states(redis, frame)
+    assets_dir = virtual_assets.frame_assets_dir(frame)
+    rgba, rendered_state = await render_scene_rgba_and_state(
         frame,
         width,
         height,
         scene_id=scene_id_override or await _active_scene_id(redis, frame),
         settings=embedded_settings_payload(db, frame),
         scenes_override=scenes_override,
+        scene_states=scene_states,
+        assets_dir=str(assets_dir) if assets_dir.is_dir() else None,
     )
+    # Previews of unsaved scenes must not clobber the stored state; neither
+    # may a render whose state seeding failed (old wasm bundle without the
+    # set_scene_state export) — its readback is just scene defaults.
+    if (
+        rendered_state is not None
+        and scenes_override is None
+        and rendered_state.get("seeded", True)
+    ):
+        await store_rendered_scene_state(
+            redis, frame, rendered_state.get("sceneId"), rendered_state.get("state")
+        )
     if rgba is not None:
         image = Image.frombytes("RGBA", (width, height), rgba).convert("RGB")
     else:
@@ -184,7 +341,6 @@ async def refresh_virtual_frame_image(
     ``scenes_override`` renders unsaved scenes (preview-on-frame) without
     persisting them.
     """
-    import json
     import time
 
     from app.models.log import new_log as log

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -269,7 +269,7 @@ async def _virtual_frame_png(
     width, height = virtual_frame_dimensions(frame)
     scene_states = await get_virtual_scene_states(redis, frame)
     assets_dir = virtual_assets.frame_assets_dir(frame)
-    rgba, rendered_state = await render_scene_rgba_and_state(
+    rgba, rendered_state, saved_assets = await render_scene_rgba_and_state(
         frame,
         width,
         height,
@@ -277,8 +277,20 @@ async def _virtual_frame_png(
         settings=embedded_settings_payload(db, frame),
         scenes_override=scenes_override,
         scene_states=scene_states,
-        assets_dir=str(assets_dir) if assets_dir.is_dir() else None,
+        assets_dir=str(assets_dir),
+        save_assets=frame.save_assets,
+        assets_write_budget=max(
+            0, virtual_assets.quota_bytes(frame) - virtual_assets.usage_bytes(frame)
+        ),
     )
+    if saved_assets is not None and saved_assets.get("files"):
+        # Scene apps saved new assets (OpenAI images, downloaded photos):
+        # drop the cached listing so the workspace sees them.
+        from .frames import _invalidate_frame_assets_cache
+
+        await _invalidate_frame_assets_cache(
+            redis, frame, frame.assets_path or "/srv/assets"
+        )
     # Previews of unsaved scenes must not clobber the stored state; neither
     # may a render whose state seeding failed (old wasm bundle without the
     # set_scene_state export) — its readback is just scene defaults.

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -622,6 +622,17 @@ def embedded_platform_spec_for_frame(frame: Frame) -> dict[str, Any]:
     return EMBEDDED_PLATFORMS[embedded_platform_for_frame(frame)]
 
 
+def is_virtual_frame(frame: Frame) -> bool:
+    """Backend-rendered frame with no hardware: assets and scene state live on
+    the backend instead of a device."""
+    if (frame.mode or "rpios") != "embedded":
+        return False
+    try:
+        return embedded_platform_spec_for_frame(frame)["family"] == "virtual"
+    except ValueError:
+        return False
+
+
 def _embedded_platform_or_default(frame: Frame) -> str:
     """The frame's chip target, tolerating malformed metadata (error paths)."""
     try:

--- a/backend/app/tasks/frame_deploy_workflow.py
+++ b/backend/app/tasks/frame_deploy_workflow.py
@@ -45,6 +45,7 @@ from app.tasks.setup_json_reset import (
     setup_json_reset_file_path,
 )
 from app.utils.build_environment import selected_build_environment_provider
+from app.utils import embedded_assets
 from app.utils.frame_http import _fetch_frame_http_bytes
 from app.utils.remote_exec import upload_file
 from app.utils.ssh_authorized_keys import _install_authorized_keys
@@ -1098,6 +1099,8 @@ class FrameDeployWorkflow:
             "stdinfo",
             f"{icon} Uploading {len(scenes)} scene(s) to embedded frame over HTTP",
         )
+        # Scene payloads reach a few hundred KB; on a weak link the default
+        # 20s frame timeout is not enough (observed 408s at ~114KB).
         status, body, _headers = await _fetch_frame_http_bytes(
             frame,
             self.redis,
@@ -1105,6 +1108,7 @@ class FrameDeployWorkflow:
             method="POST",
             body=payload,
             headers={"Content-Type": "application/json"},
+            timeout=embedded_assets.UPLOAD_TIMEOUT,
         )
         if status >= 300:
             message = body.decode("utf-8", errors="replace").strip()

--- a/backend/app/tasks/tests/test_frame_deploy_workflow.py
+++ b/backend/app/tasks/tests/test_frame_deploy_workflow.py
@@ -1902,6 +1902,7 @@ async def test_execute_embedded_fast_uploads_scenes_then_reloads(monkeypatch: py
         method: str,
         body=None,
         headers=None,
+        timeout=None,
     ):
         calls.append({"path": path, "method": method, "body": body, "headers": headers})
         return 200, b'{"status":"ok"}', {}
@@ -1978,6 +1979,7 @@ async def test_execute_embedded_fast_failure_includes_status_context(monkeypatch
         method: str,
         body=None,
         headers=None,
+        timeout=None,
     ):
         calls.append(path)
         if path == "/status":
@@ -2541,7 +2543,7 @@ async def test_execute_embedded_full_builds_ota_waits_for_boot_and_uploads_scene
         }
         return {"ok": True}
 
-    async def fake_fetch_frame_http_bytes(_frame, _redis, *, path, method, body=None, headers=None):
+    async def fake_fetch_frame_http_bytes(_frame, _redis, *, path, method, body=None, headers=None, timeout=None):
         http_calls.append(path)
         return 200, b"{}", {}
 
@@ -2636,7 +2638,7 @@ async def test_execute_embedded_full_skips_boot_wait_when_device_runs_current_fi
     async def fake_request_ota(_db, _redis, _frame, *_args, **_kwargs):
         return {"ok": True}
 
-    async def fake_fetch_frame_http_bytes(_frame, _redis, *, path, method, body=None, headers=None):
+    async def fake_fetch_frame_http_bytes(_frame, _redis, *, path, method, body=None, headers=None, timeout=None):
         http_calls.append(path)
         return 200, b"{}", {}
 

--- a/backend/app/utils/embedded_assets.py
+++ b/backend/app/utils/embedded_assets.py
@@ -25,16 +25,21 @@ from __future__ import annotations
 import json
 import os
 import posixpath
+import re
+import uuid
 from http import HTTPStatus
 from typing import Any, Optional
 
+import httpx
 from arq import ArqRedis as Redis
 from fastapi import HTTPException
 
 from app.models.frame import Frame
+from app.utils.env import get_env_float, get_env_int
 from app.utils.frame_http import _fetch_frame_http_bytes
 
 _FORM_URLENCODED = {"Content-Type": "application/x-www-form-urlencoded"}
+_OCTET_STREAM = {"Content-Type": "application/octet-stream"}
 # Device statuses forwarded to the caller verbatim; anything else becomes 502.
 _PASSTHROUGH_STATUSES = {
     HTTPStatus.BAD_REQUEST,
@@ -43,6 +48,29 @@ _PASSTHROUGH_STATUSES = {
     HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
     HTTPStatus.INSUFFICIENT_STORAGE,
 }
+
+# One backend→device request per chunk keeps each transfer well inside the
+# frame HTTP timeouts on slow links (an 8MB single POST to an ESP32 on weak
+# WiFi reliably outlives them).
+EMBEDDED_UPLOAD_CHUNK_BYTES = get_env_int("FRAME_EMBEDDED_UPLOAD_CHUNK_BYTES", 256 * 1024)
+
+# Upload requests get a far longer read/write budget than the 20s default:
+# a 256KB chunk on a struggling link (weak RSSI, VPN hop, device mid-render)
+# can legitimately take minutes. The device aborts a genuinely dead transfer
+# itself after ~30s of zero bytes, so this mostly bounds slow-but-alive ones.
+_UPLOAD_RW_TIMEOUT = get_env_float("FRAME_HTTP_UPLOAD_TIMEOUT", 180.0)
+UPLOAD_TIMEOUT = httpx.Timeout(
+    connect=get_env_float("FRAME_HTTP_CONNECT_TIMEOUT", 10.0),
+    read=_UPLOAD_RW_TIMEOUT,
+    write=_UPLOAD_RW_TIMEOUT,
+    pool=get_env_float("FRAME_HTTP_POOL_TIMEOUT", 10.0),
+)
+
+_UPLOAD_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,47}$")
+
+
+def valid_upload_id(upload_id: str) -> bool:
+    return bool(_UPLOAD_ID_RE.fullmatch(upload_id or ""))
 
 
 def embedded_assets_path(frame: Frame) -> str:
@@ -151,25 +179,106 @@ async def download_asset(frame: Frame, redis: Redis, full_path: str) -> tuple[by
     return body, content_type or "application/octet-stream"
 
 
-async def upload_asset(frame: Frame, redis: Redis, full_path: str, data: bytes) -> dict[str, Any]:
-    """Upload raw bytes to the device (parent dirs auto-created, existing file
-    replaced). Returns the device's stat dict for the new file when parseable."""
-    rel = to_relative_asset_path(frame, full_path)
+def _parse_device_payload(body: bytes) -> dict[str, Any]:
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        payload = None
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _upload_asset_single(
+    frame: Frame, redis: Redis, rel: str, data: bytes
+) -> dict[str, Any]:
     status, body, _headers = await _fetch_frame_http_bytes(
         frame,
         redis,
         path=f"/api/frames/{frame.id}/assets/upload?path={_quote_rel(rel)}",
         method="POST",
         body=data,
-        headers={"Content-Type": "application/octet-stream"},
+        headers=dict(_OCTET_STREAM),
+        timeout=UPLOAD_TIMEOUT,
     )
     if status not in (HTTPStatus.OK, HTTPStatus.CREATED):
         raise _device_error(status, body)
-    try:
-        payload = json.loads(body)
-    except ValueError:
-        payload = None
-    return payload if isinstance(payload, dict) else {}
+    return _parse_device_payload(body)
+
+
+async def upload_asset_chunk(
+    frame: Frame,
+    redis: Redis,
+    full_path: str,
+    chunk: bytes,
+    *,
+    upload_id: str,
+    chunk_index: int,
+    offset: int,
+    complete: bool,
+) -> Optional[dict[str, Any]]:
+    """Forward one chunk of a chunked upload to the device.
+
+    Returns the device payload ({"pending": true, ...} for a non-final chunk,
+    the final stat dict for the last one) — or None when the device firmware
+    predates chunked uploads: legacy firmware ignores the chunk params, stores
+    the chunk as the whole file and answers with a stat dict, which is only
+    distinguishable on a non-final chunk (no "pending" key). Callers must then
+    fall back to a single-shot upload of the full payload.
+    """
+    if not valid_upload_id(upload_id):
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid upload id")
+    rel = to_relative_asset_path(frame, full_path)
+    status, body, _headers = await _fetch_frame_http_bytes(
+        frame,
+        redis,
+        path=(
+            f"/api/frames/{frame.id}/assets/upload?path={_quote_rel(rel)}"
+            f"&upload_id={upload_id}&chunk_index={int(chunk_index)}"
+            f"&offset={int(offset)}&complete={1 if complete else 0}"
+        ),
+        method="POST",
+        body=chunk,
+        headers=dict(_OCTET_STREAM),
+        timeout=UPLOAD_TIMEOUT,
+    )
+    if status not in (HTTPStatus.OK, HTTPStatus.CREATED):
+        raise _device_error(status, body)
+    payload = _parse_device_payload(body)
+    if not complete and not payload.get("pending"):
+        return None
+    return payload
+
+
+async def upload_asset(frame: Frame, redis: Redis, full_path: str, data: bytes) -> dict[str, Any]:
+    """Upload raw bytes to the device (parent dirs auto-created, existing file
+    replaced). Returns the device's stat dict for the new file when parseable.
+
+    Payloads larger than EMBEDDED_UPLOAD_CHUNK_BYTES are streamed as several
+    chunk requests so no single device request outlives the HTTP timeouts."""
+    rel = to_relative_asset_path(frame, full_path)
+    if len(data) <= EMBEDDED_UPLOAD_CHUNK_BYTES:
+        return await _upload_asset_single(frame, redis, rel, data)
+
+    upload_id = uuid.uuid4().hex[:32]
+    chunk_size = EMBEDDED_UPLOAD_CHUNK_BYTES
+    total_chunks = (len(data) + chunk_size - 1) // chunk_size
+    payload: Optional[dict[str, Any]] = {}
+    for index in range(total_chunks):
+        offset = index * chunk_size
+        payload = await upload_asset_chunk(
+            frame,
+            redis,
+            full_path,
+            data[offset:offset + chunk_size],
+            upload_id=upload_id,
+            chunk_index=index,
+            offset=offset,
+            complete=index == total_chunks - 1,
+        )
+        if payload is None:
+            # Legacy firmware without chunk support: one big request is the
+            # only option it understands.
+            return await _upload_asset_single(frame, redis, rel, data)
+    return payload or {}
 
 
 async def _post_form(

--- a/backend/app/utils/embedded_render.py
+++ b/backend/app/utils/embedded_render.py
@@ -56,7 +56,24 @@ def thin_client_renderer_available() -> bool:
     return shutil.which("node") is not None and wasm_assets_dir() is not None and RENDER_HARNESS.is_file()
 
 
-async def render_scene_rgba(
+# The harness reports the post-render scene state on stderr as one
+# `__FRAMEOS_SCENE_STATE__{"sceneId":...,"state":...}` line.
+_STATE_MARKER = "__FRAMEOS_SCENE_STATE__"
+
+
+def _parse_rendered_state(stderr: bytes) -> dict | None:
+    for line in reversed(stderr.decode("utf-8", errors="replace").splitlines()):
+        if not line.startswith(_STATE_MARKER):
+            continue
+        try:
+            payload = json.loads(line[len(_STATE_MARKER):])
+        except ValueError:
+            return None
+        return payload if isinstance(payload, dict) else None
+    return None
+
+
+async def render_scene_rgba_and_state(
     frame: Frame,
     width: int,
     height: int,
@@ -64,23 +81,30 @@ async def render_scene_rgba(
     scene_id: str | None = None,
     settings: dict | None = None,
     scenes_override: list | None = None,
+    scene_states: dict | None = None,
+    assets_dir: str | None = None,
     timeout: float = RENDER_TIMEOUT_SECONDS,
-) -> bytes | None:
-    """One frame of the scene as width*height*4 RGBA bytes, or None.
+) -> tuple[bytes | None, dict | None]:
+    """One frame of the scene as (width*height*4 RGBA bytes, post-render state).
 
-    None means "no render available" (no scenes, no toolchain, render error,
-    timeout) — the caller falls back to the diagnostic bitmap. Failures are
-    expected operational states here, not exceptions: the device keeps
+    A None image means "no render available" (no scenes, no toolchain, render
+    error, timeout) — the caller falls back to the diagnostic bitmap. Failures
+    are expected operational states here, not exceptions: the device keeps
     polling, and a broken scene must not take the endpoint down with it.
+
+    ``scene_states`` ({sceneId: state}) seeds backend-persisted scene state
+    into the renderer; ``assets_dir`` is a host directory preloaded into the
+    wasm filesystem at the frame's asset path (virtual frames). The returned
+    state is {"sceneId": ..., "state": {...}} or None when unavailable.
     """
     source = scenes_override if scenes_override is not None else frame.scenes
     scenes = [scene for scene in (source or []) if isinstance(scene, dict)]
     if not scenes:
-        return None
+        return None, None
     node = shutil.which("node")
     assets = wasm_assets_dir()
     if node is None or assets is None or not RENDER_HARNESS.is_file():
-        return None
+        return None, None
 
     request = {
         "assetsDir": str(assets),
@@ -93,6 +117,10 @@ async def render_scene_rgba(
     }
     if scene_id:
         request["sceneId"] = scene_id
+    if scene_states:
+        request["statesJson"] = json.dumps(scene_states, separators=(",", ":"))
+    if assets_dir:
+        request["frameAssetsRoot"] = assets_dir
 
     expected = int(width) * int(height) * 4
     async with _render_semaphore:
@@ -111,7 +139,7 @@ async def render_scene_rgba(
         except asyncio.TimeoutError:
             process.kill()
             await process.wait()
-            return None
+            return None, None
 
     if process.returncode != 0 or len(stdout) != expected:
         detail = stderr.decode("utf-8", errors="replace").strip().splitlines()
@@ -119,5 +147,28 @@ async def render_scene_rgba(
         # Log through print (uvicorn stdout); the device-facing endpoint has
         # no frame log context worth spamming on every poll.
         print(f"embedded_render: frame {frame.id} scene render failed: {tail}")
-        return None
-    return stdout
+        return None, None
+    return stdout, _parse_rendered_state(stderr)
+
+
+async def render_scene_rgba(
+    frame: Frame,
+    width: int,
+    height: int,
+    *,
+    scene_id: str | None = None,
+    settings: dict | None = None,
+    scenes_override: list | None = None,
+    timeout: float = RENDER_TIMEOUT_SECONDS,
+) -> bytes | None:
+    """Image-only wrapper around render_scene_rgba_and_state (thin clients)."""
+    rgba, _state = await render_scene_rgba_and_state(
+        frame,
+        width,
+        height,
+        scene_id=scene_id,
+        settings=settings,
+        scenes_override=scenes_override,
+        timeout=timeout,
+    )
+    return rgba

--- a/backend/app/utils/embedded_render.py
+++ b/backend/app/utils/embedded_render.py
@@ -56,17 +56,20 @@ def thin_client_renderer_available() -> bool:
     return shutil.which("node") is not None and wasm_assets_dir() is not None and RENDER_HARNESS.is_file()
 
 
-# The harness reports the post-render scene state on stderr as one
-# `__FRAMEOS_SCENE_STATE__{"sceneId":...,"state":...}` line.
+# The harness reports the post-render scene state and any assets the scene
+# saved (written back to the host asset store) on stderr, one line each:
+# `__FRAMEOS_SCENE_STATE__{"sceneId":...,"state":...}` and
+# `__FRAMEOS_SAVED_ASSETS__{"files":[...],"skippedOverBudget":n}`.
 _STATE_MARKER = "__FRAMEOS_SCENE_STATE__"
+_SAVED_ASSETS_MARKER = "__FRAMEOS_SAVED_ASSETS__"
 
 
-def _parse_rendered_state(stderr: bytes) -> dict | None:
-    for line in reversed(stderr.decode("utf-8", errors="replace").splitlines()):
-        if not line.startswith(_STATE_MARKER):
+def _parse_marker(stderr_text: str, marker: str) -> dict | None:
+    for line in reversed(stderr_text.splitlines()):
+        if not line.startswith(marker):
             continue
         try:
-            payload = json.loads(line[len(_STATE_MARKER):])
+            payload = json.loads(line[len(marker):])
         except ValueError:
             return None
         return payload if isinstance(payload, dict) else None
@@ -83,9 +86,11 @@ async def render_scene_rgba_and_state(
     scenes_override: list | None = None,
     scene_states: dict | None = None,
     assets_dir: str | None = None,
+    save_assets=None,
+    assets_write_budget: int | None = None,
     timeout: float = RENDER_TIMEOUT_SECONDS,
-) -> tuple[bytes | None, dict | None]:
-    """One frame of the scene as (width*height*4 RGBA bytes, post-render state).
+) -> tuple[bytes | None, dict | None, dict | None]:
+    """One frame of the scene as (RGBA bytes, post-render state, saved assets).
 
     A None image means "no render available" (no scenes, no toolchain, render
     error, timeout) — the caller falls back to the diagnostic bitmap. Failures
@@ -94,17 +99,21 @@ async def render_scene_rgba_and_state(
 
     ``scene_states`` ({sceneId: state}) seeds backend-persisted scene state
     into the renderer; ``assets_dir`` is a host directory preloaded into the
-    wasm filesystem at the frame's asset path (virtual frames). The returned
-    state is {"sceneId": ..., "state": {...}} or None when unavailable.
+    wasm filesystem at the frame's asset path (virtual frames), and files the
+    scene saves there (saveAssets-enabled apps) are written back to it, up to
+    ``assets_write_budget`` bytes; ``save_assets`` is the frame's saveAssets
+    config forwarded to the runtime. The returned state is
+    {"sceneId": ..., "state": {...}} and the saved-assets report is
+    {"files": [...], "skippedOverBudget": n}; either is None when unavailable.
     """
     source = scenes_override if scenes_override is not None else frame.scenes
     scenes = [scene for scene in (source or []) if isinstance(scene, dict)]
     if not scenes:
-        return None, None
+        return None, None, None
     node = shutil.which("node")
     assets = wasm_assets_dir()
     if node is None or assets is None or not RENDER_HARNESS.is_file():
-        return None, None
+        return None, None, None
 
     request = {
         "assetsDir": str(assets),
@@ -121,6 +130,10 @@ async def render_scene_rgba_and_state(
         request["statesJson"] = json.dumps(scene_states, separators=(",", ":"))
     if assets_dir:
         request["frameAssetsRoot"] = assets_dir
+    if save_assets is not None:
+        request["saveAssetsJson"] = json.dumps(save_assets)
+    if assets_write_budget is not None:
+        request["assetsWriteBudget"] = max(0, int(assets_write_budget))
 
     expected = int(width) * int(height) * 4
     async with _render_semaphore:
@@ -139,7 +152,7 @@ async def render_scene_rgba_and_state(
         except asyncio.TimeoutError:
             process.kill()
             await process.wait()
-            return None, None
+            return None, None, None
 
     if process.returncode != 0 or len(stdout) != expected:
         detail = stderr.decode("utf-8", errors="replace").strip().splitlines()
@@ -147,8 +160,13 @@ async def render_scene_rgba_and_state(
         # Log through print (uvicorn stdout); the device-facing endpoint has
         # no frame log context worth spamming on every poll.
         print(f"embedded_render: frame {frame.id} scene render failed: {tail}")
-        return None, None
-    return stdout, _parse_rendered_state(stderr)
+        return None, None, None
+    stderr_text = stderr.decode("utf-8", errors="replace")
+    return (
+        stdout,
+        _parse_marker(stderr_text, _STATE_MARKER),
+        _parse_marker(stderr_text, _SAVED_ASSETS_MARKER),
+    )
 
 
 async def render_scene_rgba(
@@ -162,7 +180,7 @@ async def render_scene_rgba(
     timeout: float = RENDER_TIMEOUT_SECONDS,
 ) -> bytes | None:
     """Image-only wrapper around render_scene_rgba_and_state (thin clients)."""
-    rgba, _state = await render_scene_rgba_and_state(
+    rgba, _state, _saved = await render_scene_rgba_and_state(
         frame,
         width,
         height,

--- a/backend/app/utils/frame_http.py
+++ b/backend/app/utils/frame_http.py
@@ -233,8 +233,12 @@ async def _fetch_frame_http_bytes(
     method: str = "GET",
     body: bytes | str | None = None,
     headers: Optional[dict[str, str]] = None,
+    timeout: Optional[httpx.Timeout] = None,
 ) -> tuple[int, bytes, dict[str, str]]:
-    """Fetch *path* from the frame returning (status, body-bytes, headers)."""
+    """Fetch *path* from the frame returning (status, body-bytes, headers).
+
+    `timeout` overrides FRAME_HTTP_TIMEOUT for requests that legitimately
+    take long (e.g. asset uploads crawling over a weak WiFi link)."""
     if await _use_remote(frame, redis):
         remote_body: str | None
         if isinstance(body, bytes):
@@ -277,7 +281,7 @@ async def _fetch_frame_http_bytes(
                             url,
                             headers=hdrs,
                             content=body,
-                            timeout=FRAME_HTTP_TIMEOUT,
+                            timeout=timeout if timeout is not None else FRAME_HTTP_TIMEOUT,
                         )
                         return response.status_code, response.content, dict(response.headers)
                     except timeout_errors:

--- a/backend/app/utils/tests/test_embedded_render.py
+++ b/backend/app/utils/tests/test_embedded_render.py
@@ -1,0 +1,32 @@
+from app.utils.embedded_render import (
+    _SAVED_ASSETS_MARKER,
+    _STATE_MARKER,
+    _parse_marker,
+)
+
+STDERR = """[scene] {"event":"render:done","sceneId":"scene-a","ms":1.0}
+__FRAMEOS_SCENE_STATE__{"sceneId":"scene-a","state":{"word":"hi"},"seeded":true}
+__FRAMEOS_SAVED_ASSETS__{"files":["wikicommons/a.jpg"],"skippedOverBudget":1}
+"""
+
+
+def test_parse_marker_extracts_each_payload():
+    state = _parse_marker(STDERR, _STATE_MARKER)
+    assert state == {"sceneId": "scene-a", "state": {"word": "hi"}, "seeded": True}
+    saved = _parse_marker(STDERR, _SAVED_ASSETS_MARKER)
+    assert saved == {"files": ["wikicommons/a.jpg"], "skippedOverBudget": 1}
+
+
+def test_parse_marker_missing_and_invalid():
+    assert _parse_marker("[scene] nothing here\n", _STATE_MARKER) is None
+    assert _parse_marker(f"{_STATE_MARKER}not-json\n", _STATE_MARKER) is None
+    # A spoofed marker mid-line does not match; only line starts count.
+    assert _parse_marker(f"[scene] {_STATE_MARKER}{{}}\n", _STATE_MARKER) is None
+
+
+def test_parse_marker_takes_last_line():
+    text = (
+        f'{_STATE_MARKER}{{"sceneId":"old"}}\n'
+        f'{_STATE_MARKER}{{"sceneId":"new"}}\n'
+    )
+    assert _parse_marker(text, _STATE_MARKER) == {"sceneId": "new"}

--- a/backend/app/utils/virtual_assets.py
+++ b/backend/app/utils/virtual_assets.py
@@ -1,0 +1,212 @@
+"""Asset storage for virtual frames.
+
+Virtual frames have no hardware, so their assets live on the backend itself:
+one directory per frame under ``FRAMEOS_VIRTUAL_ASSETS_DIR`` (default
+``../db/virtual_assets``, next to the SQLite database so docker installs keep
+it on the persistent volume).
+
+The helpers mirror ``app.utils.embedded_assets`` — same names, same
+signatures, same absolute-path convention (paths prefixed with
+``frame.assets_path``) — so the asset routes dispatch to either module
+interchangeably. The ``redis`` parameter is unused here and kept only for
+that symmetry.
+
+Uploads are quota-limited per frame: ``device_config.assetsQuotaMb`` when set,
+else ``FRAMEOS_VIRTUAL_ASSETS_QUOTA_MB``, else 100 MB. Exceeding it returns
+507 Insufficient Storage, the same status a full SD card produces on embedded
+frames.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import shutil
+import tempfile
+from http import HTTPStatus
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException
+
+from app.models.frame import Frame
+from app.utils.embedded_assets import embedded_assets_path, to_relative_asset_path
+
+DEFAULT_QUOTA_MB = 100
+
+
+def _storage_base() -> Path:
+    return Path(os.environ.get("FRAMEOS_VIRTUAL_ASSETS_DIR") or "../db/virtual_assets")
+
+
+def frame_assets_dir(frame: Frame) -> Path:
+    """Physical directory holding this frame's assets (may not exist yet)."""
+    return _storage_base() / f"frame_{int(frame.id)}"
+
+
+def quota_bytes(frame: Frame) -> int:
+    device_config = frame.device_config if isinstance(frame.device_config, dict) else {}
+    override = device_config.get("assetsQuotaMb")
+    if isinstance(override, (int, float)) and not isinstance(override, bool) and override > 0:
+        return int(override * 1024 * 1024)
+    env_value = os.environ.get("FRAMEOS_VIRTUAL_ASSETS_QUOTA_MB")
+    try:
+        if env_value and float(env_value) > 0:
+            return int(float(env_value) * 1024 * 1024)
+    except ValueError:
+        pass
+    return DEFAULT_QUOTA_MB * 1024 * 1024
+
+
+def usage_bytes(frame: Frame) -> int:
+    total = 0
+    root = frame_assets_dir(frame)
+    if not root.is_dir():
+        return 0
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, name))
+            except OSError:
+                continue
+    return total
+
+
+def _physical_path(frame: Frame, full_path: str, *, allow_root: bool = False) -> Path:
+    """Map an absolute logical path (``/srv/assets/...``) to the on-disk file,
+    re-checking containment after resolution so nothing escapes the frame dir."""
+    rel = to_relative_asset_path(frame, full_path, allow_root=allow_root)
+    root = frame_assets_dir(frame)
+    target = (root / rel) if rel else root
+    resolved_root = root.resolve()
+    if not target.resolve().is_relative_to(resolved_root):
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid asset path")
+    return target
+
+
+async def list_assets(frame: Frame, redis=None) -> list[dict[str, Any]]:
+    root = frame_assets_dir(frame)
+    assets_root = embedded_assets_path(frame).rstrip("/")
+    assets: list[dict[str, Any]] = []
+    if not root.is_dir():
+        return assets
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in dirnames:
+            path = Path(dirpath) / name
+            rel = path.relative_to(root).as_posix()
+            try:
+                mtime = int(path.stat().st_mtime)
+            except OSError:
+                mtime = 0
+            assets.append({
+                "path": f"{assets_root}/{rel}",
+                "size": 0,
+                "mtime": mtime,
+                "is_dir": True,
+            })
+        for name in filenames:
+            path = Path(dirpath) / name
+            rel = path.relative_to(root).as_posix()
+            try:
+                stat = path.stat()
+                size, mtime = int(stat.st_size), int(stat.st_mtime)
+            except OSError:
+                size, mtime = 0, 0
+            assets.append({
+                "path": f"{assets_root}/{rel}",
+                "size": size,
+                "mtime": mtime,
+                "is_dir": False,
+            })
+    assets.sort(key=lambda a: a["path"])
+    return assets
+
+
+async def download_asset(frame: Frame, redis, full_path: str) -> tuple[bytes, str]:
+    target = _physical_path(frame, full_path)
+    if not target.is_file():
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Asset not found")
+    content_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    return target.read_bytes(), content_type
+
+
+async def upload_asset(frame: Frame, redis, full_path: str, data: bytes) -> dict[str, Any]:
+    target = _physical_path(frame, full_path)
+    if target.is_dir():
+        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="Path is a directory")
+
+    replaced = 0
+    if target.is_file():
+        try:
+            replaced = target.stat().st_size
+        except OSError:
+            replaced = 0
+    quota = quota_bytes(frame)
+    projected = usage_bytes(frame) - replaced + len(data)
+    if projected > quota:
+        raise HTTPException(
+            status_code=HTTPStatus.INSUFFICIENT_STORAGE,
+            detail=(
+                f"Assets quota exceeded: upload needs {projected} bytes, "
+                f"quota is {quota} bytes"
+            ),
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # Write-then-rename so a crashed upload never leaves a truncated asset.
+    fd, tmp_name = tempfile.mkstemp(dir=target.parent, prefix=".upload-")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        os.replace(tmp_name, target)
+    except OSError:
+        _unlink_quietly(tmp_name)
+        raise
+    return {
+        "path": full_path,
+        "size": len(data),
+        "mtime": int(target.stat().st_mtime),
+        "is_dir": False,
+    }
+
+
+def _unlink_quietly(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+async def make_dir(frame: Frame, redis, full_path: str) -> None:
+    target = _physical_path(frame, full_path, allow_root=True)
+    if target.is_file():
+        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="Path is a file")
+    target.mkdir(parents=True, exist_ok=True)
+
+
+async def delete_path(frame: Frame, redis, full_path: str) -> None:
+    target = _physical_path(frame, full_path)
+    if target.is_dir():
+        shutil.rmtree(target)
+    elif target.is_file():
+        target.unlink()
+    else:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Asset not found")
+
+
+async def rename_path(frame: Frame, redis, src_full: str, dst_full: str) -> None:
+    src = _physical_path(frame, src_full)
+    dst = _physical_path(frame, dst_full)
+    if not src.exists():
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Asset not found")
+    if dst.exists():
+        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="Destination already exists")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(src, dst)
+
+
+def delete_frame_assets(frame: Frame) -> None:
+    """Remove the whole storage directory (frame deletion)."""
+    root = frame_assets_dir(frame)
+    if root.is_dir():
+        shutil.rmtree(root, ignore_errors=True)

--- a/backend/app/utils/virtual_assets.py
+++ b/backend/app/utils/virtual_assets.py
@@ -11,8 +11,8 @@ signatures, same absolute-path convention (paths prefixed with
 interchangeably. The ``redis`` parameter is unused here and kept only for
 that symmetry.
 
-Uploads are quota-limited per frame: ``device_config.assetsQuotaMb`` when set,
-else ``FRAMEOS_VIRTUAL_ASSETS_QUOTA_MB``, else 100 MB. Exceeding it returns
+Uploads are quota-limited per frame: ``device_config.assetsQuotaMb`` (edited
+in the frame's settings panel), defaulting to 100 MB. Exceeding it returns
 507 Insufficient Storage, the same status a full SD card produces on embedded
 frames.
 """
@@ -46,15 +46,15 @@ def frame_assets_dir(frame: Frame) -> Path:
 
 def quota_bytes(frame: Frame) -> int:
     device_config = frame.device_config if isinstance(frame.device_config, dict) else {}
-    override = device_config.get("assetsQuotaMb")
-    if isinstance(override, (int, float)) and not isinstance(override, bool) and override > 0:
-        return int(override * 1024 * 1024)
-    env_value = os.environ.get("FRAMEOS_VIRTUAL_ASSETS_QUOTA_MB")
-    try:
-        if env_value and float(env_value) > 0:
-            return int(float(env_value) * 1024 * 1024)
-    except ValueError:
-        pass
+    quota = device_config.get("assetsQuotaMb")
+    # The settings form may deliver the number as a string; be lenient.
+    if isinstance(quota, str):
+        try:
+            quota = float(quota)
+        except ValueError:
+            quota = None
+    if isinstance(quota, (int, float)) and not isinstance(quota, bool) and quota > 0:
+        return int(quota * 1024 * 1024)
     return DEFAULT_QUOTA_MB * 1024 * 1024
 
 

--- a/backend/tools/embedded_wasm_render.mjs
+++ b/backend/tools/embedded_wasm_render.mjs
@@ -7,7 +7,7 @@
 //
 // Protocol: a single JSON object on stdin
 //   {assetsDir, width, height, name, timeZone, settingsJson, scenesJson,
-//    sceneId, statesJson, frameAssetsRoot}
+//    sceneId, statesJson, frameAssetsRoot, saveAssetsJson, assetsWriteBudget}
 // and exactly width*height*4 bytes of RGBA on stdout on success (exit 0).
 // All logs go to stderr; any failure exits non-zero with a message there.
 // statesJson ({sceneId: stateObject}) seeds backend-persisted scene state;
@@ -16,6 +16,12 @@
 // Python caller parses. frameAssetsRoot is a host directory whose files are
 // preloaded into the wasm MEMFS under /srv/assets, so scene apps that read
 // frame assets (photo folders etc.) see them like on-device files.
+// saveAssetsJson carries the frame's saveAssets config into the runtime;
+// files that apps save during the render (saveAsset in apps.nim — OpenAI
+// images, downloaded photos) land in MEMFS and are written back to
+// frameAssetsRoot after the render, up to assetsWriteBudget bytes (the
+// frame's remaining asset quota), reported on stderr as one
+// `__FRAMEOS_SAVED_ASSETS__{"files":[...],"skippedOverBudget":n}` line.
 //
 // Sandbox posture: user scene code (QuickJS) runs inside the wasm module,
 // never natively in Node. Its host hooks are logging and the synchronous
@@ -27,9 +33,9 @@
 
 import { spawnSync } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
-import { join, relative, sep } from 'node:path'
+import { dirname, join, relative, sep } from 'node:path'
 
 // Synchronous XMLHttpRequest, as the emscripten HTTP bridge expects: each
 // send() runs fetch() in a short-lived child Node so the blocking wait is
@@ -200,11 +206,25 @@ if (request.statesJson) {
   }
 }
 
+// The frame's saveAssets config, so apps' "auto" save mode matches the
+// device. Old bundles predate the export; they keep saveAssets=false.
+if (request.saveAssetsJson) {
+  try {
+    call('frameos_wasm_set_save_assets', 'boolean', ['string'], [request.saveAssetsJson])
+  } catch (error) {
+    process.stderr.write(`embedded_wasm_render: saveAssets config unavailable (${error})\n`)
+  }
+}
+
 // Preload the frame's backend-stored assets into MEMFS so scene apps can
 // read them at the on-device path. Needs a wasm bundle built with FS in
 // EXPORTED_RUNTIME_METHODS; older bundles just skip the preload.
+// `preloadedFiles` records what existed before the render, so the
+// write-back below only copies files the scene created.
 const MAX_PRELOAD_BYTES = 128 * 1024 * 1024
-if (request.frameAssetsRoot && Module.FS) {
+const MEMFS_ASSETS_ROOT = '/srv/assets'
+const preloadedFiles = new Set()
+if (request.frameAssetsRoot && Module.FS && existsSync(request.frameAssetsRoot)) {
   const FS = Module.FS
   const ensureDir = (path) => {
     const parts = path.split('/').filter(Boolean)
@@ -226,7 +246,7 @@ if (request.frameAssetsRoot && Module.FS) {
       const hostPath = join(entry.parentPath ?? entry.path, entry.name)
       const rel = relative(request.frameAssetsRoot, hostPath).split(sep).join('/')
       if (!rel || rel.startsWith('..')) continue
-      const target = '/srv/assets/' + rel
+      const target = MEMFS_ASSETS_ROOT + '/' + rel
       if (entry.isDirectory()) {
         ensureDir(target)
         continue
@@ -235,10 +255,12 @@ if (request.frameAssetsRoot && Module.FS) {
       const size = statSync(hostPath).size
       if (preloaded + size > MAX_PRELOAD_BYTES) {
         skipped += 1
+        preloadedFiles.add(target) // over-cap files still must not be "new"
         continue
       }
       ensureDir(target.slice(0, target.lastIndexOf('/')))
       FS.writeFile(target, readFileSync(hostPath))
+      preloadedFiles.add(target)
       preloaded += size
     }
   } catch (error) {
@@ -247,8 +269,64 @@ if (request.frameAssetsRoot && Module.FS) {
   if (skipped > 0) {
     process.stderr.write(`embedded_wasm_render: skipped ${skipped} asset(s) over the ${MAX_PRELOAD_BYTES} byte preload cap\n`)
   }
-} else if (request.frameAssetsRoot) {
+} else if (request.frameAssetsRoot && !Module.FS) {
   process.stderr.write('embedded_wasm_render: wasm bundle lacks FS export, skipping asset preload\n')
+}
+
+// After the render: copy files the scene saved into MEMFS (saveAsset in
+// apps.nim — OpenAI images, downloaded photos) back to the host asset
+// store, within the remaining-quota budget the backend computed.
+function writeBackSavedAssets() {
+  if (!request.frameAssetsRoot || !Module.FS) return
+  const FS = Module.FS
+  const budget = Number.isFinite(request.assetsWriteBudget) ? request.assetsWriteBudget : 0
+  const files = []
+  let written = 0
+  let skippedOverBudget = 0
+  const walk = (dir) => {
+    let names
+    try {
+      names = FS.readdir(dir)
+    } catch {
+      return
+    }
+    for (const name of names) {
+      if (name === '.' || name === '..') continue
+      const path = dir + '/' + name
+      let stat
+      try {
+        stat = FS.stat(path)
+      } catch {
+        continue
+      }
+      if (FS.isDir(stat.mode)) {
+        walk(path)
+        continue
+      }
+      if (!FS.isFile(stat.mode) || preloadedFiles.has(path)) continue
+      const rel = path.slice(MEMFS_ASSETS_ROOT.length + 1)
+      // The path comes out of the wasm module; never let it escape the root.
+      const parts = rel.split('/')
+      if (parts.some((part) => !part || part === '.' || part === '..')) continue
+      if (written + stat.size > budget) {
+        skippedOverBudget += 1
+        continue
+      }
+      try {
+        const hostPath = join(request.frameAssetsRoot, ...parts)
+        mkdirSync(dirname(hostPath), { recursive: true })
+        writeFileSync(hostPath, FS.readFile(path))
+        written += stat.size
+        files.push(rel)
+      } catch (error) {
+        process.stderr.write(`embedded_wasm_render: asset write-back failed for ${rel}: ${error}\n`)
+      }
+    }
+  }
+  walk(MEMFS_ASSETS_ROOT)
+  if (files.length > 0 || skippedOverBudget > 0) {
+    process.stderr.write('__FRAMEOS_SAVED_ASSETS__' + JSON.stringify({ files, skippedOverBudget }) + '\n')
+  }
 }
 
 const rc = call('frameos_wasm_render', 'number', [], [])
@@ -260,6 +338,8 @@ if (rc === 2 || !ptr || !len) fail(`render failed: ${lastError()}`)
 if (len !== outWidth * outHeight * 4) {
   fail(`unexpected buffer size ${len} for ${outWidth}x${outHeight}`)
 }
+
+writeBackSavedAssets()
 
 // Report the post-render scene state so the backend can persist what the
 // scene changed. Best-effort: a failure here must not fail the render.

--- a/backend/tools/embedded_wasm_render.mjs
+++ b/backend/tools/embedded_wasm_render.mjs
@@ -6,9 +6,16 @@
 // instead of on the device.
 //
 // Protocol: a single JSON object on stdin
-//   {assetsDir, width, height, name, timeZone, settingsJson, scenesJson, sceneId}
+//   {assetsDir, width, height, name, timeZone, settingsJson, scenesJson,
+//    sceneId, statesJson, frameAssetsRoot}
 // and exactly width*height*4 bytes of RGBA on stdout on success (exit 0).
 // All logs go to stderr; any failure exits non-zero with a message there.
+// statesJson ({sceneId: stateObject}) seeds backend-persisted scene state;
+// after a successful render the post-render state is reported on stderr as
+// one `__FRAMEOS_SCENE_STATE__{"sceneId":...,"state":...}` line, which the
+// Python caller parses. frameAssetsRoot is a host directory whose files are
+// preloaded into the wasm MEMFS under /srv/assets, so scene apps that read
+// frame assets (photo folders etc.) see them like on-device files.
 //
 // Sandbox posture: user scene code (QuickJS) runs inside the wasm module,
 // never natively in Node. Its host hooks are logging and the synchronous
@@ -20,8 +27,9 @@
 
 import { spawnSync } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
-import { join } from 'node:path'
+import { join, relative, sep } from 'node:path'
 
 // Synchronous XMLHttpRequest, as the emscripten HTTP bridge expects: each
 // send() runs fetch() in a short-lived child Node so the blocking wait is
@@ -164,6 +172,85 @@ if (request.sceneId) {
   }
 }
 
+// Seed backend-persisted scene state (virtual frames). Old wasm bundles
+// predate the export; state seeding then degrades to defaults-only, and
+// stateSeeded=false tells the backend NOT to persist the post-render
+// readback (it would clobber the stored state with scene defaults).
+let stateSeeded = true
+if (request.statesJson) {
+  let states = null
+  try {
+    states = JSON.parse(request.statesJson)
+  } catch {
+    stateSeeded = false
+    process.stderr.write('embedded_wasm_render: invalid statesJson, ignoring\n')
+  }
+  if (states && typeof states === 'object') {
+    for (const [sceneId, state] of Object.entries(states)) {
+      if (!state || typeof state !== 'object') continue
+      try {
+        call('frameos_wasm_set_scene_state', 'boolean', ['string', 'string'],
+          [sceneId, JSON.stringify(state)])
+      } catch (error) {
+        stateSeeded = false
+        process.stderr.write(`embedded_wasm_render: state seeding unavailable (${error})\n`)
+        break
+      }
+    }
+  }
+}
+
+// Preload the frame's backend-stored assets into MEMFS so scene apps can
+// read them at the on-device path. Needs a wasm bundle built with FS in
+// EXPORTED_RUNTIME_METHODS; older bundles just skip the preload.
+const MAX_PRELOAD_BYTES = 128 * 1024 * 1024
+if (request.frameAssetsRoot && Module.FS) {
+  const FS = Module.FS
+  const ensureDir = (path) => {
+    const parts = path.split('/').filter(Boolean)
+    let current = ''
+    for (const part of parts) {
+      current += '/' + part
+      try {
+        FS.mkdir(current)
+      } catch {
+        // exists
+      }
+    }
+  }
+  let preloaded = 0
+  let skipped = 0
+  try {
+    const entries = readdirSync(request.frameAssetsRoot, { recursive: true, withFileTypes: true })
+    for (const entry of entries) {
+      const hostPath = join(entry.parentPath ?? entry.path, entry.name)
+      const rel = relative(request.frameAssetsRoot, hostPath).split(sep).join('/')
+      if (!rel || rel.startsWith('..')) continue
+      const target = '/srv/assets/' + rel
+      if (entry.isDirectory()) {
+        ensureDir(target)
+        continue
+      }
+      if (!entry.isFile()) continue
+      const size = statSync(hostPath).size
+      if (preloaded + size > MAX_PRELOAD_BYTES) {
+        skipped += 1
+        continue
+      }
+      ensureDir(target.slice(0, target.lastIndexOf('/')))
+      FS.writeFile(target, readFileSync(hostPath))
+      preloaded += size
+    }
+  } catch (error) {
+    process.stderr.write(`embedded_wasm_render: asset preload failed: ${error}\n`)
+  }
+  if (skipped > 0) {
+    process.stderr.write(`embedded_wasm_render: skipped ${skipped} asset(s) over the ${MAX_PRELOAD_BYTES} byte preload cap\n`)
+  }
+} else if (request.frameAssetsRoot) {
+  process.stderr.write('embedded_wasm_render: wasm bundle lacks FS export, skipping asset preload\n')
+}
+
 const rc = call('frameos_wasm_render', 'number', [], [])
 const outWidth = call('frameos_wasm_width', 'number', [], [])
 const outHeight = call('frameos_wasm_height', 'number', [], [])
@@ -172,6 +259,20 @@ const len = call('frameos_wasm_buffer_len', 'number', [], [])
 if (rc === 2 || !ptr || !len) fail(`render failed: ${lastError()}`)
 if (len !== outWidth * outHeight * 4) {
   fail(`unexpected buffer size ${len} for ${outWidth}x${outHeight}`)
+}
+
+// Report the post-render scene state so the backend can persist what the
+// scene changed. Best-effort: a failure here must not fail the render.
+try {
+  const info = JSON.parse(call('frameos_wasm_scene_info', 'string', [], []))
+  const state = JSON.parse(call('frameos_wasm_scene_state', 'string', [], []))
+  process.stderr.write('__FRAMEOS_SCENE_STATE__' + JSON.stringify({
+    sceneId: info.currentSceneId || request.sceneId || '',
+    state,
+    seeded: stateSeeded,
+  }) + '\n')
+} catch (error) {
+  process.stderr.write(`embedded_wasm_render: state readback failed: ${error}\n`)
 }
 
 process.stdout.write(Buffer.from(Module.HEAPU8.buffer, ptr, len), (err) => {

--- a/cloud/apps/auth-web/src/test/shared-spa/workspace-surfaces.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/workspace-surfaces.test.ts
@@ -316,9 +316,11 @@ describe("embedded-hardware frames on the backend control plane", () => {
   });
 
   it("leaves virtual frames to the stricter virtual gating", () => {
-    // Virtual frames additionally hide assets/metrics and reboot/restart;
-    // the embedded-hardware list must not soften that.
-    expect(frameToolPanelIsAllowed("backend", "assets", virtualFrame)).toBe(false);
+    // Virtual frames additionally hide metrics and reboot/restart; the
+    // embedded-hardware list must not soften that. Assets stay: the backend
+    // stores them (quota-limited) and feeds them to the wasm renderer.
+    expect(frameToolPanelIsAllowed("backend", "assets", virtualFrame)).toBe(true);
+    expect(frameToolPanelIsAllowed("backend", "metrics", virtualFrame)).toBe(false);
     expect(frameMenuActionIsAllowed("backend", "reboot", virtualFrame)).toBe(false);
   });
 

--- a/embedded/esp32/main/fos_assets.c
+++ b/embedded/esp32/main/fos_assets.c
@@ -259,6 +259,138 @@ void fos_assets_write_abort(fos_assets_writer_t *writer)
     unlink(writer->tmp_path);
 }
 
+void fos_assets_cleanup_stale_uploads(void)
+{
+    if (!fos_assets_available()) return;
+    char dir_path[FOS_ASSETS_FULL_PATH_MAX];
+    snprintf(dir_path, sizeof(dir_path), "%s/.uploads", fos_assets_root());
+    DIR *dir = opendir(dir_path);
+    if (!dir) return;
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        char full[FOS_ASSETS_FULL_PATH_MAX + sizeof(entry->d_name)];
+        snprintf(full, sizeof(full), "%s/%s", dir_path, entry->d_name);
+        unlink(full);
+    }
+    closedir(dir);
+}
+
+bool fos_assets_valid_upload_id(const char *upload_id)
+{
+    if (!upload_id || !upload_id[0]) return false;
+    size_t len = strlen(upload_id);
+    if (len >= FOS_ASSETS_UPLOAD_ID_MAX) return false;
+    for (size_t i = 0; i < len; i++) {
+        char c = upload_id[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '-' || c == '_')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void chunk_part_path(char *out, size_t out_len, const char *upload_id)
+{
+    snprintf(out, out_len, "%s/.uploads/%s.part", fos_assets_root(), upload_id);
+}
+
+esp_err_t fos_assets_chunk_begin(const char *upload_id, long long offset,
+                                 fos_assets_writer_t *writer, const char **err)
+{
+    set_err(err, NULL);
+    if (!writer) return ESP_ERR_INVALID_ARG;
+    writer->file = NULL;
+    writer->final_path[0] = '\0';
+    if (!fos_assets_available()) {
+        set_err(err, "not_found");
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!fos_assets_valid_upload_id(upload_id)) {
+        set_err(err, "invalid_path");
+        return ESP_ERR_INVALID_ARG;
+    }
+    char dir[FOS_ASSETS_FULL_PATH_MAX];
+    snprintf(dir, sizeof(dir), "%s/.uploads", fos_assets_root());
+    if (mkdir(dir, 0775) != 0 && errno != EEXIST) {
+        ESP_LOGW(TAG, "mkdir %s failed: errno=%d", dir, errno);
+        set_err(err, "write_failed");
+        return ESP_FAIL;
+    }
+    chunk_part_path(writer->tmp_path, sizeof(writer->tmp_path), upload_id);
+    if (offset <= 0) {
+        writer->file = fopen(writer->tmp_path, "wb");
+    } else {
+        struct stat st;
+        if (stat(writer->tmp_path, &st) != 0 || (long long)st.st_size < offset) {
+            /* An earlier chunk never landed — the client must restart. */
+            set_err(err, "chunk_gap");
+            return ESP_ERR_INVALID_STATE;
+        }
+        writer->file = fopen(writer->tmp_path, "rb+");
+        if (writer->file && fseek(writer->file, (long)offset, SEEK_SET) != 0) {
+            fclose(writer->file);
+            writer->file = NULL;
+        }
+    }
+    if (!writer->file) {
+        ESP_LOGW(TAG, "open %s failed: errno=%d", writer->tmp_path, errno);
+        set_err(err, "write_failed");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+void fos_assets_chunk_close(fos_assets_writer_t *writer)
+{
+    if (!writer || !writer->file) return;
+    fclose(writer->file);
+    writer->file = NULL;
+}
+
+esp_err_t fos_assets_chunk_finish(fos_assets_writer_t *writer,
+                                  const char *final_rel, long long *received,
+                                  const char **err)
+{
+    set_err(err, NULL);
+    if (received) *received = 0;
+    if (!writer || !writer->file) return ESP_ERR_INVALID_STATE;
+    bool flushed = fflush(writer->file) == 0;
+    long size_now = flushed ? ftell(writer->file) : -1;
+    bool closed = fclose(writer->file) == 0;
+    writer->file = NULL;
+    if (!flushed || !closed) {
+        unlink(writer->tmp_path);
+        set_err(err, "write_failed");
+        return ESP_FAIL;
+    }
+    struct stat st;
+    if (received) {
+        if (stat(writer->tmp_path, &st) == 0) *received = (long long)st.st_size;
+        else if (size_now >= 0) *received = size_now;
+    }
+    if (!final_rel) return ESP_OK; /* more chunks coming; part stays */
+    if (ensure_dirs(final_rel, false) != ESP_OK) {
+        unlink(writer->tmp_path);
+        set_err(err, "write_failed");
+        return ESP_FAIL;
+    }
+    fos_assets_full_path(writer->final_path, sizeof(writer->final_path), final_rel);
+    /* FatFS rename refuses an existing destination — replace explicitly. */
+    unlink(writer->final_path);
+    if (rename(writer->tmp_path, writer->final_path) != 0) {
+        ESP_LOGW(TAG, "rename %s -> %s failed: errno=%d", writer->tmp_path,
+                 writer->final_path, errno);
+        unlink(writer->tmp_path);
+        set_err(err, "write_failed");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
 esp_err_t fos_assets_write_file(const char *rel, const void *data, size_t len,
                                 const char **err)
 {

--- a/embedded/esp32/main/fos_assets.h
+++ b/embedded/esp32/main/fos_assets.h
@@ -18,6 +18,7 @@
 #define FOS_ASSETS_FULL_PATH_MAX (FOS_ASSETS_PATH_MAX + 128)
 #define FOS_ASSETS_LIST_MAX_ENTRIES 2000
 #define FOS_ASSETS_LIST_MAX_DEPTH 8
+#define FOS_ASSETS_UPLOAD_ID_MAX 48 /* sanitized [A-Za-z0-9_-], NUL included */
 
 /* True when the backing storage (SD card) is mounted. Every operation
  * fails cleanly when it is not. */
@@ -64,6 +65,28 @@ void fos_assets_write_abort(fos_assets_writer_t *writer);
 /* Whole-buffer convenience over begin/chunk/commit. */
 esp_err_t fos_assets_write_file(const char *rel, const void *data, size_t len,
                                 const char **err);
+
+/* Chunked (resumable) upload: the client streams a file as several requests
+ * sharing an `upload_id`. Bytes accumulate in `<root>/.uploads/<id>.part`;
+ * offset 0 truncates, offset > 0 seeks into the existing part (so a retried
+ * chunk overwrites itself instead of appending twice). A part shorter than
+ * the requested offset means an earlier chunk was lost — the caller must
+ * restart from offset 0 ("chunk_gap"). */
+esp_err_t fos_assets_chunk_begin(const char *upload_id, long long offset,
+                                 fos_assets_writer_t *writer, const char **err);
+/* Close after a failed/interrupted chunk, KEEPING the part for a retry. */
+void fos_assets_chunk_close(fos_assets_writer_t *writer);
+/* Flush + close the current chunk. final_rel NULL keeps the part open-ended
+ * (more chunks coming); non-NULL commits the part to that asset path.
+ * received (optional) gets the part's total size after this chunk. */
+esp_err_t fos_assets_chunk_finish(fos_assets_writer_t *writer,
+                                  const char *final_rel, long long *received,
+                                  const char **err);
+/* True if upload_id is non-empty [A-Za-z0-9_-] and fits the cap. */
+bool fos_assets_valid_upload_id(const char *upload_id);
+/* Delete leftover part files from interrupted uploads (call once after the
+ * assets storage mounts). */
+void fos_assets_cleanup_stale_uploads(void);
 
 esp_err_t fos_assets_mkdir(const char *rel, const char **err);
 /* Recursive delete of a file or directory tree. */

--- a/embedded/esp32/main/fos_http.c
+++ b/embedded/esp32/main/fos_http.c
@@ -1798,14 +1798,25 @@ static esp_err_t restart_post_handler(httpd_req_t *req)
 
 /* ---------------------------------------------------------- asset routes */
 
+/* Query strings on asset routes carry the (url-encoded) path plus, for
+ * chunked uploads, upload_id/offset/complete. */
+#define FOS_ASSETS_QUERY_MAX (FOS_ASSETS_PATH_MAX + 192)
+
+/* Pull one url-decoded query parameter; false when absent or truncated. */
+static bool asset_query_param(httpd_req_t *req, const char *key, char *out, size_t out_len)
+{
+    char query[FOS_ASSETS_QUERY_MAX];
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) != ESP_OK) return false;
+    if (httpd_query_key_value(query, key, out, out_len) != ESP_OK) return false;
+    url_decode(out);
+    return true;
+}
+
 /* Pull a sanitized asset path out of the request's query string. */
 static bool asset_query_path(httpd_req_t *req, bool write_rule, char *out, size_t out_len)
 {
-    char query[FOS_ASSETS_PATH_MAX + 64];
-    if (httpd_req_get_url_query_str(req, query, sizeof(query)) != ESP_OK) return false;
     char raw[FOS_ASSETS_PATH_MAX];
-    if (httpd_query_key_value(query, "path", raw, sizeof(raw)) != ESP_OK) return false;
-    url_decode(raw);
+    if (!asset_query_param(req, "path", raw, sizeof(raw))) return false;
     return write_rule ? fos_assets_sanitize_write_path(raw, out, out_len)
                       : fos_assets_sanitize_path(raw, out, out_len);
 }
@@ -1873,6 +1884,11 @@ static esp_err_t asset_file_get_handler(httpd_req_t *req)
     return err;
 }
 
+/* How many consecutive soft recv timeouts (recv_wait_timeout, 5s each) to
+ * ride out before giving up on an upload chunk. Slow links stall; a stall
+ * is only fatal once it outlives ~30s. */
+#define FOS_UPLOAD_RECV_STALL_LIMIT 6
+
 static esp_err_t asset_upload_post_handler(httpd_req_t *req)
 {
     keep_awake_for_http_mutation();
@@ -1887,9 +1903,35 @@ static esp_err_t asset_upload_post_handler(httpd_req_t *req)
     if (total <= 0) {
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "bad length");
     }
+    /* Chunked mode: bytes accumulate in a part file across requests sharing
+     * upload_id; complete=1 commits the part to `path`. Offsets make chunk
+     * retries idempotent (a resent chunk overwrites itself). */
+    char upload_id[FOS_ASSETS_UPLOAD_ID_MAX] = "";
+    bool chunked = asset_query_param(req, "upload_id", upload_id, sizeof(upload_id));
+    long long offset = 0;
+    bool complete = true;
+    if (chunked) {
+        if (!fos_assets_valid_upload_id(upload_id)) {
+            return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid upload id");
+        }
+        char val[24];
+        if (asset_query_param(req, "offset", val, sizeof(val))) offset = atoll(val);
+        if (asset_query_param(req, "complete", val, sizeof(val))) {
+            complete = strcmp(val, "1") == 0;
+        }
+    }
     const char *asset_err = NULL;
     fos_assets_writer_t writer;
-    if (fos_assets_write_begin(rel, &writer, &asset_err) != ESP_OK) {
+    esp_err_t begin = chunked
+        ? fos_assets_chunk_begin(upload_id, offset, &writer, &asset_err)
+        : fos_assets_write_begin(rel, &writer, &asset_err);
+    if (begin != ESP_OK) {
+        if (asset_err && strcmp(asset_err, "chunk_gap") == 0) {
+            /* An earlier chunk is missing — client must restart from 0. */
+            httpd_resp_set_status(req, "409 Conflict");
+            httpd_resp_set_type(req, "application/json");
+            return httpd_resp_sendstr(req, "{\"error\":\"chunk_gap\"}");
+        }
         return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
                                    asset_err ? asset_err : "write failed");
     }
@@ -1900,19 +1942,27 @@ static esp_err_t asset_upload_post_handler(httpd_req_t *req)
         chunk = malloc(cap);
     }
     if (!chunk) {
-        fos_assets_write_abort(&writer);
+        if (chunked) fos_assets_chunk_close(&writer);
+        else fos_assets_write_abort(&writer);
         return httpd_resp_send_500(req);
     }
     int received = 0;
+    int stalls = 0;
     esp_err_t err = ESP_OK;
     while (received < total) {
         int want = total - received;
         if (want > (int)cap) want = (int)cap;
         int r = httpd_req_recv(req, chunk, want);
+        if (r == HTTPD_SOCK_ERR_TIMEOUT) {
+            if (++stalls <= FOS_UPLOAD_RECV_STALL_LIMIT) continue;
+            err = ESP_FAIL;
+            break;
+        }
         if (r <= 0) {
             err = ESP_FAIL;
             break;
         }
+        stalls = 0;
         if (fos_assets_write_chunk(&writer, chunk, (size_t)r) != ESP_OK) {
             err = ESP_FAIL;
             break;
@@ -1921,14 +1971,30 @@ static esp_err_t asset_upload_post_handler(httpd_req_t *req)
     }
     free(chunk);
     if (err != ESP_OK) {
-        fos_assets_write_abort(&writer);
+        /* Keep the part on chunked failures so the client can retry the
+         * same offset; single-shot uploads roll back as before. */
+        if (chunked) fos_assets_chunk_close(&writer);
+        else fos_assets_write_abort(&writer);
         return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "write failed");
     }
-    if (fos_assets_write_commit(&writer, &asset_err) != ESP_OK) {
+    long long part_size = 0;
+    if (chunked) {
+        if (fos_assets_chunk_finish(&writer, complete ? rel : NULL, &part_size,
+                                    &asset_err) != ESP_OK) {
+            return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                                       asset_err ? asset_err : "write failed");
+        }
+    } else if (fos_assets_write_commit(&writer, &asset_err) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
                                    asset_err ? asset_err : "write failed");
     }
-    log_http_command(req, "assetUpload", (size_t)total);
+    if (chunked && !complete) {
+        char reply[96];
+        snprintf(reply, sizeof(reply), "{\"pending\":true,\"received\":%lld}", part_size);
+        httpd_resp_set_type(req, "application/json");
+        return httpd_resp_sendstr(req, reply);
+    }
+    log_http_command(req, "assetUpload", chunked ? (size_t)part_size : (size_t)total);
     struct stat st;
     bool have_stat = fos_assets_stat(rel, &st) == ESP_OK;
     char *escaped = json_escape_dup(rel);
@@ -1937,7 +2003,8 @@ static esp_err_t asset_upload_post_handler(httpd_req_t *req)
     snprintf(reply, sizeof(reply),
              "{\"path\":\"%s\",\"size\":%lld,\"mtime\":%lld,\"is_dir\":false}",
              escaped,
-             (long long)(have_stat ? st.st_size : total),
+             have_stat ? (long long)st.st_size
+                       : (chunked ? part_size : (long long)total),
              (long long)(have_stat ? st.st_mtime : 0));
     free(escaped);
     httpd_resp_set_type(req, "application/json");

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -23,6 +23,7 @@
 #include "esp_log.h"
 #include "esp_ota_ops.h"
 
+#include "fos_assets.h"
 #include "fos_assets_sd.h"
 #include "fos_battery.h"
 #include "fos_defaults.h"
@@ -139,6 +140,8 @@ void app_main(void)
 
     if (fos_assets_sd_mount(config) != ESP_OK) {
         ESP_LOGW(TAG, "SD assets unavailable, continuing without /srv/assets");
+    } else {
+        fos_assets_cleanup_stale_uploads();
     }
 
     /* Memory guardrail (M4): refuse to render a panel on-device that can't fit

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "17512aefb22bbb7041ab622820771a26f2e9ecc0",
+      "vcsRevision": "46d64bc223680fcd7bb9dc1b726e594591251006",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "e9fd1aec8be3aa9aa9111f41fbf252233ccb4552"
+        "sha1": "29851282fd75f38c66dfa862056d6d79cc465b9b"
       }
     }
   },

--- a/frameos/src/wasm/wasm_main.nim
+++ b/frameos/src/wasm/wasm_main.nim
@@ -271,6 +271,20 @@ proc frameos_wasm_load_scenes(payload: cstring): cint {.exportc, cdecl.} =
     setLastError("loadScenes failed: " & e.msg)
     0
 
+proc frameos_wasm_set_save_assets(payloadJson: cstring): bool {.exportc, cdecl.} =
+  ## The frame's saveAssets config (bool, or {nodeName: bool}), so apps'
+  ## "auto" save mode behaves like on a device. Call after init; without it
+  ## the runtime keeps the historical default of false.
+  try:
+    if frameConfig.isNil:
+      setLastError("setSaveAssets: init not called")
+      return false
+    frameConfig.saveAssets = parseJson($payloadJson)
+    true
+  except Exception as e:
+    setLastError("setSaveAssets failed: " & e.msg)
+    false
+
 proc frameos_wasm_set_scene_state(sceneId: cstring, stateJson: cstring): bool {.exportc, cdecl.} =
   ## Seed persisted state for a scene before it initializes — how the backend
   ## restores stored state for virtual frames, where every render is a fresh

--- a/frameos/src/wasm/wasm_main.nim
+++ b/frameos/src/wasm/wasm_main.nim
@@ -45,6 +45,9 @@ var
   sceneInfoBuffer: string
   sceneStateBuffer: string
   lastErrorBuffer: string
+  # Backend-persisted scene state, seeded via frameos_wasm_set_scene_state
+  # before the scene's first render and merged into scene.state at init.
+  pendingSceneStates = initTable[string, JsonNode]()
 
 proc currentSceneName(): string =
   if not currentExported.isNil and currentExported.name.len > 0:
@@ -116,7 +119,10 @@ proc ensureScene(): bool =
     setLastError("scene not found: " & sceneId.string)
     return false
   currentExported = scenes[sceneId]
-  currentScene = interpreter.init(sceneId, frameConfig, logger, %*{})
+  let persisted =
+    if pendingSceneStates.hasKey(sceneId.string): pendingSceneStates[sceneId.string]
+    else: %*{}
+  currentScene = interpreter.init(sceneId, frameConfig, logger, persisted)
   log(&"scene \"{currentSceneName()}\" initialized")
   true
 
@@ -145,6 +151,7 @@ proc frameos_wasm_init(width, height: cint, name: cstring,
     scenesLoadedCount = 0
     renderRequested = false
     lastImage = nil
+    pendingSceneStates = initTable[string, JsonNode]()
 
     var settings = %*{}
     let settingsText = $settingsJson
@@ -263,6 +270,22 @@ proc frameos_wasm_load_scenes(payload: cstring): cint {.exportc, cdecl.} =
   except Exception as e:
     setLastError("loadScenes failed: " & e.msg)
     0
+
+proc frameos_wasm_set_scene_state(sceneId: cstring, stateJson: cstring): bool {.exportc, cdecl.} =
+  ## Seed persisted state for a scene before it initializes — how the backend
+  ## restores stored state for virtual frames, where every render is a fresh
+  ## wasm process. Merged into scene.state (over field defaults) when the
+  ## scene inits, so it must be called before the first render.
+  try:
+    let parsed = parseJson($stateJson)
+    if parsed.kind != JObject:
+      setLastError("setSceneState: state must be a JSON object")
+      return false
+    pendingSceneStates[$sceneId] = parsed
+    true
+  except Exception as e:
+    setLastError("setSceneState failed: " & e.msg)
+    false
 
 proc frameos_wasm_select_scene(sceneId: cstring): bool {.exportc, cdecl.} =
   try:

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -103,8 +103,9 @@ FRAMEOS_VERSION="$(python3 tools/frameos_version.py ../versions.json)"
 # _main keeps Nim's generated main() alive: emscripten calls it on module
 # startup and that runs NimMain (all Nim module initializers, e.g. the
 # baked-in font asset tables).
-EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error
-EXPORTED_RUNTIME_METHODS=cwrap,ccall,UTF8ToString,stringToNewUTF8,lengthBytesUTF8,HEAPU8
+EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error
+# FS lets the render harness preload a virtual frame's assets into MEMFS.
+EXPORTED_RUNTIME_METHODS=cwrap,ccall,UTF8ToString,stringToNewUTF8,lengthBytesUTF8,HEAPU8,FS
 
 mkdir -p "$BUILD_DIR"
 

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -103,7 +103,7 @@ FRAMEOS_VERSION="$(python3 tools/frameos_version.py ../versions.json)"
 # _main keeps Nim's generated main() alive: emscripten calls it on module
 # startup and that runs NimMain (all Nim module initializers, e.g. the
 # baked-in font asset tables).
-EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error
+EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error
 # FS lets the render harness preload a virtual frame's assets into MEMFS.
 EXPORTED_RUNTIME_METHODS=cwrap,ccall,UTF8ToString,stringToNewUTF8,lengthBytesUTF8,HEAPU8,FS
 

--- a/frontend/src/models/longRunningTasksModel.ts
+++ b/frontend/src/models/longRunningTasksModel.ts
@@ -70,6 +70,8 @@ export interface UpdateTaskProgressPayload {
   progressCurrent: number | null
   progressTotal: number | null
   detail?: string | null
+  /** Retitle the running task — e.g. an upload that grows while running. */
+  title?: string
 }
 
 const MAX_TASK_LOGS = 200
@@ -154,6 +156,7 @@ function updateLatestTaskProgress(tasks: LongRunningTask[], payload: UpdateTaskP
   const nextTasks = [...tasks]
   nextTasks[index] = {
     ...task,
+    title: payload.title ?? task.title,
     detail: payload.detail ?? task.detail,
     progressCurrent: payload.progressCurrent,
     progressTotal: payload.progressTotal,

--- a/frontend/src/scenes/frame/panels/Assets/Assets.tsx
+++ b/frontend/src/scenes/frame/panels/Assets/Assets.tsx
@@ -549,7 +549,9 @@ function AssetsSummaryHeader({
           </div>
         ))}
         <div className="bg-[var(--tool-bg)] px-3 py-2 @3xl:px-4 @3xl:py-3">
-          <div className="frame-tool-muted text-xs font-semibold uppercase tracking-wide">Disk</div>
+          <div className="frame-tool-muted text-xs font-semibold uppercase tracking-wide">
+            {diskStats?.isQuota ? 'Quota' : 'Disk'}
+          </div>
           {diskStats ? (
             <>
               <div className="mt-0.5 text-base font-semibold text-[color:var(--tool-strong)] @3xl:mt-1 @3xl:text-lg">
@@ -562,7 +564,9 @@ function AssetsSummaryHeader({
                 />
               </div>
               <div className="frame-tool-muted mt-1 truncate text-xs">
-                {humaniseSize(diskStats.availableBytes)} free / {humaniseSize(diskStats.totalBytes)}
+                {diskStats.isQuota
+                  ? `${humaniseSize(diskStats.usedBytes)} of ${humaniseSize(diskStats.totalBytes)} quota`
+                  : `${humaniseSize(diskStats.availableBytes)} free / ${humaniseSize(diskStats.totalBytes)}`}
               </div>
             </>
           ) : (

--- a/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
+++ b/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
@@ -531,14 +531,22 @@ export const assetsLogic = kea<assetsLogicType>([
             detail,
           })
         }
+        // Embedded frames always upload in chunks: the backend forwards each
+        // chunk to the device synchronously, so one slow request never has to
+        // carry the whole file and the progress bar tracks what the device
+        // actually received. Retried chunks overwrite themselves (offset
+        // semantics) — safe on the backend + ESP32, not on the Nim admin API.
+        const chunkedUpload = isInFrameAdminMode() || values.frame.mode === 'embedded'
         try {
-          const asset = isInFrameAdminMode()
+          const asset = chunkedUpload
             ? await uploadFileInChunks({
                 frameId: props.frameId,
                 suffix: 'assets/upload',
                 file,
                 path,
                 filename: file.name,
+                chunkSize: isInFrameAdminMode() ? undefined : 256 * 1024,
+                retries: isInFrameAdminMode() ? 0 : 2,
                 onProgress: (size) => updateProgress(size),
               })
             : await (async () => {

--- a/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
+++ b/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
@@ -492,112 +492,153 @@ export const assetsLogic = kea<assetsLogicType>([
       },
     ],
   }),
-  listeners(({ actions, props, values }) => ({
+  listeners(({ actions, props, values, cache }) => ({
     uploadDroppedFiles: async ({ path, files }) => {
       if (files.length === 0) {
         return
       }
       const assetsPath = values.frame.assets_path ?? '/srv/assets'
       const uploadedFiles = files.map((file) => normalizeAssetPath(`${path ? path + '/' : ''}${file.name}`, assetsPath))
-      const taskId = `asset-upload:${props.frameId}:${Date.now()}:${files.length}`
-      const taskTotalBytes = files.reduce((total, file) => total + Math.max(file.size, 1), 0)
-      let completedTaskBytes = 0
-      let failures = 0
-
-      longRunningTasksModel.actions.startTask({
-        id: taskId,
-        frameId: props.frameId,
-        kind: 'upload',
-        title: files.length === 1 ? 'Uploading asset' : `Uploading ${files.length} assets`,
-        detail: files.length === 1 ? files[0].name : 'Preparing upload',
-        progressCurrent: 0,
-        progressTotal: taskTotalBytes,
-      })
-
       actions.filesToUpload(uploadedFiles)
+
+      // One toast per frame: files dropped while an upload is running join
+      // the running task (queue + growing totals) instead of replacing it.
+      const queue: { file: File; path: string }[] = (cache.uploadQueue ??= [])
       for (const file of files) {
-        const uploadPath = frameAssetsApiPath(props.frameId, 'assets/upload')
-        const normalizedPath = normalizeAssetPath(`${path ? path + '/' : ''}${file.name}`, assetsPath)
-        const fileTaskBytes = Math.max(file.size, 1)
-        const updateProgress = (fileUploadedBytes: number, detail = `Uploading ${file.name}`) => {
-          const safeFileUploadedBytes = Math.max(0, Math.min(fileTaskBytes, fileUploadedBytes || 0))
-          actions.uploadProgress(normalizedPath, Math.min(file.size, fileUploadedBytes || 0))
-          longRunningTasksModel.actions.updateTaskProgress({
-            taskId,
-            frameId: props.frameId,
-            kind: 'upload',
-            progressCurrent: Math.min(taskTotalBytes, completedTaskBytes + safeFileUploadedBytes),
-            progressTotal: taskTotalBytes,
-            detail,
-          })
-        }
-        // Embedded frames always upload in chunks: the backend forwards each
-        // chunk to the device synchronously, so one slow request never has to
-        // carry the whole file and the progress bar tracks what the device
-        // actually received. Retried chunks overwrite themselves (offset
-        // semantics) — safe on the backend + ESP32, not on the Nim admin API.
-        const chunkedUpload = isInFrameAdminMode() || values.frame.mode === 'embedded'
-        try {
-          const asset = chunkedUpload
-            ? await uploadFileInChunks({
-                frameId: props.frameId,
-                suffix: 'assets/upload',
-                file,
-                path,
-                filename: file.name,
-                chunkSize: isInFrameAdminMode() ? undefined : 256 * 1024,
-                retries: isInFrameAdminMode() ? 0 : 2,
-                onProgress: (size) => updateProgress(size),
-              })
-            : await (async () => {
-                const formData = new FormData()
-                formData.append('file', file)
-                formData.append('path', path)
-                return await uploadFormDataWithProgress<AssetType>({
-                  url: uploadPath,
-                  formData,
-                  onProgress: (uploadedBytes, totalBytes) => {
-                    const fileUploadedBytes =
-                      totalBytes && totalBytes > 0
-                        ? Math.round((uploadedBytes / totalBytes) * fileTaskBytes)
-                        : uploadedBytes
-                    updateProgress(fileUploadedBytes)
-                  },
-                })
-              })()
-          completedTaskBytes += fileTaskBytes
-          updateProgress(fileTaskBytes, `Uploaded ${file.name}`)
-          actions.assetUploaded({
-            ...asset,
-            path: normalizeAssetPath(asset.path, assetsPath),
-          })
-        } catch (error) {
-          failures += 1
-          completedTaskBytes += fileTaskBytes
-          actions.uploadFailure(normalizedPath)
-          longRunningTasksModel.actions.updateTaskProgress({
-            taskId,
-            frameId: props.frameId,
-            kind: 'upload',
-            progressCurrent: Math.min(taskTotalBytes, completedTaskBytes),
-            progressTotal: taskTotalBytes,
-            detail: `Failed ${file.name}`,
-          })
-        }
+        queue.push({ file, path })
       }
-      if (failures > 0) {
-        longRunningTasksModel.actions.taskFailed({
-          taskId,
+      const batchBytes = files.reduce((total, file) => total + Math.max(file.size, 1), 0)
+
+      const uploadTitle = (totalFiles: number): string =>
+        totalFiles === 1 ? 'Uploading asset' : `Uploading ${totalFiles} assets`
+
+      if (cache.uploadTask) {
+        // A drain loop is already running: grow its totals and retitle.
+        const task = cache.uploadTask
+        task.totalFiles += files.length
+        task.totalBytes += batchBytes
+        longRunningTasksModel.actions.updateTaskProgress({
+          taskId: task.id,
           frameId: props.frameId,
           kind: 'upload',
-          detail: failures === 1 ? '1 asset failed to upload' : `${failures} assets failed to upload`,
+          title: uploadTitle(task.totalFiles),
+          progressCurrent: task.lastReportedBytes,
+          progressTotal: task.totalBytes,
+        })
+        return
+      }
+
+      const task = (cache.uploadTask = {
+        id: `asset-upload:${props.frameId}:${Date.now()}:${files.length}`,
+        totalFiles: files.length,
+        totalBytes: batchBytes,
+        completedBytes: 0,
+        lastReportedBytes: 0,
+        failures: 0,
+        firstFileName: files[0].name,
+      })
+
+      longRunningTasksModel.actions.startTask({
+        id: task.id,
+        frameId: props.frameId,
+        kind: 'upload',
+        title: uploadTitle(task.totalFiles),
+        detail: files.length === 1 ? files[0].name : 'Preparing upload',
+        progressCurrent: 0,
+        progressTotal: task.totalBytes,
+      })
+
+      try {
+        while (queue.length > 0) {
+          const { file, path: filePath } = queue.shift()!
+          const uploadPath = frameAssetsApiPath(props.frameId, 'assets/upload')
+          const normalizedPath = normalizeAssetPath(`${filePath ? filePath + '/' : ''}${file.name}`, assetsPath)
+          const fileTaskBytes = Math.max(file.size, 1)
+          const updateProgress = (fileUploadedBytes: number, detail = `Uploading ${file.name}`) => {
+            const safeFileUploadedBytes = Math.max(0, Math.min(fileTaskBytes, fileUploadedBytes || 0))
+            actions.uploadProgress(normalizedPath, Math.min(file.size, fileUploadedBytes || 0))
+            task.lastReportedBytes = Math.min(task.totalBytes, task.completedBytes + safeFileUploadedBytes)
+            longRunningTasksModel.actions.updateTaskProgress({
+              taskId: task.id,
+              frameId: props.frameId,
+              kind: 'upload',
+              progressCurrent: task.lastReportedBytes,
+              progressTotal: task.totalBytes,
+              detail,
+            })
+          }
+          // Embedded frames always upload in chunks: the backend forwards each
+          // chunk to the device synchronously, so one slow request never has to
+          // carry the whole file and the progress bar tracks what the device
+          // actually received. Retried chunks overwrite themselves (offset
+          // semantics) — safe on the backend + ESP32, not on the Nim admin API.
+          const chunkedUpload = isInFrameAdminMode() || values.frame.mode === 'embedded'
+          try {
+            const asset = chunkedUpload
+              ? await uploadFileInChunks({
+                  frameId: props.frameId,
+                  suffix: 'assets/upload',
+                  file,
+                  path: filePath,
+                  filename: file.name,
+                  chunkSize: isInFrameAdminMode() ? undefined : 256 * 1024,
+                  retries: isInFrameAdminMode() ? 0 : 2,
+                  onProgress: (size) => updateProgress(size),
+                })
+              : await (async () => {
+                  const formData = new FormData()
+                  formData.append('file', file)
+                  formData.append('path', filePath)
+                  return await uploadFormDataWithProgress<AssetType>({
+                    url: uploadPath,
+                    formData,
+                    onProgress: (uploadedBytes, totalBytes) => {
+                      const fileUploadedBytes =
+                        totalBytes && totalBytes > 0
+                          ? Math.round((uploadedBytes / totalBytes) * fileTaskBytes)
+                          : uploadedBytes
+                      updateProgress(fileUploadedBytes)
+                    },
+                  })
+                })()
+            task.completedBytes += fileTaskBytes
+            updateProgress(fileTaskBytes, `Uploaded ${file.name}`)
+            actions.assetUploaded({
+              ...asset,
+              path: normalizeAssetPath(asset.path, assetsPath),
+            })
+          } catch (error) {
+            task.failures += 1
+            task.completedBytes += fileTaskBytes
+            task.lastReportedBytes = Math.min(task.totalBytes, task.completedBytes)
+            actions.uploadFailure(normalizedPath)
+            longRunningTasksModel.actions.updateTaskProgress({
+              taskId: task.id,
+              frameId: props.frameId,
+              kind: 'upload',
+              progressCurrent: task.lastReportedBytes,
+              progressTotal: task.totalBytes,
+              detail: `Failed ${file.name}`,
+            })
+          }
+        }
+      } finally {
+        cache.uploadTask = null
+      }
+
+      if (task.failures > 0) {
+        longRunningTasksModel.actions.taskFailed({
+          taskId: task.id,
+          frameId: props.frameId,
+          kind: 'upload',
+          detail: task.failures === 1 ? '1 asset failed to upload' : `${task.failures} assets failed to upload`,
         })
       } else {
         longRunningTasksModel.actions.finishTask({
-          taskId,
+          taskId: task.id,
           frameId: props.frameId,
           kind: 'upload',
-          detail: files.length === 1 ? `Uploaded ${files[0].name}` : `Uploaded ${files.length} assets`,
+          detail: task.totalFiles === 1 ? `Uploaded ${task.firstFileName}` : `Uploaded ${task.totalFiles} assets`,
         })
       }
     },

--- a/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
+++ b/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
@@ -9,7 +9,7 @@ import { frameLogic } from '../../frameLogic'
 import { metricsLogic } from '../Metrics/metricsLogic'
 import { apiFetch } from '../../../../utils/apiFetch'
 import { isInFrameAdminMode } from '../../../../utils/frameAdmin'
-import { workspaceMode } from '../../../workspace/workspaceSurfaces'
+import { isVirtualFrame, workspaceMode } from '../../../workspace/workspaceSurfaces'
 import { frameAssetsApiPath } from '../../../../utils/frameAssetsApi'
 import { uploadFileInChunks } from '../../../../utils/uploadFileInChunks'
 import { uploadFormDataWithProgress } from '../../../../utils/uploadFormDataWithProgress'
@@ -41,6 +41,21 @@ export interface DiskStats {
   usedBytes: number
   availableBytes: number
   usedPercent: number
+  // Virtual frames have no disk metrics; their stats describe the
+  // backend-enforced asset quota instead.
+  isQuota?: boolean
+}
+
+// Mirrors backend virtual_assets.quota_bytes: per-frame override in the
+// frame settings, 100 MB default.
+const VIRTUAL_ASSETS_DEFAULT_QUOTA_MB = 100
+
+function virtualQuotaBytes(frame: { device_config?: Record<string, any> | null } | null): number {
+  const raw = frame?.device_config?.assetsQuotaMb
+  const parsed = typeof raw === 'string' ? parseFloat(raw) : raw
+  const quotaMb =
+    typeof parsed === 'number' && Number.isFinite(parsed) && parsed > 0 ? parsed : VIRTUAL_ASSETS_DEFAULT_QUOTA_MB
+  return quotaMb * 1024 * 1024
 }
 
 interface FrameAssetsResponse {
@@ -453,7 +468,29 @@ export const assetsLogic = kea<assetsLogicType>([
       },
     ],
     assetStats: [(s) => [s.assetTree], (assetTree) => collectAssetStats(assetTree)],
-    diskStats: [(s) => [s.sortedMetrics], (sortedMetrics): DiskStats | null => latestDiskStats(sortedMetrics)],
+    diskStats: [
+      (s) => [s.sortedMetrics, s.cleanedAssets, s.frame],
+      (sortedMetrics, cleanedAssets, frame): DiskStats | null => {
+        // Virtual frames never emit disk metrics; show the backend asset
+        // quota instead, with usage summed from the full listing (system
+        // folders included — the quota counts them too).
+        if (isVirtualFrame(frame)) {
+          const usedBytes = cleanedAssets.reduce(
+            (sum: number, asset: AssetType) => sum + (asset.is_dir ? 0 : asset.size || 0),
+            0
+          )
+          const totalBytes = virtualQuotaBytes(frame)
+          return {
+            totalBytes,
+            usedBytes,
+            availableBytes: Math.max(0, totalBytes - usedBytes),
+            usedPercent: totalBytes > 0 ? Math.min(100, (usedBytes / totalBytes) * 100) : 0,
+            isQuota: true,
+          }
+        }
+        return latestDiskStats(sortedMetrics)
+      },
+    ],
   }),
   listeners(({ actions, props, values }) => ({
     uploadDroppedFiles: async ({ path, files }) => {

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -2109,6 +2109,24 @@ export function FrameSettings({
                     />
                   )}
                 </Field>
+                <Field
+                  name="assetsQuotaMb"
+                  label="Assets quota (MB)"
+                  tooltip="How much disk space this frame's assets may use on the backend — uploads and images scenes save (OpenAI, Wikimedia, ...). Leave empty for the default of 100 MB."
+                >
+                  {({ value, onChange }) => (
+                    <TextInput
+                      name="device_config.assetsQuotaMb"
+                      type="number"
+                      placeholder="100"
+                      value={value === undefined || value === null ? '' : String(value)}
+                      onChange={(newValue) => {
+                        const parsed = parseFloat(String(newValue))
+                        onChange(Number.isFinite(parsed) && parsed > 0 ? parsed : undefined)
+                      }}
+                    />
+                  )}
+                </Field>
               </Group>
             </div>
           </>

--- a/frontend/src/scenes/workspace/FrameWorkspace.tsx
+++ b/frontend/src/scenes/workspace/FrameWorkspace.tsx
@@ -267,7 +267,7 @@ const frameToolDefinitions: FrameToolDefinition[] = [
 // Schedule on an esp32 cloud frame, whose firmware refuses `set_schedule`),
 // so the workspace keeps its shape whatever the hardware. Virtual frames are
 // the one exception: panels whose concepts don't exist for them (terminal,
-// ping, assets, metrics) are hidden outright — see workspaceSurfaces.ts.
+// ping, metrics) are hidden outright — see workspaceSurfaces.ts.
 function frameToolDefinitionsForMode(
   mode: WorkspaceMode = workspaceMode(),
   frame?: FrameType | null

--- a/frontend/src/scenes/workspace/workspaceSurfaces.ts
+++ b/frontend/src/scenes/workspace/workspaceSurfaces.ts
@@ -300,11 +300,12 @@ export function isVirtualFrame(frame?: FrameCapabilityInput | null): boolean {
  * Unlike the esp32 cloud profile above — which DISABLES controls, because the
  * verbs exist and the firmware merely doesn't answer them yet — a virtual
  * frame HIDES these surfaces: the concepts themselves don't exist. There is
- * no shell to open, no device to ping or reboot, no on-device storage to
- * browse, and no host to chart metrics for, so a disabled button would have
- * nothing to explain.
+ * no shell to open, no device to ping or reboot, and no host to chart
+ * metrics for, so a disabled button would have nothing to explain. Assets
+ * stay: the backend stores them (quota-limited) and preloads them into the
+ * wasm renderer, so the panel works like on any other frame.
  */
-const virtualFrameHiddenPanels: readonly WorkspaceUtilityPanel[] = ['terminal', 'ping', 'assets', 'metrics']
+const virtualFrameHiddenPanels: readonly WorkspaceUtilityPanel[] = ['terminal', 'ping', 'metrics']
 
 const virtualFrameHiddenMenuActions: readonly FrameMenuAction[] = [
   'buildSdCard',

--- a/frontend/src/utils/uploadFileInChunks.ts
+++ b/frontend/src/utils/uploadFileInChunks.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from './apiFetch'
+import { getBasePath } from './getBasePath'
 import { frameAssetsApiPath } from './frameAssetsApi'
 import { secureToken } from './secureToken'
 import type { FrameId } from '../types'
@@ -12,16 +12,68 @@ interface UploadFileInChunksOptions {
   path?: string
   filename?: string
   chunkSize?: number
+  /** Extra attempts per chunk after a failure. Offsets make a resent chunk
+   * overwrite itself on the backend/ESP32 protocol; keep 0 against the
+   * on-device Nim admin API, which appends blindly. */
+  retries?: number
   onProgress?: (uploadedBytes: number) => void
 }
 
-export async function uploadFileInChunks({
+class ChunkGapError extends Error {}
+
+interface ChunkResponse {
+  status: number
+  payload: any
+}
+
+/** Raw-body POST with XHR so we get upload progress events (fetch has none).
+ * Resolves for any HTTP status; rejects only on network failure. */
+function postChunk(url: string, body: Blob, onProgress?: (sentBytes: number) => void): Promise<ChunkResponse> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    const requestUrl = getBasePath() && url.startsWith('/') ? `${getBasePath()}${url}` : url
+    xhr.open('POST', requestUrl)
+    xhr.withCredentials = true
+    xhr.setRequestHeader('Content-Type', 'application/octet-stream')
+    xhr.upload.onprogress = (event) => onProgress?.(event.loaded)
+    xhr.onerror = () => reject(new Error('Upload failed'))
+    xhr.onload = () => {
+      let payload: any = null
+      try {
+        payload = JSON.parse(xhr.responseText)
+      } catch {
+        // non-JSON error bodies are fine; status carries the outcome
+      }
+      resolve({ status: xhr.status, payload })
+    }
+    xhr.send(body)
+  })
+}
+
+export async function uploadFileInChunks(options: UploadFileInChunksOptions): Promise<any> {
+  // A 409 means the server lost earlier bytes (device rebooted, backend
+  // restarted): the whole upload restarts once under a fresh upload id.
+  let restartsLeft = 1
+  for (;;) {
+    try {
+      return await uploadOnce(options)
+    } catch (error) {
+      if (error instanceof ChunkGapError && restartsLeft-- > 0) {
+        continue
+      }
+      throw error
+    }
+  }
+}
+
+async function uploadOnce({
   frameId,
   suffix,
   file,
   path,
   filename,
   chunkSize = DEFAULT_UPLOAD_CHUNK_SIZE,
+  retries = 0,
   onProgress,
 }: UploadFileInChunksOptions): Promise<any> {
   const uploadId = secureToken(18)
@@ -37,23 +89,42 @@ export async function uploadFileInChunks({
       upload_id: uploadId,
       filename: filename || file.name,
       chunk_index: String(chunkIndex),
+      offset: String(start),
       complete: chunkIndex === totalChunks - 1 ? '1' : '0',
     })
     if (path) {
       params.set('path', path)
     }
+    const url = `${frameAssetsApiPath(frameId, suffix)}?${params.toString()}`
+    const body = file.slice(start, end)
 
-    const response = await apiFetch(`${frameAssetsApiPath(frameId, suffix)}?${params.toString()}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/octet-stream' },
-      body: file.slice(start, end),
-    })
-
-    if (!response.ok) {
-      throw new Error(`Upload failed with status ${response.status}`)
+    let response: ChunkResponse | null = null
+    for (let attempt = 0; ; attempt++) {
+      try {
+        response = await postChunk(url, body, (sentBytes) => {
+          onProgress?.(Math.min(end, start + sentBytes))
+        })
+      } catch (error) {
+        if (attempt < retries) {
+          await new Promise((r) => setTimeout(r, 500 * (attempt + 1)))
+          continue
+        }
+        throw error
+      }
+      if (response.status === 409) {
+        throw new ChunkGapError('Upload lost earlier bytes; restarting')
+      }
+      if (response.status < 200 || response.status >= 300) {
+        if (attempt < retries) {
+          await new Promise((r) => setTimeout(r, 500 * (attempt + 1)))
+          continue
+        }
+        throw new Error(`Upload failed with status ${response.status}`)
+      }
+      break
     }
 
-    finalPayload = await response.json()
+    finalPayload = response.payload
     onProgress?.(end)
   }
 


### PR DESCRIPTION
## What

Virtual frames (backend-rendered, no hardware) previously routed asset and state requests to a device that does not exist — the asset panel and scene state controls were dead ends. Both now live on the backend.

### Assets
- New `backend/app/utils/virtual_assets.py`: per-frame storage under `FRAMEOS_VIRTUAL_ASSETS_DIR` (default `../db/virtual_assets/frame_{id}`, which lands on the docker `frameos-db` volume). It mirrors `embedded_assets`' function signatures, so the existing asset routes (list, download/thumbnail, upload, upload_image, mkdir, delete, rename) dispatch through a small `_device_assets(frame)` helper with no per-route rewrites. Frame deletion removes the directory.
- **Quota**: per-frame, edited in the frame's settings panel (`device_config.assetsQuotaMb`), default **100 MB**. Exceeding it returns **507 Insufficient Storage** (same status a full SD card produces on embedded frames); replacing a file doesn't double-count its old bytes.
- The render harness preloads the frame's asset directory into the wasm MEMFS at `/srv/assets` (128 MB cap), so scene apps that read frame assets see them like on-device files.

### Scene-saved assets (write-back)
- Apps that save assets (`saveAsset` in apps.nim: OpenAI images, Wikimedia Commons photos, Immich downloads) now persist on virtual frames: the frame's `save_assets` config reaches the wasm runtime via a new `frameos_wasm_set_save_assets` export, and after a successful render the harness copies files the scene created in MEMFS back into the frame's backend asset store — capped by an `assetsWriteBudget` computed from the remaining quota — and the backend invalidates the asset-list cache.
- `saveAsset` filenames embed the content md5 and existing files are skipped, so repeated renders act as a cache instead of duplicating.

### Scene state
- Stored in redis at `frame:{id}:virtual:scene_states` (no TTL, same convention as `active_scene`). `setSceneState`/`setCurrentScene` payloads are filtered to the scene's public fields exactly like the device runtime (json-typed strings parsed too); a 256 KB cap returns 413.
- Renders seed the stored state via a new `frameos_wasm_set_scene_state` export (merged over field defaults at scene init). After each render the harness reports the scene's state back on stderr (`__FRAMEOS_SCENE_STATE__` line); the backend persists fields that are public or `persist: disk`, so state the scene changes itself survives between renders.
- `GET /state` and `/states` answer directly from the store for virtual frames — no device-polling cache dance. Previews of unsaved scenes never touch stored state.
- **Stale-bundle guard**: a prebuilt wasm bundle without the new exports can't seed state; the harness then reports `seeded: false` and the backend skips persisting the readback, so it cannot clobber user-set state with scene defaults. (Dev checkouts: rebuild with `frameos/tools/build_wasm.sh`; docker builds the bundle fresh.)

### Frontend
- The Assets panel was hidden outright for virtual frames in `workspaceSurfaces.ts` — now shown; terminal/ping/metrics stay hidden. The shared-SPA `workspace-surfaces` test is updated accordingly.
- Frame settings gains an "Assets quota (MB)" field in the Virtual frame section.

## Tests
- New tests in `test_virtual_frame.py`: asset upload/list/download roundtrip, mkdir/rename/delete, quota enforcement incl. the replace case and value parsing, state roundtrip with public-field filtering, merge + json parsing, setCurrentScene state, oversized-state rejection, and write-back plumbing (save_assets/budget forwarding + cache invalidation). Marker-parsing unit tests in `test_embedded_render.py`.
- Full backend suite: 1010 passed, 3 skipped. Cloud shared-SPA suite: 35 passed. Frontend `tsc` clean.
- Harness verified manually end-to-end: seeded state beats scene defaults; a wikicommons pictureOfTheDay scene saves its image into the host asset dir; a too-small budget skips the file and reports `skippedOverBudget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)