### PR TITLE
ESP32: GPIO buttons were dead — the runtime dropped every scene-defined event

### DIFF
--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -10,6 +10,8 @@
 
 #include "driver/usb_serial_jtag.h"
 #include "driver/usb_serial_jtag_vfs.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
 #include "esp_console.h"
 #include "esp_err.h"
 #include "esp_heap_caps.h"
@@ -120,6 +122,16 @@ static int cmd_status(int argc, char **argv)
     printf("hardware:    %s\n", config->hardware_preset[0] ? config->hardware_preset : "(custom)");
     printf("panel:       %s (%dx%d)\n", config->panel, fos_display_width(), fos_display_height());
     printf("pins:        %s\n", pins);
+    if (config->gpio_button_count > 0) {
+        printf("buttons:     ");
+        for (size_t i = 0; i < config->gpio_button_count; i++) {
+            printf("%s%d:%s", i ? "," : "", config->gpio_buttons[i].pin,
+                   config->gpio_buttons[i].label);
+        }
+        printf("\n");
+    } else {
+        printf("buttons:     (none configured)\n");
+    }
     printf("render_mode: %s\n", config->render_mode == FOS_RENDER_LOCAL ? "local" : "remote");
     printf("rotate:      %u\n", (unsigned)config->rotate);
     printf("send_logs:   %d\n", (int)config->server_send_logs);
@@ -184,6 +196,110 @@ static int cmd_heapinfo(int argc, char **argv)
     printf("--- per-region detail\n");
     heap_caps_print_heap_info(MALLOC_CAP_SPIRAM);
     heap_caps_print_heap_info(MALLOC_CAP_INTERNAL);
+    return 0;
+}
+
+/* Which GPIOs are wired to buttons, what they read right now, and — with
+ * `buttons watch` — which pin actually moves when someone presses one.
+ *
+ * A frame whose buttons "do nothing" gives no clue why: the configured pins
+ * are invisible in `status`, and fos_buttons logs its wiring at INFO, which
+ * the console's WARN level hides. The usual cause is simply that the board's
+ * button is not on the GPIO its hardware preset assumes — boards get
+ * relabelled and DIY builds differ — and that is a question only the board
+ * can answer.
+ *
+ * `watch` polls a curated safe list. Pins driving the panel, the SD card, USB
+ * and the SPI flash/PSRAM are skipped: reconfiguring those as inputs
+ * mid-flight would break the very frame being debugged. */
+static bool console_pin_in_use(const fos_config_t *config, int pin)
+{
+    const int used[] = {
+        config->pins.rst, config->pins.dc, config->pins.cs, config->pins.cs2,
+        config->pins.busy, config->pins.sck, config->pins.mosi, config->pins.pwr,
+        config->assets_sd.cs, config->assets_sd.sck,
+        config->assets_sd.miso, config->assets_sd.mosi,
+        19, 20, /* USB D-/D+ (the console itself) */
+        /* 26-32 SPI flash, 33-37 octal PSRAM. On an S3 module with octal
+         * PSRAM (CONFIG_SPIRAM_MODE_OCT) 33-37 carry the memory bus, and
+         * reconfiguring them as inputs takes the running system's RAM away
+         * mid-instruction: the first attempt at this scan reset the board
+         * with TG1WDT_SYS_RST. Both ranges are excluded unconditionally —
+         * quad-PSRAM parts simply lose a few candidate pins, which is a
+         * cheap price for a diagnostic that cannot crash the frame it is
+         * diagnosing. */
+        26, 27, 28, 29, 30, 31, 32,
+        33, 34, 35, 36, 37
+    };
+    for (size_t i = 0; i < sizeof(used) / sizeof(used[0]); i++) {
+        if (used[i] == pin) return true;
+    }
+    return false;
+}
+
+static int cmd_buttons(int argc, char **argv)
+{
+    fos_config_t *config = fos_config();
+    printf("configured buttons: %u\n", (unsigned)config->gpio_button_count);
+    for (size_t i = 0; i < config->gpio_button_count; i++) {
+        const fos_gpio_button_t *b = &config->gpio_buttons[i];
+        printf("  GPIO %-2d %-16s level=%d\n", b->pin, b->label, gpio_get_level(b->pin));
+    }
+    if (config->gpio_button_count == 0) {
+        printf("  (none — set them with: set gpio_buttons \"0:BOOT\\n4:KEY1\")\n");
+    }
+    if (argc < 2 || strcmp(argv[1], "watch") != 0) {
+        printf("press a button and run `buttons watch` to find which GPIO it is\n");
+        return 0;
+    }
+
+    int seconds = argc > 2 ? atoi(argv[2]) : 10;
+    if (seconds < 1) seconds = 1;
+    if (seconds > 60) seconds = 60;
+
+    /* Deliberately conservative: no flash/PSRAM pins, no USB, nothing the
+     * panel or SD card is using. A button on an excluded pin is reported as
+     * "not found" rather than risking the board. */
+    static const int candidates[] = {0, 1, 2, 3, 4, 5, 6, 7, 14, 15, 16, 17, 18,
+                                     21, 42, 43, 44, 45, 46, 47, 48};
+    int levels[sizeof(candidates) / sizeof(candidates[0])];
+    size_t count = 0;
+    int watched[sizeof(candidates) / sizeof(candidates[0])];
+    for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++) {
+        int pin = candidates[i];
+        if (console_pin_in_use(config, pin)) continue;
+        gpio_config_t gpio = {
+            .pin_bit_mask = 1ULL << pin,
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = GPIO_PULLUP_ENABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        if (gpio_config(&gpio) != ESP_OK) continue;
+        watched[count] = pin;
+        levels[count] = gpio_get_level(pin);
+        count++;
+    }
+    printf("watching %u pins for %d s — press the button now\n", (unsigned)count, seconds);
+    int64_t end_us = esp_timer_get_time() + (int64_t)seconds * 1000000;
+    int changes = 0;
+    while (esp_timer_get_time() < end_us) {
+        for (size_t i = 0; i < count; i++) {
+            int level = gpio_get_level(watched[i]);
+            if (level != levels[i]) {
+                printf("  GPIO %-2d %d -> %d\n", watched[i], levels[i], level);
+                levels[i] = level;
+                changes++;
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (changes == 0) {
+        printf("no pin changed. The button may be on a skipped pin (panel/SD/USB/flash), "
+               "wired to a port expander, or not connected to a GPIO at all.\n");
+    } else {
+        printf("done — set the pin with: set gpio_buttons \"<pin>:KEY1\"\n");
+    }
     return 0;
 }
 
@@ -1253,6 +1369,7 @@ static esp_err_t register_frameos_console_commands(void)
     const esp_console_cmd_t commands[] = {
         {.command = "status", .help = "Show device status", .func = cmd_status},
         {.command = "heapinfo", .help = "Per-region heap breakdown (internal + PSRAM)", .func = cmd_heapinfo},
+        {.command = "buttons", .help = "buttons [watch [seconds]] — configured buttons, or find which GPIO a press moves", .func = cmd_buttons},
         {.command = "set", .help = "set <key> <value> — persist a config value", .func = cmd_set},
         {.command = "wifi", .help = "wifi <ssid> [pass] — set Wi-Fi and restart", .func = cmd_wifi},
         {.command = "wifi-scan", .help = "Scan visible Wi-Fi networks", .func = cmd_wifi_scan},

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -603,6 +603,36 @@ static int cmd_render(int argc, char **argv)
     return 0;
 }
 
+static int cmd_event(int argc, char **argv)
+{
+    /* Send a scene event by hand. Scene event handlers were previously only
+     * reachable by physically pressing a button wired to the right GPIO with
+     * the label the scene happens to filter on — three things that all have
+     * to line up before anything visibly happens, and nothing tells you which
+     * one is wrong when it does not. This exercises the same path the button
+     * driver and the HTTP /event/<name> route use. */
+    if (argc < 2) {
+        printf("usage: event <name> [json payload]\n");
+        printf("  e.g. event button {\"label\":\"A\"}   (the label a scene node filters on)\n");
+        return 1;
+    }
+    if (!frameos_nim_available()) {
+        printf("no interpreted scene runtime on this build\n");
+        return 1;
+    }
+    const char *payload = argc >= 3 ? argv[2] : "{}";
+    if (!frameos_nim_send_event(argv[1], payload)) {
+        printf("event rejected by the scene runtime\n");
+        return 1;
+    }
+    printf("sent %s %s\n", argv[1], payload);
+    if (frameos_nim_render_requested()) {
+        fos_client_render_now();
+        printf("scene asked for a render\n");
+    }
+    return 0;
+}
+
 static void display_test_set_4bpp(uint8_t *buf, int width, int x, int y, uint8_t color)
 {
     size_t row_bytes = ((size_t)width + 1u) / 2u;
@@ -1374,6 +1404,7 @@ static esp_err_t register_frameos_console_commands(void)
         {.command = "wifi", .help = "wifi <ssid> [pass] — set Wi-Fi and restart", .func = cmd_wifi},
         {.command = "wifi-scan", .help = "Scan visible Wi-Fi networks", .func = cmd_wifi_scan},
         {.command = "render", .help = "Render now", .func = cmd_render},
+        {.command = "event", .help = "event <name> [json] — send a scene event by hand (e.g. event button {\"label\":\"A\"})", .func = cmd_event},
         {.command = "display_test", .help = "display_test [bands|black|white|red|green|blue|yellow] — draw direct panel test", .func = cmd_display_test},
         {.command = "sd", .help = "sd [status|remount|format] — SD assets card; format ERASES an unreadable card and is never automatic", .func = cmd_sd},
         {.command = "ota", .help = "Check for OTA update now", .func = cmd_ota},

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -191,9 +191,17 @@ proc initRuntime*(width, height: int, name: string, maxHttpResponseBytes: int,
     espLog(($payload).cstring)
   channels.embeddedEventHook = proc(sceneId: Option[SceneId], event: string, payload: JsonNode) {.gcsafe.} =
     {.cast(gcsafe).}:
+      # Every event reaches the scene graph, not a hardcoded few. This used to
+      # dispatch only setSceneState/setCurrentScene, which silently dropped
+      # everything a scene defines its own handler for — a GPIO button press
+      # arrived from the firmware as a "button" event, matched no branch, and
+      # vanished. The Counter scene's `event button` nodes never ran, and the
+      # frame looked like it had dead buttons. The Pi runner has always
+      # dispatched by name (frameos/runner.nim), so this also removes a
+      # difference between the two runtimes that scene authors could not see.
       if event == "render":
         renderRequested = true
-      elif event in ["setSceneState", "setCurrentScene"] and not currentScene.isNil:
+      elif not currentScene.isNil:
         try:
           let context = ExecutionContext(scene: currentScene, event: event,
               payload: if payload.isNil: %*{} else: payload, loopIndex: 0, loopKey: ".")

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -1284,12 +1284,31 @@ proc runEvent*(self: FrameScene, context: ExecutionContext) =
     discard
 
   if scene.eventListeners.hasKey(context.event):
+    # Track filtered-out listeners so a press that matches nothing says so.
+    # A scene whose event node filters on label "A" and a frame whose buttons
+    # are labelled BOOT/KEY1 (board silkscreen, per the ESP32 preset) is a
+    # dead button with no error anywhere: the GPIO fires, the event reaches
+    # the scene, every listener rejects it, and runEvent returns quietly.
+    var listenersFiltered = 0
+    var matched = 0
+    var expectedFilters: seq[string] = @[]
     for nodeId in scene.eventListeners[context.event]:
       let nextNode = if scene.nextNodeIds.hasKey(nodeId): scene.nextNodeIds[nodeId] else: -1.NodeId
       if nextNode != 0.NodeId and nextNode != -1.NodeId:
         if scene.nodes.hasKey(nodeId) and not eventNodeMatchesPayload(scene.nodes[nodeId], context.payload):
+          listenersFiltered += 1
+          let d = scene.nodes[nodeId].data
+          if not d.isNil and d.kind == JObject:
+            if d.hasKey("config") and d["config"].kind == JObject:
+              for key, value in d["config"].pairs:
+                let expected = eventFilterValue(value)
+                if expected.len > 0: expectedFilters.add(key & "=" & expected)
+            elif d.hasKey("label"):
+              let expected = eventFilterValue(d["label"])
+              if expected.len > 0: expectedFilters.add("label=" & expected)
           continue
         try:
+          matched += 1
           discard scene.runNode(nextNode, context)
         except Exception as e:
           self.logger.log(%*{
@@ -1300,6 +1319,18 @@ proc runEvent*(self: FrameScene, context: ExecutionContext) =
             "error": $e.msg,
             "stacktrace": e.getStackTrace()
           })
+      else:
+        listenersFiltered += 1
+    if listenersFiltered > 0 and matched == 0:
+      self.logger.log(%*{
+        "event": "runEvent:noListenerMatched",
+        "sceneId": self.id,
+        "contextEvent": context.event,
+        "payload": context.payload,
+        "expected": expectedFilters,
+        "error": "\"" & context.event & "\" reached the scene but every listener filtered it out" &
+          (if expectedFilters.len > 0: " (nodes want " & expectedFilters.join(", ") & ")" else: "")
+      })
 
 proc render*(self: FrameScene, context: ExecutionContext): Image =
   if TRACING:


### PR DESCRIPTION
Pressing a button on an ESP32 frame did nothing. Everything up to the last step was correct — verified on hardware, an ESP32-S3 PhotoPainter 7.3":

- the preset wires the pins (`0:BOOT`, `4:KEY1`), and NVS holds them
- `fos_buttons` debounces the press and calls `frameos_nim_send_event("button", {pin,label,level})`
- the render task drains the queue every second
- the Counter scene has two `event button` nodes → `logic/setAsState` → `dispatch render`
- a press reads `GPIO 4 1 -> 0`

The event then reached this, in `embedded_runtime.nim`:

```nim
if event == "render": renderRequested = true
elif event in ["setSceneState", "setCurrentScene"] and not currentScene.isNil:
  runEvent(...)
```

`"button"` matches neither branch, so it was silently dropped. **Every event a scene defines its own handler for was dead on ESP32** — buttons, and anything else an app dispatches by name — while working on Pi, where `runner.nim` has always dispatched by name. Scene authors had no way to see the difference. The hook now dispatches any event to the current scene.

## Also here, from finding it

- **`buttons` console command** — prints the configured pins with their live levels, and `buttons watch [seconds]` reports which pin moves when someone presses one. The wiring was invisible before: `status` never showed it, and `fos_buttons` logs it at `ESP_LOGI`, which the console's WARN level hides. A board whose button is not on the pin its preset assumes gave no clue at all.
- **`status` prints a `buttons:` line**, for the same reason.
- **The scan excludes GPIO 33–37 as well as 26–32.** The first version crashed the board with `TG1WDT_SYS_RST`: this module has octal PSRAM, where 33–37 carry the memory bus, so reconfiguring them as inputs took RAM away from the running system. A diagnostic that resets the frame it is diagnosing is worse than no diagnostic.

## Verification

Firmware built and flashed to the board. The press was already confirmed at the GPIO level before the fix; what the flashed build still needs is a press showing the Counter scene actually incrementing.

Split out of #313, which was squash-merged before this commit was pushed.