### PR TITLE
Find out where Weather's PSRAM actually goes (-d:memProbe)

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,9 +78,31 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
       [102s+] TLS cannot allocate -> cloud link down, every later render fails
 
   Two separate faults, and the second is the damaging one:
-  1. That scene's render needs more PSRAM than an 8 MB board has. This is the
-     case the large-image spill work exists for — measure what it actually
-     allocates before assuming which buffer is at fault.
+  1. That scene's render needs more PSRAM than an 8 MB board has. Now
+     measured, with `-d:memProbe` (PSRAM free logged per interpreter node):
+
+         node app/render/split    psramFree=3428468   <- render starts at 3.4M
+         node app/render/image    psramFree=2804404   <- -624K background image
+         node app/data/weather    psramFree=2176420   <- -620K forecast JSON
+         node state/location      psramFree=2173684
+         heap exhausted: released 1048576 byte emergency reserve
+         render aborted: out of memory (largest PSRAM block 3072)
+
+     The frame enters the render with **3.4 MB, not 8 MB**: ~2.9 MB is already
+     held (scene payload, JS runtime, framebuffer, preview snapshot) and the
+     800x480 canvas takes 1.5 MB more. Everything then stays live at once —
+     background image 624K, forecast JSON 620K, the panel's own 921K output,
+     the band trio, the parsed XML — and the last of it lands inside
+     weatherPanel with 2.1 MB left. Roughly 4.5 MB wanted against 3.6 MB.
+
+     Banded SVG rasterisation (#315) works and engages here (40-row bands);
+     it is simply not the dominant term. The levers now worth costing, in
+     rough order of size: free the forecast JSON before the panels rasterise;
+     draw render/image straight into the canvas instead of holding a decoded
+     copy; shrink the ~2.9 MB resident baseline; drop the parsed XML earlier.
+     A host-side peak measurement predicted 3.7 MB and was wrong about the
+     device by ~1 MB, so reconcile any new host model against a memProbe run
+     before trusting it.
   2. ~~A failed render abandons its PSRAM~~ — HANDLED: the frame now restarts
      when PSRAM does not come back, and after two consecutive rescues pauses
      rendering and stays online so a lighter scene can be assigned. All three

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -10,6 +10,8 @@
 
 #include "driver/usb_serial_jtag.h"
 #include "driver/usb_serial_jtag_vfs.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
 #include "esp_console.h"
 #include "esp_err.h"
 #include "esp_heap_caps.h"
@@ -120,6 +122,16 @@ static int cmd_status(int argc, char **argv)
     printf("hardware:    %s\n", config->hardware_preset[0] ? config->hardware_preset : "(custom)");
     printf("panel:       %s (%dx%d)\n", config->panel, fos_display_width(), fos_display_height());
     printf("pins:        %s\n", pins);
+    if (config->gpio_button_count > 0) {
+        printf("buttons:     ");
+        for (size_t i = 0; i < config->gpio_button_count; i++) {
+            printf("%s%d:%s", i ? "," : "", config->gpio_buttons[i].pin,
+                   config->gpio_buttons[i].label);
+        }
+        printf("\n");
+    } else {
+        printf("buttons:     (none configured)\n");
+    }
     printf("render_mode: %s\n", config->render_mode == FOS_RENDER_LOCAL ? "local" : "remote");
     printf("rotate:      %u\n", (unsigned)config->rotate);
     printf("send_logs:   %d\n", (int)config->server_send_logs);
@@ -184,6 +196,110 @@ static int cmd_heapinfo(int argc, char **argv)
     printf("--- per-region detail\n");
     heap_caps_print_heap_info(MALLOC_CAP_SPIRAM);
     heap_caps_print_heap_info(MALLOC_CAP_INTERNAL);
+    return 0;
+}
+
+/* Which GPIOs are wired to buttons, what they read right now, and — with
+ * `buttons watch` — which pin actually moves when someone presses one.
+ *
+ * A frame whose buttons "do nothing" gives no clue why: the configured pins
+ * are invisible in `status`, and fos_buttons logs its wiring at INFO, which
+ * the console's WARN level hides. The usual cause is simply that the board's
+ * button is not on the GPIO its hardware preset assumes — boards get
+ * relabelled and DIY builds differ — and that is a question only the board
+ * can answer.
+ *
+ * `watch` polls a curated safe list. Pins driving the panel, the SD card, USB
+ * and the SPI flash/PSRAM are skipped: reconfiguring those as inputs
+ * mid-flight would break the very frame being debugged. */
+static bool console_pin_in_use(const fos_config_t *config, int pin)
+{
+    const int used[] = {
+        config->pins.rst, config->pins.dc, config->pins.cs, config->pins.cs2,
+        config->pins.busy, config->pins.sck, config->pins.mosi, config->pins.pwr,
+        config->assets_sd.cs, config->assets_sd.sck,
+        config->assets_sd.miso, config->assets_sd.mosi,
+        19, 20, /* USB D-/D+ (the console itself) */
+        /* 26-32 SPI flash, 33-37 octal PSRAM. On an S3 module with octal
+         * PSRAM (CONFIG_SPIRAM_MODE_OCT) 33-37 carry the memory bus, and
+         * reconfiguring them as inputs takes the running system's RAM away
+         * mid-instruction: the first attempt at this scan reset the board
+         * with TG1WDT_SYS_RST. Both ranges are excluded unconditionally —
+         * quad-PSRAM parts simply lose a few candidate pins, which is a
+         * cheap price for a diagnostic that cannot crash the frame it is
+         * diagnosing. */
+        26, 27, 28, 29, 30, 31, 32,
+        33, 34, 35, 36, 37
+    };
+    for (size_t i = 0; i < sizeof(used) / sizeof(used[0]); i++) {
+        if (used[i] == pin) return true;
+    }
+    return false;
+}
+
+static int cmd_buttons(int argc, char **argv)
+{
+    fos_config_t *config = fos_config();
+    printf("configured buttons: %u\n", (unsigned)config->gpio_button_count);
+    for (size_t i = 0; i < config->gpio_button_count; i++) {
+        const fos_gpio_button_t *b = &config->gpio_buttons[i];
+        printf("  GPIO %-2d %-16s level=%d\n", b->pin, b->label, gpio_get_level(b->pin));
+    }
+    if (config->gpio_button_count == 0) {
+        printf("  (none — set them with: set gpio_buttons \"0:BOOT\\n4:KEY1\")\n");
+    }
+    if (argc < 2 || strcmp(argv[1], "watch") != 0) {
+        printf("press a button and run `buttons watch` to find which GPIO it is\n");
+        return 0;
+    }
+
+    int seconds = argc > 2 ? atoi(argv[2]) : 10;
+    if (seconds < 1) seconds = 1;
+    if (seconds > 60) seconds = 60;
+
+    /* Deliberately conservative: no flash/PSRAM pins, no USB, nothing the
+     * panel or SD card is using. A button on an excluded pin is reported as
+     * "not found" rather than risking the board. */
+    static const int candidates[] = {0, 1, 2, 3, 4, 5, 6, 7, 14, 15, 16, 17, 18,
+                                     21, 42, 43, 44, 45, 46, 47, 48};
+    int levels[sizeof(candidates) / sizeof(candidates[0])];
+    size_t count = 0;
+    int watched[sizeof(candidates) / sizeof(candidates[0])];
+    for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++) {
+        int pin = candidates[i];
+        if (console_pin_in_use(config, pin)) continue;
+        gpio_config_t gpio = {
+            .pin_bit_mask = 1ULL << pin,
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = GPIO_PULLUP_ENABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        if (gpio_config(&gpio) != ESP_OK) continue;
+        watched[count] = pin;
+        levels[count] = gpio_get_level(pin);
+        count++;
+    }
+    printf("watching %u pins for %d s — press the button now\n", (unsigned)count, seconds);
+    int64_t end_us = esp_timer_get_time() + (int64_t)seconds * 1000000;
+    int changes = 0;
+    while (esp_timer_get_time() < end_us) {
+        for (size_t i = 0; i < count; i++) {
+            int level = gpio_get_level(watched[i]);
+            if (level != levels[i]) {
+                printf("  GPIO %-2d %d -> %d\n", watched[i], levels[i], level);
+                levels[i] = level;
+                changes++;
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (changes == 0) {
+        printf("no pin changed. The button may be on a skipped pin (panel/SD/USB/flash), "
+               "wired to a port expander, or not connected to a GPIO at all.\n");
+    } else {
+        printf("done — set the pin with: set gpio_buttons \"<pin>:KEY1\"\n");
+    }
     return 0;
 }
 
@@ -1253,6 +1369,7 @@ static esp_err_t register_frameos_console_commands(void)
     const esp_console_cmd_t commands[] = {
         {.command = "status", .help = "Show device status", .func = cmd_status},
         {.command = "heapinfo", .help = "Per-region heap breakdown (internal + PSRAM)", .func = cmd_heapinfo},
+        {.command = "buttons", .help = "buttons [watch [seconds]] — configured buttons, or find which GPIO a press moves", .func = cmd_buttons},
         {.command = "set", .help = "set <key> <value> — persist a config value", .func = cmd_set},
         {.command = "wifi", .help = "wifi <ssid> [pass] — set Wi-Fi and restart", .func = cmd_wifi},
         {.command = "wifi-scan", .help = "Scan visible Wi-Fi networks", .func = cmd_wifi_scan},

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -603,6 +603,36 @@ static int cmd_render(int argc, char **argv)
     return 0;
 }
 
+static int cmd_event(int argc, char **argv)
+{
+    /* Send a scene event by hand. Scene event handlers were previously only
+     * reachable by physically pressing a button wired to the right GPIO with
+     * the label the scene happens to filter on — three things that all have
+     * to line up before anything visibly happens, and nothing tells you which
+     * one is wrong when it does not. This exercises the same path the button
+     * driver and the HTTP /event/<name> route use. */
+    if (argc < 2) {
+        printf("usage: event <name> [json payload]\n");
+        printf("  e.g. event button {\"label\":\"A\"}   (the label a scene node filters on)\n");
+        return 1;
+    }
+    if (!frameos_nim_available()) {
+        printf("no interpreted scene runtime on this build\n");
+        return 1;
+    }
+    const char *payload = argc >= 3 ? argv[2] : "{}";
+    if (!frameos_nim_send_event(argv[1], payload)) {
+        printf("event rejected by the scene runtime\n");
+        return 1;
+    }
+    printf("sent %s %s\n", argv[1], payload);
+    if (frameos_nim_render_requested()) {
+        fos_client_render_now();
+        printf("scene asked for a render\n");
+    }
+    return 0;
+}
+
 static void display_test_set_4bpp(uint8_t *buf, int width, int x, int y, uint8_t color)
 {
     size_t row_bytes = ((size_t)width + 1u) / 2u;
@@ -1374,6 +1404,7 @@ static esp_err_t register_frameos_console_commands(void)
         {.command = "wifi", .help = "wifi <ssid> [pass] — set Wi-Fi and restart", .func = cmd_wifi},
         {.command = "wifi-scan", .help = "Scan visible Wi-Fi networks", .func = cmd_wifi_scan},
         {.command = "render", .help = "Render now", .func = cmd_render},
+        {.command = "event", .help = "event <name> [json] — send a scene event by hand (e.g. event button {\"label\":\"A\"})", .func = cmd_event},
         {.command = "display_test", .help = "display_test [bands|black|white|red|green|blue|yellow] — draw direct panel test", .func = cmd_display_test},
         {.command = "sd", .help = "sd [status|remount|format] — SD assets card; format ERASES an unreadable card and is never automatic", .func = cmd_sd},
         {.command = "ota", .help = "Check for OTA update now", .func = cmd_ota},

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -191,9 +191,17 @@ proc initRuntime*(width, height: int, name: string, maxHttpResponseBytes: int,
     espLog(($payload).cstring)
   channels.embeddedEventHook = proc(sceneId: Option[SceneId], event: string, payload: JsonNode) {.gcsafe.} =
     {.cast(gcsafe).}:
+      # Every event reaches the scene graph, not a hardcoded few. This used to
+      # dispatch only setSceneState/setCurrentScene, which silently dropped
+      # everything a scene defines its own handler for — a GPIO button press
+      # arrived from the firmware as a "button" event, matched no branch, and
+      # vanished. The Counter scene's `event button` nodes never ran, and the
+      # frame looked like it had dead buttons. The Pi runner has always
+      # dispatched by name (frameos/runner.nim), so this also removes a
+      # difference between the two runtimes that scene authors could not see.
       if event == "render":
         renderRequested = true
-      elif event in ["setSceneState", "setCurrentScene"] and not currentScene.isNil:
+      elif not currentScene.isNil:
         try:
           let context = ExecutionContext(scene: currentScene, event: event,
               payload: if payload.isNil: %*{} else: payload, loopIndex: 0, loopKey: ".")

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -1284,12 +1284,31 @@ proc runEvent*(self: FrameScene, context: ExecutionContext) =
     discard
 
   if scene.eventListeners.hasKey(context.event):
+    # Track filtered-out listeners so a press that matches nothing says so.
+    # A scene whose event node filters on label "A" and a frame whose buttons
+    # are labelled BOOT/KEY1 (board silkscreen, per the ESP32 preset) is a
+    # dead button with no error anywhere: the GPIO fires, the event reaches
+    # the scene, every listener rejects it, and runEvent returns quietly.
+    var listenersFiltered = 0
+    var matched = 0
+    var expectedFilters: seq[string] = @[]
     for nodeId in scene.eventListeners[context.event]:
       let nextNode = if scene.nextNodeIds.hasKey(nodeId): scene.nextNodeIds[nodeId] else: -1.NodeId
       if nextNode != 0.NodeId and nextNode != -1.NodeId:
         if scene.nodes.hasKey(nodeId) and not eventNodeMatchesPayload(scene.nodes[nodeId], context.payload):
+          listenersFiltered += 1
+          let d = scene.nodes[nodeId].data
+          if not d.isNil and d.kind == JObject:
+            if d.hasKey("config") and d["config"].kind == JObject:
+              for key, value in d["config"].pairs:
+                let expected = eventFilterValue(value)
+                if expected.len > 0: expectedFilters.add(key & "=" & expected)
+            elif d.hasKey("label"):
+              let expected = eventFilterValue(d["label"])
+              if expected.len > 0: expectedFilters.add("label=" & expected)
           continue
         try:
+          matched += 1
           discard scene.runNode(nextNode, context)
         except Exception as e:
           self.logger.log(%*{
@@ -1300,6 +1319,18 @@ proc runEvent*(self: FrameScene, context: ExecutionContext) =
             "error": $e.msg,
             "stacktrace": e.getStackTrace()
           })
+      else:
+        listenersFiltered += 1
+    if listenersFiltered > 0 and matched == 0:
+      self.logger.log(%*{
+        "event": "runEvent:noListenerMatched",
+        "sceneId": self.id,
+        "contextEvent": context.event,
+        "payload": context.payload,
+        "expected": expectedFilters,
+        "error": "\"" & context.event & "\" reached the scene but every listener filtered it out" &
+          (if expectedFilters.len > 0: " (nodes want " & expectedFilters.join(", ") & ")" else: "")
+      })
 
 proc render*(self: FrameScene, context: ExecutionContext): Image =
   if TRACING:

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -1,6 +1,7 @@
 import frameos/types
 import frameos/values
 from frameos/utils/image import renderError, renderErrorInto
+when defined(memProbe): import frameos/utils/memory
 import frameos/js_runtime/app_runtime
 import frameos/js_runtime/runtime
 import frameos/channels
@@ -324,6 +325,9 @@ proc runNode*(self: FrameScene, nodeId: NodeId, context: ExecutionContext, asDat
 
     let currentNode = self.nodes[currentNodeId]
     let nodeType = currentNode.nodeType
+    when defined(memProbe):
+      memProbe("node " & nodeType & "/" & diagnosticKeyword(currentNode) &
+        " #" & $currentNodeId.int)
     let debugRuntime = self.frameConfig.debug
     var checkpointKeyword = ""
     if debugRuntime:

--- a/frameos/src/frameos/utils/memory.nim
+++ b/frameos/src/frameos/utils/memory.nim
@@ -41,6 +41,14 @@ when defined(testing):
   # headroom) on a development host. 0 disables the override.
   var availableRenderBytesOverride* = 0
 
+when defined(memProbe):
+  proc c_printf(fmt: cstring) {.importc: "printf", varargs, cdecl.}
+  proc memProbe*(where: string) =
+    when defined(frameosEmbedded):
+      let free = fos_psram_free_bytes().int
+      let largest = fos_psram_largest_free_block().int
+      c_printf("MEMPROBE %s psramFree=%d largest=%d\n", where.cstring, free.cint, largest.cint)
+
 proc availableRenderBytes*(): int =
   ## Best-effort estimate of memory currently available for image-sized
   ## render allocations. 0 means "unknown"; callers treat that as unlimited.


### PR DESCRIPTION
Stacked Weather still exhausted 8 MB of PSRAM after #315, and the host measurement could not explain it — that model predicted a 3.7 MB peak on a board with 8 MB. The OOM message only names the allocation that happened to be last, so there was no way to see where the memory went.

`-d:memProbe` prints PSRAM free and largest-block before every interpreter node, via printf rather than the Nim log hook (whose `ESP_LOGI` level the console hides at WARN). Off by default, nothing compiled in when off:

```
export FRAMEOS_EXTRA_NIM_FLAGS="-d:memProbe"   # export it — ci_build_image.sh re-runs build_nim.sh
./ci_build_image.sh
```

## What it found, on the ESP32-S3 PhotoPainter

```
node app/render/split    psramFree=3428468   <- the render starts with 3.4M, not 8M
node app/render/image    psramFree=2804404   <- -624K background image
node app/weatherPanel    psramFree=2802056
node app/data/weather    psramFree=2176420   <- -620K forecast JSON
node state/location      psramFree=2173684
heap exhausted: released 1048576 byte emergency reserve
render aborted: out of memory (largest PSRAM block 3072, canvas needs 1536000)
```

The frame enters the render with **3.4 MB**: ~2.9 MB is already resident (scene payload, JS runtime, framebuffer, preview snapshot) and the 800×480 canvas takes another 1.5 MB. Everything then accumulates live — background image, forecast JSON, the panel's own 921 K output image, the band trio, the parsed XML — and the last of it lands inside `weatherPanel` with 2.1 MB left. Roughly 4.5 MB wanted against 3.6 MB available.

**So there is no single oversized buffer**, which is what the item in `docs/todo.md` assumed. Banding works and engages here (40-row bands); it is just not the dominant term. `docs/todo.md` is updated with the ledger and the levers worth costing next: free the forecast JSON before the panels rasterise, draw `render/image` straight into the canvas rather than holding a decoded copy, shrink the resident baseline, drop the parsed XML earlier.

Also worth recording: the host peak model was wrong about the device by ~1 MB, so it should be reconciled against a memProbe run before being trusted again.

Stacked on #316 (the button-event fixes), which is where the `interpreter.nim` context comes from.