### PR TITLE
Cloud ESP32: USB firmware update, and fix OTA's artifact

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -409,6 +409,17 @@ jobs:
               bash embedded/esp32/ci_build_image.sh
               cp embedded/esp32/build-ci/merged-binary.bin \
                 "/release-assets/frameos-$DOCKER_VERSION-esp32-s3-generic.bin"
+              # TWO artifacts per platform, and they are not interchangeable:
+              # merged-binary.bin is the whole flash from 0x0 (bootloader +
+              # partition table + blank otadata + app) and is what a USB
+              # flasher writes, while frameos_esp32.bin is the bare app image
+              # — the ONLY thing esp_ota_write accepts. Handing an OTA slot the
+              # merged image fails validation (its first bytes are the
+              # bootloader, which carries no esp_app_desc), so the cloud OTA
+              # manifest serves this one. Same split the self-hosted backend
+              # makes (backend/app/api/embedded_device.py).
+              cp embedded/esp32/build-ci/frameos_esp32.bin \
+                "/release-assets/frameos-$DOCKER_VERSION-esp32-s3-generic-app.bin"
               # ESP32-C3 thin-client firmware (TRMNL OG/BWRY, XTEINK X4):
               # 4MB no-OTA layout, no on-device Nim renderer.
               FRAMEOS_ESP32_PLATFORM=esp32-c3 \
@@ -416,6 +427,10 @@ jobs:
                 bash embedded/esp32/ci_build_image.sh
               cp embedded/esp32/build-ci-c3/merged-binary.bin \
                 "/release-assets/frameos-$DOCKER_VERSION-esp32-c3-generic.bin"
+              # No OTA slot in the C3 4MB layout, so its app image is
+              # published for symmetry/debugging only — nothing consumes it.
+              cp embedded/esp32/build-ci-c3/frameos_esp32.bin \
+                "/release-assets/frameos-$DOCKER_VERSION-esp32-c3-generic-app.bin"
             '
           ls -lh release-assets/
 
@@ -467,8 +482,12 @@ jobs:
           path: |
             release-assets/*-esp32-s3-generic.bin
             release-assets/*-esp32-s3-generic.bin.minisig
+            release-assets/*-esp32-s3-generic-app.bin
+            release-assets/*-esp32-s3-generic-app.bin.minisig
             release-assets/*-esp32-c3-generic.bin
             release-assets/*-esp32-c3-generic.bin.minisig
+            release-assets/*-esp32-c3-generic-app.bin
+            release-assets/*-esp32-c3-generic-app.bin.minisig
           if-no-files-found: error
 
   # Prebuilt thin-client firmware for Raspberry Pi Pico W / Pico 2 W (the

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/firmware/download/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/firmware/download/route.ts
@@ -3,8 +3,7 @@ import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flo
 import { authenticateFrameDevice } from "../../../../../../src/lib/frame-device-auth";
 import {
   fetchLatestRelease,
-  findAsset,
-  provisioningAssets,
+  findOtaAsset,
   streamablePlatforms,
   devFirmwareOverride,
   streamDevFirmwareResponse,
@@ -65,12 +64,10 @@ export async function GET(
   if (!release) {
     return jsonError("release_lookup_failed", 502);
   }
-  const entry = provisioningAssets.find(
-    (candidate) => candidate.platform === platform,
-  );
-  const asset = entry ? findAsset(release, entry.suffix) : undefined;
+  // Must be the same artifact the manifest described: the bare app image.
+  const asset = findOtaAsset(release, platform);
   if (!asset) {
-    return jsonError("firmware_not_published", 404, {
+    return jsonError("ota_image_not_published", 404, {
       platform,
       release: release.tag_name ?? null,
     });

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/firmware/manifest/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/firmware/manifest/route.ts
@@ -5,8 +5,7 @@ import {
   devFirmwareOverride,
   fetchLatestRelease,
   fetchReleaseAssetText,
-  findAsset,
-  provisioningAssets,
+  findOtaAsset,
   streamablePlatforms,
 } from "../../../../../../src/lib/firmware-release";
 import { rateLimitResponse } from "../../../../../../src/lib/rate-limit";
@@ -20,6 +19,10 @@ export const runtime = "nodejs";
 //
 //   GET /api/frames/{id}/firmware/manifest?platform=esp32-s3-generic
 //   -> { platform, version, size, minisig, downloadUrl }
+//
+// The image behind it is the release's bare APP binary (`…-app.bin`), not the
+// merged flash image the browser flasher writes — an OTA slot accepts nothing
+// else (src/lib/firmware-release.ts, otaAssets).
 //
 // `minisig` is the full text of the release's detached minisign signature
 // (tools/sign_firmware.py: Ed25519 over BLAKE2b-512 of the image, verified
@@ -85,12 +88,11 @@ export async function GET(
   if (!release) {
     return jsonError("release_lookup_failed", 502);
   }
-  const entry = provisioningAssets.find(
-    (candidate) => candidate.platform === platform,
-  );
-  const asset = entry ? findAsset(release, entry.suffix) : undefined;
+  // The bare app image, never the merged flash image: only the former is a
+  // valid OTA payload (src/lib/firmware-release.ts, otaAssets).
+  const asset = findOtaAsset(release, platform);
   if (!asset) {
-    return jsonError("firmware_not_published", 404, {
+    return jsonError("ota_image_not_published", 404, {
       platform,
       release: release.tag_name ?? null,
     });

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/firmware/route.test.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/firmware/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authenticateFrameDevice } from "../../../../../src/lib/frame-device-auth";
+import { devFirmwareOverride } from "../../../../../src/lib/firmware-release";
 import { jsonError } from "../../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../../src/lib/rate-limit";
 import { GET as getManifest } from "./manifest/route";
@@ -23,8 +24,19 @@ vi.mock("../../../../../src/lib/device-flow", async (importOriginal) => ({
   ...(await importOriginal<object>()),
   requireDatabase: () => ({ db: {} as never, response: undefined }),
 }));
+// devFirmwareOverride reads a `.dev-firmware/` directory relative to the CWD
+// (two levels up lands on the cloud workspace root, where anyone testing
+// signed OTA against a locally built image keeps one). Left real, it wins over
+// every mocked release below and rewrites this whole suite's expectations on
+// whichever machine happens to have that directory. Overridable per test so
+// the dev path itself can still be pinned.
+vi.mock("../../../../../src/lib/firmware-release", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  devFirmwareOverride: vi.fn(() => Promise.resolve(undefined)),
+}));
 
 const authMock = vi.mocked(authenticateFrameDevice);
+const devFirmwareMock = vi.mocked(devFirmwareOverride);
 const rateLimitMock = vi.mocked(rateLimitResponse);
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -36,13 +48,18 @@ const minisigText =
   "trusted comment: frameos frameos-1.2.3-esp32-s3-generic.bin\n" +
   "RWQfakeGlobalSignature\n";
 
+// A real release publishes BOTH images per platform: the merged one the
+// browser flasher writes at 0x0, and the bare app image OTA needs. These
+// routes must pick the app image every time — see otaAssets in
+// src/lib/firmware-release.ts.
+const mergedBytes = new Uint8Array(64).fill(0xe9);
 const releasePayload = {
   assets: [
     {
       browser_download_url:
         "https://github.com/FrameOS/frameos/releases/download/v1.2.3/frameos-1.2.3-esp32-s3-generic.bin",
       name: "frameos-1.2.3-esp32-s3-generic.bin",
-      size: firmwareBytes.length,
+      size: mergedBytes.length,
     },
     {
       browser_download_url:
@@ -52,8 +69,20 @@ const releasePayload = {
     },
     {
       browser_download_url:
-        "https://github.com/FrameOS/frameos/releases/download/v1.2.3/frameos-1.2.3-esp32-c3-generic.bin",
-      name: "frameos-1.2.3-esp32-c3-generic.bin",
+        "https://github.com/FrameOS/frameos/releases/download/v1.2.3/frameos-1.2.3-esp32-s3-generic-app.bin",
+      name: "frameos-1.2.3-esp32-s3-generic-app.bin",
+      size: firmwareBytes.length,
+    },
+    {
+      browser_download_url:
+        "https://github.com/FrameOS/frameos/releases/download/v1.2.3/frameos-1.2.3-esp32-s3-generic-app.bin.minisig",
+      name: "frameos-1.2.3-esp32-s3-generic-app.bin.minisig",
+      size: minisigText.length,
+    },
+    {
+      browser_download_url:
+        "https://github.com/FrameOS/frameos/releases/download/v1.2.3/frameos-1.2.3-esp32-c3-generic-app.bin",
+      name: "frameos-1.2.3-esp32-c3-generic-app.bin",
       size: 16,
     },
   ],
@@ -70,9 +99,11 @@ function mockGitHub(release: unknown = releasePayload) {
       if (url.endsWith(".minisig")) {
         return Promise.resolve(new Response(minisigText));
       }
+      // Distinct bytes per artifact, so "served the wrong one" is visible.
+      const body = url.endsWith("-app.bin") ? firmwareBytes : mergedBytes;
       return Promise.resolve(
-        new Response(firmwareBytes.slice(), {
-          headers: { "content-length": String(firmwareBytes.length) },
+        new Response(body.slice(), {
+          headers: { "content-length": String(body.length) },
         }),
       );
     }
@@ -100,6 +131,8 @@ afterEach(() => {
   fetchMock.mockReset();
   rateLimitMock.mockClear();
   authMock.mockReset();
+  devFirmwareMock.mockReset();
+  devFirmwareMock.mockResolvedValue(undefined);
   vi.unstubAllGlobals();
 });
 
@@ -169,14 +202,36 @@ describe("GET /api/frames/[frameId]/firmware/manifest", () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: "firmware_not_published",
+      error: "ota_image_not_published",
+      platform: "esp32-s3-generic",
+      release: "v1.2.3",
+    });
+  });
+
+  it("404s a release that publishes only the merged flash image", async () => {
+    // Every release up to and including v2026.8.12. Falling back to the
+    // merged image here would hand the device several MB it can only reject:
+    // esp_ota_end validates an esp_app_desc at 0x20, and a merged image has
+    // the bootloader there.
+    mockGitHub({
+      assets: releasePayload.assets.filter(
+        (asset) => !asset.name.includes("-app.bin"),
+      ),
+      tag_name: "v1.2.3",
+    });
+
+    const response = await manifest();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "ota_image_not_published",
       platform: "esp32-s3-generic",
       release: "v1.2.3",
     });
   });
 
   it("409s a release whose .bin carries no .minisig — never offer an unverifiable image", async () => {
-    // esp32-c3-generic.bin exists in the fixture, its .minisig does not.
+    // esp32-c3-generic-app.bin exists in the fixture, its .minisig does not.
     mockGitHub();
 
     const response = await manifest("esp32-c3-generic");
@@ -199,6 +254,28 @@ describe("GET /api/frames/[frameId]/firmware/manifest", () => {
       error: "release_lookup_failed",
     });
   });
+
+  it("prefers a local .dev-firmware image over the release, without touching GitHub", async () => {
+    mockGitHub();
+    devFirmwareMock.mockResolvedValue({
+      version: "9.9.9-dev",
+      size: 4096,
+      minisig: minisigText,
+      filePath: "/tmp/esp32-s3-generic.bin",
+    });
+
+    const response = await manifest();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      platform: "esp32-s3-generic",
+      version: "9.9.9-dev",
+      size: 4096,
+      minisig: minisigText,
+      downloadUrl: `/api/frames/${frameId}/firmware/download?platform=esp32-s3-generic`,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/frames/[frameId]/firmware/download", () => {
@@ -218,7 +295,7 @@ describe("GET /api/frames/[frameId]/firmware/download", () => {
       "application/octet-stream",
     );
     expect(response.headers.get("x-frameos-image-name")).toBe(
-      "frameos-1.2.3-esp32-s3-generic.bin",
+      "frameos-1.2.3-esp32-s3-generic-app.bin",
     );
     expect(response.headers.get("x-frameos-release")).toBe("v1.2.3");
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(firmwareBytes);
@@ -230,14 +307,14 @@ describe("GET /api/frames/[frameId]/firmware/download", () => {
       assets: [
         {
           browser_download_url:
-            "https://evil.example/frameos-1.2.3-esp32-s3-generic.bin",
-          name: "frameos-1.2.3-esp32-s3-generic.bin",
+            "https://evil.example/frameos-1.2.3-esp32-s3-generic-app.bin",
+          name: "frameos-1.2.3-esp32-s3-generic-app.bin",
           size: 32,
         },
         {
           browser_download_url:
-            "https://evil.example/frameos-1.2.3-esp32-s3-generic.bin.minisig",
-          name: "frameos-1.2.3-esp32-s3-generic.bin.minisig",
+            "https://evil.example/frameos-1.2.3-esp32-s3-generic-app.bin.minisig",
+          name: "frameos-1.2.3-esp32-s3-generic-app.bin.minisig",
           size: 128,
         },
       ],

--- a/cloud/apps/auth-web/src/lib/firmware-release.ts
+++ b/cloud/apps/auth-web/src/lib/firmware-release.ts
@@ -40,6 +40,32 @@ export const provisioningAssets = [
   },
 ] as const;
 
+// OTA images. NOT the same file as above, and the difference is the whole
+// reason this list exists: `provisioningAssets` points at the MERGED image
+// (`idf.py merge-bin` — bootloader at 0x0, partition table, blank otadata,
+// app at 0x10000), which is what a flasher writes to a blank board. An OTA
+// slot takes only the bare app image: esp_ota_write/esp_ota_end validate an
+// esp_app_desc at offset 0x20, and the merged image has the BOOTLOADER there,
+// so a device offered one downloads several MB and then rejects it at the last
+// step — every time, on every release. The release publishes both; the
+// device-authed manifest/download routes serve this one.
+//
+// Releases from before the `-app.bin` assets shipped have no OTA image at all;
+// those answer 404 ota_image_not_published rather than falling back to the
+// merged image, which could only ever fail on the device.
+export const otaAssets = [
+  { platform: "esp32-s3-generic", suffix: "-esp32-s3-generic-app.bin" },
+  // 4MB single-slot layout — no OTA partition on the device, so this is
+  // published (and served) only for completeness.
+  { platform: "esp32-c3-generic", suffix: "-esp32-c3-generic-app.bin" },
+] as const;
+
+/** The bare app image for a platform, or undefined on an older release. */
+export function findOtaAsset(release: Release, platform: string) {
+  const entry = otaAssets.find((candidate) => candidate.platform === platform);
+  return entry ? findAsset(release, entry.suffix) : undefined;
+}
+
 // Only the ESP32 firmware (a few MB) is ever streamed from here; the
 // gigabyte-sized SD images go through app/api/frames/sd-image with its own
 // much tighter budget.
@@ -164,6 +190,12 @@ export async function fetchReleaseAssetText(
 // `<platform>.bin`, `<platform>.bin.minisig` and `version.txt` into a
 // `.dev-firmware/` directory (next to the auth-web app, or two levels up at
 // the cloud workspace root). Disabled in production builds.
+//
+// `<platform>.bin` must be the OTA APP image (`build/frameos_esp32.bin`), not
+// `merged-binary.bin` — see the otaAssets comment above. `version.txt` must
+// match the app's version string (esp_app_get_description()->version, i.e.
+// what `idf.py build` stamped), or the device sees itself as up to date and
+// does nothing.
 
 export interface DevFirmware {
   version: string;

--- a/cloud/apps/auth-web/src/test/integration/frame-firmware.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frame-firmware.integration.test.ts
@@ -23,6 +23,14 @@ import { createSession, sessionCookieName } from "../../lib/session";
 
 const cookieJar = vi.hoisted(() => new Map<string, string>());
 
+// A `.dev-firmware/` directory at the cloud workspace root (the local
+// signed-OTA test rig) would otherwise outrank every mocked release below and
+// answer these routes with whatever image happens to sit there.
+vi.mock("../../lib/firmware-release", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  devFirmwareOverride: () => Promise.resolve(undefined),
+}));
+
 vi.mock("next/headers", () => ({
   cookies: async () => ({
     get: (name: string) => {
@@ -47,6 +55,9 @@ const minisigText =
   "trusted comment: frameos frameos-2026.8.1-esp32-s3-generic.bin\n" +
   "RWQfakeGlobalSignature\n";
 
+// OTA serves the bare app image (`…-app.bin`), never the merged flash image
+// a USB flasher writes — see otaAssets in src/lib/firmware-release.ts. The
+// merged asset is in the fixture precisely because it must be ignored here.
 function releasePayload(options: { signed?: boolean } = {}) {
   const signed = options.signed !== false;
   return {
@@ -55,14 +66,26 @@ function releasePayload(options: { signed?: boolean } = {}) {
         browser_download_url:
           "https://github.com/FrameOS/frameos/releases/download/v2026.8.1/frameos-2026.8.1-esp32-s3-generic.bin",
         name: "frameos-2026.8.1-esp32-s3-generic.bin",
+        size: 4096,
+      },
+      {
+        browser_download_url:
+          "https://github.com/FrameOS/frameos/releases/download/v2026.8.1/frameos-2026.8.1-esp32-s3-generic.bin.minisig",
+        name: "frameos-2026.8.1-esp32-s3-generic.bin.minisig",
+        size: minisigText.length,
+      },
+      {
+        browser_download_url:
+          "https://github.com/FrameOS/frameos/releases/download/v2026.8.1/frameos-2026.8.1-esp32-s3-generic-app.bin",
+        name: "frameos-2026.8.1-esp32-s3-generic-app.bin",
         size: firmwareBytes.length,
       },
       ...(signed
         ? [
             {
               browser_download_url:
-                "https://github.com/FrameOS/frameos/releases/download/v2026.8.1/frameos-2026.8.1-esp32-s3-generic.bin.minisig",
-              name: "frameos-2026.8.1-esp32-s3-generic.bin.minisig",
+                "https://github.com/FrameOS/frameos/releases/download/v2026.8.1/frameos-2026.8.1-esp32-s3-generic-app.bin.minisig",
+              name: "frameos-2026.8.1-esp32-s3-generic-app.bin.minisig",
               size: minisigText.length,
             },
           ]

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-deploy-dialog.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-deploy-dialog.test.tsx
@@ -53,6 +53,12 @@ type CloudTestWindow = Window & {
 const testWindow = window as CloudTestWindow;
 
 beforeEach(() => {
+  // Both USB surfaces render a "this browser can't do it" note without Web
+  // Serial, so the controls under test only exist when it is present.
+  Object.defineProperty(navigator, "serial", {
+    configurable: true,
+    value: { getPorts: () => Promise.resolve([]), requestPort: () => Promise.reject(new Error("no port")) },
+  });
   testWindow.FRAMEOS_APP_CONFIG = { cloudMode: true };
   testWindow.FRAMEOS_EMBEDDED_NO_BACKEND = true;
   document.body.innerHTML = '<div id="popper"></div><div id="root"></div>';
@@ -64,6 +70,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  delete (navigator as { serial?: unknown }).serial;
   vi.unstubAllGlobals();
   delete testWindow.FRAMEOS_APP_CONFIG;
   delete testWindow.FRAMEOS_EMBEDDED_NO_BACKEND;
@@ -78,6 +85,10 @@ describe("the deploy dialog in cloud mode", () => {
     expect(screen.getByRole("button", { name: "Push scenes" })).toBeTruthy();
     // The firmware nudge, previously reachable only from the "…" menu.
     expect(screen.getByRole("button", { name: /Update firmware/ })).toBeTruthy();
+    // ...and the USB route to the same released image, which is the only one
+    // that works on a board that cannot reach the network — the state the USB
+    // block below exists to repair.
+    expect(screen.getByRole("button", { name: /Update over USB/ })).toBeTruthy();
     // The point of the whole exercise.
     expect(screen.getByText("USB setup")).toBeTruthy();
   });
@@ -110,6 +121,7 @@ describe("the deploy dialog in cloud mode", () => {
     // firmware image, and it has no serial console to provision over.
     expect(screen.queryByText("USB setup")).toBeNull();
     expect(screen.queryByRole("button", { name: /Update firmware/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Update over USB/ })).toBeNull();
   });
 
   it("fetches no deploy plan (the cloud has no such endpoint)", () => {

--- a/cloud/apps/auth-web/src/test/shared-spa/embedded-flash-image.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/embedded-flash-image.test.ts
@@ -1,0 +1,180 @@
+// The write plan behind "Update over USB" on an already-enrolled ESP32 frame.
+//
+// The whole point of the plan is one guarantee: the NVS partition — where the
+// board keeps its Wi-Fi credentials AND its cloud enrollment (cloud_url,
+// cloud_fid, cloud_token; embedded/esp32/main/fos_cloud.c) — is never written.
+// Flashing the merged release image at 0x0 the way the enrollment flasher does
+// blanks it with the image's 0xFF padding, which turns a firmware update into
+// an un-enrollment: the account keeps an orphaned frame row and the board comes
+// back a stranger. These tests pin that the hole is in the right place and that
+// anything the planner cannot prove fails loudly instead.
+//
+// Lives here (auth-web's vitest) because frontend/ has no test runner; same
+// cross-package arrangement as the other shared-spa suites.
+import { describe, expect, it } from "vitest";
+import {
+  ESP32_PARTITION_TABLE_OFFSET,
+  deviceLayoutMatchesPlan,
+  esp32NvsPartition,
+  firmwareUpdateWritePlan,
+  parseEsp32PartitionTable,
+  partitionTableFromMergedImage,
+  type Esp32Partition,
+} from "../../../../../../frontend/src/scenes/workspace/embeddedFlashImage";
+
+const PARTITION_ENTRY_SIZE = 32;
+
+/** One esp_partition_info_t, as gen_esp32part.py writes it. */
+function partitionEntry(partition: Esp32Partition): Uint8Array {
+  const entry = new Uint8Array(PARTITION_ENTRY_SIZE);
+  const view = new DataView(entry.buffer);
+  view.setUint16(0, 0x50aa, true);
+  view.setUint8(2, partition.type);
+  view.setUint8(3, partition.subtype);
+  view.setUint32(4, partition.offset, true);
+  view.setUint32(8, partition.size, true);
+  entry.set(new TextEncoder().encode(partition.name).subarray(0, 16), 12);
+  return entry;
+}
+
+// The 8MB OTA layout every cloud-flashed board runs (embedded/esp32/partitions.csv).
+const defaultLayout: Esp32Partition[] = [
+  { name: "nvs", type: 1, subtype: 2, offset: 0x9000, size: 16 * 1024 },
+  { name: "otadata", type: 1, subtype: 0, offset: 0xd000, size: 8 * 1024 },
+  { name: "phy_init", type: 1, subtype: 1, offset: 0xf000, size: 4 * 1024 },
+  { name: "ota_0", type: 0, subtype: 0x10, offset: 0x10000, size: 3520 * 1024 },
+  { name: "ota_1", type: 0, subtype: 0x11, offset: 0x380000, size: 3520 * 1024 },
+];
+
+function partitionTable(partitions: Esp32Partition[]): Uint8Array {
+  const table = new Uint8Array(0x1000);
+  partitions.forEach((partition, index) => {
+    table.set(partitionEntry(partition), index * PARTITION_ENTRY_SIZE);
+  });
+  return table;
+}
+
+/** A stand-in for `idf.py merge-bin` output: table at 0x8000, app at 0x10000. */
+function mergedImage(
+  partitions: Esp32Partition[] = defaultLayout,
+  appBytes = 0x2000,
+): Uint8Array {
+  const image = new Uint8Array(0x10000 + appBytes).fill(0xff);
+  image[0] = 0xe9; // bootloader image magic
+  image.set(partitionTable(partitions), ESP32_PARTITION_TABLE_OFFSET);
+  image.fill(0xab, 0x10000);
+  image[0x10000] = 0xe9; // app image magic
+  return image;
+}
+
+describe("parseEsp32PartitionTable", () => {
+  it("reads entries until the first non-magic one", () => {
+    const table = partitionTable(defaultLayout);
+    // gen_esp32part.py appends an 0xEBEB md5 entry after the real ones.
+    table.set([0xeb, 0xeb], defaultLayout.length * PARTITION_ENTRY_SIZE);
+
+    const parsed = parseEsp32PartitionTable(table);
+
+    expect(parsed.map((partition) => partition.name)).toEqual([
+      "nvs",
+      "otadata",
+      "phy_init",
+      "ota_0",
+      "ota_1",
+    ]);
+    expect(esp32NvsPartition(parsed)).toMatchObject({
+      offset: 0x9000,
+      size: 16 * 1024,
+    });
+  });
+
+  it("returns nothing for a blank or truncated table", () => {
+    expect(parseEsp32PartitionTable(new Uint8Array(0x1000))).toEqual([]);
+    expect(partitionTableFromMergedImage(new Uint8Array(64))).toEqual([]);
+  });
+});
+
+describe("firmwareUpdateWritePlan", () => {
+  it("writes everything around the NVS partition and nothing inside it", () => {
+    const image = mergedImage();
+
+    const plan = firmwareUpdateWritePlan(image);
+
+    expect(plan.preserved).toMatchObject({ name: "nvs", offset: 0x9000 });
+    expect(
+      plan.segments.map((segment) => [
+        segment.address,
+        segment.address + segment.data.byteLength,
+      ]),
+    ).toEqual([
+      [0, 0x9000],
+      [0xd000, image.byteLength],
+    ]);
+    // Bootloader, partition table, otadata and app are all still covered: the
+    // only gap is the NVS.
+    expect(plan.totalBytes).toBe(image.byteLength - 16 * 1024);
+    expect(plan.segments[0]!.data[0]).toBe(0xe9);
+    expect(plan.segments[1]!.data[0x10000 - 0xd000]).toBe(0xe9);
+  });
+
+  it("resets otadata, so the board boots the slot that was just written", () => {
+    // otadata (0xd000) sits after the NVS, inside the second segment. If it
+    // were skipped too, a board that had previously OTA'd into ota_1 would keep
+    // booting ota_1 and the flash would look like it did nothing.
+    const plan = firmwareUpdateWritePlan(mergedImage());
+    const tail = plan.segments[1]!;
+
+    expect(tail.address).toBe(0xd000);
+    expect(tail.data.subarray(0, 8 * 1024).every((byte) => byte === 0xff)).toBe(
+      true,
+    );
+  });
+
+  it("refuses an image with no readable partition table", () => {
+    expect(() => firmwareUpdateWritePlan(new Uint8Array(0x20000))).toThrow(
+      /no readable partition table/i,
+    );
+  });
+
+  it("refuses an image whose table declares no NVS", () => {
+    const withoutNvs = defaultLayout.filter(
+      (partition) => partition.name !== "nvs",
+    );
+
+    expect(() => firmwareUpdateWritePlan(mergedImage(withoutNvs))).toThrow(
+      /no NVS partition/i,
+    );
+  });
+
+  it("refuses a misaligned NVS rather than erasing a neighbouring sector", () => {
+    const misaligned = defaultLayout.map((partition) =>
+      partition.name === "nvs" ? { ...partition, offset: 0x9100 } : partition,
+    );
+
+    expect(() => firmwareUpdateWritePlan(mergedImage(misaligned))).toThrow(
+      /sector aligned/i,
+    );
+  });
+});
+
+describe("deviceLayoutMatchesPlan", () => {
+  it("accepts a board partitioned exactly like the image", () => {
+    const plan = firmwareUpdateWritePlan(mergedImage());
+
+    expect(deviceLayoutMatchesPlan(defaultLayout, plan)).toBe(true);
+  });
+
+  it("rejects a board whose NVS sits elsewhere", () => {
+    // The 16MB layout puts a 24KB NVS at the same offset but ends it later:
+    // the hole this plan leaves would clip it and wipe the enrollment.
+    const sixteenMb = defaultLayout.map((partition) =>
+      partition.name === "nvs"
+        ? { ...partition, size: 24 * 1024 }
+        : partition,
+    );
+    const plan = firmwareUpdateWritePlan(mergedImage());
+
+    expect(deviceLayoutMatchesPlan(sixteenMb, plan)).toBe(false);
+    expect(deviceLayoutMatchesPlan([], plan)).toBe(false);
+  });
+});

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -560,7 +560,14 @@ provisions the panel key over serial instead of picking a per-panel binary.
 The generic image boots with `EPD_7in5_V2` as the default panel for backward
 compatibility. Artifact file names are an implementation detail of the
 release archive — read them from the release metadata rather than
-constructing them. (Transitional: the generic binary is published as
+constructing them. Each ESP32 platform publishes **two** images, and they are
+not interchangeable: `…-esp32-s3-generic.bin` is the merged flash image
+(bootloader, partition table, blank otadata, app) that a USB flasher writes at
+`0x0`, while `…-esp32-s3-generic-app.bin` is the bare app image — the only
+thing an OTA slot accepts, since `esp_ota_end` validates an `esp_app_desc` at
+offset `0x20` and the merged image has the bootloader there. The device-authed
+OTA manifest/download routes serve the `-app.bin`; the browser flasher serves
+the merged one. (Transitional: the generic binary is published as
 `…-esp32-s3-generic.bin`, with an identical copy under the legacy
 `…-esp32-s3-epd7in5v2.bin` name for one release cycle.) A second generic
 image, `…-esp32-c3-generic.bin`, targets PSRAM-less ESP32-C3 boards

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,11 +56,16 @@ Known gaps from the 2026-08-08 audit (in flight or open):
   in the cloud protocol — structural, not a gap to close).
 - Cloud-managed ESP32-C3 frames still have no render source (wasm harness
   is the building block; C3 boards stay out of the cloud flasher until then).
-- **Re-flash an ALREADY-ENROLLED cloud frame** — the deploy dialog now offers
-  cloud esp32 frames the full USB *provisioning* set (status, Wi-Fi
-  scan/apply, restart, factory reset — `EmbeddedUsbSetup`, pure WebSerial),
-  but deliberately NOT a "flash firmware" button, because browser flashing
-  currently forks a duplicate frame row. `Esp32CloudFlasher`
+- **Re-ENROLL an already-enrolled cloud frame** — *updating* the firmware of
+  an enrolled board shipped 2026-08-08: the deploy dialog's Firmware section
+  has "Update over USB" (`EmbeddedUsbFirmwareUpdate`), which writes the
+  published image around the board's NVS partition
+  (`embeddedFlashImage.ts`), so Wi-Fi, settings and the cloud enrollment all
+  survive and no claim token is involved. What is still missing is
+  RE-enrollment — pointing an already-owned board at a different account, or
+  recovering one whose NVS was blanked (a factory reset, or a full 0x0 flash
+  from the "Add frame" panel). That still forks a duplicate frame row.
+  `Esp32CloudFlasher`
   (`cloud-frontend/src/components/Esp32CloudFlasher.tsx`) is an *enrollment*
   flow end to end: `mintEnrollmentCode()` always POSTs
   `/api/frames/claim-tokens` for a FRESH single-use token, provisions it over
@@ -81,8 +86,15 @@ Known gaps from the 2026-08-08 audit (in flight or open):
   3. A flasher mode that takes a known `frameId` + its bound token, skips
      the new-frame watch entirely, and reports success against the row the
      user started from.
-  Until 1–3 land, re-flashing an enrolled board stays a delete-and-re-enroll
-  (or a manual esptool flash + factory reset over the USB setup block).
+  Until 1–3 land, MOVING an enrolled board (or rescuing a blanked one) stays a
+  delete-and-re-enroll.
+- **Cloud OTA needs a released `-app.bin`** — fixed 2026-08-08 in the release
+  workflow and the manifest/download routes, but every release up to and
+  including v2026.8.12 published only the merged flash image, which an OTA
+  slot can never accept. Cloud OTA therefore does nothing until the first
+  release carrying `…-esp32-s3-generic-app.bin`; the routes answer
+  `ota_image_not_published` (404) until then, and the USB updater is the way
+  to move a board onto a newer build meanwhile.
 
 ## Cloud-managed frames
 

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -531,10 +531,31 @@ static int cmd_sd(int argc, char **argv)
     return err == ESP_OK ? 0 : 1;
 }
 
+/* Two OTA paths exist and a board only ever has one of them: the backend one
+ * (manifest under backend_url, authenticated with the frame api_key, applied
+ * by the early updater after a reboot) and the cloud one (device-authed
+ * manifest + minisign verification, fos_ota_request_cloud_update). An enrolled
+ * cloud frame has no backend_url/api_key at all, so sending it down the
+ * backend path could only ever answer ESP_ERR_INVALID_STATE — which read like
+ * "OTA is broken" rather than "wrong path". Pick by what this board is. */
+static esp_err_t ota_request_for_control_plane(const char **plane_out)
+{
+    const fos_config_t *config = fos_config();
+    bool backend_ready = config->backend_url[0] && config->frame_id != 0 && config->api_key[0];
+    if (!backend_ready && fos_cloud_frame_id()[0]) {
+        if (plane_out) *plane_out = "cloud";
+        fos_ota_request_cloud_update();
+        return ESP_OK;
+    }
+    if (plane_out) *plane_out = "backend";
+    return fos_ota_request_check();
+}
+
 static int cmd_ota(int argc, char **argv)
 {
-    esp_err_t err = fos_ota_request_check();
-    printf("ota: %s\n", esp_err_to_name(err));
+    const char *plane = "backend";
+    esp_err_t err = ota_request_for_control_plane(&plane);
+    printf("ota: %s (%s)\n", esp_err_to_name(err), plane);
     return err == ESP_OK ? 0 : 1;
 }
 
@@ -764,7 +785,7 @@ static int cmd_usb_api(int argc, char **argv)
     }
 
     if (strcmp(subcommand, "ota") == 0) {
-        esp_err_t err = fos_ota_request_check();
+        esp_err_t err = ota_request_for_control_plane(NULL);
         if (err == ESP_OK) {
             usb_api_ok(subcommand);
             return 0;

--- a/embedded/esp32/main/fos_ota.c
+++ b/embedded/esp32/main/fos_ota.c
@@ -757,7 +757,13 @@ static esp_err_t cloud_ota_run(void)
         esp_http_client_cleanup(client);
         ESP_LOGW(TAG, "cloud ota: manifest HTTP %d (%lld bytes)", status,
                  (long long)content_length);
-        cloud_ota_log("error", status == 409 ? "unsigned-release" : "manifest-unavailable");
+        /* 404 = the release carries no OTA app image for this platform (every
+         * release up to v2026.8.12); 409 = it has one but no signature. Both
+         * are "nothing to install", and telling them apart in the log is the
+         * difference between waiting for a release and chasing a bug. */
+        cloud_ota_log("error", status == 409   ? "unsigned-release"
+                               : status == 404 ? "no-image-published"
+                                               : "manifest-unavailable");
         return ESP_FAIL;
     }
     char *body = malloc(FOS_CLOUD_OTA_MANIFEST_MAX + 1);

--- a/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useState } from 'react'
+import { ArrowUpCircleIcon } from '@heroicons/react/24/outline'
+import { useActions } from 'kea'
+import type { Transport as EspTransport } from 'esptool-js'
+
+import { Spinner } from '../../components/Spinner'
+import {
+  embeddedUsbLogStreamSessionPort,
+  prepareSerialPortReconnect,
+  startEmbeddedUsbLogStream,
+  stopEmbeddedUsbLogStream,
+} from '../../models/embeddedUsbLogsModel'
+import { framesModel } from '../../models/framesModel'
+import type { FrameType } from '../../types'
+import { apiFetch } from '../../utils/apiFetch'
+import {
+  POST_FLASH_BOOT_WAIT_MS,
+  appendBrowserFlashLog,
+  createUsbLogTerminal,
+  mirrorTransportTrace,
+  sleep,
+  waitForUsbApiReadyAfterFlash,
+  watchdogResetAfterFlash,
+  type FlashLogTerminal,
+  type FlashPhase,
+} from './EmbeddedWebFlasher'
+import {
+  ESP32_PARTITION_TABLE_OFFSET,
+  ESP32_PARTITION_TABLE_SIZE,
+  deviceLayoutMatchesPlan,
+  firmwareUpdateWritePlan,
+  parseEsp32PartitionTable,
+  type FirmwareUpdateWritePlan,
+} from './embeddedFlashImage'
+import { workspaceLogic } from './workspaceLogic'
+
+// USB firmware update for a frame that is ALREADY enrolled — the counterpart
+// of the cloud's "Add frame" flasher, which enrolls a blank board.
+//
+// The two differ in exactly one way, and it is the important one: this flow
+// never touches the NVS partition and never mints a claim token, so the board
+// keeps its Wi-Fi credentials and its cloud identity and comes back as the
+// same frame. (Flashing the merged image at 0x0 the way enrollment does would
+// blank the NVS along with everything else — the account would then own an
+// orphaned row and a board that no longer knows about it.) See
+// embeddedFlashImage.ts for the write plan and why it is derived from the
+// image's own partition table.
+//
+// Firmware bytes come from the control plane's release pipe, same as
+// enrollment: /api/frames/firmware serves the published image so the browser
+// never talks to api.github.com (no CORS, 60 req/h per IP).
+
+const firmwareListingUrl = '/api/frames/firmware'
+const releasePlatformByHardware: Record<string, string> = {
+  'esp32-s3': 'esp32-s3-generic',
+  'esp32-c3': 'esp32-c3-generic',
+}
+
+interface ReleaseFirmwareAsset {
+  name: string
+  platform: string
+  size: number
+}
+
+/** Which published asset fits the hardware the device reported at enrollment. */
+export function releaseFirmwarePlatform(frame: FrameType): string {
+  const platform = (frame.hardware?.platform ?? '').toLowerCase()
+  return releasePlatformByHardware[platform] ?? 'esp32-s3-generic'
+}
+
+async function downloadReleaseFirmware(
+  platform: string,
+  log: (message: string) => void
+): Promise<{ bytes: Uint8Array; name: string; release: string }> {
+  const listingResponse = await apiFetch(firmwareListingUrl)
+  if (!listingResponse.ok) {
+    throw new Error('Could not look up the latest FrameOS release.')
+  }
+  const listing = (await listingResponse.json()) as { assets?: ReleaseFirmwareAsset[]; release?: string }
+  const asset = listing.assets?.find((entry) => entry.platform === platform)
+  if (!asset) {
+    throw new Error(`Release ${listing.release || '?'} publishes no ${platform} firmware to update to.`)
+  }
+  log(`Downloading ${asset.name} (${(asset.size / 1024 / 1024).toFixed(1)} MB)`)
+  const response = await apiFetch(`${firmwareListingUrl}?platform=${encodeURIComponent(platform)}`, {
+    cache: 'no-store',
+  })
+  if (!response.ok) {
+    throw new Error('Could not download the firmware image.')
+  }
+  return { bytes: new Uint8Array(await response.arrayBuffer()), name: asset.name, release: listing.release ?? '' }
+}
+
+/**
+ * Refuse the update when the board is partitioned differently from the image:
+ * the hole this plan leaves would then land somewhere other than the board's
+ * NVS, wiping the credentials it exists to protect. An unreadable table is not
+ * treated as a mismatch — some chips/stubs decline flash reads — but it is
+ * logged, because then the guarantee rests on the image alone.
+ */
+async function assertDeviceLayoutMatches(
+  loader: { readFlash?: (address: number, size: number) => Promise<Uint8Array> },
+  plan: FirmwareUpdateWritePlan,
+  log: (message: string) => void
+): Promise<void> {
+  if (typeof loader.readFlash !== 'function') {
+    return
+  }
+  let table: Uint8Array
+  try {
+    table = await loader.readFlash(ESP32_PARTITION_TABLE_OFFSET, ESP32_PARTITION_TABLE_SIZE)
+  } catch (error) {
+    log("Could not read the board's partition table; trusting the image's own layout.")
+    return
+  }
+  const partitions = parseEsp32PartitionTable(table)
+  if (partitions.length === 0) {
+    log("The board has no readable partition table yet; trusting the image's own layout.")
+    return
+  }
+  if (!deviceLayoutMatchesPlan(partitions, plan)) {
+    throw new Error(
+      'This board is partitioned differently from the published firmware, so its settings partition cannot be ' +
+        'spared. Re-enroll it from the "Add frame" panel instead.'
+    )
+  }
+}
+
+export function EmbeddedUsbFirmwareUpdate({ frame }: { frame: FrameType }): JSX.Element {
+  const [phase, setPhase] = useState<FlashPhase>('idle')
+  const [message, setMessage] = useState<string | null>(null)
+  const [progress, setProgress] = useState<number | null>(null)
+  const { openFrameToolBehindDrawer } = useActions(workspaceLogic)
+  const { loadFrame } = useActions(framesModel)
+
+  const webSerialSupported = typeof navigator !== 'undefined' && 'serial' in navigator
+  const busy = phase === 'connecting' || phase === 'preparing' || phase === 'flashing'
+
+  useEffect(() => {
+    setPhase('idle')
+    setMessage(null)
+    setProgress(null)
+  }, [frame.id])
+
+  const update = async (): Promise<void> => {
+    let port: SerialPort | null = null
+    let transport: EspTransport | null = null
+    let flashTerminal: FlashLogTerminal | null = null
+    let flashed = false
+    const setFlashMessage = (nextMessage: string | null): void => {
+      setMessage(nextMessage)
+      if (nextMessage) {
+        appendBrowserFlashLog(frame.id, nextMessage)
+      }
+    }
+
+    setPhase('connecting')
+    setProgress(null)
+    setFlashMessage('Selecting USB port')
+    try {
+      // Must run inside the click gesture, before any other await, or the
+      // browser refuses the port prompt.
+      const activeLogPort = embeddedUsbLogStreamSessionPort(frame.id)
+      port = activeLogPort ? await stopEmbeddedUsbLogStream(frame.id) : await navigator.serial.requestPort()
+      if (!port) {
+        setPhase('idle')
+        setMessage(null)
+        return
+      }
+      await prepareSerialPortReconnect(port)
+      openFrameToolBehindDrawer(frame.id, 'logs')
+
+      setPhase('preparing')
+      const platform = releaseFirmwarePlatform(frame)
+      const firmware = await downloadReleaseFirmware(platform, setFlashMessage)
+      // Planned before the board is touched: a plan that cannot spare the NVS
+      // must fail while nothing has been written.
+      const plan = firmwareUpdateWritePlan(firmware.bytes)
+
+      // Loaded on demand: esptool-js adds ~380KB we only need when flashing.
+      const { ESPLoader, Transport } = await import('esptool-js')
+      transport = new Transport(port, false)
+      mirrorTransportTrace(frame.id, transport)
+      flashTerminal = createUsbLogTerminal(frame.id)
+
+      setFlashMessage('Connecting to the board')
+      const loader = new ESPLoader({ transport, baudrate: 460800, enableTracing: true, terminal: flashTerminal })
+      const chip = await loader.main()
+      await assertDeviceLayoutMatches(loader, plan, (line) => appendBrowserFlashLog(frame.id, line))
+
+      setPhase('flashing')
+      setFlashMessage(
+        `Flashing ${firmware.name} to ${chip}, keeping the frame's Wi-Fi and cloud settings (${
+          plan.preserved.name
+        }, ${Math.round(plan.preserved.size / 1024)}KB).`
+      )
+      // reportProgress counts per segment; weight them into one bar.
+      const segmentOffsets = plan.segments.map((_, index) =>
+        plan.segments.slice(0, index).reduce((total, segment) => total + segment.data.byteLength, 0)
+      )
+      await loader.writeFlash({
+        fileArray: plan.segments.map((segment) => ({ address: segment.address, data: segment.data })),
+        flashSize: 'keep',
+        flashMode: 'keep',
+        flashFreq: 'keep',
+        // eraseAll would take the whole chip, NVS included — the entire point
+        // of this flow is that it does not.
+        eraseAll: false,
+        compress: true,
+        reportProgress: (fileIndex, written, total) => {
+          const done = (segmentOffsets[fileIndex] ?? 0) + (total > 0 ? written : 0)
+          setProgress(plan.totalBytes > 0 ? Math.min(100, Math.round((done / plan.totalBytes) * 100)) : null)
+        },
+      })
+      flashed = true
+
+      if (!(await watchdogResetAfterFlash(loader))) {
+        try {
+          await transport.setDTR(false)
+          await transport.setRTS(true)
+          await sleep(100)
+          await transport.setRTS(false)
+          await transport.setDTR(false)
+        } catch (error) {
+          // The port drops if the chip already reset mid-command; the
+          // post-flash wait re-acquires it.
+        }
+      }
+      setPhase('preparing')
+      setProgress(null)
+      setFlashMessage('Firmware written. Waiting for the board to reboot.')
+    } catch (error) {
+      setPhase('error')
+      setProgress(null)
+      const detail = error instanceof Error ? error.message : String(error)
+      if (/No port selected/i.test(detail)) {
+        setPhase('idle')
+        setMessage(null)
+      } else {
+        const displayMessage = /Failed to open serial port/i.test(detail)
+          ? 'Could not open the serial port. Close other serial monitors and try again.'
+          : detail
+        setMessage(displayMessage)
+        appendBrowserFlashLog(frame.id, `Firmware update failed: ${displayMessage}`)
+      }
+    } finally {
+      flashTerminal?.flush()
+      if (transport) {
+        try {
+          await transport.disconnect()
+        } catch (error) {}
+      }
+      if (flashed && port) {
+        try {
+          await sleep(POST_FLASH_BOOT_WAIT_MS)
+          port = await waitForUsbApiReadyAfterFlash(
+            frame,
+            port,
+            setFlashMessage,
+            'Waiting for the board to come back on USB.'
+          )
+          setPhase('done')
+          setFlashMessage('Firmware updated. The frame kept its Wi-Fi and cloud settings and is reconnecting.')
+          // Its reported firmware version changes as soon as it re-syncs.
+          loadFrame(frame.id)
+        } catch (error) {
+          setPhase('error')
+          const detail = error instanceof Error ? error.message : String(error)
+          setFlashMessage(`Firmware written, but the board did not answer over USB afterwards: ${detail}`)
+        }
+        const logStreamStarted = await startEmbeddedUsbLogStream(frame.id, port)
+        openFrameToolBehindDrawer(frame.id, 'logs')
+        if (!logStreamStarted) {
+          appendBrowserFlashLog(frame.id, 'USB serial log stream could not be reopened after the update.')
+        }
+      }
+    }
+  }
+
+  if (!webSerialSupported) {
+    return (
+      <div className="frame-tool-muted text-xs leading-5">
+        Updating over USB needs Web Serial, which this browser doesn't support. Use Chrome or Edge.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={update}
+        disabled={busy}
+        className="frameos-secondary-button inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40"
+      >
+        {busy ? <Spinner /> : <ArrowUpCircleIcon className="h-4 w-4" />}
+        {phase === 'flashing' && progress !== null ? `Updating ${progress}%` : busy ? 'Updating' : 'Update over USB'}
+      </button>
+      {phase === 'flashing' && progress !== null ? (
+        <div className="frameos-inset h-2 w-full overflow-hidden rounded-full border">
+          <div className="h-full rounded-full bg-blue-500 transition-all" style={{ width: `${progress}%` }} />
+        </div>
+      ) : null}
+      {message ? (
+        <div
+          className={
+            phase === 'error'
+              ? 'text-xs font-semibold text-red-500'
+              : phase === 'done'
+              ? 'text-xs font-semibold text-green-600'
+              : 'frame-tool-muted text-xs leading-5'
+          }
+        >
+          {message}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/scenes/workspace/EmbeddedUsbSetup.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedUsbSetup.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../models/embeddedUsbLogsModel'
 import type { FrameType } from '../../types'
 import { EmbeddedUsbConnectionButton } from './EmbeddedWebFlasher'
+import { isEsp32CloudFrame } from './workspaceSurfaces'
 
 // fos_wifi_state_t in embedded/esp32/main/fos_wifi.h
 const WIFI_STATE_LABELS = ['offline', 'connecting', 'connected', 'captive portal'] as const
@@ -83,6 +84,7 @@ export function EmbeddedUsbSetup({ frame }: { frame: FrameType }): JSX.Element |
 
   const busy = statusBusy || scanBusy || applyBusy || restartBusy || factoryResetBusy
   const frameName = frame.name || frameHost(frame)
+  const cloudManaged = isEsp32CloudFrame(frame)
 
   const refreshStatus = async (): Promise<void> => {
     setStatusBusy(true)
@@ -162,9 +164,17 @@ export function EmbeddedUsbSetup({ frame }: { frame: FrameType }): JSX.Element |
   }
 
   const factoryReset = async (): Promise<void> => {
+    // A reset is `nvs_erase_all` on the whole frameos namespace (fos_config.c),
+    // which takes the cloud enrollment with it — cloud_url, cloud_fid and the
+    // device token all live there. On a cloud-managed frame that is not a
+    // reset but an unlink: the row here keeps existing with nothing behind it,
+    // and the board can only come back through a fresh enrollment. Say so
+    // instead of listing "Wi-Fi, backend and hardware settings".
     if (
       !window.confirm(
-        `Factory reset "${frameName}"? This erases the device's Wi-Fi, backend and hardware settings and reboots it. This cannot be undone.`
+        cloudManaged
+          ? `Factory reset "${frameName}"? This erases everything the board has stored — Wi-Fi, hardware settings AND its enrollment in this account. It will NOT come back as this frame: you have to flash and enroll it again from "Add frame", and this frame row is left behind empty. To install new firmware, use "Update over USB" instead — that keeps the enrollment. This cannot be undone.`
+          : `Factory reset "${frameName}"? This erases the device's Wi-Fi, backend and hardware settings and reboots it. This cannot be undone.`
       )
     ) {
       return
@@ -176,7 +186,11 @@ export function EmbeddedUsbSetup({ frame }: { frame: FrameType }): JSX.Element |
       await usbFactoryReset(frame.id)
       setStatus(null)
       setNetworks(null)
-      setMessage('Factory reset complete. The device erased its settings and rebooted.')
+      setMessage(
+        cloudManaged
+          ? 'Factory reset complete. The device erased its settings — including its enrollment — and rebooted. Enroll it again from "Add frame"; this frame row no longer has a device behind it.'
+          : 'Factory reset complete. The device erased its settings and rebooted.'
+      )
     } catch (resetError) {
       setError(`Factory reset failed: ${errorDetail(resetError)}`)
     } finally {
@@ -364,6 +378,12 @@ export function EmbeddedUsbSetup({ frame }: { frame: FrameType }): JSX.Element |
               {factoryResetBusy ? 'Resetting' : 'Factory reset'}
             </button>
           </div>
+          {cloudManaged ? (
+            <div className="frame-tool-muted text-xs leading-4">
+              A factory reset also erases the board's enrollment, so it stops being this frame and has to be enrolled
+              again. To install new firmware without losing that, use “Update over USB” under Firmware.
+            </div>
+          ) : null}
 
           {message ? <div className="text-xs font-semibold text-green-600">{message}</div> : null}
           {error ? <div className="text-xs font-semibold text-red-500">{error}</div> : null}

--- a/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
@@ -21,14 +21,14 @@ import type { FrameType, FrameId } from '../../types'
 import { apiFetch } from '../../utils/apiFetch'
 import { workspaceLogic } from './workspaceLogic'
 
-type FlashPhase = 'idle' | 'connecting' | 'preparing' | 'flashing' | 'done' | 'error'
+export type FlashPhase = 'idle' | 'connecting' | 'preparing' | 'flashing' | 'done' | 'error'
 type EspFlashSize = '4MB' | '8MB' | '16MB' | '32MB'
-type FlashLogTerminal = IEspLoaderTerminal & { flush: () => void }
+export type FlashLogTerminal = IEspLoaderTerminal & { flush: () => void }
 type TraceableTransportInternals = { trace: (message: string) => void; lastTraceTime?: number }
 
 const FIRMWARE_POLL_INTERVAL_MS = 3000
 const FIRMWARE_POLL_TIMEOUT_MS = 10 * 60 * 1000
-const POST_FLASH_BOOT_WAIT_MS = 7000
+export const POST_FLASH_BOOT_WAIT_MS = 7000
 // First boot after an erase-all flash formats the 24MB SPIFFS state
 // partition before the console starts — measured ~180s on a XIAO ESP32-S3
 // with 32MB flash. Wait well past that.
@@ -40,7 +40,7 @@ const POST_FLASH_SCENE_UPLOAD_ATTEMPTS = 3
 const POST_FLASH_SCENE_UPLOAD_RETRY_MS = 3000
 const ESP_FLASH_SIZES = new Set<EspFlashSize>(['4MB', '8MB', '16MB', '32MB'])
 
-function sleep(ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
@@ -59,7 +59,7 @@ const S3_RTC_WDT_RESET_CONFIG = (0x80000000 | (5 << 28) | (1 << 8) | 2) >>> 0
 // some boards (XIAO ESP32-S3) latches the chip back into ROM download mode so
 // the app never boots after flashing (arduino-esp32#6762). The watchdog reset
 // runs over the flasher-stub protocol and never touches the strap pins.
-async function watchdogResetAfterFlash(loader: ESPLoader): Promise<boolean> {
+export async function watchdogResetAfterFlash(loader: ESPLoader): Promise<boolean> {
   if (loader.chip?.CHIP_NAME !== 'ESP32-S3') {
     return false
   }
@@ -84,7 +84,7 @@ async function watchdogResetAfterFlash(loader: ESPLoader): Promise<boolean> {
 
 type FirmwareStatus = NonNullable<NonNullable<FrameType['embedded']>['firmware']>
 
-function appendBrowserFlashLog(frameId: FrameId, message: string): void {
+export function appendBrowserFlashLog(frameId: FrameId, message: string): void {
   appendEmbeddedUsbLogLine(frameId, `[browser flash] ${message}`)
 }
 
@@ -124,7 +124,7 @@ function flashTraceLogMessage(message: string): string | null {
   return message
 }
 
-function createUsbLogTerminal(frameId: FrameId): FlashLogTerminal {
+export function createUsbLogTerminal(frameId: FrameId): FlashLogTerminal {
   let pendingLine = ''
   let flushTimer: ReturnType<typeof window.setTimeout> | null = null
 
@@ -173,7 +173,7 @@ function createUsbLogTerminal(frameId: FrameId): FlashLogTerminal {
   }
 }
 
-function mirrorTransportTrace(frameId: FrameId, transport: EspTransport): void {
+export function mirrorTransportTrace(frameId: FrameId, transport: EspTransport): void {
   const traceableTransport = transport as unknown as TraceableTransportInternals
   const originalTrace = traceableTransport.trace.bind(traceableTransport)
   traceableTransport.trace = (message: string): void => {
@@ -341,17 +341,20 @@ function usbStatusSummary(text: string | undefined): string {
 // Returns the port the board answered on: the watchdog reset after flashing
 // re-enumerates the USB device, so the original SerialPort object may have
 // been replaced by a fresh grant from getPorts().
-async function waitForUsbApiReadyAfterFlash(
+export async function waitForUsbApiReadyAfterFlash(
   frame: FrameType,
   port: SerialPort,
-  onStatus: (message: string) => void
+  onStatus: (message: string) => void,
+  // The storage-format warning is specific to a flash that wiped the state
+  // partition; a flow that kept it (the USB firmware update) says so instead.
+  initialMessage = 'Waiting for board USB API. A brand-new or fully erased board formats its storage first (~3 minutes).'
 ): Promise<SerialPort> {
   const started = Date.now()
   const deadline = started + POST_FLASH_USB_READY_TIMEOUT_MS
   let attempt = 0
   let lastError: unknown = null
   let resetHintShown = false
-  onStatus('Waiting for board USB API. A brand-new or fully erased board formats its storage first (~3 minutes).')
+  onStatus(initialMessage)
 
   while (Date.now() < deadline) {
     attempt += 1

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -63,6 +63,7 @@ import { buildRemoteUpgradeNotice, frameosGitHubReleaseUrl, type RemoteUpgradeNo
 import { frameCompilationModeOptions } from '../../utils/frameBuildOptions'
 import { logsLogic } from '../frame/panels/Logs/logsLogic'
 import { settingsLogic } from '../settings/settingsLogic'
+import { EmbeddedUsbFirmwareUpdate } from './EmbeddedUsbFirmwareUpdate'
 import { EmbeddedUsbSetup } from './EmbeddedUsbSetup'
 import { EmbeddedWebFlasher } from './EmbeddedWebFlasher'
 import { frameBootstrapLogic } from './frameBootstrapLogic'
@@ -2019,8 +2020,13 @@ function EmbeddedFirmwareSection({
  *   1. Push scenes      the settings push + one checksummed set_scenes
  *                       (frameLogic's cloudSaveAndDeploy) — the footer's
  *                       primary button.
- *   2. Update firmware  notify_update_available; the device fetches and
- *                       signature-verifies the image itself.
+ *   2. Update firmware  two paths to the same released image:
+ *                       notify_update_available over the wire (the device
+ *                       fetches and signature-verifies it itself), and
+ *                       EmbeddedUsbFirmwareUpdate over WebSerial for a board
+ *                       plugged into this computer — the latter also being
+ *                       the only route for a board that cannot reach the
+ *                       network.
  *   3. USB setup        WebSerial provisioning for esp32 boards, the same
  *                       component the backend's embedded view mounts. It
  *                       speaks only to the serial port, so it works
@@ -2028,11 +2034,13 @@ function EmbeddedFirmwareSection({
  *                       API at all — and it is the only way to fix the Wi-Fi
  *                       credentials of a board that cannot reach the cloud.
  *
- * Deliberately absent: the firmware BUILD/flash controls
- * (EmbeddedWebFlasher, OTA-from-this-backend, esptool command, footprint
- * chart). Those all read frame.embedded.firmware, which the backend builds
- * and cloud frames do not have. Re-flashing an enrolled cloud board also
- * needs a claim token bound to the existing frame — see docs/todo.md.
+ * Deliberately absent: the firmware BUILD controls (EmbeddedWebFlasher,
+ * OTA-from-this-backend, esptool command, footprint chart). Those all read
+ * frame.embedded.firmware, which the backend builds and cloud frames do not
+ * have — the cloud only ever installs published release binaries. Re-ENROLLING
+ * an already-enrolled board (moving it to another account, or recovering a
+ * blanked NVS) still needs a claim token bound to the existing frame; see
+ * docs/todo.md. Updating one does not: the USB updater writes around the NVS.
  */
 function CloudDeploySection({ frame }: { frame: FrameType }): JSX.Element {
   const { frameForm, unsavedChangeDetails } = useValues(frameLogic({ frameId: frame.id }))
@@ -2069,24 +2077,42 @@ function CloudDeploySection({ frame }: { frame: FrameType }): JSX.Element {
           />
         </div>
       </section>
-      {canUpdateFirmware ? (
+      {isEsp32 ? (
         <section className="space-y-2">
           <DrawerHeading>Firmware</DrawerHeading>
-          <div className="frame-tool-card flex flex-wrap items-start justify-between gap-3 rounded-[22px] p-4">
-            <div className="frame-tool-muted min-w-0 flex-1 text-sm leading-5">
-              Ask the frame to check for new firmware and install it in the background. The device downloads the image
-              and verifies its signature itself.
+          {canUpdateFirmware ? (
+            <div className="frame-tool-card flex flex-wrap items-start justify-between gap-3 rounded-[22px] p-4">
+              <div className="frame-tool-muted min-w-0 flex-1 text-sm leading-5">
+                <span className="font-semibold text-[color:var(--tool-strong)]">Over the air.</span> Ask the frame to
+                check for new firmware and install it in the background. The device downloads the image and verifies its
+                signature itself. It needs to be online and reachable.
+              </div>
+              <button
+                type="button"
+                title={firmwareDisabledReason ?? 'Queue a firmware update notification'}
+                disabled={Boolean(firmwareDisabledReason)}
+                onClick={() => updateFrameFirmware(frame.id)}
+                className="frameos-secondary-button inline-flex shrink-0 items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40"
+              >
+                <CloudArrowDownIcon className="h-4 w-4" />
+                Update firmware
+              </button>
             </div>
-            <button
-              type="button"
-              title={firmwareDisabledReason ?? 'Queue a firmware update notification'}
-              disabled={Boolean(firmwareDisabledReason)}
-              onClick={() => updateFrameFirmware(frame.id)}
-              className="frameos-secondary-button inline-flex shrink-0 items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40"
-            >
-              <CloudArrowDownIcon className="h-4 w-4" />
-              Update firmware
-            </button>
+          ) : null}
+          {/* The USB path, for a board that is plugged into this computer:
+              writes the published image around the settings partition, so the
+              frame keeps its Wi-Fi and its cloud enrollment and comes back as
+              itself. Works on a board that cannot reach the network at all —
+              which is exactly when the OTA nudge above cannot help. */}
+          {/* Stacked, not side by side like the OTA row: this control grows a
+              progress bar and status lines while it runs. */}
+          <div className="frame-tool-card space-y-3 rounded-[22px] p-4">
+            <div className="frame-tool-muted text-sm leading-5">
+              <span className="font-semibold text-[color:var(--tool-strong)]">Over USB.</span> Flash the latest released
+              firmware straight from this browser. The frame keeps its Wi-Fi credentials, its settings and its link to
+              this account — no re-enrollment, and no network needed.
+            </div>
+            <EmbeddedUsbFirmwareUpdate frame={frame} />
           </div>
         </section>
       ) : null}
@@ -2538,11 +2564,7 @@ export function FrameDeployPlanDrawer({ frame }: { frame: FrameType }): JSX.Elem
               {!isEmbeddedFrame || embeddedFullDeploySupported ? (
                 <button
                   type="button"
-                  title={
-                    isEmbeddedFrame
-                      ? 'Rebuild the firmware and update the frame over the air (OTA)'
-                      : undefined
-                  }
+                  title={isEmbeddedFrame ? 'Rebuild the firmware and update the frame over the air (OTA)' : undefined}
                   onClick={() => closeAndRun(saveAndFullDeployFrame)}
                   className={clsx(
                     'rounded-lg px-4 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',

--- a/frontend/src/scenes/workspace/embeddedFlashImage.ts
+++ b/frontend/src/scenes/workspace/embeddedFlashImage.ts
@@ -1,0 +1,148 @@
+/**
+ * ESP32 partition-table parsing and the "keep the NVS" write plan.
+ *
+ * A released FrameOS ESP32 image (`frameos-<version>-esp32-s3-generic.bin`) is
+ * the MERGED image `idf.py merge-bin` writes: one contiguous file from 0x0
+ * holding the bootloader, the partition table, a blank otadata and the app,
+ * with 0xFF padding in between. Flashing all of it at 0x0 — what the
+ * enrollment flasher does — therefore also writes 0xFF over the NVS partition,
+ * which is where the board keeps its Wi-Fi credentials AND its cloud
+ * enrollment (cloud_url, cloud_fid, cloud_token; fos_cloud.c). That is fine
+ * when the board is being enrolled, and destructive when it already belongs to
+ * a frame: the device would come back as a stranger and the account would end
+ * up with an orphaned frame row.
+ *
+ * Updating the firmware of an enrolled board therefore writes everything in
+ * that image EXCEPT the NVS range, in two chunks around it. The partition
+ * table sits inside the image, so the range is read out of the image itself
+ * rather than assumed — and the caller cross-checks it against the table
+ * actually on the device before writing anything.
+ */
+
+export interface Esp32Partition {
+  name: string
+  type: number
+  subtype: number
+  offset: number
+  size: number
+}
+
+export interface FlashSegment {
+  address: number
+  data: Uint8Array
+}
+
+export interface FirmwareUpdateWritePlan {
+  /** The NVS partition left untouched by this plan. */
+  preserved: Esp32Partition
+  segments: FlashSegment[]
+  totalBytes: number
+}
+
+/** Where `idf.py` always puts the partition table on ESP32 targets. */
+export const ESP32_PARTITION_TABLE_OFFSET = 0x8000
+export const ESP32_PARTITION_TABLE_SIZE = 0x1000
+/** Smallest erasable unit: every written range must be a multiple of this. */
+export const ESP32_FLASH_SECTOR_SIZE = 0x1000
+
+// esp_partition_info_t (esp_partition.h): magic, type, subtype, offset, size,
+// 16-byte label, flags — 32 bytes per entry. The table ends at the first
+// non-magic entry; the generator appends an 0xEBEB md5 entry there.
+const PARTITION_ENTRY_MAGIC = 0x50aa
+const PARTITION_ENTRY_SIZE = 32
+const PARTITION_TYPE_DATA = 0x01
+const PARTITION_SUBTYPE_NVS = 0x02
+
+export function parseEsp32PartitionTable(table: Uint8Array): Esp32Partition[] {
+  const view = new DataView(table.buffer, table.byteOffset, table.byteLength)
+  const partitions: Esp32Partition[] = []
+  for (let offset = 0; offset + PARTITION_ENTRY_SIZE <= table.byteLength; offset += PARTITION_ENTRY_SIZE) {
+    if (view.getUint16(offset, true) !== PARTITION_ENTRY_MAGIC) {
+      break
+    }
+    const labelBytes = table.subarray(offset + 12, offset + 28)
+    const terminator = labelBytes.indexOf(0)
+    partitions.push({
+      name: new TextDecoder().decode(terminator === -1 ? labelBytes : labelBytes.subarray(0, terminator)),
+      type: view.getUint8(offset + 2),
+      subtype: view.getUint8(offset + 3),
+      offset: view.getUint32(offset + 4, true),
+      size: view.getUint32(offset + 8, true),
+    })
+  }
+  return partitions
+}
+
+export function esp32NvsPartition(partitions: readonly Esp32Partition[]): Esp32Partition | undefined {
+  return partitions.find(
+    (partition) => partition.type === PARTITION_TYPE_DATA && partition.subtype === PARTITION_SUBTYPE_NVS
+  )
+}
+
+/** The partition table carried inside a merged flash image, or []. */
+export function partitionTableFromMergedImage(image: Uint8Array): Esp32Partition[] {
+  if (image.byteLength < ESP32_PARTITION_TABLE_OFFSET + ESP32_PARTITION_TABLE_SIZE) {
+    return []
+  }
+  return parseEsp32PartitionTable(
+    image.subarray(ESP32_PARTITION_TABLE_OFFSET, ESP32_PARTITION_TABLE_OFFSET + ESP32_PARTITION_TABLE_SIZE)
+  )
+}
+
+/**
+ * Split a merged image into the chunks to write around its NVS partition.
+ * Throws rather than guessing: a plan that cannot prove where the NVS is would
+ * silently un-enroll the board it is supposed to update.
+ */
+export function firmwareUpdateWritePlan(image: Uint8Array): FirmwareUpdateWritePlan {
+  const partitions = partitionTableFromMergedImage(image)
+  if (partitions.length === 0) {
+    throw new Error(
+      'This firmware image has no readable partition table, so its settings partition cannot be spared. ' +
+        'Flash it from the "Add frame" panel instead — that enrolls the board from scratch.'
+    )
+  }
+  const nvs = esp32NvsPartition(partitions)
+  if (!nvs) {
+    throw new Error("This firmware image declares no NVS partition, so the frame's settings cannot be preserved.")
+  }
+  if (nvs.offset % ESP32_FLASH_SECTOR_SIZE !== 0 || nvs.size % ESP32_FLASH_SECTOR_SIZE !== 0) {
+    throw new Error("The firmware image's NVS partition is not flash-sector aligned; refusing to flash around it.")
+  }
+  if (nvs.offset >= image.byteLength) {
+    throw new Error('The firmware image is shorter than its own partition table claims.')
+  }
+
+  const segments: FlashSegment[] = []
+  const head = image.subarray(0, nvs.offset)
+  if (head.byteLength > 0) {
+    segments.push({ address: 0, data: head })
+  }
+  const tailStart = nvs.offset + nvs.size
+  if (tailStart < image.byteLength) {
+    segments.push({ address: tailStart, data: image.subarray(tailStart) })
+  }
+  if (segments.length === 0) {
+    throw new Error('The firmware image contains nothing to write outside its NVS partition.')
+  }
+
+  return {
+    preserved: nvs,
+    segments,
+    totalBytes: segments.reduce((total, segment) => total + segment.data.byteLength, 0),
+  }
+}
+
+/**
+ * Whether the layout on the device matches the one in the image being written.
+ * The NVS is only preserved if the two tables agree about where it lives —
+ * writing an 8MB-layout image onto a board partitioned for 16MB would move the
+ * hole and wipe the credentials it was meant to protect.
+ */
+export function deviceLayoutMatchesPlan(
+  devicePartitions: readonly Esp32Partition[],
+  plan: FirmwareUpdateWritePlan
+): boolean {
+  const deviceNvs = esp32NvsPartition(devicePartitions)
+  return Boolean(deviceNvs && deviceNvs.offset === plan.preserved.offset && deviceNvs.size === plan.preserved.size)
+}


### PR DESCRIPTION
Reported from the deploy drawer of a USB-connected cloud ESP32 frame: nothing there offers a firmware upgrade, the primary button is "Push scenes", "Update firmware" (OTA) does not appear to work, and factory reset "did something weird". All three turned out to be real, and separate.

## 1. Cloud OTA could never have succeeded

The release publishes one ESP32 artifact per platform — `merged-binary.bin`, renamed `frameos-<v>-esp32-s3-generic.bin`. That is the whole flash from `0x0`: bootloader, partition table, blank otadata, app at `0x10000`. The device-authed manifest/download routes handed exactly that file to `esp_ota_write`.

An OTA slot accepts only a **bare app image**: `esp_ota_end` validates an `esp_app_desc` at offset `0x20`, and a merged image has the bootloader there. Confirmed against the published v2026.8.12 asset — `0x0` is an IDF bootloader header, the app descriptor magic only appears at `0x10000`.

The self-hosted backend already gets this right (`embedded_device.py`: *"the OTA app image (`frameos_esp32.bin`), not the merged flash image"*). The cloud path never did, on any release.

- the release job now also copies and signs `…-esp32-s3-generic-app.bin` (plus the C3 one, for symmetry — the 4MB layout has no OTA slot)
- `otaAssets` in `firmware-release.ts`; manifest + download serve the app image
- a release without one answers `ota_image_not_published` (404) rather than falling back to an image the device can only reject after downloading several MB

**This takes effect with the next release.** Until then cloud OTA stays a no-op, which is what §2 is for.

## 2. "Update over USB" for an already-enrolled board

`docs/todo.md` withheld a flash button because `Esp32CloudFlasher` always mints a fresh claim token and watches for a *new* frame id, so pointing it at an enrolled board forks a duplicate row. True — but that is about **re-enrolling**, not updating.

Flashing the merged image at `0x0` blanks the NVS with its own `0xFF` padding, and the NVS is where the board keeps its Wi-Fi credentials *and* `cloud_url` / `cloud_fid` / `cloud_token`. So the new Firmware → **Update over USB** writes everything in the image **except** that range:

- `embeddedFlashImage.ts` parses the partition table out of the image itself (it is right there at `0x8000`), finds the NVS, and splits the write into `[0, nvs)` and `[nvs_end, end)`
- the second segment still covers otadata, so the board boots the slot that was just written instead of an older OTA slot
- the board's own table is read back over the stub and compared; a layout mismatch refuses the update rather than putting the hole in the wrong place
- the SPIFFS state partition sits past the image, so scenes and assets survive too

No claim token, no new frame row, no network needed — the frame reboots on the new firmware and reconnects as itself.

## 3. Factory reset is an unlink, not a reset

`fos_config_erase()` is `nvs_erase_all` over the whole `frameos` namespace, cloud enrollment included. On a cloud frame that permanently orphans the row and the board can only return through a fresh enrollment. The dialog claimed it "erases the device's Wi-Fi, backend and hardware settings". It now says what actually happens and points at the USB updater as the non-destructive option.

## Also

- the console's `ota` / `usb-api ota` always took the *backend* OTA path, which on a cloud frame can only answer `ESP_ERR_INVALID_STATE` — it now picks the control plane the board actually belongs to, so a cloud OTA can be triggered and watched live over serial
- a 404 manifest logs `no-image-published` instead of the generic `manifest-unavailable`
- the OTA route tests mocked GitHub but not `devFirmwareOverride`, so a local `.dev-firmware/` directory silently rewrote every expectation (7 failures on a clean checkout of `main`, on any machine that has one). Both suites now mock it, and the dev-override path is pinned by its own test.

## Verification

- frontend + auth-web typecheck clean
- 455 auth-web tests pass, including new write-plan unit tests and a regression test that the OTA routes never serve the merged image
- both changed C files compile with the real Xtensa toolchain (ESP-IDF v5.5.4)
- **not** verified: an actual flash on hardware, and the integration test (needs Postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)