### PR TITLE
Make the USB flash log readable

### DIFF
--- a/frontend/src/models/embeddedUsbLogsModel.ts
+++ b/frontend/src/models/embeddedUsbLogsModel.ts
@@ -45,6 +45,7 @@ interface UsbLogSession {
   readLoop?: Promise<void>
   stopRequested: boolean
   pendingLine: string
+  logFilter: (line: string) => string | null
   failureMessage?: string
 }
 
@@ -69,6 +70,11 @@ interface EmbeddedUsbApiCommandOptions {
   // the flasher's reconnect flow (resolveLiveSerialPort) instead of
   // surfacing the dead port as a read error.
   expectReboot?: boolean
+  // A liveness probe repeated until the board answers (e.g. while it boots
+  // after a flash). Its attempts are not events a person needs to see, and
+  // its failures are the expected case, so keep them out of the log — the
+  // caller reports the progress and the final error itself.
+  probe?: boolean
 }
 
 function sleep(ms: number): Promise<void> {
@@ -114,12 +120,20 @@ export function appendEmbeddedUsbLogLine(frameId: FrameId, line: string, type = 
   appendUsbLine(frameId, line, type)
 }
 
+/** Append a line that came off the device's console, minus the wire protocol. */
+function appendFilteredUsbLine(frameId: FrameId, filter: (line: string) => string | null, line: string): void {
+  const visible = filter(line)
+  if (visible !== null) {
+    appendUsbLine(frameId, visible)
+  }
+}
+
 function appendUsbText(session: UsbLogSession, text: string): void {
   session.pendingLine += text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
   const lines = session.pendingLine.split('\n')
   session.pendingLine = lines.pop() ?? ''
   for (const line of lines) {
-    appendUsbLine(session.frameId, line)
+    appendFilteredUsbLine(session.frameId, session.logFilter, line)
   }
 }
 
@@ -127,7 +141,7 @@ function flushUsbText(session: UsbLogSession): void {
   if (!session.pendingLine) {
     return
   }
-  appendUsbLine(session.frameId, session.pendingLine)
+  appendFilteredUsbLine(session.frameId, session.logFilter, session.pendingLine)
   session.pendingLine = ''
 }
 
@@ -442,6 +456,91 @@ function tailHasUsbTerminator(received: string, freshLength: number): boolean {
   return usbResponseTerminators.some((marker) => tail.includes(marker))
 }
 
+/** One-line digest of the device's status JSON, for people reading the log. */
+export function summarizeUsbStatusJson(text: string): string | null {
+  let status: EmbeddedUsbStatus
+  try {
+    status = JSON.parse(text) as EmbeddedUsbStatus
+  } catch (error) {
+    return null
+  }
+  const parts: string[] = []
+  if (status.version) {
+    parts.push(`version=${status.version}`)
+  }
+  if (status.config?.panel) {
+    parts.push(`panel=${status.config.panel}`)
+  }
+  if (status.scenes) {
+    parts.push(`scenes=${status.scenes.loaded ?? 0}/${status.scenes.available ?? 0}`)
+  }
+  const wifi = [status.config?.wifiSsid, status.wifi?.ip].filter(Boolean).join(' ')
+  parts.push(`wifi=${wifi || 'not connected'}`)
+  return parts.join(' ')
+}
+
+// Slack over the declared payload size: base64 line breaks and the trailing
+// newline are not counted in it.
+const USB_PAYLOAD_SUPPRESSION_SLACK = 1024
+const USB_PAYLOAD_SUMMARY_CHARS = 16384
+
+/**
+ * The device console is a shared stdout: the usb_api wire protocol (BEGIN/END
+ * markers, base64 or JSON payload bodies) lands in the same stream a person
+ * reads in the logs panel. Strip the framing, drop payload bodies, and turn a
+ * status dump into a single summary line. Stateful across lines, so each sink
+ * (log stream, command mirror) needs its own instance.
+ */
+export function createUsbProtocolLogFilter(): (line: string) => string | null {
+  let payloadCommand: string | null = null
+  let payloadEncoding = ''
+  let payloadBudget = 0
+  let payloadText = ''
+
+  const endPayload = (): void => {
+    payloadCommand = null
+    payloadText = ''
+  }
+
+  return (line: string): string | null => {
+    if (payloadCommand !== null) {
+      if (line.startsWith(`__FRAMEOS_USB_END__ ${payloadCommand}`)) {
+        const summary = payloadCommand === 'status' ? summarizeUsbStatusJson(payloadText) : null
+        const command = payloadCommand
+        endPayload()
+        return summary ? `${command}: ${summary}` : null
+      }
+      if (payloadEncoding === 'text' && payloadText.length < USB_PAYLOAD_SUMMARY_CHARS) {
+        payloadText += line
+      }
+      payloadBudget -= line.length + 1
+      // A payload whose END never arrives (board reset mid-transfer) must not
+      // swallow every log line that follows it.
+      if (payloadBudget < 0) {
+        endPayload()
+      }
+      return null
+    }
+
+    const begin = line.match(/^__FRAMEOS_USB_BEGIN__\s+(\S+)\s+(\d+)\s+(\S+)/)
+    if (begin) {
+      payloadCommand = begin[1]
+      payloadBudget = Number(begin[2]) + USB_PAYLOAD_SUPPRESSION_SLACK
+      payloadEncoding = begin[3]
+      payloadText = ''
+      return null
+    }
+    const error = line.match(/^__FRAMEOS_USB_ERROR__\s+(\S+)\s+(.*)$/)
+    if (error) {
+      return `${error[1]} failed: ${error[2].trim()}`
+    }
+    if (/^__FRAMEOS_USB_(OK|READY|END)__\b/.test(line)) {
+      return null
+    }
+    return line
+  }
+}
+
 async function writeUsbPayload(writer: WritableStreamDefaultWriter<Uint8Array>, payload: Uint8Array): Promise<void> {
   for (let offset = 0; offset < payload.byteLength; offset += USB_PAYLOAD_CHUNK_SIZE) {
     await writer.write(payload.slice(offset, Math.min(payload.byteLength, offset + USB_PAYLOAD_CHUNK_SIZE)))
@@ -685,11 +784,14 @@ async function runEmbeddedUsbApiCommandLocked(
     await prepareSerialPortReconnect(port)
   }
   const payload = typeof options?.payload === 'string' ? new TextEncoder().encode(options.payload) : options?.payload
-  appendUsbLine(frameId, `[USB API] ${command}${payload ? ` (${payload.byteLength} bytes)` : ''}`)
-  if (payload) {
-    appendUsbLine(frameId, `[USB API] waiting for ${command} ready marker`)
+  if (!options?.probe) {
+    appendUsbLine(frameId, `[USB API] ${command}${payload ? ` (${payload.byteLength} bytes)` : ''}`)
+    if (payload) {
+      appendUsbLine(frameId, `[USB API] waiting for ${command} ready marker`)
+    }
   }
   const mirrorSerialText = options?.mirrorOutput !== false && usbApiResponseCommand(command) !== 'image'
+  const commandLogFilter = createUsbProtocolLogFilter()
   let pendingCommandLogLine = ''
   const appendCommandLogText = mirrorSerialText
     ? (text: string): void => {
@@ -697,13 +799,13 @@ async function runEmbeddedUsbApiCommandLocked(
         const lines = pendingCommandLogLine.split('\n')
         pendingCommandLogLine = lines.pop() ?? ''
         for (const line of lines) {
-          appendUsbLine(frameId, line)
+          appendFilteredUsbLine(frameId, commandLogFilter, line)
         }
       }
     : undefined
   const flushCommandLogText = (): void => {
     if (pendingCommandLogLine) {
-      appendUsbLine(frameId, pendingCommandLogLine)
+      appendFilteredUsbLine(frameId, commandLogFilter, pendingCommandLogLine)
       pendingCommandLogLine = ''
     }
   }
@@ -749,12 +851,16 @@ async function runEmbeddedUsbApiCommandLocked(
       )
     }
     flushCommandLogText()
-    appendUsbLine(frameId, `[USB API] ${command} complete`)
+    if (!options?.probe) {
+      appendUsbLine(frameId, `[USB API] ${command} complete`)
+    }
     rebootAcknowledged = options?.expectReboot === true
     return result
   } catch (error) {
     flushCommandLogText()
-    appendUsbLine(frameId, `[USB API] ${command} failed: ${serialErrorMessage(error)}`)
+    if (!options?.probe) {
+      appendUsbLine(frameId, `[USB API] ${command} failed: ${serialErrorMessage(error)}`)
+    }
     throw error
   } finally {
     if (rebootAcknowledged) {
@@ -883,6 +989,7 @@ export async function startEmbeddedUsbLogStream(frameId: FrameId, port?: SerialP
 
     const session: UsbLogSession = {
       frameId,
+      logFilter: createUsbProtocolLogFilter(),
       pendingLine: '',
       port: selectedPort,
       stopRequested: false,

--- a/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
@@ -17,12 +17,13 @@ import {
   POST_FLASH_BOOT_WAIT_MS,
   appendBrowserFlashLog,
   createUsbLogTerminal,
-  mirrorTransportTrace,
+  recordTransportTrace,
   sleep,
   waitForUsbApiReadyAfterFlash,
   watchdogResetAfterFlash,
   type FlashLogTerminal,
   type FlashPhase,
+  type FlashTraceRecorder,
 } from './EmbeddedWebFlasher'
 import {
   ESP32_PARTITION_TABLE_OFFSET,
@@ -146,6 +147,7 @@ export function EmbeddedUsbFirmwareUpdate({ frame }: { frame: FrameType }): JSX.
     let port: SerialPort | null = null
     let transport: EspTransport | null = null
     let flashTerminal: FlashLogTerminal | null = null
+    let traceRecorder: FlashTraceRecorder | null = null
     let flashed = false
     const setFlashMessage = (nextMessage: string | null): void => {
       setMessage(nextMessage)
@@ -180,7 +182,7 @@ export function EmbeddedUsbFirmwareUpdate({ frame }: { frame: FrameType }): JSX.
       // Loaded on demand: esptool-js adds ~380KB we only need when flashing.
       const { ESPLoader, Transport } = await import('esptool-js')
       transport = new Transport(port, false)
-      mirrorTransportTrace(frame.id, transport)
+      traceRecorder = recordTransportTrace(frame.id, transport)
       flashTerminal = createUsbLogTerminal(frame.id)
 
       setFlashMessage('Connecting to the board')
@@ -213,6 +215,7 @@ export function EmbeddedUsbFirmwareUpdate({ frame }: { frame: FrameType }): JSX.
         },
       })
       flashed = true
+      traceRecorder.expectReboot()
 
       if (!(await watchdogResetAfterFlash(loader))) {
         try {
@@ -242,6 +245,7 @@ export function EmbeddedUsbFirmwareUpdate({ frame }: { frame: FrameType }): JSX.
           : detail
         setMessage(displayMessage)
         appendBrowserFlashLog(frame.id, `Firmware update failed: ${displayMessage}`)
+        traceRecorder?.dumpAfterFailure()
       }
     } finally {
       flashTerminal?.flush()

--- a/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
@@ -15,6 +15,7 @@ import {
   serialPortReconnectRequiresReselection,
   startEmbeddedUsbLogStream,
   stopEmbeddedUsbLogStream,
+  summarizeUsbStatusJson,
 } from '../../models/embeddedUsbLogsModel'
 import { embeddedUsbUploadTimeoutMs, framesModel, scheduleEmbeddedUsbFrameImageRefresh } from '../../models/framesModel'
 import type { FrameType, FrameId } from '../../types'
@@ -173,16 +174,59 @@ export function createUsbLogTerminal(frameId: FrameId): FlashLogTerminal {
   }
 }
 
-export function mirrorTransportTrace(frameId: FrameId, transport: EspTransport): void {
+// esptool's transport chatter ("command op:0x09 data len=16", "Read 12
+// bytes") is the only record of what the protocol did, and the only thing
+// worth having when a flash fails — but it is meaningless to someone
+// watching a working flash. Keep it in a ring buffer and put it in the log
+// only if the flash actually fails.
+const FLASH_TRACE_BUFFERED_LINES = 500
+
+export interface FlashTraceRecorder {
+  /** The write finished: the next port loss is the reboot, not a fault. */
+  expectReboot: () => void
+  /** Replay the buffered protocol trace so a failed flash stays diagnosable. */
+  dumpAfterFailure: () => void
+}
+
+export function recordTransportTrace(frameId: FrameId, transport: EspTransport): FlashTraceRecorder {
   const traceableTransport = transport as unknown as TraceableTransportInternals
   const originalTrace = traceableTransport.trace.bind(traceableTransport)
+  const buffered: string[] = []
+  let rebootExpected = false
+
   traceableTransport.trace = (message: string): void => {
     const delta = Date.now() - (traceableTransport.lastTraceTime ?? Date.now())
     const logMessage = flashTraceLogMessage(message)
     if (logMessage) {
-      appendEmbeddedUsbLogLine(frameId, `TRACE ${delta.toFixed(3)} ${logMessage}`)
+      buffered.push(`TRACE ${delta.toFixed(3)} ${logMessage}`)
+      if (buffered.length > FLASH_TRACE_BUFFERED_LINES) {
+        buffered.shift()
+      }
+    }
+    // esptool reports the post-write reboot as "Unrecoverable serial port
+    // error: The device has been lost." — a catastrophe only if it happens
+    // before the image is written, and then the flash fails and says so.
+    if (rebootExpected && /device has been lost|unrecoverable serial port error/i.test(message)) {
+      rebootExpected = false
+      appendBrowserFlashLog(frameId, 'The board dropped off USB — it is rebooting into the new firmware.')
     }
     originalTrace(message)
+  }
+
+  return {
+    expectReboot: () => {
+      rebootExpected = true
+    },
+    dumpAfterFailure: () => {
+      if (buffered.length === 0) {
+        return
+      }
+      appendBrowserFlashLog(frameId, `Flasher protocol trace (last ${buffered.length} lines):`)
+      for (const line of buffered) {
+        appendEmbeddedUsbLogLine(frameId, line)
+      }
+      buffered.length = 0
+    },
   }
 }
 
@@ -314,28 +358,8 @@ async function uploadScenesOverUsbAfterFlash(
 }
 
 function usbStatusSummary(text: string | undefined): string {
-  if (!text) {
-    return 'USB API ready'
-  }
-  try {
-    const status = JSON.parse(text)
-    const parts = ['USB API ready']
-    if (status.version) {
-      parts.push(`version=${status.version}`)
-    }
-    if (status.config?.panel) {
-      parts.push(`panel=${status.config.panel}`)
-    }
-    if (status.render?.count !== undefined) {
-      parts.push(`renders=${status.render.count}`)
-    }
-    if (status.scenes?.loaded !== undefined) {
-      parts.push(`scenes=${status.scenes.loaded}`)
-    }
-    return parts.join(' ')
-  } catch (error) {
-    return 'USB API ready'
-  }
+  const summary = text ? summarizeUsbStatusJson(text) : null
+  return summary ? `The board answered on USB: ${summary}` : 'The board answered on USB'
 }
 
 // Returns the port the board answered on: the watchdog reset after flashing
@@ -373,14 +397,24 @@ export async function waitForUsbApiReadyAfterFlash(
         timeoutMs: Math.min(POST_FLASH_USB_READY_COMMAND_TIMEOUT_MS, Math.max(1000, deadline - Date.now())),
         mirrorOutput: false,
         keepOpen: true,
+        probe: true,
       })
       appendBrowserFlashLog(frame.id, usbStatusSummary(result.text))
       return port
     } catch (error) {
       lastError = error
       if (attempt === 1 || attempt % 4 === 0) {
+        // A board that is still booting simply does not answer; that is
+        // progress, not a failure. Anything else is worth naming.
         const detail = error instanceof Error ? error.message : String(error)
-        appendBrowserFlashLog(frame.id, `USB API not ready yet: ${detail}`)
+        const stillBooting = /Timed out waiting for USB command (?:response|ready)/i.test(detail)
+        const waited = Math.round((Date.now() - started) / 1000)
+        appendBrowserFlashLog(
+          frame.id,
+          stillBooting
+            ? `Waiting for the board to boot (attempt ${attempt}, ${waited}s)`
+            : `Waiting for the board to boot (attempt ${attempt}, ${waited}s): ${detail}`
+        )
       }
       if (!resetHintShown && Date.now() - started > POST_FLASH_USB_RESET_HINT_MS) {
         resetHintShown = true
@@ -485,6 +519,7 @@ export function EmbeddedWebFlasher({
     let port: SerialPort | null = null
     let transport: EspTransport | null = null
     let flashTerminal: FlashLogTerminal | null = null
+    let traceRecorder: FlashTraceRecorder | null = null
     let streamLogsAfterFlash = false
     const setFlashMessage = (nextMessage: string | null): void => {
       setMessage(nextMessage)
@@ -516,7 +551,7 @@ export function EmbeddedWebFlasher({
       // Loaded on demand: esptool-js adds ~380KB we only need when actually flashing
       const { ESPLoader, Transport } = await import('esptool-js')
       transport = new Transport(port, false)
-      mirrorTransportTrace(frame.id, transport)
+      traceRecorder = recordTransportTrace(frame.id, transport)
       flashTerminal = createUsbLogTerminal(frame.id)
 
       setFlashMessage('Connecting to the board')
@@ -551,6 +586,7 @@ export function EmbeddedWebFlasher({
           setProgress(total > 0 ? Math.round((written / total) * 100) : null)
         },
       })
+      traceRecorder.expectReboot()
       // Prefer a watchdog reset: a DTR/RTS pulse can strap USB-Serial/JTAG
       // boards back into ROM download mode instead of booting the app. Fall
       // back to pulsing the reset line the way the esptool CLI does —
@@ -586,6 +622,7 @@ export function EmbeddedWebFlasher({
         setPhase('idle')
       } else if (displayMessage) {
         appendBrowserFlashLog(frame.id, `Flash failed: ${displayMessage}`)
+        traceRecorder?.dumpAfterFailure()
       }
     } finally {
       flashTerminal?.flush()


### PR DESCRIPTION
Flashing an ESP32 over USB from the workspace produced a log that was almost entirely machine chatter. This changes only what is **shown** — timings, retry counts, the write plan and the wire protocol are untouched.

## Before

```
[USB] TRACE 19950.000 command op:0x09 data len=16 wait_response=1 timeout=3.000 (raw data hidden)
[USB] TRACE 19950.000 Write 26 bytes (raw data hidden)
[USB] TRACE 19955.000 Read 12 bytes (raw data hidden)
        ... dozens more of the same ...
[USB] TRACE 20271.000 Unrecoverable serial port error: The device has been lost.
[USB] [browser flash] Firmware written. Waiting for the board to reboot.
[USB] [USB API] status
[USB] [USB API] status failed: Timed out waiting for USB command response: status
[USB] [browser flash] USB API not ready yet: Timed out waiting for USB command response: status
[USB] [USB API] status
[USB] [USB API] status failed: Timed out waiting for USB command response: status
[USB] __FRAMEOS_USB_BEGIN__ status 2605 text
[USB] {"app":"frameos","version":"0.0.0-unknown","uptimeSec":12, ... ~2600 bytes ... }
[USB] __FRAMEOS_USB_END__ status
[USB] __FRAMEOS_USB_BEGIN__ status 2605 text
[USB] {"app":"frameos", ... the same ~2600 bytes again ... }
[USB] __FRAMEOS_USB_END__ status
```

## After

```
[USB] [browser flash] Flashing frameos-esp32-s3-generic.bin to ESP32-S3, keeping the frame's Wi-Fi and cloud settings (nvs, 24KB).
[USB] [browser flash] The board dropped off USB — it is rebooting into the new firmware.
[USB] [browser flash] Firmware written. Waiting for the board to reboot.
[USB] [browser flash] Waiting for the board to boot (attempt 1, 8s)
[USB] [browser flash] Waiting for the board to boot (attempt 4, 18s)
[USB] [browser flash] The board answered on USB: version=2026.8.12 panel=EPD_13IN3E scenes=2/3 wifi=HomeNet 10.0.0.42
[USB] [browser flash] Firmware updated. The frame kept its Wi-Fi and cloud settings and is reconnecting.
```

And when a flash **fails**, the detail is still there — the buffered protocol trace is replayed right after the failure line:

```
[USB] [browser flash] Flash failed: Timed out waiting for packet header
[USB] [browser flash] Flasher protocol trace (last 137 lines):
[USB] TRACE 19950.000 command op:0x09 data len=16 wait_response=1 timeout=3.000 (raw data hidden)
[USB] TRACE 19950.000 Write 26 bytes (raw data hidden)
        ...
```

## What changed

| Problem | Fix |
| --- | --- |
| Dozens of esptool `TRACE` lines | `mirrorTransportTrace` → `recordTransportTrace`: traces go into a 500-line ring buffer and are written to the log only by `dumpAfterFailure()`, called from both flash flows' error paths. `enableTracing` stays on. |
| "Unrecoverable serial port error: The device has been lost." | After `writeFlash` the flow calls `traceRecorder.expectReboot()`; the first port-loss trace after that becomes "The board dropped off USB — it is rebooting into the new firmware." Before the write it is still an error, and the flash fails and says so. |
| Three "failures" that are normal boot latency | New `probe: true` option on `runEmbeddedUsbApiCommand` suppresses the per-attempt `[USB API] status` / `... failed:` lines for a liveness poll. `waitForUsbApiReadyAfterFlash` logs `Waiting for the board to boot (attempt N, Ns)` instead — same attempt cadence (`attempt === 1 \|\| attempt % 4 === 0`), same timeouts. A non-timeout error still prints its detail. |
| 2.6KB status JSON, three times | `createUsbProtocolLogFilter()` summarises a `status` payload to `version= panel= scenes= wifi=`; the JSON itself never reaches the log. The full status is still available in the USB setup panel, which reads it directly. |
| `__FRAMEOS_USB_BEGIN__` / `__FRAMEOS_USB_END__` leaking | The same filter drops BEGIN/END/OK/READY markers and payload bodies. It runs on both sinks that carry raw console text (the log stream and the per-command mirror), so it catches these markers whichever reader saw them. `__FRAMEOS_USB_ERROR__` survives, rewritten as `<command> failed: <detail>`. A payload whose END never arrives cannot swallow the rest of the log — suppression is bounded by the declared byte count. |

## Testing

`npx tsc --noEmit -p tsconfig.json` and `node build.mjs` both pass. The protocol filter was exercised directly against a synthetic console transcript (status payload, base64 payload, OK/READY/ERROR markers, truncated payload).

**Unverified:** Web Serial cannot be driven headlessly, so the flash flow itself was not run end to end against a board. The log wording and suppression above are reasoned from the code paths, not observed on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
