### PR TITLE
Load the default font on first use, not at boot: 1.65 MB of PSRAM back

### DIFF
--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -107,6 +107,19 @@ static void log_bootup_event(bool online)
     frameos_nim_flush_logs();
 }
 
+/* Boot-time memory attribution, the C-side companion to the Nim -d:memProbe.
+ * Off by default; build with -DFRAMEOS_BOOTMEM=1 to find out which init step
+ * is holding the PSRAM a render needs. This is how the 1.57 MB default-font
+ * parse was found: every other step on this list costs a couple of KB. */
+#if defined(FRAMEOS_BOOTMEM) && FRAMEOS_BOOTMEM
+#define BOOTMEM(stage) ESP_LOGW(TAG, "BOOTMEM %-24s psram_free=%u largest=%u internal=%u", \
+    stage, (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM), \
+    (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM), \
+    (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL))
+#else
+#define BOOTMEM(stage) ((void)0)
+#endif
+
 void app_main(void)
 {
     const esp_app_desc_t *app = esp_app_get_description();
@@ -114,6 +127,7 @@ void app_main(void)
     ESP_LOGI(TAG, "FrameOS %s (idf %s) booting from %s",
              app->version, app->idf_ver, running ? running->label : "?");
 
+    BOOTMEM("start");
     ESP_ERROR_CHECK(fos_config_init());
     fos_config_t *config = fos_config();
 
@@ -134,6 +148,7 @@ void app_main(void)
         .busy = config->pins.busy, .sck = config->pins.sck,
         .mosi = config->pins.mosi, .pwr = config->pins.pwr,
     };
+    BOOTMEM("after-config");
     if (fos_display_init(&display_config) != ESP_OK) {
         ESP_LOGW(TAG, "display init failed, continuing headless");
     }
@@ -142,6 +157,7 @@ void app_main(void)
      * log ring (and replays it to the backend/cloud once upload is enabled,
      * below) — a mount failure must never be a serial-only event, or "why are
      * my assets empty?" has no remote answer. */
+    BOOTMEM("after-display");
     if (fos_assets_sd_mount(config) != ESP_OK) {
         ESP_LOGW(TAG, "SD assets unavailable, continuing without %s: %s",
                  config->assets_path[0] ? config->assets_path : "/srv/assets",
@@ -175,6 +191,7 @@ void app_main(void)
         }
     }
 
+    BOOTMEM("after-sd");
     ESP_ERROR_CHECK(fos_wifi_init());
     fos_http_set_actions(action_render_now, action_ota_now);
 
@@ -206,9 +223,11 @@ void app_main(void)
      * below, so starting it here only claims the stack. */
     /* Before any render: decides whether the previous boot was a memory
      * rescue and whether rendering should stay paused this time. */
+    BOOTMEM("after-wifi");
     fos_client_render_recovery_boot();
     fos_client_start();
 
+    BOOTMEM("after-client-start");
     if (frameos_nim_available() && local_render_ok) {
         int width = fos_display_present() ? fos_display_width() : 800;
         int height = fos_display_present() ? fos_display_height() : 480;
@@ -229,9 +248,11 @@ void app_main(void)
 
     /* Interpreted scenes: mount /state and queue any cached scenes.json;
      * the render task applies it and keeps it synced with the backend. */
+    BOOTMEM("after-nim-init");
     if (fos_scenes_init() != ESP_OK) {
         ESP_LOGW(TAG, "scene storage unavailable, continuing without");
     }
+    BOOTMEM("after-scenes-init");
     fos_schedule_init();
 
     /* Oversized HTTP bodies (multi-MB gallery images) spill to storage
@@ -270,11 +291,13 @@ void app_main(void)
         }
     }
 
+    BOOTMEM("after-spill");
     fos_console_start();
 
     /* Cloud-managed frames (docs/cloud-frames.md): idles until cloud_url and
      * a claim token are provisioned (USB `set`, flasher) and Wi-Fi is up,
      * then enrolls and, when enrolled, runs the management WebSocket. */
+    BOOTMEM("after-console");
     if (fos_cloud_start() != ESP_OK) {
         ESP_LOGW(TAG, "cloud client unavailable");
     }
@@ -285,6 +308,7 @@ void app_main(void)
         log_bootup_event(true);
         fos_http_start(false);
         fos_ota_start_periodic_task(24);
+        BOOTMEM("after-http+ota");
     } else {
         frameos_nim_set_log_upload_enabled(false);
         if (!fos_config_wifi_ready()) {

--- a/frameos/src/embedded/embedded_main.nim
+++ b/frameos/src/embedded/embedded_main.nim
@@ -332,9 +332,13 @@ proc fos_nim_init_impl(width, height: cint; name: cstring; maxHttpResponseBytes:
     frameRotate = 0
   frameName = $name
   try:
+    when defined(memProbe): memProbe("INIT start")
     armEmergencyReserve()
+    when defined(memProbe): memProbe("INIT after armEmergencyReserve")
     initRuntime(frameWidth, frameHeight, frameName, maxHttpResponseBytes.int, frameRotate)
+    when defined(memProbe): memProbe("INIT after initRuntime")
     initScene()
+    when defined(memProbe): memProbe("INIT after initScene")
     log(&"nim runtime initialized: {frameWidth}x{frameHeight} rotate={frameRotate} " &
         &"\"{frameName}\", nim {NimVersion}")
     true

--- a/frameos/src/embedded/embedded_scene.nim
+++ b/frameos/src/embedded/embedded_scene.nim
@@ -11,13 +11,25 @@ import frameos/utils/font as fontUtils
 const frameosSceneName {.strdefine.}: string = "default"
 const frameosSceneBackground {.strdefine.}: string = "#ffffff"
 
-var typeface: Typeface
-
 proc initScene*() =
-  typeface = fontUtils.getDefaultTypeface()
+  ## Deliberately does nothing but exist.
+  ##
+  ## This used to parse the default typeface, which is 1.57 MB of PSRAM on an
+  ## ESP32-S3 — measured with -d:memProbe, it was the whole of the resident
+  ## baseline apart from the 1 MB emergency reserve, and it was paid at boot by
+  ## every frame whether or not anything ever drew text. The scene below is
+  ## only rendered when no interpreted scene is loaded, and plenty of scenes
+  ## (the bundled Weather scene, for one, which draws through SVG) never ask
+  ## for a glyph at all.
+  ##
+  ## getDefaultTypeface already caches behind a lock, so the parse simply
+  ## happens on the first piece of text instead of on every boot. Kept as a
+  ## no-op rather than removed so the init sequence in embedded_main stays
+  ## readable, and so there is somewhere for this explanation to live.
+  discard
 
 proc newFont(size: float32; color: Color): Font =
-  result = newFont(typeface)
+  result = newFont(fontUtils.getDefaultTypeface())
   result.size = size
   result.paint = newPaint(SolidPaint)
   result.paint.color = color


### PR DESCRIPTION
The resident baseline — what a frame holds before any render begins — was **2.72 MB of an 8 MB board**, and it is why the render budget was tight enough for the bundled Weather scene to exhaust PSRAM at all (#318). Attributing it needed a boot-time probe, added here as the C-side companion to `-d:memProbe` from #317.

```
BOOTMEM after-wifi           psram_free=8342704
BOOTMEM after-client-start   psram_free=8342704
BOOTMEM after-nim-init       psram_free=5626776   <- -2,715,928
BOOTMEM after-scenes-init    psram_free=5626740
BOOTMEM after-http+ota       psram_free=5624984
```

**The whole baseline is one call.** Wi-Fi, scene storage, the console, HTTP and OTA cost about 2 KB of PSRAM between them. Inside `frameos_nim_init`:

```
INIT after armEmergencyReserve   -1,048,580   the 1 MB reserve, deliberate
INIT after initRuntime           -1,252       nothing
INIT after initScene             -1,648,548   the default typeface
```

`initScene` did exactly one thing: **parse the default font**. 1.57 MB, at boot, on every frame, whether or not anything ever drew text — and the fallback scene it exists for only renders when no interpreted scene is loaded. Plenty of scenes never ask for a glyph; the bundled Weather scene draws through SVG.

`getDefaultTypeface` already caches behind a lock, so the fix is to let the first piece of text trigger the parse instead of the boot sequence. `initScene` stays as a no-op so the init sequence reads the same and the explanation has somewhere to live.

## Measured on hardware

ESP32-S3 PhotoPainter, 8 MB PSRAM:

| | before | after |
|---|---|---|
| free after nim init | 5,626,776 | **7,275,324** |
| free when a render starts | 5,494,132 | **7,142,896** |

Weather still renders, now **without touching the emergency reserve in steady state** (it still dips on the first render after a boot, which also pays the transpile). Counter, which draws through `render/text`, renders unchanged — the typeface loads on its first glyph rather than at boot, which is the case that proves the lazy path works.

The `BOOTMEM` probe is compiled out unless built with `-DFRAMEOS_BOOTMEM=1`.

Independent of #318 — different files, and either can merge first.