### PR TITLE
ESP32: render OOM recovery, USB console commands, and two workspace fixes

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -87,7 +87,13 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
   1. That scene's render needs more PSRAM than an 8 MB board has. This is the
      case the large-image spill work exists for — measure what it actually
      allocates before assuming which buffer is at fault.
-  2. **A failed render abandons its PSRAM.** After the failure the pool sits
+  2. ~~A failed render abandons its PSRAM~~ — HANDLED: the frame now restarts
+     when PSRAM does not come back, and after two consecutive rescues pauses
+     rendering and stays online so a lighter scene can be assigned. All three
+     paths verified on hardware (restart, pause, resume-on-scene-select).
+     What remains is the cause below.
+
+  Historical note on 2: After the failure the pool sits
      at ~4 KB indefinitely, so the frame can neither render nor open its
      cloud link (mbedTLS allocates from PSRAM under
      CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC). It is dead until power-cycled.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -74,6 +74,33 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
 
 ### Memory
 
+- **The Nim heap in PSRAM squeezes the renderer, and an OOM wedges the frame.**
+  Moving the Nim heap to PSRAM fixed internal RAM (12 KB → ~100 KB free) but
+  took the same memory out of the render budget: scene graphs and QuickJS now
+  compete with the canvas and image decode. Measured on an 8 MB XIAO-class
+  board with a 6-scene set, boot timeline over `heapinfo`:
+
+      [16s] render #1 started
+      [19-54s] psram_free 2.7M -> 1.9M          (normal working set)
+      [59s]  psram_free 1,978,364 -> 3,776      blocks 4431 -> 6960
+      [59s+] pinned at 3,776; render never completes, TLS cannot handshake
+
+  The step at 59 s is the OOM abort: `fos_nim_fatal_oom` longjmps out of the
+  render and the ~2 MB it had allocated is abandoned (the glue says as much).
+  PSRAM then sits at ~0, so every later render fails the same way and the
+  cloud link cannot open — the frame is wedged until it is power-cycled.
+  `FOS_NIM_OOM_ABORT_RESTART_STREAK` is 4, and with a 300 s interval that is
+  20 minutes of dead frame at best.
+
+  Two things to decide, and they are separable:
+  1. Where the interpreter's memory should live. Options: keep PSRAM but hold
+     a hard render reserve; split (graphs in PSRAM, QuickJS internal); or
+     revert and solve internal RAM another way. Needs measurement per scene
+     set, not a guess.
+  2. Recovery. An OOM abort that leaks the render's heap should restart the
+     runtime immediately rather than after a streak — a frame that cannot
+     render and cannot phone home is worse than one that reboots.
+
 - **Move QuickJS off internal RAM** — it allocates through libc malloc, and
   `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=16384` sends everything under 16 KB to
   the internal pool, so the active scene's JS context is an internal-RAM cost

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -74,32 +74,31 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
 
 ### Memory
 
-- **The Nim heap in PSRAM squeezes the renderer, and an OOM wedges the frame.**
-  Moving the Nim heap to PSRAM fixed internal RAM (12 KB → ~100 KB free) but
-  took the same memory out of the render budget: scene graphs and QuickJS now
-  compete with the canvas and image decode. Measured on an 8 MB XIAO-class
-  board with a 6-scene set, boot timeline over `heapinfo`:
+- **One heavy scene can exhaust PSRAM and wedge the frame until it is
+  power-cycled.** Measured on an 8 MB XIAO-class board rendering the
+  "Weather" scene, via the new `heapinfo` console command:
 
-      [16s] render #1 started
-      [19-54s] psram_free 2.7M -> 1.9M          (normal working set)
-      [59s]  psram_free 1,978,364 -> 3,776      blocks 4431 -> 6960
-      [59s+] pinned at 3,776; render never completes, TLS cannot handshake
+      [36s] render #1 started            internal 154K free, psram 5.6M free
+      [80s] Dynamic Impl: alloc(4437) failed -> render #1 failed at complete
+      [84s] psram 3,952 free             abandoned, and it stays there
+      [102s+] TLS cannot allocate -> cloud link down, every later render fails
 
-  The step at 59 s is the OOM abort: `fos_nim_fatal_oom` longjmps out of the
-  render and the ~2 MB it had allocated is abandoned (the glue says as much).
-  PSRAM then sits at ~0, so every later render fails the same way and the
-  cloud link cannot open — the frame is wedged until it is power-cycled.
-  `FOS_NIM_OOM_ABORT_RESTART_STREAK` is 4, and with a 300 s interval that is
-  20 minutes of dead frame at best.
+  Two separate faults, and the second is the damaging one:
+  1. That scene's render needs more PSRAM than an 8 MB board has. This is the
+     case the large-image spill work exists for — measure what it actually
+     allocates before assuming which buffer is at fault.
+  2. **A failed render abandons its PSRAM.** After the failure the pool sits
+     at ~4 KB indefinitely, so the frame can neither render nor open its
+     cloud link (mbedTLS allocates from PSRAM under
+     CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC). It is dead until power-cycled.
+     `FOS_NIM_OOM_ABORT_RESTART_STREAK` is 4 and only covers the longjmp
+     abort path, not this one. A frame that cannot render and cannot phone
+     home should restart itself promptly.
 
-  Two things to decide, and they are separable:
-  1. Where the interpreter's memory should live. Options: keep PSRAM but hold
-     a hard render reserve; split (graphs in PSRAM, QuickJS internal); or
-     revert and solve internal RAM another way. Needs measurement per scene
-     set, not a guess.
-  2. Recovery. An OOM abort that leaks the render's heap should restart the
-     runtime immediately rather than after a streak — a frame that cannot
-     render and cannot phone home is worse than one that reboots.
+  NOT caused by moving the Nim heap to PSRAM: that was the first suspicion,
+  and reverting it changed nothing — the same scene still exhausted PSRAM and
+  still wedged the frame, while internal RAM went back to being tight. The
+  move stays. Do not re-litigate it without re-running this measurement.
 
 - **Move QuickJS off internal RAM** — it allocates through libc malloc, and
   `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=16384` sends everything under 16 KB to

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -144,8 +144,23 @@ void frameos_nim_free_render_buffer(void *ptr)
  * (fragmentation, or PSRAM absent on a board built with SPIRAM_IGNORE_NOTFOUND)
  * still succeeds rather than turning into a fatal OOM. free() needs no
  * counterpart — heap_caps_free/free accept pointers from either region. */
+/* Zero-size requests are rounded up to one byte, and that is load-bearing
+ * rather than tidy-mindedness.
+ *
+ * heap_caps_realloc(ptr, 0, caps) FREES ptr and returns NULL. The caller
+ * here cannot tell that apart from a failed allocation, so the obvious
+ * `if (next == NULL) next = realloc(ptr, size);` fallback calls realloc on
+ * an already-freed pointer — a double free that corrupts the heap. The Nim
+ * side compounds it by retrying the same call on the same dead pointer after
+ * releasing the emergency reserve.
+ *
+ * Rounding up also keeps the NULL return meaning exactly one thing —
+ * "allocation failed" — which is what patched_malloc.nim treats it as. A
+ * zero-size malloc returning NULL would otherwise be reported as an
+ * out-of-memory abort. */
 void *fos_nim_heap_malloc(size_t size)
 {
+    if (size == 0) size = 1;
     void *ptr = heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (ptr == NULL) ptr = malloc(size);
     return ptr;
@@ -153,6 +168,7 @@ void *fos_nim_heap_malloc(size_t size)
 
 void *fos_nim_heap_calloc(size_t count, size_t size)
 {
+    if (count == 0 || size == 0) { count = 1; size = 1; }
     void *ptr = heap_caps_calloc(count, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (ptr == NULL) ptr = calloc(count, size);
     return ptr;
@@ -160,7 +176,10 @@ void *fos_nim_heap_calloc(size_t count, size_t size)
 
 void *fos_nim_heap_realloc(void *ptr, size_t size)
 {
+    if (size == 0) size = 1;
     void *next = heap_caps_realloc(ptr, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    /* Safe now that size is never 0: a failed heap_caps_realloc leaves the
+     * original block untouched, so the fallback gets a live pointer. */
     if (next == NULL) next = realloc(ptr, size);
     return next;
 }

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -783,8 +783,22 @@ static esp_err_t render_once(void)
 /* Called once at startup, before the first render. */
 void fos_client_render_recovery_boot(void)
 {
+    /* A power-on reset means a person intervened, and intervening is how they
+     * say "try again" — so the streak starts over.
+     *
+     * esp_reset_reason(), not the RTC magic below: RTC memory is NOT reliably
+     * cleared by a brief unplug. Observed on hardware — a frame paused after
+     * repeated out-of-memory renders was unplugged, replugged, and came back
+     * still paused, because the counter survived the power interruption. The
+     * magic can only detect memory that was never stamped, which is a
+     * different (and rarer) thing than a deliberate power cycle. */
+    if (esp_reset_reason() == ESP_RST_POWERON) {
+        s_render_recovery_magic = FOS_RENDER_RECOVERY_MAGIC;
+        s_render_recovery_restarts = 0;
+        return;
+    }
     if (s_render_recovery_magic != FOS_RENDER_RECOVERY_MAGIC) {
-        /* Cold boot: RTC memory is undefined until we stamp it. */
+        /* First boot on this board, or RTC memory that was never stamped. */
         s_render_recovery_magic = FOS_RENDER_RECOVERY_MAGIC;
         s_render_recovery_restarts = 0;
         return;

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -12,9 +12,11 @@
 
 #include "esp_crt_bundle.h"
 #include "esp_err.h"
+#include "esp_attr.h"
 #include "esp_heap_caps.h"
 #include "esp_http_client.h"
 #include "esp_log.h"
+#include "esp_system.h"
 #include "nvs.h"
 #include "esp_sleep.h"
 #include "esp_timer.h"
@@ -345,6 +347,12 @@ static bool json_string_value(const char *json, const char *key, char *out, size
     return used > 0;
 }
 
+RTC_NOINIT_ATTR static uint32_t s_render_recovery_restarts;
+RTC_NOINIT_ATTR static uint32_t s_render_recovery_magic;
+#define FOS_RENDER_RECOVERY_MAGIC 0x5245434fu /* "RECO" */
+
+static bool s_render_paused_for_memory = false;
+
 static void json_escape_value(const char *src, char *out, size_t out_len)
 {
     if (!out || out_len == 0) return;
@@ -383,6 +391,9 @@ static void current_scene_details(char *scene_id, size_t scene_id_len,
     json_string_value(info, "currentSceneId", scene_id, scene_id_len);
     json_string_value(info, "currentSceneName", scene_name, scene_name_len);
 }
+
+/* Defined below, next to the other render helpers. */
+static void render_failure_recover(const char *scene_name);
 
 static void log_render_event(const char *event, const char *scene_id,
                              const char *scene_name, const char *status,
@@ -723,6 +734,7 @@ static esp_err_t render_once(void)
         store_snapshot(buf, buf_len, width, height, format, s_render_count, s_last_render_ms);
         ESP_LOGI(TAG, "render #%lu done in %lld ms",
                  (unsigned long)s_render_count, s_last_render_ms);
+        s_render_recovery_restarts = 0; /* a good render clears the streak */
         if (s_render_count == 1) {
             ESP_LOGI(TAG, "render task stack free at low-water mark: %u bytes",
                      (unsigned)uxTaskGetStackHighWaterMark(NULL));
@@ -737,7 +749,98 @@ static esp_err_t render_once(void)
                      width, height, format, buf_len, err);
     frameos_nim_flush_logs();
     free(buf);
+    if (err != ESP_OK) {
+        render_failure_recover(scene_name);
+    }
     return err;
+}
+
+/* A render that fails without releasing its PSRAM leaves a frame that can do
+ * nothing at all: the next render fails the same way, and mbedTLS cannot
+ * handshake either (CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC puts its buffers in
+ * PSRAM), so the cloud link stays down and the frame cannot even be told to
+ * switch to a lighter scene. Measured on an 8 MB board rendering a heavy
+ * scene: the pool drops to ~4 KB at the moment of failure and stays there
+ * indefinitely. The only way out was a power cycle.
+ *
+ * So: after a failed render, check whether the pool came back. If it did,
+ * this was an ordinary failure and the frame carries on. If it did not, the
+ * runtime is holding memory it will never return, and a reboot is strictly
+ * better than a frame that is silently dead — it comes back able to render,
+ * able to connect, and able to receive a different scene.
+ *
+ * The threshold is deliberately far below any working render (which needs
+ * megabytes): only a frame that is genuinely stuck reaches it. */
+#define FOS_RENDER_RECOVERY_MIN_PSRAM (256 * 1024)
+/* Restarting rescues a wedged frame, but a scene that always exhausts memory
+ * would restart it forever. After this many consecutive rescues the frame
+ * stops rendering instead and stays up: a reachable frame showing a stale
+ * image can be given a lighter scene, a rebooting one cannot. Survives the
+ * software reset in RTC memory (not a power cycle, which is the right scope —
+ * unplugging is how a person says "try again"). */
+#define FOS_RENDER_RECOVERY_MAX_RESTARTS 2
+
+/* Called once at startup, before the first render. */
+void fos_client_render_recovery_boot(void)
+{
+    if (s_render_recovery_magic != FOS_RENDER_RECOVERY_MAGIC) {
+        /* Cold boot: RTC memory is undefined until we stamp it. */
+        s_render_recovery_magic = FOS_RENDER_RECOVERY_MAGIC;
+        s_render_recovery_restarts = 0;
+        return;
+    }
+    if (s_render_recovery_restarts >= FOS_RENDER_RECOVERY_MAX_RESTARTS) {
+        s_render_paused_for_memory = true;
+        ESP_LOGE(TAG, "rendering paused: the active scene exhausted PSRAM %u times in a row. "
+                      "The frame stays online so a lighter scene can be assigned; "
+                      "select another scene or power-cycle to retry.",
+                 (unsigned)s_render_recovery_restarts);
+        frameos_nim_log_hook(
+            "{\"event\":\"render:paused\",\"source\":\"esp32\","
+            "\"reason\":\"psram-exhausted-repeatedly\","
+            "\"detail\":\"rendering paused so the frame stays reachable; assign a lighter scene\"}");
+        frameos_nim_flush_logs();
+    }
+}
+
+bool fos_client_render_paused(void) { return s_render_paused_for_memory; }
+
+void fos_client_clear_render_pause(void)
+{
+    /* A new scene selection or a new payload is the user saying "try this
+     * instead", so give rendering another chance. */
+    s_render_recovery_restarts = 0;
+    if (s_render_paused_for_memory) {
+        s_render_paused_for_memory = false;
+        ESP_LOGI(TAG, "rendering resumed after a scene change");
+    }
+}
+
+static void render_failure_recover(const char *scene_name)
+{
+    size_t free_psram = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (free_psram >= FOS_RENDER_RECOVERY_MIN_PSRAM) {
+        return; /* memory came back; nothing to recover from */
+    }
+    s_render_recovery_restarts += 1;
+    ESP_LOGE(TAG, "render failed and PSRAM did not recover (%u bytes free); "
+                  "restarting so the frame can render and reconnect",
+             (unsigned)free_psram);
+    /* Escaped and bounded: a scene name is user-controlled and goes into a
+     * JSON log line that the cloud parses. */
+    char scene_esc[128];
+    json_escape_value(scene_name ? scene_name : "", scene_esc, sizeof(scene_esc));
+    char line[320];
+    snprintf(line, sizeof(line),
+             "{\"event\":\"render:recover\",\"source\":\"esp32\","
+             "\"status\":\"restarting\",\"reason\":\"psram-exhausted\","
+             "\"freePsram\":%u,\"sceneName\":\"%s\"}",
+             (unsigned)free_psram, scene_esc);
+    frameos_nim_log_hook(line);
+    frameos_nim_flush_logs();
+    /* Give the log upload and any USB reader a moment before the reset. */
+    vTaskDelay(pdMS_TO_TICKS(1500));
+    esp_restart();
 }
 
 static void log_render_skipped(const char *reason, int battery_pct)
@@ -819,7 +922,13 @@ static void client_task(void *arg)
         int battery_pct = fos_battery_present() ? fos_battery_percent() : -1;
         bool battery_critical = battery_pct >= 0 && battery_pct <= FOS_BATTERY_CRITICAL_PCT;
         bool rendered = false;
-        if (battery_critical) {
+        if (s_render_paused_for_memory) {
+            /* Paused after repeated PSRAM exhaustion — see
+             * fos_client_render_recovery_boot. Skipping the render is what
+             * keeps this frame reachable, so it can be handed a lighter
+             * scene instead of rebooting forever. */
+            log_render_skipped("memory", -1);
+        } else if (battery_critical) {
             ESP_LOGW(TAG, "battery critical (%d%%); skipping render to protect the cell", battery_pct);
             log_render_skipped("battery", battery_pct);
         } else {

--- a/embedded/esp32/main/fos_client.h
+++ b/embedded/esp32/main/fos_client.h
@@ -18,6 +18,13 @@ void fos_client_start(void);
 /* Allow the render loop to run after startup has reserved its stack. */
 void fos_client_resume(void);
 /* Trigger an immediate render from another task (HTTP action, console). */
+/* Repeated-OOM rescue (fos_client.c). A render that exhausts PSRAM and does
+ * not get it back leaves a frame that can neither render nor reach the cloud,
+ * so it restarts itself; after two consecutive rescues it stops rendering and
+ * stays online instead, so a lighter scene can be assigned. */
+void fos_client_render_recovery_boot(void);
+bool fos_client_render_paused(void);
+void fos_client_clear_render_pause(void);
 void fos_client_render_now(void);
 /* Keep Wi-Fi/HTTP available briefly after a control request on deep-sleep frames. */
 void fos_client_keep_awake_ms(uint32_t ms);

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -78,27 +78,29 @@ static const char *NVS_NS = "frameos";
  * client init/start was never retried at all — either way the link used to
  * stay dead until a reboot. */
 #define FOS_CLOUD_WS_STALL_RESTART_US (120LL * 1000 * 1000)
-/* Internal-RAM floor for opening the management WebSocket.
+/* Memory floors for opening the management WebSocket, split by pool because
+ * the dial draws on both and they run out for different reasons.
  *
- * The dial needs internal (non-PSRAM) memory for three things at once: the
- * client's own task stack (task_stack below, ~10 KB), lwIP's socket and
- * pbufs, and the mbedTLS handshake. Below the floor the connect fails deep in
- * the stack and surfaces as "delayed connect error: Connection reset by peer"
- * from esp-tls — which reads exactly like a network fault and sent one
- * debugging session chasing DNS, nginx and Cloudflare before the heap was
- * looked at. So check first and SAY so.
+ * INTERNAL pays for the client's own task stack (task_stack below, ~10 KB)
+ * and lwIP's socket and pbufs. PSRAM pays for the mbedTLS handshake: the
+ * build sets CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC, so record buffers and
+ * certificate work come from there. The observed failure when PSRAM runs dry
+ * is "Dynamic Impl: alloc(4770 bytes) failed" followed by
+ * mbedtls_ssl_handshake -0x7F00; when internal runs dry it is esp-tls
+ * "delayed connect error: Connection reset by peer", which reads exactly
+ * like a network fault. Both have cost real debugging time, so check first
+ * and say which pool is short.
  *
- * The numbers match the log uploader's own TLS thresholds
- * (FOS_NIM_LOG_MIN_INTERNAL_FREE_TLS / _BLOCK_TLS in
- * components/frameos_nim/frameos_nim_glue.c): 48 KB free with a 16 KB
- * contiguous block. Fragmentation matters as much as the total — mbedTLS
- * wants sizable single buffers — which is why both are checked.
+ * An earlier version of this guard demanded 48 KB INTERNAL, copied from the
+ * log uploader's thresholds. That was wrong for this path: those thresholds
+ * predate mbedTLS being pushed to PSRAM, and a frame with a healthy PSRAM
+ * budget but a busy internal pool would refuse to dial for no reason.
  *
- * This is a floor for STARTING a session, not for keeping one: an established
- * connection costs far less, so a frame that got up before the renderer
- * claimed memory keeps running. */
-#define FOS_CLOUD_WS_MIN_INTERNAL_FREE (48 * 1024)
-#define FOS_CLOUD_WS_MIN_INTERNAL_BLOCK (16 * 1024)
+ * These are floors for STARTING a session, not for keeping one — an
+ * established connection costs far less. */
+#define FOS_CLOUD_WS_MIN_INTERNAL_FREE (24 * 1024)
+#define FOS_CLOUD_WS_MIN_INTERNAL_BLOCK (12 * 1024)
+#define FOS_CLOUD_WS_MIN_PSRAM_FREE (128 * 1024)
 /* How long scene_ack waits for the render task to hot-load a pushed payload. */
 #define FOS_CLOUD_SCENE_ACK_TIMEOUT_MS (120 * 1000)
 /* Asset verbs (docs/cloud-frames.md assets_list/asset_get). Files are read
@@ -2114,41 +2116,43 @@ static bool ws_heap_ready(void)
     size_t free_internal = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
     size_t largest_internal =
         heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    size_t free_psram = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (free_internal >= FOS_CLOUD_WS_MIN_INTERNAL_FREE &&
-        largest_internal >= FOS_CLOUD_WS_MIN_INTERNAL_BLOCK) {
+        largest_internal >= FOS_CLOUD_WS_MIN_INTERNAL_BLOCK &&
+        free_psram >= FOS_CLOUD_WS_MIN_PSRAM_FREE) {
         if (warned) {
             warned = false;
-            ESP_LOGI(TAG, "ws: internal RAM recovered (%u free, %u largest); dialing again",
-                     (unsigned)free_internal, (unsigned)largest_internal);
+            ESP_LOGI(TAG, "ws: memory recovered (internal %u free/%u block, psram %u free); dialing again",
+                     (unsigned)free_internal, (unsigned)largest_internal, (unsigned)free_psram);
             set_last_error("");
         }
         return true;
     }
+    /* Name the pool that is short: "low memory" alone sends people to the
+     * wrong half of the device. */
+    const char *pool = free_psram < FOS_CLOUD_WS_MIN_PSRAM_FREE ? "PSRAM" : "internal RAM";
+    /* Kept short on purpose: s_last_error is a small fixed buffer and `status`
+     * prints it on one line. The full numbers go to the log line below. */
     char detail[sizeof(s_last_error)];
     snprintf(detail, sizeof(detail),
-             "low internal RAM for the cloud link: %uB free/%uB block, needs %uB/%uB",
-             (unsigned)free_internal, (unsigned)largest_internal,
-             (unsigned)FOS_CLOUD_WS_MIN_INTERNAL_FREE,
-             (unsigned)FOS_CLOUD_WS_MIN_INTERNAL_BLOCK);
+             "low %s for the cloud link (internal %uK, psram %uK free)",
+             pool, (unsigned)(free_internal / 1024), (unsigned)(free_psram / 1024));
     set_last_error(detail);
     if (!warned) {
         warned = true;
-        ESP_LOGW(TAG, "ws: %s", detail);
-        ESP_LOGW(TAG, "ws: the link stays down until internal RAM frees up "
-                      "(fewer/lighter scenes, or a smaller panel canvas). "
-                      "PSRAM is not the constraint: %u free.",
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-        /* One structured line so this reaches the log panel and the metrics
-         * story, not just whoever is holding a USB cable. */
-        char event[224];
+        ESP_LOGW(TAG, "ws: %s — internal %u free/%u block (needs %u/%u), psram %u free (needs %u)",
+                 detail, (unsigned)free_internal, (unsigned)largest_internal,
+                 (unsigned)FOS_CLOUD_WS_MIN_INTERNAL_FREE,
+                 (unsigned)FOS_CLOUD_WS_MIN_INTERNAL_BLOCK,
+                 (unsigned)free_psram, (unsigned)FOS_CLOUD_WS_MIN_PSRAM_FREE);
+        ESP_LOGW(TAG, "ws: the link stays down until memory frees up; it retries on its own.");
+        char event[288];
         snprintf(event, sizeof(event),
                  "{\"event\":\"cloud:ws_deferred\",\"source\":\"esp32\","
-                 "\"reason\":\"low_internal_ram\",\"freeInternal\":%u,"
-                 "\"largestInternalBlock\":%u,\"needFreeInternal\":%u,"
-                 "\"needInternalBlock\":%u,\"loadedScenes\":%d}",
-                 (unsigned)free_internal, (unsigned)largest_internal,
-                 (unsigned)FOS_CLOUD_WS_MIN_INTERNAL_FREE,
-                 (unsigned)FOS_CLOUD_WS_MIN_INTERNAL_BLOCK, fos_scenes_loaded());
+                 "\"reason\":\"low_memory\",\"pool\":\"%s\",\"freeInternal\":%u,"
+                 "\"largestInternalBlock\":%u,\"freePsram\":%u,\"loadedScenes\":%d}",
+                 pool, (unsigned)free_internal, (unsigned)largest_internal,
+                 (unsigned)free_psram, fos_scenes_loaded());
         frameos_nim_log_hook(event);
     }
     return false;

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -160,6 +160,33 @@ static int cmd_status(int argc, char **argv)
     return 0;
 }
 
+/* Block-level heap truth, for when the totals in `status` are not enough.
+ *
+ * "psram 3856 free" says a frame is out of memory but not what took it, and
+ * guessing from totals wastes hours. This prints ESP-IDF's per-region
+ * breakdown (largest free block, minimum-ever free, allocation counts) for
+ * both pools, which is what distinguishes exhaustion from fragmentation and
+ * a leak from a big legitimate buffer. */
+static int cmd_heapinfo(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    printf("--- internal (MALLOC_CAP_INTERNAL)\n");
+    printf("free=%u largest=%u min_ever_free=%u\n",
+           (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+           (unsigned)heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL));
+    printf("--- psram (MALLOC_CAP_SPIRAM)\n");
+    printf("total=%u free=%u largest=%u min_ever_free=%u\n",
+           (unsigned)heap_caps_get_total_size(MALLOC_CAP_SPIRAM),
+           (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
+           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM),
+           (unsigned)heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM));
+    printf("--- per-region detail\n");
+    heap_caps_print_heap_info(MALLOC_CAP_SPIRAM);
+    heap_caps_print_heap_info(MALLOC_CAP_INTERNAL);
+    return 0;
+}
+
 static int cmd_set(int argc, char **argv)
 {
     if (argc < 3) {
@@ -1225,6 +1252,7 @@ static esp_err_t register_frameos_console_commands(void)
 {
     const esp_console_cmd_t commands[] = {
         {.command = "status", .help = "Show device status", .func = cmd_status},
+        {.command = "heapinfo", .help = "Per-region heap breakdown (internal + PSRAM)", .func = cmd_heapinfo},
         {.command = "set", .help = "set <key> <value> — persist a config value", .func = cmd_set},
         {.command = "wifi", .help = "wifi <ssid> [pass] — set Wi-Fi and restart", .func = cmd_wifi},
         {.command = "wifi-scan", .help = "Scan visible Wi-Fi networks", .func = cmd_wifi_scan},

--- a/embedded/esp32/main/fos_scenes.c
+++ b/embedded/esp32/main/fos_scenes.c
@@ -17,6 +17,7 @@
 #include "freertos/semphr.h"
 
 #include "cJSON.h"
+#include "fos_client.h"
 #include "fos_config.h"
 #include "fos_mem.h"
 #include "fos_wifi.h"
@@ -903,6 +904,9 @@ bool fos_scenes_apply_pending_selection(void)
     }
     persist_last_scene(scene_id);
     s_last_scene_settled = true; /* explicit selection makes the boot restore moot */
+    /* Picking a scene is the user saying "try this one instead", so a frame
+     * paused after repeated out-of-memory renders gets another chance. */
+    fos_client_clear_render_pause();
     ESP_LOGI(TAG, "scene selected: %s", scene_id);
     printf("scene changed: %s\n", scene_id); /* visible on the USB serial stream */
     log_scene_event("event:setCurrentScene", "ok", "queued", scene_id,

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -204,6 +204,9 @@ void app_main(void)
      * consume internal RAM, but after early-boot OTA had a chance to run with
      * the leanest possible task set. The task waits until fos_client_resume()
      * below, so starting it here only claims the stack. */
+    /* Before any render: decides whether the previous boot was a memory
+     * rescue and whether rendering should stay paused this time. */
+    fos_client_render_recovery_boot();
     fos_client_start();
 
     if (frameos_nim_available() && local_render_ok) {

--- a/frontend/src/decorators/frame.tsx
+++ b/frontend/src/decorators/frame.tsx
@@ -1,4 +1,5 @@
 import { FrameConnectionDot } from '../components/FrameConnectionDot'
+import { isCloudMode } from '../utils/cloudMode'
 import { Spinner } from '../components/Spinner'
 import { FrameType, LogType } from '../types'
 import { frameAdminPath } from '../utils/frameAdmin'
@@ -120,6 +121,16 @@ export function frameStatusLabel(frame: FrameType): string {
 }
 
 export function frameNeedsInitialDeploy(frame: FrameType): boolean {
+  // Cloud-managed frames are judged by what the DEVICE acked, not by a
+  // deploy record. `last_successful_deploy_at` and `mode` are backend-only
+  // columns that frameSummary does not return, so the rule below read
+  // undefined for both and called every cloud frame "waiting for first
+  // deploy" — permanently, including frames that were rendering and shipping
+  // logs. The cloud's equivalent of a deploy is a set_scenes the device
+  // acknowledged, which is exactly what scenes_checksum records.
+  if (isCloudMode() || frame.managed_by === 'cloud') {
+    return !frame.scenes_checksum && !frameHasActivityLog(frame)
+  }
   if ((frame.mode ?? 'rpios') === 'embedded' && frameHasActivityLog(frame)) {
     return false
   }

--- a/frontend/src/models/embeddedUsbLogsModel.ts
+++ b/frontend/src/models/embeddedUsbLogsModel.ts
@@ -827,6 +827,54 @@ export function embeddedUsbLogStreamSessionPort(frameId: FrameId): SerialPort | 
   return sessions.get(frameId)?.port ?? null
 }
 
+/**
+ * Type a line into the board's console REPL over the live log stream.
+ *
+ * This piggybacks on the streaming session on purpose. Web Serial grants a
+ * port exclusively, so a second opener would fail with "port already open"
+ * — but a port's readable and writable are locked independently, so the log
+ * reader can keep running while we take the writer, push a line and hand it
+ * back. The reply arrives through the same reader as ordinary log output,
+ * which is exactly what makes this useful: you see the answer in context.
+ *
+ * The command is echoed into the log view locally. The firmware's line
+ * editor does not echo input that arrives programmatically, so without this
+ * the transcript would show answers with no questions.
+ *
+ * Whatever is typed is sent verbatim — this is the same REPL the USB cable
+ * exposes (`status`, `scenes`, `set …`, `restart`, `factory-reset`), and it
+ * is reachable by anyone holding the board anyway. No allow-list here; the
+ * device validates its own commands.
+ */
+export async function sendEmbeddedUsbConsoleCommand(frameId: FrameId, command: string): Promise<void> {
+  const line = command.trim()
+  if (!line) {
+    return
+  }
+  const session = sessions.get(frameId)
+  if (!session || session.stopRequested) {
+    throw new Error('Connect the USB log stream first — commands go over that same connection.')
+  }
+  const writable = session.port.writable
+  if (!writable) {
+    throw new Error('The USB serial port is not writable. Reconnect the log stream and try again.')
+  }
+  if (writable.locked) {
+    // Another write is mid-flight; serializing here would hide a bug rather
+    // than fix one, and console commands are hand-typed, not batched.
+    throw new Error('The USB serial port is busy. Try again in a moment.')
+  }
+  const writer = writable.getWriter()
+  try {
+    await writer.write(new TextEncoder().encode(line + '\n'))
+  } catch (error) {
+    throw new Error(serialErrorMessage(error))
+  } finally {
+    writer.releaseLock()
+  }
+  appendEmbeddedUsbLogLine(frameId, `> ${line}`)
+}
+
 export async function stopEmbeddedUsbLogStream(frameId: FrameId): Promise<SerialPort | null> {
   const session = sessions.get(frameId)
   if (!session) {

--- a/frontend/src/scenes/frame/panels/Logs/Logs.tsx
+++ b/frontend/src/scenes/frame/panels/Logs/Logs.tsx
@@ -663,72 +663,6 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
           ) : null}
         </div>
       )}
-      {showUsbLogControls && usbLogStreamOpen && commandOpen && (
-        <div
-          className={clsx(
-            'flex shrink-0 flex-wrap items-center gap-2 border-b px-3 py-2',
-            renderTheme === 'dark' ? 'border-slate-700 bg-slate-900/40' : 'border-slate-200 bg-slate-50'
-          )}
-        >
-          <span
-            className={clsx(
-              'font-mono text-xs font-semibold',
-              renderTheme === 'dark' ? 'text-slate-400' : 'text-slate-500'
-            )}
-          >
-            frameos&gt;
-          </span>
-          <input
-            ref={commandInputRef}
-            aria-label="Serial console command"
-            className={clsx(
-              'frameos-control min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 font-mono text-xs focus:border-blue-500 focus:ring-blue-500',
-              fullScreen ? 'h-8' : 'h-9'
-            )}
-            disabled={commandSending}
-            onChange={(event) => setCommand(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault()
-                void submitCommand()
-              } else if (event.key === 'Escape') {
-                setCommandOpen(false)
-                setCommandError(null)
-              }
-            }}
-            placeholder="status, scenes, set …, restart — the board's own console"
-            spellCheck={false}
-            autoComplete="off"
-            value={command}
-          />
-          <button
-            type="button"
-            onClick={() => void submitCommand()}
-            disabled={commandSending || !command.trim()}
-            className={clsx(
-              'frameos-secondary-button inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 font-sans text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40',
-              fullScreen ? 'h-8' : 'h-9'
-            )}
-          >
-            {commandSending ? <Spinner className="h-4 w-4" /> : null}
-            Send
-          </button>
-          {commandError ? (
-            <div className="min-w-0 flex-[1_1_12rem] truncate font-sans text-xs font-semibold text-red-500">
-              {commandError}
-            </div>
-          ) : (
-            <div
-              className={clsx(
-                'min-w-0 flex-[1_1_12rem] truncate font-sans text-xs',
-                renderTheme === 'dark' ? 'text-slate-500' : 'text-slate-400'
-              )}
-            >
-              The reply appears in the log above.
-            </div>
-          )}
-        </div>
-      )}
       <Virtuoso
         key={virtuosoKey}
         useWindowScroll={fullScreen && !customScrollParent}
@@ -832,13 +766,87 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
           )
         }}
       />
+      {showUsbLogControls && usbLogStreamOpen && commandOpen && (
+        <div
+          className={clsx(
+            'flex shrink-0 flex-wrap items-center gap-2 border-t px-3 py-2',
+            renderTheme === 'dark' ? 'border-slate-700 bg-slate-900/40' : 'border-slate-200 bg-slate-50'
+          )}
+        >
+          <span
+            className={clsx(
+              'font-mono text-xs font-semibold',
+              renderTheme === 'dark' ? 'text-slate-400' : 'text-slate-500'
+            )}
+          >
+            frameos&gt;
+          </span>
+          <input
+            ref={commandInputRef}
+            aria-label="Serial console command"
+            className={clsx(
+              'frameos-control min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 font-mono text-xs focus:border-blue-500 focus:ring-blue-500',
+              fullScreen ? 'h-8' : 'h-9'
+            )}
+            disabled={commandSending}
+            onChange={(event) => setCommand(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void submitCommand()
+              } else if (event.key === 'Escape') {
+                setCommandOpen(false)
+                setCommandError(null)
+              }
+            }}
+            placeholder="status, scenes, set …, restart — the board's own console"
+            spellCheck={false}
+            autoComplete="off"
+            value={command}
+          />
+          <button
+            type="button"
+            onClick={() => void submitCommand()}
+            disabled={commandSending || !command.trim()}
+            className={clsx(
+              'frameos-secondary-button inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 font-sans text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40',
+              fullScreen ? 'h-8' : 'h-9'
+            )}
+          >
+            {commandSending ? <Spinner className="h-4 w-4" /> : null}
+            Send
+          </button>
+          {commandError ? (
+            <div className="min-w-0 flex-[1_1_12rem] truncate font-sans text-xs font-semibold text-red-500">
+              {commandError}
+            </div>
+          ) : (
+            <div
+              className={clsx(
+                'min-w-0 flex-[1_1_12rem] truncate font-sans text-xs',
+                renderTheme === 'dark' ? 'text-slate-500' : 'text-slate-400'
+              )}
+            >
+              The reply appears in the log above.
+            </div>
+          )}
+        </div>
+      )}
       {!atBottom && (
         <button
           type="button"
           onClick={() => scrollToLatest()}
           className={clsx(
             'frameos-secondary-button z-40 rounded-lg px-4 py-2 text-sm font-semibold shadow-lg transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
-            fullScreen ? 'fixed bottom-6 right-4 @4xl:right-8' : 'absolute bottom-5 right-6'
+            fullScreen ? 'fixed right-4 @4xl:right-8' : 'absolute right-6',
+            // Clear the console row when it is open, instead of covering it.
+            showUsbLogControls && usbLogStreamOpen && commandOpen
+              ? fullScreen
+                ? 'bottom-20'
+                : 'bottom-[4.5rem]'
+              : fullScreen
+              ? 'bottom-6'
+              : 'bottom-5'
           )}
         >
           Scroll to latest

--- a/frontend/src/scenes/frame/panels/Logs/Logs.tsx
+++ b/frontend/src/scenes/frame/panels/Logs/Logs.tsx
@@ -8,13 +8,14 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import { DropdownMenu } from '../../../../components/DropdownMenu'
 import { Spinner } from '../../../../components/Spinner'
 import { ArrowDownTrayIcon, ArrowUpTrayIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/solid'
-import { CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
+import { ChevronRightIcon, CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
 import { EMBEDDED_ESP32_S3 } from '../../../../devices'
 import { workspaceLogic, type WorkspaceTheme } from '../../../workspace/workspaceLogic'
 import { frameSupportsUsbSerialConsole, workspaceMode } from '../../../workspace/workspaceSurfaces'
 import {
   embeddedUsbLogsModel,
   isEmbeddedUsbLogStreamOpen,
+  sendEmbeddedUsbConsoleCommand,
   startEmbeddedUsbLogStream,
 } from '../../../../models/embeddedUsbLogsModel'
 
@@ -368,6 +369,22 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
     usbLogStreamState?.status === 'selecting' ||
     usbLogStreamState?.status === 'connecting' ||
     usbLogStreamState?.status === 'stopping'
+  // Console input over the live stream. Kept collapsed until asked for: the
+  // panel is a log reader first, and an always-visible command box on a frame
+  // that has no USB connection is just clutter.
+  const [commandOpen, setCommandOpen] = useState(false)
+  const [command, setCommand] = useState('')
+  const [commandError, setCommandError] = useState<string | null>(null)
+  const [commandSending, setCommandSending] = useState(false)
+  const commandInputRef = useRef<HTMLInputElement | null>(null)
+  // Losing the connection closes the box, so it can never sit there implying
+  // it will send something.
+  useEffect(() => {
+    if (!usbLogStreamOpen && commandOpen) {
+      setCommandOpen(false)
+      setCommandError(null)
+    }
+  }, [usbLogStreamOpen, commandOpen])
   const usbLogButtonLabel =
     usbLogStreamState?.status === 'selecting'
       ? 'Select USB port'
@@ -462,6 +479,25 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
 
   const streamUsbLogs = async (): Promise<void> => {
     await startEmbeddedUsbLogStream(frameId)
+  }
+
+  const submitCommand = async (): Promise<void> => {
+    const line = command.trim()
+    if (!line || commandSending) {
+      return
+    }
+    setCommandSending(true)
+    setCommandError(null)
+    try {
+      await sendEmbeddedUsbConsoleCommand(frameId, line)
+      // Cleared only on success, so a failed send leaves the text to retry
+      // or edit rather than making the user retype it.
+      setCommand('')
+    } catch (error) {
+      setCommandError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setCommandSending(false)
+    }
   }
 
   const menuItems = [
@@ -597,11 +633,100 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
               {usbLogButtonLabel}
             </button>
           ) : null}
+          {showUsbLogControls && usbLogStreamOpen ? (
+            <button
+              type="button"
+              onClick={() => {
+                const next = !commandOpen
+                setCommandOpen(next)
+                setCommandError(null)
+                // Focus after the input exists, so the box is ready to type in.
+                if (next) {
+                  window.setTimeout(() => commandInputRef.current?.focus(), 0)
+                }
+              }}
+              title="Type a command into the board's serial console"
+              className={clsx(
+                'frameos-secondary-button inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 font-sans text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400',
+                commandOpen && 'ring-2 ring-blue-400',
+                fullScreen ? 'h-8' : 'h-10'
+              )}
+            >
+              <ChevronRightIcon className="h-4 w-4" />
+              Send command
+            </button>
+          ) : null}
           {showUsbLogControls && usbLogStreamState?.status === 'error' && usbLogStreamState.error ? (
             <div className="min-w-0 flex-[1_1_12rem] truncate font-sans text-xs font-semibold text-red-500">
               {usbLogStreamState.error}
             </div>
           ) : null}
+        </div>
+      )}
+      {showUsbLogControls && usbLogStreamOpen && commandOpen && (
+        <div
+          className={clsx(
+            'flex shrink-0 flex-wrap items-center gap-2 border-b px-3 py-2',
+            renderTheme === 'dark' ? 'border-slate-700 bg-slate-900/40' : 'border-slate-200 bg-slate-50'
+          )}
+        >
+          <span
+            className={clsx(
+              'font-mono text-xs font-semibold',
+              renderTheme === 'dark' ? 'text-slate-400' : 'text-slate-500'
+            )}
+          >
+            frameos&gt;
+          </span>
+          <input
+            ref={commandInputRef}
+            aria-label="Serial console command"
+            className={clsx(
+              'frameos-control min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 font-mono text-xs focus:border-blue-500 focus:ring-blue-500',
+              fullScreen ? 'h-8' : 'h-9'
+            )}
+            disabled={commandSending}
+            onChange={(event) => setCommand(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void submitCommand()
+              } else if (event.key === 'Escape') {
+                setCommandOpen(false)
+                setCommandError(null)
+              }
+            }}
+            placeholder="status, scenes, set …, restart — the board's own console"
+            spellCheck={false}
+            autoComplete="off"
+            value={command}
+          />
+          <button
+            type="button"
+            onClick={() => void submitCommand()}
+            disabled={commandSending || !command.trim()}
+            className={clsx(
+              'frameos-secondary-button inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 font-sans text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40',
+              fullScreen ? 'h-8' : 'h-9'
+            )}
+          >
+            {commandSending ? <Spinner className="h-4 w-4" /> : null}
+            Send
+          </button>
+          {commandError ? (
+            <div className="min-w-0 flex-[1_1_12rem] truncate font-sans text-xs font-semibold text-red-500">
+              {commandError}
+            </div>
+          ) : (
+            <div
+              className={clsx(
+                'min-w-0 flex-[1_1_12rem] truncate font-sans text-xs',
+                renderTheme === 'dark' ? 'text-slate-500' : 'text-slate-400'
+              )}
+            >
+              The reply appears in the log above.
+            </div>
+          )}
         </div>
       )}
       <Virtuoso

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -175,6 +175,13 @@ export interface FrameType {
   active_scene_id?: string
   /** Cloud only: the device-reported state the hub mirrors onto the frame row (e.g. active_scene). */
   last_state?: Record<string, any>
+  /** Cloud only: the checksum of the scene payload the CONTROL PLANE has
+   * assigned, and the one the DEVICE last acknowledged applying. Equal means
+   * in sync; a device that never acked one has never had a scene delivered,
+   * which is the cloud's notion of "not deployed yet" (there is no
+   * last_successful_deploy_at on this control plane). */
+  assigned_checksum?: string | null
+  scenes_checksum?: string | null
   /** Cloud only: the newest metrics sample the device sent. Read for the
    * memory advisory (utils/frameMemory.ts) — an embedded frame can render
    * fine while having too little internal RAM left to open its TLS link. */


### PR DESCRIPTION
Today's work, moved off `main` for review. Eight commits, base `1a610268`.

Most of this came out of one investigation: a cloud-managed ESP32 that stopped rendering and could not open its cloud link after a USB flash, needing a physical replug. Everything below is either that fault, a defect found while chasing it, or an unrelated bug spotted in the same logs.

## The fault: a frame that could neither render nor phone home

A render that fails **without releasing its PSRAM** leaves a frame that can do nothing. The next render fails identically, and mbedTLS cannot handshake either (`CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC` puts its buffers in PSRAM), so the cloud link stays down and the frame cannot even be *told* to switch to a lighter scene. Measured on an 8 MB board:

```
[36s] render #1 started            internal 154K free, psram 5.6M free
[80s] Dynamic Impl: alloc(4437) failed -> render #1 failed at complete
[84s] psram 3,952 free             abandoned, and it stays there
[102s+] TLS cannot allocate -> cloud link down, every later render fails
```

Two steps, because the first alone trades a dead frame for a rebooting one:

- **Restart** when PSRAM does not come back after a failed render.
- **After two consecutive rescues, stop rendering and stay online.** A reachable frame showing a stale image can be handed a lighter scene; a rebooting one cannot. Selecting a scene clears the pause; any successful render clears the streak.

All three paths confirmed on hardware: restart (`rst:0xc` where the frame used to sit dead), pause (`render:skipped`/`stage=guard` while still connected and shipping logs), resume (scene select → render completed in 35.7 s).

A wrong assumption surfaced during that testing and is fixed here too: RTC memory survives a brief unplug, so a paused frame came back still paused after a replug — ignoring the clearest signal that a person wants it to retry. It now uses `esp_reset_reason() == ESP_RST_POWERON`.

## Defects found on the way

- **Zero-size double free in the PSRAM allocator.** `heap_caps_realloc(ptr, 0, caps)` frees `ptr` and returns NULL, which is indistinguishable from failure — so the fallback called `realloc()` on a freed pointer, and the Nim side retried the same dead pointer after releasing the emergency reserve. All three wrappers now round zero-size up to one byte.
- **The WS heap guard checked the wrong pool.** It demanded 48 KB *internal*, copied from the log uploader's thresholds — but TLS allocates from PSRAM here. It now checks both, with numbers matching what each is for, and names the short one.
- **`heapinfo`** console command: per-region breakdown for both pools. `status` totals cannot tell exhaustion from fragmentation or a leak from a large legitimate buffer, which cost hours of guessing; the numbers that settled this came from here.

## Unrelated, from the same logs

- **Cloud frames read "waiting for first deploy" forever.** `frameNeedsInitialDeploy` is written against `mode` and `last_successful_deploy_at`, and `frameSummary` returns neither — so every cloud frame claimed it, including ones rendering and shipping logs. Cloud frames are now judged by what the device acked (`scenes_checksum`).
- **USB console commands from the Logs panel.** The panel could stream a board's console but not talk back, so debugging meant closing the stream and opening a terminal (Web Serial grants a port exclusively). It piggybacks on the streaming session — a port's readable and writable lock independently — so replies land in the log in context. Includes the follow-up fix putting the input at the bottom where the newest lines are.

## Verification

Hardware-verified: the three recovery paths, the allocator fix (built and flashed), `heapinfo`, the WS guard message. Frontend: typecheck and bundle build. **Not** verified in a browser: the USB console send path needs a real port grant, unreachable headless — though the mechanism is the same one used to drive the board throughout this investigation.

## Known limitation, not addressed here

The underlying cause is untouched: one scene ("Weather") needs more PSRAM than an 8 MB board has. Three `weatherPanel` nodes each materialize a full image that a `render/image` draws into a split cell, plus icons and two split canvases — several 800×480 RGBA buffers (1.5 MB each) alive at once. Sizing panel output to the cell it lands in is the lead. Tracked in `docs/todo.md` with the measurements.