### PR TITLE
CI: stop redoing work in the two slowest jobs

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -108,9 +108,24 @@ jobs:
         run: |
           docker build --target esp32-ci -t frameos-esp32-ci .
 
+      # The step below builds the firmware three times (8 MB, QEMU, 32 MB).
+      # They share a nimcache but not a single object file, and ESP-IDF ships
+      # ccache support that was simply never switched on — so every run
+      # recompiled all of ESP-IDF three times over. The cache is keyed loosely
+      # and restored from any previous run: a stale entry only costs misses,
+      # never correctness, since ccache hashes the compiler, flags and source.
+      - name: Cache ESP-IDF ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-esp32-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-esp32-ccache-
+
       - name: Build and boot ESP32 firmware image
         timeout-minutes: 60
         run: |
+          mkdir -p "$GITHUB_WORKSPACE/.ccache"
           # The esp32-ci image does not carry versions.json (only the
           # app-builder stage copies it), so the firmware version has to come
           # from the runner's checkout. ci_build_image.sh refuses to build
@@ -120,6 +135,10 @@ jobs:
           docker run --rm \
             -e FRAMEOS_SELECTED_PANEL=EPD_7in5_V2 \
             -e FRAMEOS_VERSION="$FRAMEOS_VERSION" \
+            -e IDF_CCACHE_ENABLE=1 \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE=2G \
+            -v "$GITHUB_WORKSPACE/.ccache:/ccache" \
             frameos-esp32-ci \
             bash -lc '
               set -euo pipefail
@@ -131,7 +150,10 @@ jobs:
               # incremental cost is one IDF configure+link.
               FRAMEOS_ESP32_PLATFORM=esp32-s3-32mb FRAMEOS_ESP32_BUILD_DIR=build-ci-32mb \
                 bash embedded/esp32/ci_build_image.sh
+              ccache --show-stats || true
             '
+          # The container writes as root; actions/cache runs as the runner user.
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE/.ccache"
 
   build-and-test:
     name: build-and-test

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -552,6 +552,24 @@ jobs:
           uv venv
           uv pip install -r requirements.txt
 
+      # The other two Nim jobs cache these; this one did not, so every run
+      # re-cloned ~15 nimble dependencies and rebuilt QuickJS from scratch —
+      # about 100 s of the step below, on a job that is the slowest in the
+      # workflow. Same keys as the jobs above so all three share the entries.
+      - name: Cache nimble packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nimble/pkgs2
+          key: ${{ runner.os }}-nimble-${{ hashFiles('frameos/nimble.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nimble-
+
+      - name: Cache QuickJS
+        uses: actions/cache@v4
+        with:
+          path: frameos/quickjs
+          key: ${{ runner.os }}-quickjs-${{ hashFiles('frameos/frameos.nimble', 'frameos/tools/install_prebuilt_quickjs.py', 'versions.json') }}
+
       - name: Prepare FrameOS build inputs
         run: |
           cd frameos
@@ -561,6 +579,21 @@ jobs:
           nimble setup
           FRAMEOS_ROOT_DIR="." python3 ../e2e/makeapploaders.py
           nimble build
+
+      # The test builds a Debian image with a toolchain in it (~54 s). Its tag
+      # is a hash of the build context, so building it here with a layer cache
+      # means the test finds it already present and skips the build; an edit to
+      # the context changes the tag and both this and the test rebuild.
+      - name: Pre-build SSH target image
+        run: |
+          TAG="$(python3 backend/app/tasks/tests/deploy_ssh_target/context_tag.py)"
+          echo "SSH target image: $TAG"
+          docker buildx build \
+            --load \
+            --cache-from type=gha,scope=deploy-e2e-ssh-target \
+            --cache-to type=gha,mode=max,scope=deploy-e2e-ssh-target \
+            -t "$TAG" \
+            backend/app/tasks/tests/deploy_ssh_target
 
       - name: Run SSH deploy E2E test
         run: |

--- a/backend/app/tasks/tests/deploy_ssh_target/context_tag.py
+++ b/backend/app/tasks/tests/deploy_ssh_target/context_tag.py
@@ -1,0 +1,46 @@
+"""Content-addressed tag for the disposable SSH target image.
+
+The deploy E2E test builds a Debian image with a compiler toolchain in it, which
+takes ~54 s of a ~4.5 minute test — and rebuilds it on every run, because the
+tag was a fixed ``:latest`` that told nobody whether the existing image matched
+the current Dockerfile.
+
+Naming the image after a hash of its build context makes reuse safe: a matching
+tag can only have been built from exactly these files, so the test can skip the
+build when one is already present, and CI can pre-build it into the daemon (with
+a layer cache) under the same name. Edit anything in this directory and the tag
+changes, so a stale image is never silently reused.
+
+Run as a script to print the tag, which is what the workflow does.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+IMAGE_NAME = "frameos-deploy-e2e-ssh-target"
+
+
+def context_digest(context_dir: Path | None = None) -> str:
+    """Short digest over every file in the build context, path names included."""
+    root = context_dir or Path(__file__).parent
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        # This helper is part of the context but not part of the image, so
+        # changing the tag logic must not invalidate the image it names.
+        if path.name == Path(__file__).name:
+            continue
+        digest.update(path.relative_to(root).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()[:12]
+
+
+def context_tag(context_dir: Path | None = None) -> str:
+    return f"{IMAGE_NAME}:{context_digest(context_dir)}"
+
+
+if __name__ == "__main__":
+    print(context_tag())

--- a/backend/app/tasks/tests/test_real_ssh_deploy_e2e.py
+++ b/backend/app/tasks/tests/test_real_ssh_deploy_e2e.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tarfile
 import threading
 import time
@@ -131,6 +132,15 @@ def _external_target_from_env() -> SshTarget | None:
     )
 
 
+def _docker_image_exists(tag: str) -> bool:
+    return subprocess.run(
+        ["docker", "image", "inspect", tag],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode == 0
+
+
 def _run_docker(args: list[str]) -> str:
     _say("docker " + " ".join(args))
     result = subprocess.run(
@@ -160,11 +170,21 @@ def ssh_target() -> Iterator[SshTarget]:
         pytest.skip("docker is required for FRAMEOS_E2E_DEPLOY without FRAMEOS_E2E_DEPLOY_HOST")
 
     dockerfile = Path(__file__).with_name("deploy_ssh_target") / "Dockerfile"
-    tag = "frameos-deploy-e2e-ssh-target:latest"
+    # Tagged by a hash of the build context, so an image with this name can
+    # only have come from exactly these files. That makes reuse safe: CI
+    # pre-builds it with a layer cache and this skips the ~54 s rebuild, while
+    # any edit here produces a different tag and a fresh build.
+    sys.path.insert(0, str(dockerfile.parent))
+    from context_tag import context_tag  # noqa: E402  (path set just above)
+
+    tag = context_tag(dockerfile.parent)
     container_id = ""
     try:
-        with _phase("build disposable SSH target image"):
-            _run_docker(["build", "-q", "-t", tag, str(dockerfile.parent)])
+        if _docker_image_exists(tag):
+            _say(f"reusing SSH target image {tag}")
+        else:
+            with _phase("build disposable SSH target image"):
+                _run_docker(["build", "-q", "-t", tag, str(dockerfile.parent)])
         with _phase("start disposable SSH target container"):
             container_id = _run_docker(["run", "-d", "-p", "127.0.0.1::22", tag])
         port = int(_run_docker(["port", container_id, "22/tcp"]).rsplit(":", 1)[1])


### PR DESCRIPTION
Timings from run `31336096796` / `31336096791` — the two checks that gate everything else:

| job | wall | dominated by |
|---|---|---|
| Build and boot ESP32 firmware image | 11m | one 537 s step |
| Deploy E2E SSH | 8m | 274 s test + 119 s prepare |

Each was repeating work it already had.

## ESP32 firmware — 537 s

That step builds the firmware **three times** (8 MB, QEMU, 32 MB). They share a nimcache but not a single object file, and **ESP-IDF's ccache support was never switched on**, so every run recompiled all of ESP-IDF three times over.

`IDF_CCACHE_ENABLE=1`, with the cache directory bind-mounted out of the container and kept by `actions/cache`. The key is loose and restores from any earlier run — a stale entry costs misses, never correctness, since ccache hashes the compiler, the flags and the source. `ccache --show-stats` runs at the end so the hit rate is visible in the log.

## Deploy E2E SSH — 119 s prepare

This job was **the only one of the three Nim jobs without the nimble and QuickJS caches** — the other two have had them all along. So it re-cloned ~15 dependencies and rebuilt QuickJS on every run. Same cache keys as those jobs, so all three share the entries.

## Deploy E2E SSH — 274 s test

Phase breakdown from the log:

```
build disposable SSH target image        54.3s
full deploy with compile on device       85.3s
full deploy with backend cross compile  113.6s
everything else                          ~10s
```

The 54 s built a Debian image with a toolchain in it, every run, because the tag was a fixed `:latest` that told nobody whether the existing image matched the Dockerfile. **The tag is now a hash of the build context**, which makes reuse safe — a matching tag can only have been built from exactly those files. CI pre-builds it with a GHA layer cache and the test skips the build when it is already present; edit anything in that directory and the tag changes, so both rebuild.

The remaining 220 s is two real compiles (85 s on the target, 114 s cross-compiling). That is what the test exists to exercise, so it is left alone.

## Verification

The image builds under its content tag locally, and the reuse check returns `True` for it and `False` for a bogus tag. The rest is CI-only and will show its numbers on this PR's own run — worth comparing the two job times here against the table above before merging.