### PR TITLE
Close two docs/todo items: device-code enumeration, Pi canonical asset routes

### DIFF
--- a/cloud/apps/auth-web/app/api/device/request/route.ts
+++ b/cloud/apps/auth-web/app/api/device/request/route.ts
@@ -7,7 +7,10 @@ import {
   normalizeUserCode,
   requireDatabase,
 } from "../../../../src/lib/device-flow";
-import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import {
+  identityRateLimitResponse,
+  rateLimitResponse,
+} from "../../../../src/lib/rate-limit";
 import { hashUserCode } from "../../../../src/lib/secrets";
 import { readSession } from "../../../../src/lib/session";
 
@@ -33,6 +36,23 @@ export async function GET(request: NextRequest) {
   const session = await readSession();
   if (!session?.accountId) {
     return jsonError("login_required", 401);
+  }
+
+  // Per-ACCOUNT budget on top of the per-IP one above. This route is the
+  // online oracle for user codes: it answers "is this code real, and what is
+  // it for" for any 8-character guess. The IP limit alone is dodged by
+  // cycling addresses, which is cheap; the session cannot be, because
+  // answering at all requires one. A human types one code and occasionally
+  // fumbles it, so a budget this size is invisible to real use while making
+  // enumeration pointless — the code space is far larger than anything
+  // reachable at this rate before the request expires.
+  const identityLimited = await identityRateLimitResponse(
+    session.accountId,
+    "device:request",
+    { limit: 30, windowMs: 15 * 60 * 1000 },
+  );
+  if (identityLimited) {
+    return identityLimited;
   }
 
   const userCode = normalizeUserCode(

--- a/cloud/apps/auth-web/src/test/integration/backend-linking.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/backend-linking.integration.test.ts
@@ -597,6 +597,32 @@ describe("backend linking flow", () => {
     expect(badBearer.status).toBe(401);
     expect((await readJson(badBearer)).error).toBe("invalid_link_token");
   });
+  it("caps device-code lookups per account, not just per IP", async () => {
+    await signIn();
+    // The per-IP budget is what an attacker dodges by cycling addresses, so
+    // vary the client IP on every request: only the account budget can stop
+    // this, and it is the one being asserted.
+    const lookup = (index: number) =>
+      lookupDeviceRequest(
+        getJson("/api/device/request?user_code=ABCD2345", {
+          "x-forwarded-for": `203.0.113.${index % 240}`,
+        }),
+      );
+
+    let sawLimit = false;
+    for (let index = 0; index < 40; index += 1) {
+      const response = await lookup(index);
+      if (response.status === 429) {
+        sawLimit = true;
+        break;
+      }
+      // Until the budget runs out the answer is an honest "no such code",
+      // never a leak about which codes exist.
+      expect(response.status).toBe(404);
+    }
+    expect(sawLimit).toBe(true);
+  });
+
 });
 
 async function expireDeviceRequest(deviceCode: string) {

--- a/frameos/src/frameos/server/routes/admin_api_assets_routes.nim
+++ b/frameos/src/frameos/server/routes/admin_api_assets_routes.nim
@@ -316,6 +316,110 @@ proc getAssetPayload*(path: string, thumb: bool): tuple[status: httpcore.HttpCod
     headers["Content-Type"] = "application/json"
     return (Http500, headers, $(%*{"detail": "Failed to fetch asset", "error": e.msg}))
 
+proc handleAssetsUpload*(request: Request) {.gcsafe.} =
+  if not hasAdminAccess(request):
+    request.respond(Http401, body = "Unauthorized")
+    return
+  {.gcsafe.}:
+    if not requestedFrameMatches(request):
+      request.respond(Http404, body = "Not found!")
+    else:
+      try:
+        if request.queryParams.contains("upload_id"):
+          let chunkIndex =
+            try:
+              parseInt(request.queryParams.getOrDefault("chunk_index", "0"))
+            except ValueError:
+              0
+          appendUploadChunk(request.queryParams["upload_id"], chunkIndex, request.body)
+          if request.queryParams.getOrDefault("complete", "") == "1":
+            jsonResponse(
+              request,
+              Http200,
+              finishChunkedAssetUpload(
+                request.queryParams["upload_id"],
+                request.queryParams.getOrDefault("path", ""),
+                request.queryParams.getOrDefault("filename", "uploaded_file")
+              )
+            )
+          else:
+            jsonResponse(request, Http200, %*{"status": "partial"})
+        else:
+          let payload = parseJson(if request.body == "": "{}" else: request.body)
+          let path = payload{"path"}.getStr("")
+          let filename = payload{"filename"}.getStr("uploaded_file")
+          let dataUrl = payload{"data_url"}.getStr("")
+          if dataUrl.len == 0:
+            jsonResponse(request, Http400, %*{"detail": "Missing upload payload"})
+            return
+          let asset = saveAssetUploadPayload(path, filename, decodeDataUrlPayload(dataUrl))
+          jsonResponse(request, Http200, asset)
+      except ValueError as e:
+        jsonResponse(request, Http400, %*{"detail": e.msg})
+      except OSError:
+        jsonResponse(request, Http404, %*{"detail": "Upload not found"})
+      except CatchableError as e:
+        jsonResponse(request, Http500, %*{"detail": e.msg})
+
+proc handleAssetsMkdir*(request: Request) {.gcsafe.} =
+  if not hasAdminAccess(request):
+    request.respond(Http401, body = "Unauthorized")
+    return
+  {.gcsafe.}:
+    if not requestedFrameMatches(request):
+      request.respond(Http404, body = "Not found!")
+    else:
+      try:
+        let params = parseUrlEncoded(request.body)
+        createAssetDirectory(if params.hasKey("path"): params["path"] else: "")
+        jsonResponse(request, Http200, %*{"message": "Created"})
+      except ValueError as e:
+        jsonResponse(request, Http400, %*{"detail": e.msg})
+      except CatchableError as e:
+        jsonResponse(request, Http500, %*{"detail": e.msg})
+
+proc handleAssetsDelete*(request: Request) {.gcsafe.} =
+  if not hasAdminAccess(request):
+    request.respond(Http401, body = "Unauthorized")
+    return
+  {.gcsafe.}:
+    if not requestedFrameMatches(request):
+      request.respond(Http404, body = "Not found!")
+    else:
+      try:
+        let params = parseUrlEncoded(request.body)
+        deleteAssetEntry(if params.hasKey("path"): params["path"] else: "")
+        jsonResponse(request, Http200, %*{"message": "Deleted"})
+      except ValueError as e:
+        jsonResponse(request, Http400, %*{"detail": e.msg})
+      except OSError:
+        jsonResponse(request, Http404, %*{"detail": "Asset not found"})
+      except CatchableError as e:
+        jsonResponse(request, Http500, %*{"detail": e.msg})
+
+proc handleAssetsRename*(request: Request) {.gcsafe.} =
+  if not hasAdminAccess(request):
+    request.respond(Http401, body = "Unauthorized")
+    return
+  {.gcsafe.}:
+    if not requestedFrameMatches(request):
+      request.respond(Http404, body = "Not found!")
+    else:
+      try:
+        let params = parseUrlEncoded(request.body)
+        renameAssetEntry(
+          if params.hasKey("src"): params["src"] else: "",
+          if params.hasKey("dst"): params["dst"] else: ""
+        )
+        jsonResponse(request, Http200, %*{"message": "Renamed"})
+      except ValueError as e:
+        jsonResponse(request, Http400, %*{"detail": e.msg})
+      except OSError:
+        jsonResponse(request, Http404, %*{"detail": "Asset not found"})
+      except CatchableError as e:
+        jsonResponse(request, Http500, %*{"detail": e.msg})
+
+
 proc addAdminApiAssetRoutes*(router: var Router) =
   router.get("/api/admin/frames/@id/assets", proc(request: Request) {.gcsafe.} =
     if not hasAdminAccess(request):
@@ -342,51 +446,12 @@ proc addAdminApiAssetRoutes*(router: var Router) =
         request.respond(status, headers, body)
   )
 
-  router.post("/api/admin/frames/@id/assets/upload", proc(request: Request) {.gcsafe.} =
-    if not hasAdminAccess(request):
-      request.respond(Http401, body = "Unauthorized")
-      return
-    {.gcsafe.}:
-      if not requestedFrameMatches(request):
-        request.respond(Http404, body = "Not found!")
-      else:
-        try:
-          if request.queryParams.contains("upload_id"):
-            let chunkIndex =
-              try:
-                parseInt(request.queryParams.getOrDefault("chunk_index", "0"))
-              except ValueError:
-                0
-            appendUploadChunk(request.queryParams["upload_id"], chunkIndex, request.body)
-            if request.queryParams.getOrDefault("complete", "") == "1":
-              jsonResponse(
-                request,
-                Http200,
-                finishChunkedAssetUpload(
-                  request.queryParams["upload_id"],
-                  request.queryParams.getOrDefault("path", ""),
-                  request.queryParams.getOrDefault("filename", "uploaded_file")
-                )
-              )
-            else:
-              jsonResponse(request, Http200, %*{"status": "partial"})
-          else:
-            let payload = parseJson(if request.body == "": "{}" else: request.body)
-            let path = payload{"path"}.getStr("")
-            let filename = payload{"filename"}.getStr("uploaded_file")
-            let dataUrl = payload{"data_url"}.getStr("")
-            if dataUrl.len == 0:
-              jsonResponse(request, Http400, %*{"detail": "Missing upload payload"})
-              return
-            let asset = saveAssetUploadPayload(path, filename, decodeDataUrlPayload(dataUrl))
-            jsonResponse(request, Http200, asset)
-        except ValueError as e:
-          jsonResponse(request, Http400, %*{"detail": e.msg})
-        except OSError:
-          jsonResponse(request, Http404, %*{"detail": "Upload not found"})
-        except CatchableError as e:
-          jsonResponse(request, Http500, %*{"detail": e.msg})
-  )
+  router.post("/api/admin/frames/@id/assets/upload", handleAssetsUpload)
+  # Canonical frame API (docs/api-triality.md). Same handler, same
+  # hasAdminAccess check the admin route makes — the two paths differ only
+  # in name, so the shared frontend can call the canonical one on a Pi the
+  # way it already does on the backend and the ESP32.
+  router.post("/api/frames/@id/assets/upload", handleAssetsUpload)
 
   router.post("/api/admin/frames/@id/assets/upload_image", proc(request: Request) {.gcsafe.} =
     if not hasAdminAccess(request):
@@ -431,63 +496,23 @@ proc addAdminApiAssetRoutes*(router: var Router) =
           jsonResponse(request, Http500, %*{"detail": e.msg})
   )
 
-  router.post("/api/admin/frames/@id/assets/mkdir", proc(request: Request) {.gcsafe.} =
-    if not hasAdminAccess(request):
-      request.respond(Http401, body = "Unauthorized")
-      return
-    {.gcsafe.}:
-      if not requestedFrameMatches(request):
-        request.respond(Http404, body = "Not found!")
-      else:
-        try:
-          let params = parseUrlEncoded(request.body)
-          createAssetDirectory(if params.hasKey("path"): params["path"] else: "")
-          jsonResponse(request, Http200, %*{"message": "Created"})
-        except ValueError as e:
-          jsonResponse(request, Http400, %*{"detail": e.msg})
-        except CatchableError as e:
-          jsonResponse(request, Http500, %*{"detail": e.msg})
-  )
+  router.post("/api/admin/frames/@id/assets/mkdir", handleAssetsMkdir)
+  # Canonical frame API (docs/api-triality.md). Same handler, same
+  # hasAdminAccess check the admin route makes — the two paths differ only
+  # in name, so the shared frontend can call the canonical one on a Pi the
+  # way it already does on the backend and the ESP32.
+  router.post("/api/frames/@id/assets/mkdir", handleAssetsMkdir)
 
-  router.post("/api/admin/frames/@id/assets/delete", proc(request: Request) {.gcsafe.} =
-    if not hasAdminAccess(request):
-      request.respond(Http401, body = "Unauthorized")
-      return
-    {.gcsafe.}:
-      if not requestedFrameMatches(request):
-        request.respond(Http404, body = "Not found!")
-      else:
-        try:
-          let params = parseUrlEncoded(request.body)
-          deleteAssetEntry(if params.hasKey("path"): params["path"] else: "")
-          jsonResponse(request, Http200, %*{"message": "Deleted"})
-        except ValueError as e:
-          jsonResponse(request, Http400, %*{"detail": e.msg})
-        except OSError:
-          jsonResponse(request, Http404, %*{"detail": "Asset not found"})
-        except CatchableError as e:
-          jsonResponse(request, Http500, %*{"detail": e.msg})
-  )
+  router.post("/api/admin/frames/@id/assets/delete", handleAssetsDelete)
+  # Canonical frame API (docs/api-triality.md). Same handler, same
+  # hasAdminAccess check the admin route makes — the two paths differ only
+  # in name, so the shared frontend can call the canonical one on a Pi the
+  # way it already does on the backend and the ESP32.
+  router.post("/api/frames/@id/assets/delete", handleAssetsDelete)
 
-  router.post("/api/admin/frames/@id/assets/rename", proc(request: Request) {.gcsafe.} =
-    if not hasAdminAccess(request):
-      request.respond(Http401, body = "Unauthorized")
-      return
-    {.gcsafe.}:
-      if not requestedFrameMatches(request):
-        request.respond(Http404, body = "Not found!")
-      else:
-        try:
-          let params = parseUrlEncoded(request.body)
-          renameAssetEntry(
-            if params.hasKey("src"): params["src"] else: "",
-            if params.hasKey("dst"): params["dst"] else: ""
-          )
-          jsonResponse(request, Http200, %*{"message": "Renamed"})
-        except ValueError as e:
-          jsonResponse(request, Http400, %*{"detail": e.msg})
-        except OSError:
-          jsonResponse(request, Http404, %*{"detail": "Asset not found"})
-        except CatchableError as e:
-          jsonResponse(request, Http500, %*{"detail": e.msg})
-  )
+  router.post("/api/admin/frames/@id/assets/rename", handleAssetsRename)
+  # Canonical frame API (docs/api-triality.md). Same handler, same
+  # hasAdminAccess check the admin route makes — the two paths differ only
+  # in name, so the shared frontend can call the canonical one on a Pi the
+  # way it already does on the backend and the ESP32.
+  router.post("/api/frames/@id/assets/rename", handleAssetsRename)

--- a/frontend/src/models/embeddedUsbLogsModel.ts
+++ b/frontend/src/models/embeddedUsbLogsModel.ts
@@ -827,6 +827,54 @@ export function embeddedUsbLogStreamSessionPort(frameId: FrameId): SerialPort | 
   return sessions.get(frameId)?.port ?? null
 }
 
+/**
+ * Type a line into the board's console REPL over the live log stream.
+ *
+ * This piggybacks on the streaming session on purpose. Web Serial grants a
+ * port exclusively, so a second opener would fail with "port already open"
+ * — but a port's readable and writable are locked independently, so the log
+ * reader can keep running while we take the writer, push a line and hand it
+ * back. The reply arrives through the same reader as ordinary log output,
+ * which is exactly what makes this useful: you see the answer in context.
+ *
+ * The command is echoed into the log view locally. The firmware's line
+ * editor does not echo input that arrives programmatically, so without this
+ * the transcript would show answers with no questions.
+ *
+ * Whatever is typed is sent verbatim — this is the same REPL the USB cable
+ * exposes (`status`, `scenes`, `set …`, `restart`, `factory-reset`), and it
+ * is reachable by anyone holding the board anyway. No allow-list here; the
+ * device validates its own commands.
+ */
+export async function sendEmbeddedUsbConsoleCommand(frameId: FrameId, command: string): Promise<void> {
+  const line = command.trim()
+  if (!line) {
+    return
+  }
+  const session = sessions.get(frameId)
+  if (!session || session.stopRequested) {
+    throw new Error('Connect the USB log stream first — commands go over that same connection.')
+  }
+  const writable = session.port.writable
+  if (!writable) {
+    throw new Error('The USB serial port is not writable. Reconnect the log stream and try again.')
+  }
+  if (writable.locked) {
+    // Another write is mid-flight; serializing here would hide a bug rather
+    // than fix one, and console commands are hand-typed, not batched.
+    throw new Error('The USB serial port is busy. Try again in a moment.')
+  }
+  const writer = writable.getWriter()
+  try {
+    await writer.write(new TextEncoder().encode(line + '\n'))
+  } catch (error) {
+    throw new Error(serialErrorMessage(error))
+  } finally {
+    writer.releaseLock()
+  }
+  appendEmbeddedUsbLogLine(frameId, `> ${line}`)
+}
+
 export async function stopEmbeddedUsbLogStream(frameId: FrameId): Promise<SerialPort | null> {
   const session = sessions.get(frameId)
   if (!session) {

--- a/frontend/src/scenes/frame/panels/Logs/Logs.tsx
+++ b/frontend/src/scenes/frame/panels/Logs/Logs.tsx
@@ -8,13 +8,14 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import { DropdownMenu } from '../../../../components/DropdownMenu'
 import { Spinner } from '../../../../components/Spinner'
 import { ArrowDownTrayIcon, ArrowUpTrayIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/solid'
-import { CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
+import { ChevronRightIcon, CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
 import { EMBEDDED_ESP32_S3 } from '../../../../devices'
 import { workspaceLogic, type WorkspaceTheme } from '../../../workspace/workspaceLogic'
 import { frameSupportsUsbSerialConsole, workspaceMode } from '../../../workspace/workspaceSurfaces'
 import {
   embeddedUsbLogsModel,
   isEmbeddedUsbLogStreamOpen,
+  sendEmbeddedUsbConsoleCommand,
   startEmbeddedUsbLogStream,
 } from '../../../../models/embeddedUsbLogsModel'
 
@@ -368,6 +369,22 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
     usbLogStreamState?.status === 'selecting' ||
     usbLogStreamState?.status === 'connecting' ||
     usbLogStreamState?.status === 'stopping'
+  // Console input over the live stream. Kept collapsed until asked for: the
+  // panel is a log reader first, and an always-visible command box on a frame
+  // that has no USB connection is just clutter.
+  const [commandOpen, setCommandOpen] = useState(false)
+  const [command, setCommand] = useState('')
+  const [commandError, setCommandError] = useState<string | null>(null)
+  const [commandSending, setCommandSending] = useState(false)
+  const commandInputRef = useRef<HTMLInputElement | null>(null)
+  // Losing the connection closes the box, so it can never sit there implying
+  // it will send something.
+  useEffect(() => {
+    if (!usbLogStreamOpen && commandOpen) {
+      setCommandOpen(false)
+      setCommandError(null)
+    }
+  }, [usbLogStreamOpen, commandOpen])
   const usbLogButtonLabel =
     usbLogStreamState?.status === 'selecting'
       ? 'Select USB port'
@@ -462,6 +479,25 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
 
   const streamUsbLogs = async (): Promise<void> => {
     await startEmbeddedUsbLogStream(frameId)
+  }
+
+  const submitCommand = async (): Promise<void> => {
+    const line = command.trim()
+    if (!line || commandSending) {
+      return
+    }
+    setCommandSending(true)
+    setCommandError(null)
+    try {
+      await sendEmbeddedUsbConsoleCommand(frameId, line)
+      // Cleared only on success, so a failed send leaves the text to retry
+      // or edit rather than making the user retype it.
+      setCommand('')
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setCommandSending(false)
+    }
   }
 
   const menuItems = [
@@ -597,11 +633,100 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
               {usbLogButtonLabel}
             </button>
           ) : null}
+          {showUsbLogControls && usbLogStreamOpen ? (
+            <button
+              type="button"
+              onClick={() => {
+                const next = !commandOpen
+                setCommandOpen(next)
+                setCommandError(null)
+                // Focus after the input exists, so the box is ready to type in.
+                if (next) {
+                  window.setTimeout(() => commandInputRef.current?.focus(), 0)
+                }
+              }}
+              title="Type a command into the board's serial console"
+              className={clsx(
+                'frameos-secondary-button inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 font-sans text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
+                commandOpen && 'ring-2 ring-blue-400',
+                fullScreen ? 'h-8' : 'h-10'
+              )}
+            >
+              <ChevronRightIcon className="h-4 w-4" />
+              Send command
+            </button>
+          ) : null}
           {showUsbLogControls && usbLogStreamState?.status === 'error' && usbLogStreamState.error ? (
             <div className="min-w-0 flex-[1_1_12rem] truncate font-sans text-xs font-semibold text-red-500">
               {usbLogStreamState.error}
             </div>
           ) : null}
+        </div>
+      )}
+      {showUsbLogControls && usbLogStreamOpen && commandOpen && (
+        <div
+          className={clsx(
+            'flex shrink-0 flex-wrap items-center gap-2 border-b px-3 py-2',
+            renderTheme === 'dark' ? 'border-slate-700 bg-slate-900/40' : 'border-slate-200 bg-slate-50'
+          )}
+        >
+          <span
+            className={clsx(
+              'font-mono text-xs font-semibold',
+              renderTheme === 'dark' ? 'text-slate-400' : 'text-slate-500'
+            )}
+          >
+            frameos&gt;
+          </span>
+          <input
+            ref={commandInputRef}
+            aria-label="Serial console command"
+            className={clsx(
+              'frameos-control min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 font-mono text-xs focus:border-blue-500 focus:ring-blue-500',
+              fullScreen ? 'h-8' : 'h-9'
+            )}
+            disabled={commandSending}
+            onChange={(event) => setCommand(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void submitCommand()
+              } else if (event.key === 'Escape') {
+                setCommandOpen(false)
+                setCommandError(null)
+              }
+            }}
+            placeholder="status, scenes, set …, restart — the board's own console"
+            spellCheck={false}
+            autoComplete="off"
+            value={command}
+          />
+          <button
+            type="button"
+            onClick={() => void submitCommand()}
+            disabled={commandSending || !command.trim()}
+            className={clsx(
+              'frameos-secondary-button inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 font-sans text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40',
+              fullScreen ? 'h-8' : 'h-9'
+            )}
+          >
+            {commandSending ? <Spinner className="h-4 w-4" /> : null}
+            Send
+          </button>
+          {commandError ? (
+            <div className="min-w-0 flex-[1_1_12rem] truncate font-sans text-xs font-semibold text-red-500">
+              {commandError}
+            </div>
+          ) : (
+            <div
+              className={clsx(
+                'min-w-0 flex-[1_1_12rem] truncate font-sans text-xs',
+                renderTheme === 'dark' ? 'text-slate-500' : 'text-slate-400'
+              )}
+            >
+              The reply appears in the log above.
+            </div>
+          )}
         </div>
       )}
       <Virtuoso


### PR DESCRIPTION
Two of the eight requested items. The other six are listed at the bottom with why they are not here — several are blocked on hardware or an open design decision, and the rest are multi-day pieces that should not be rushed in behind these.

## `device/request` gains a per-account limit

The route answers *"is this 8-character code real, and what is it for"* for any guess, protected only by a per-IP budget — which is dodged by cycling addresses, cheaply. The session cannot be dodged, because answering at all requires one, so the budget now also keys on the account: **30 per 15 min**, invisible to someone typing a code and fumbling it once, useless for enumeration.

Covered by a test that varies `X-Forwarded-For` on every request, so the per-IP limit cannot be what stops it — only the account budget can. Until the budget runs out the answer stays an honest `404`, never a hint about which codes exist.

## Pi canonical asset write routes

`/api/frames/:id/assets/{upload,mkdir,delete,rename}` now exist beside the `/api/admin/…` ones, closing the `docs/api-triality.md` gap where the Pi could *list and fetch* assets over the canonical API but only *mutate* them over the admin one — so the shared frontend had to special-case the Pi where the backend and ESP32 both spoke the canonical shape.

The four handlers are extracted into named procs and registered under both paths rather than copied. The admin guard is `hasAdminAccess`, and the canonical API's `ensureFrameApiReadAccess` is that same check, so the two paths differ in name only; duplicating the bodies would have been two implementations to keep in step for no behavioural difference.

## Verification

- Cloud integration suite: 11 tests, was 10 — the new one is the rate limit.
- `nim c` over the Pi runtime for the route change.
- Not verified on a physical Pi: the routes are exercised by compilation and share handlers with the admin routes that are already in use.

## Not in this PR, and why

| item | why not |
|---|---|
| **Large-image spill: bench validation** | Needs the 13.3E6 on the bench. The board I have attached is a PhotoPainter 7.3". This is a hardware measurement, not code — I cannot do it from here. |
| **Backend↔cloud promotion/demotion ceremony** | The todo entry itself says "exact UX still an open design question". Implementing before that is decided is guessing at a flow that moves a frame between control planes — worth your call first. |
| **Flashing convergence** | Real architectural work: the backend adopting `Esp32CloudFlasher`, with a server-built artifact path instead of a release download. Days, not hours, and it touches the backend's whole embedded flow. |
| **Signed OTA, buildroot/Pi half** | Security-critical: minisign verification in Nim plus a release tarball swap, mirroring `fos_ota.c`. Deserves its own PR and careful review, not a tail-end commit. |
| **Surface memory over a channel that survives the link being down** | Needs a design decision first — the natural channel is USB (the device already reports heap over `usb_api status`), which means teaching the workspace advisory to read USB when the frame is offline. Tractable, but a different shape from these two. |
| **Spill follow-ups** | Marked optional in the todo, and one part changes the pixie fork. |

Happy to take any of these next; the first two need a decision or a board more than they need code.