### PR TITLE
Cut peak render memory for gradient SVG scenes (Weather on 8MB ESP32)

### DIFF
--- a/frameos/src/apps/render/split/app.nim
+++ b/frameos/src/apps/render/split/app.nim
@@ -137,6 +137,12 @@ proc render*(self: App, context: ExecutionContext, image: var Image) =
       let renderer: NodeId = if row >= 0 and row < renderFunctions.len and column >= 0 and column < renderFunctions[
           row].len and renderFunctions[row][column] == 0: renderFunction else: renderFunctions[row][column]
       if renderer != 0:
+        # Cells already render at cell size, not canvas size: the child sees a
+        # cellWidth x cellHeight context and everything downstream (JS apps,
+        # render/image, nested splits) sizes itself from context.image. The
+        # copy is what carries the parent's pixels under a cell that draws
+        # with alpha; pixie has no image view, so a real sub-region render
+        # would need one buffer per cell either way.
         let img = image.subImage(cellX.toInt, cellY.toInt, cellWidth, cellHeight)
         var cellContext = ExecutionContext(
             scene: context.scene,

--- a/frameos/src/frameos/tests/test_interpreter_svg_banding.nim
+++ b/frameos/src/frameos/tests/test_interpreter_svg_banding.nim
@@ -1,0 +1,96 @@
+import std/[json, os, tables, strutils]
+import pixie
+import ../interpreter
+import ../types
+import ../utils/memory
+
+# End-to-end check for the banded SVG rasteriser on a real, JS-generated
+# scene: the bundled "Weather" graph in stacked mode. It puts a render/split
+# with two cells in front of three weatherPanel apps, each of which emits an
+# 800x192 / 800x288 SVG with a gradient background — the shape that made an
+# 8MB-PSRAM ESP32 run out of memory (see docs in utils/image.nim).
+#
+# The scene must render the same picture whether the SVGs are rasterised in
+# one pass (hosts, RAM-rich frames) or band by band (memory-tight devices).
+
+const SceneFile = "../e2e/scenes/weatherStacked.json"
+
+proc testLogger(): Logger =
+  var logger = Logger(enabled: false)
+  logger.log = proc(payload: JsonNode) =
+    let event = payload{"event"}.getStr()
+    doAssert not (event.contains("error") or event.contains("Error")),
+      "weatherStacked render logged an error: " & $payload
+  logger.enable = proc() = discard
+  logger.disable = proc() = discard
+  logger
+
+proc renderScene(): Image =
+  let raw = readFile(SceneFile).strip()
+  # The e2e scene files hold a single scene object; scenes.json holds an array.
+  let data = if raw.startsWith("["): raw else: "[" & raw & "]"
+  let inputs = parseInterpretedSceneInputs(data)
+  doAssert inputs.len == 1
+  var uploaded = initTable[SceneId, ExportedInterpretedScene]()
+  for id, exported in buildInterpretedScenes(inputs):
+    uploaded[id] = exported
+  setUploadedInterpretedScenes(uploaded)
+  resetInterpretedScenes()
+
+  let config = FrameConfig(
+    name: "test", mode: "embedded", width: 800, height: 480, rotate: 0,
+    scalingMode: "cover", assetsPath: getTempDir(), debug: false,
+    settings: %*{}, saveAssets: %*false
+  )
+  let scene = init(inputs[0].id, config, testLogger(), %*{})
+  var context = ExecutionContext(
+    scene: scene, event: "render", payload: %*{}, hasImage: false,
+    loopIndex: 0, loopKey: ".", nextSleep: 0.0
+  )
+  result = render(scene, context)
+  setUploadedInterpretedScenes(initTable[SceneId, ExportedInterpretedScene]())
+
+doAssert fileExists(SceneFile), "missing " & SceneFile
+
+# Plenty of memory: pixie rasterises each panel SVG in one pass.
+availableRenderBytesOverride = 0
+let onePass = renderScene()
+doAssert onePass.width == 800 and onePass.height == 480
+
+# The scene really did draw something (a blank frame would compare equal).
+var inked = 0
+for color in onePass.data:
+  if color.r.int + color.g.int + color.b.int > 60:
+    inc inked
+doAssert inked > 20000, "weatherStacked drew only " & $inked & " bright pixels"
+
+# ESP32-class headroom: the panels come back band by band.
+availableRenderBytesOverride = 3 * 1024 * 1024
+refreshDecodeBudget()
+let banded = renderScene()
+doAssert banded.width == 800 and banded.height == 480
+
+var worst = 0
+var differing = 0
+for i in 0 ..< onePass.data.len:
+  let
+    p = onePass.data[i]
+    q = banded.data[i]
+    d = max(max(abs(p.r.int - q.r.int), abs(p.g.int - q.g.int)),
+            max(abs(p.b.int - q.b.int), abs(p.a.int - q.a.int)))
+  if d > 0:
+    inc differing
+    if d > worst: worst = d
+
+# Only float32 rounding of the band-shifted shape coordinates may move an
+# antialiased edge sample; nothing structural may change.
+doAssert worst <= 8, "banded weatherStacked differs by " & $worst & " (max channel)"
+doAssert differing * 100 <= onePass.data.len,
+  "banded weatherStacked differs in " & $differing & " of " &
+  $onePass.data.len & " pixels"
+
+availableRenderBytesOverride = 0
+refreshDecodeBudget()
+
+echo "test_interpreter_svg_banding: worstDiff=", worst, " differingPixels=",
+  differing, "/", onePass.data.len

--- a/frameos/src/frameos/tests/test_svg_banding.nim
+++ b/frameos/src/frameos/tests/test_svg_banding.nim
@@ -1,0 +1,124 @@
+import std/[strutils, math, options]
+import pixie
+import ../utils/image
+import ../utils/memory
+
+# Rasterising an SVG that paints with a gradient costs 3x its output image in
+# pixie: the output plus the mask+fill pair `fillPath` allocates for non-solid
+# paints. On memory-tight devices `decodeSvgWithFallback` renders the SVG one
+# horizontal band at a time so only the band-sized pair is ever live. The
+# banded result must match the one-pass result.
+
+proc buildSvg(width, height: int): string =
+  var parts: seq[string] = @[]
+  parts.add("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" & $width &
+    "\" height=\"" & $height & "\" viewBox=\"0 0 " & $width & " " & $height & "\">")
+  # pixie ignores <defs>; gradients have to sit at the top level and be in
+  # user space (the same shape the bundled JS apps emit).
+  parts.add("<linearGradient id=\"bg\" gradientUnits=\"userSpaceOnUse\" " &
+    "x1=\"0\" y1=\"0\" x2=\"0\" y2=\"" & $height & "\">" &
+    "<stop offset=\"0\" stop-color=\"#12305a\"/><stop offset=\"1\" stop-color=\"#7a1f4b\"/>" &
+    "</linearGradient>")
+  parts.add("<rect x=\"0\" y=\"0\" width=\"" & $width & "\" height=\"" & $height &
+    "\" fill=\"url(#bg)\"/>")
+  # Solid shapes, strokes and transforms spread over the whole canvas so every
+  # band contains geometry that starts outside it.
+  for i in 0 ..< 24:
+    let
+      cx = 20.0 + i.float * (width.float - 40.0) / 24.0
+      cy = 10.0 + (i mod 7).float * (height.float - 20.0) / 7.0
+      r = 6.0 + (i mod 5).float * 4.0
+    parts.add("<circle cx=\"" & formatFloat(cx, ffDecimal, 2) & "\" cy=\"" &
+      formatFloat(cy, ffDecimal, 2) & "\" r=\"" & formatFloat(r, ffDecimal, 2) &
+      "\" fill=\"#ffcc33\" fill-opacity=\"0.7\"/>")
+    parts.add("<line x1=\"0\" y1=\"" & formatFloat(cy, ffDecimal, 2) & "\" x2=\"" &
+      $width & "\" y2=\"" & formatFloat(cy + 13.5, ffDecimal, 2) &
+      "\" stroke=\"#ffffff\" stroke-width=\"1.5\" stroke-opacity=\"0.5\"/>")
+  parts.add("<g transform=\"translate(12 9)\">")
+  var d = "M 0 " & $(height div 2)
+  for i in 1 .. 40:
+    let
+      x = i.float * width.float / 40.0
+      y = height.float / 2.0 + sin(i.float / 3.0) * height.float / 5.0
+    d.add(" L " & formatFloat(x, ffDecimal, 2) & " " & formatFloat(y, ffDecimal, 2))
+  parts.add("<path d=\"" & d & "\" fill=\"none\" stroke=\"#33ffaa\" stroke-width=\"2.5\"/>")
+  parts.add("</g>")
+  parts.add("</svg>")
+  parts.join("")
+
+proc maxChannelDiff(a, b: Image): (int, int) =
+  ## (largest per-channel difference, number of differing pixels)
+  doAssert a.width == b.width and a.height == b.height
+  var worst = 0
+  var differing = 0
+  for i in 0 ..< a.data.len:
+    let
+      p = a.data[i]
+      q = b.data[i]
+      d = max(max(abs(p.r.int - q.r.int), abs(p.g.int - q.g.int)),
+              max(abs(p.b.int - q.b.int), abs(p.a.int - q.a.int)))
+    if d > 0:
+      inc differing
+      if d > worst: worst = d
+  (worst, differing)
+
+const W = 400
+const H = 320
+
+let svg = buildSvg(W, H)
+doAssert svgNeedsPaintServer(svg)
+doAssert not svgNeedsPaintServer(svg.replace("url(#bg)", "#123456"))
+
+# Hosts and RAM-rich frames keep pixie's single-pass behaviour.
+availableRenderBytesOverride = 0
+doAssert svgBandHeight(W, H, svg) == H, "unlimited memory must not band"
+availableRenderBytesOverride = 512 * 1024 * 1024
+doAssert svgBandHeight(W, H, svg) == H, "a roomy budget must not band"
+doAssert svgBandHeight(W, H, svg.replace("url(#bg)", "#123456")) == H,
+  "gradient-free SVGs must never band"
+
+let reference = decodeSvgWithFallback(svg, W, H)
+doAssert reference.isSome
+doAssert reference.get().width == W and reference.get().height == H
+
+# ESP32-class headroom: the 3x one-pass plan no longer fits.
+availableRenderBytesOverride = 2 * 1024 * 1024
+let bandHeight = svgBandHeight(W, H, svg)
+doAssert svgBandHeight(W, H, svg.replace("url(#bg)", "#123456")) == H,
+  "gradient-free SVGs must never band, however tight memory is"
+doAssert bandHeight < H, "a tight budget must band, got " & $bandHeight
+doAssert bandHeight >= 8
+
+let banded = decodeSvgWithFallback(svg, W, H)
+doAssert banded.isSome
+doAssert banded.get().width == W and banded.get().height == H
+
+let (worst, differing) = maxChannelDiff(reference.get(), banded.get())
+# The band transform is an exact integer device-space translation, so the same
+# scanlines get the same coverage. Only float32 rounding of the shifted shape
+# coordinates can nudge an antialiased edge sample, so a handful of pixels may
+# differ by a bit or two.
+doAssert worst <= 8, "banded SVG differs by " & $worst & " (max channel)"
+doAssert differing * 100 <= W * H,
+  "banded SVG differs in " & $differing & " of " & $(W * H) & " pixels"
+
+# An SVG whose root already carries a transform must come back unchanged too.
+let rotated = svg.replace("<svg xmlns=", "<svg transform=\"translate(3 5)\" xmlns=")
+availableRenderBytesOverride = 0
+let rotatedReference = decodeSvgWithFallback(rotated, W, H)
+doAssert rotatedReference.isSome
+availableRenderBytesOverride = 2 * 1024 * 1024
+let rotatedBanded = decodeSvgWithFallback(rotated, W, H)
+doAssert rotatedBanded.isSome
+let (rotWorst, rotDiffering) = maxChannelDiff(rotatedReference.get(), rotatedBanded.get())
+doAssert rotWorst <= 8, "banded SVG with a root transform differs by " & $rotWorst
+doAssert rotDiffering * 100 <= W * H
+
+# Malformed SVG still fails the same way through the banded entry point.
+availableRenderBytesOverride = 2 * 1024 * 1024
+doAssert decodeSvgWithFallback("<svg>not really", W, H).isNone
+
+availableRenderBytesOverride = 0
+
+echo "test_svg_banding: bandHeight=", bandHeight, " worstDiff=", worst,
+  " differingPixels=", differing, "/", W * H

--- a/frameos/src/frameos/utils/image.nim
+++ b/frameos/src/frameos/utils/image.nim
@@ -10,6 +10,9 @@ import sequtils
 import strutils
 import strformat
 import uri
+import std/xmlparser
+import std/xmltree
+import std/strtabs
 
 import frameos/utils/http_client
 import frameos/utils/memory
@@ -184,9 +187,96 @@ proc decodeSvgWithImageMagick*(svg: string, width: int, height: int): Option[Ima
     return decodeImageMagickOutput(output.get())
   return none(Image)
 
+const SvgBandMinHeight = 8
+const SvgBandMinBytes = 128 * 1024
+
+proc svgNeedsPaintServer*(svg: string): bool =
+  ## True when the SVG paints with a gradient/pattern reference. pixie fills
+  ## those through a full-canvas mask + fill image pair (paths.fillPath), so
+  ## such an SVG costs 3x its output image to rasterise in one pass. Solid
+  ## fills and strokes rasterise straight into the canvas and cost 1x.
+  svg.contains("url(")
+
+proc svgBandHeight*(width, height: int, svg: string): int =
+  ## Height of the horizontal slice an SVG is rasterised in. Returns `height`
+  ## (a single pass, pixie's own behaviour) unless the 3x one-pass plan would
+  ## take a big share of the memory still available for rendering — which on
+  ## development hosts, the backend, wasm and RAM-rich frames it never does.
+  if width <= 0 or height <= 0 or not svgNeedsPaintServer(svg):
+    return height
+  let
+    rowBytes = width.int64 * 4
+    fullBytes = rowBytes * height.int64
+    available = availableRenderBytes().int64
+  # Banding keeps the parsed XML document live across every pass, where a
+  # single pass drops it before allocating the canvas. Documents that big are
+  # not worth banding.
+  if svg.len.int64 * 16 > fullBytes:
+    return height
+  if available <= 0:
+    return height
+  if fullBytes * 3 <= available div 2:
+    return height
+  var bandBytes = available div 12
+  # The finished image stays live while the bands are rasterised, so the
+  # band-sized trio has to fit in what is left once it exists.
+  let headroom = available - fullBytes
+  if headroom > 0 and bandBytes * 3 > headroom:
+    bandBytes = headroom div 3
+  if bandBytes < SvgBandMinBytes:
+    bandBytes = SvgBandMinBytes
+  if bandBytes >= fullBytes:
+    return height
+  result = max(SvgBandMinHeight, int(bandBytes div max(1'i64, rowBytes)))
+  if result >= height:
+    result = height
+
+proc renderSvgBanded(svg: string, width, height, bandHeight: int): Image =
+  ## Rasterises the SVG one horizontal slice at a time, so pixie's gradient
+  ## mask+fill pair is band-sized instead of canvas-sized.
+  ##
+  ## Each pass re-renders the whole element list into a band-tall canvas with
+  ## the root shifted up by the band's offset, so shapes are clipped by the
+  ## band's scanline range rather than being cut geometrically: coverage for
+  ## an output row is computed from the full shape either way.
+  let root = parseXml(svg)
+  let attrs = root.attrs
+  if attrs.isNil:
+    # No attributes means no viewBox; parseSvg would reject it anyway.
+    raise newException(PixieError, "SVG root has no attributes")
+  let baseTransform = root.attr("transform")
+  result = newImage(width, height)
+  try:
+    var y = 0
+    while y < height:
+      let bandH = min(bandHeight, height - y)
+      # Leftmost transform is applied last, i.e. in device space: this shifts
+      # the finished drawing up by `y` so the band shows rows y ..< y+bandH.
+      attrs["transform"] = strutils.strip("translate(0 " & $(-y) & ") " & baseTransform)
+      let parsed = parseSvg(root, width, height)
+      # parseSvg already derived the scale from the full height; shrinking the
+      # canvas afterwards only changes how much of it gets rasterised.
+      parsed.height = bandH
+      let band = newImage(parsed)
+      copyMem(result.data[y * width].addr, band.data[0].addr, bandH * width * 4)
+      y += bandH
+  finally:
+    if baseTransform.len == 0:
+      attrs.del("transform")
+    else:
+      attrs["transform"] = baseTransform
+
 proc decodeSvgWithFallback*(svg: string, width: int, height: int): Option[Image] =
   if useImageMagick():
     return decodeSvgWithImageMagick(svg, width, height)
+  let bandHeight = svgBandHeight(width, height, svg)
+  if bandHeight > 0 and bandHeight < height:
+    try:
+      return some(renderSvgBanded(svg, width, height, bandHeight))
+    except CatchableError:
+      # Banding is an optimisation; anything it cannot handle falls through
+      # to the plain one-pass render below.
+      discard
   try:
     return some(newImage(parseSvg(svg, width, height)))
   except CatchableError:


### PR DESCRIPTION
## What I measured

I instrumented a copy of the pinned pixie fork to log every `newImage` of
32K or more, and rendered the bundled Weather graph through the interpreter
at 800x480 (the e2e `weatherStacked` / `weatherCurrent` scenes are the same
graph with the network node replaced by canned data).

**The peak is not the split.** `render/split` already renders each cell at
cell size — a 800x288 cell hands the child a 800x288 context, and everything
downstream (`render/image`, the `weatherPanel` JS app) sizes itself from
`context.image`. Nothing allocates 800x480 for a cell.

The peak is pixie's gradient fill. `Image.fillPath` allocates **two**
full-canvas images (a mask and a fill) for any non-solid paint:

```nim
# pixie/paths.nim
let
  mask = newImage(image.width, image.height)
  fill = newImage(image.width, image.height)
```

`weatherPanel` paints one `<rect ... fill="url(#bg)">` over the whole panel,
so every panel SVG costs 3x its output image.

Live bytes at peak, 800x480 panel (measured, not derived):

| | before |
|---|---|
| `mode=current` (full frame) | canvas 1500K + SVG out 1500K + grad mask 1500K + grad fill 1500K = **6000K** |
| `mode=stacked` (split rows=2, ratios 2:3, worst cell 800x288) | canvas 1500K + cell subImage 900K + SVG out 900K + grad mask 900K + grad fill 900K = **5100K** |
| `mode=stacked`, first cell 800x192 | 1500K + 600K + 600K + 600K + 600K = 3900K |

The embedded `image.jpg` is not involved: it is the scene's repo preview, not
a render input.

## What I changed

`decodeSvgWithFallback` (`frameos/src/frameos/utils/image.nim`) now
rasterises a gradient SVG **one horizontal band at a time**. Each pass
re-renders the whole element list into a band-tall canvas with the root
shifted by `translate(0 -y)` in device space, and the band is `copyMem`'d
into the output. Only a band-sized mask+fill pair is ever live.

Measured after, with 3MB of headroom:

| | after | change |
|---|---|---|
| `mode=current` | 1500K + 1500K + 3x253K = **3759K** | −37% |
| `mode=stacked`, 800x288 cell | 1500K + 900K + 900K + 3x140K = **3720K** | −27% |

The band size adapts to `availableRenderBytes()`, so it tightens further as
PSRAM fills.

**Behaviour is unchanged everywhere it can be.** Banding only engages when
`availableRenderBytes()` says the 3x one-pass plan no longer fits — never on
development hosts (1GB), the backend, wasm, or RAM-rich Linux frames, where
`decodeSvgWithFallback` calls exactly the same pixie code as before.
Gradient-free SVGs never band (they already cost 1x, and banding would cost
one extra buffer). Neither do documents whose XML tree would rival the image.
Anything the banded path cannot handle falls through to the one-pass render.

`render/split` gets a comment only — see "what I did not change".

## Tests

* `frameos/src/frameos/tests/test_svg_banding.nim` — a gradient SVG with
  circles, strokes, a group transform and a polyline, rendered one-pass and
  banded, compared pixel by pixel. Also covers: unlimited/roomy budgets do not
  band, gradient-free SVGs never band, an SVG whose root already carries a
  transform round-trips, malformed SVG still fails the same way.
  Result: `bandHeight=109 worstDiff=3 differingPixels=43/128000`.
* `frameos/src/frameos/tests/test_interpreter_svg_banding.nim` — the real
  `e2e/scenes/weatherStacked.json` graph (render/split + three weatherPanel
  JS apps) rendered through the interpreter both ways.
  Result: `worstDiff=1 differingPixels=43/384000` (0.011%).

The residual differences are float32 rounding of the band-shifted shape
coordinates nudging a few antialiased edge samples. Nothing structural moves;
the band boundaries themselves are seam-free because coverage for an output
row is computed from the full shape either way.

Also run green: `test_repo_scenes_esp32` (13 scenes at a 4MB budget),
`utils/tests/test_image.nim`, `apps/render/svg/tests/test_app.nim`,
`nim c --compileOnly src/frameos.nim`, and `embedded/esp32/build_nim.sh`
(nimcache generates, 224 files).

## What I did not change, and why

* **`render/split`.** The cell buffer (900K for the 800x288 cell) is the
  smallest of the four live buffers, and it cannot be removed: pixie has no
  image *view*, so "render into a sub-region of the parent" needs one buffer
  per cell either way. The `subImage` copy is also what carries the parent's
  pixels under a cell that draws with alpha. Added a comment saying so.
* **The gradient mask+fill in pixie itself.** Sizing them to the path's
  bounding box instead of the canvas would remove 1800K here and 3000K in the
  full-frame path with *zero* visual risk, and would help every gradient
  anywhere. That is a change to `FrameOS/pixie`, not this repo, so it is out
  of scope for this PR — but it is the single biggest remaining win.
* **Handing the panel the canvas as a decode target.** The interpreter
  already has this (`ExecutionContext.decodeTargetImage`) for a hand-picked
  list of built-in producers. Extending it to JS render apps would remove the
  panel's own 900–1500K output image. It is doable and provably equivalent
  when the produced image is 1:1 with the target (a per-pixel blend of the
  whole image equals the same blend band by band), but it needs a blend mode
  plumbed through the context and would have to be gated the same way. Left
  as the next lever rather than shipped untested.
* **A modified copy of the Weather scene.** Not needed: the built-in fix
  covers it, and the scene already exposes the knob that removes the gradient
  entirely. `lowContrast: true` selects the flat theme, whose background is a
  solid `<rect>`, not `url(#bg)` — measured on `weatherStackedLow`: **3300K**
  peak (canvas 1500K + cell 900K + SVG 900K, no mask, no fill), and 3000K for
  the full-frame modes. That is a public, per-frame setting today. Shipping a
  duplicate scene would also add a second copy of an 83KB scenes.json to every
  firmware's embedded repo assets.

## Not verified — needs hardware

I could not flash or run anything on the board (deliberately: a physical
frame is attached to another session). Specifically unverified:

* That the new peak actually fits an 8MB board end to end. All numbers above
  are host measurements of pixie allocations with an ESP32-like
  `availableRenderBytes()` override; the device also holds the packed
  framebuffer, preview snapshot and TLS buffers that
  `availableRenderBytes()` only accounts for through its reserve.
* The band size the device actually picks. On the host this comes from a test
  override; on-device it comes from live PSRAM (`min(largest free block,
  free - reserve)`), so the real band will be smaller than the 81/140-row
  bands measured here — which is the intended behaviour, but it is untested.
* Render *time* on the device. Banding re-walks the SVG element list once per
  band. Rasterisation work is roughly unchanged (each scanline is still
  filled once), but path building is repeated, and I have no on-device timing.
* That no ESP32-only pixie/decode path interacts badly with the extra
  `parseXml` tree being live during rasterisation.
