### PR TITLE
ESP32: image producers cropped to the frame's scaling mode, ignoring the node's placement

### DIFF
--- a/frameos/src/apps/data/frameOSGallery/app.nim
+++ b/frameos/src/apps/data/frameOSGallery/app.nim
@@ -34,10 +34,19 @@ proc get*(self: App, context: ExecutionContext): Image =
   let category = self.appConfig.resolvedCategory()
   self.log(%*{"category": category})
   let url = galleryUrl(category)
-  let target = context.contextImage()
+  # Decode straight into the consumer's canvas only when the interpreter says
+  # the consumer will draw this full-frame, and with the placement it asked
+  # for. Taking context.image plus the frame's scaling mode instead meant a
+  # node asking for "contain" silently got the frame default; downloadImageFor-
+  # Target falls back to a display-bounded decode when there is no target.
+  let target = context.decodeTargetImage
+  let targetScalingMode = context.decodeTargetScalingMode
+  if not target.isNil:
+    context.decodeTargetImage = nil
+    context.decodeTargetScalingMode = ""
   try:
     result = galleryDownloadHook(url, self.maxImageResponseBytes(), target,
-        scaledDecodeFitForFrame(self.frameConfig))
+        scaledDecodeFit(targetScalingMode))
   except CatchableError as e:
     let detail = if e.msg.len > 0: e.msg else: "unknown error"
     self.logError "An error occurred while downloading the gallery image: " & detail

--- a/frameos/src/apps/data/frameOSGallery/tests/test_app.nim
+++ b/frameos/src/apps/data/frameOSGallery/tests/test_app.nim
@@ -10,6 +10,8 @@ type LogStore = ref object
 var
   galleryHookUrl {.global.}: string
   galleryHookMaxBytes {.global.}: int
+  galleryHookTarget {.global.}: Image
+  galleryHookFit {.global.}: ScaledDecodeFit
 
 proc newLogger(store: LogStore): Logger =
   Logger(
@@ -23,6 +25,13 @@ proc fakeGalleryDownload(url: string, maxBytes: int, target: Image, fit: ScaledD
   check target.isNil
   check fit == fitCover
   newImage(2, 3)
+
+proc recordingGalleryDownload(url: string, maxBytes: int, target: Image,
+    fit: ScaledDecodeFit): Image =
+  galleryHookUrl = url
+  galleryHookTarget = target
+  galleryHookFit = fit
+  if target.isNil: newImage(2, 3) else: target
 
 suite "data/frameOSGallery app":
   test "resolvedCategory chooses categoryOther when category is other":
@@ -56,3 +65,58 @@ suite "data/frameOSGallery app":
     check galleryHookMaxBytes == 1234
     check logs.items.len == 1
     check logs.items[0]["category"].getStr() == "nature"
+
+suite "data/frameOSGallery decode-into-canvas hint":
+  # The decode target and its fit come from the interpreter's hint, which is
+  # the only thing that knows what the consumer will do with the image. Taking
+  # context.image and the FRAME's scalingMode instead is what made an
+  # ESP32 render `placement: "contain"` as cover: the producer cropped to the
+  # frame default before the consumer ever saw the image.
+  setup:
+    galleryHookUrl = ""
+    galleryHookTarget = nil
+    galleryHookFit = fitCover
+
+  proc newApp(scalingMode: string): App =
+    App(
+      nodeId: 11.NodeId,
+      nodeName: "data/frameOSGallery",
+      scene: FrameScene(logger: newLogger(LogStore(items: @[]))),
+      frameConfig: FrameConfig(maxHttpResponseBytes: 1234, scalingMode: scalingMode),
+      appConfig: AppConfig(category: "nature")
+    )
+
+  test "uses the hint's placement, not the frame's scaling mode":
+    let previousHook = galleryDownloadHook
+    galleryDownloadHook = recordingGalleryDownload
+    defer: galleryDownloadHook = previousHook
+
+    let canvas = newImage(8, 4)
+    let context = ExecutionContext(
+      image: canvas, hasImage: true,
+      decodeTargetImage: canvas, decodeTargetScalingMode: "contain"
+    )
+    # Frame says cover; the consuming node asked for contain. The node wins.
+    discard newApp("cover").get(context)
+
+    check galleryHookTarget == canvas
+    check galleryHookFit == fitContain
+    # The hint is for one decode: a sibling producer under the same context
+    # must not inherit this canvas.
+    check context.decodeTargetImage.isNil
+    check context.decodeTargetScalingMode == ""
+
+  test "without a hint it does not decode into the canvas":
+    let previousHook = galleryDownloadHook
+    galleryDownloadHook = recordingGalleryDownload
+    defer: galleryDownloadHook = previousHook
+
+    let canvas = newImage(8, 4)
+    # A canvas is present, but the interpreter did not offer it — the consumer
+    # will place the image itself, so cropping to it here would be wrong.
+    let context = ExecutionContext(image: canvas, hasImage: true)
+    let image = newApp("cover").get(context)
+
+    check galleryHookTarget.isNil
+    check image.width == 2
+    check image.height == 3

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -370,7 +370,18 @@ proc runNode*(self: FrameScene, nodeId: NodeId, context: ExecutionContext, asDat
       # 7.7MB a decode is, and OOM'd the 16MB-PSRAM ESP32 boards the same way
       # (render/calendar was the repro). Add producers here only after their
       # get() consumes context.decodeTargetImage.
-      const decodeTargetProducers = ["data/localImage", "render/calendar"]
+      const decodeTargetProducers = [
+        "data/localImage", "render/calendar",
+        # Download-based producers: all of these go through
+        # downloadImageWithDataForContext, which consumes the hint and falls
+        # back to a display-bounded decode without one. Before they were on
+        # this list they decoded into the canvas anyway, but with the frame's
+        # scaling mode rather than the consumer's placement — the XKCD scene
+        # asked for "contain" and got "cover".
+        "data/downloadImage", "data/unsplash", "data/immich",
+        "data/googlePhotos", "data/openaiImage", "data/wikicommons",
+        "data/frameOSGallery",
+      ]
       var setDecodeTargetHint = false
       var directImageProducer = false
       if keyword == "render/image" and not asDataNode and cacheEnabled == false and

--- a/frameos/src/frameos/utils/app_images.nim
+++ b/frameos/src/frameos/utils/app_images.nim
@@ -47,17 +47,26 @@ proc renderErrorForContext*(self: AppRoot, context: ExecutionContext, message: s
       return target
   renderError(self.contextImageWidth(context), self.contextImageHeight(context), message)
 
+proc scaledDecodeFit*(scalingMode: string): ScaledDecodeFit =
+  ## Decode-time fit for a placement string, for decoding straight into a
+  ## consumer-sized target on embedded builds.
+  case scalingMode
+  of "contain": fitContain
+  of "stretch": fitStretch
+  else: fitCover
+
 proc scaledDecodeFitForFrame*(frameConfig: FrameConfig): ScaledDecodeFit =
   ## The decode-time fit that best matches the frame's scaling mode when an
   ## image is decoded straight into a region-sized target on embedded builds.
   ## Hosts decode downloads at native resolution, so the fit only applies
   ## on embedded targets.
+  ##
+  ## Only a fallback: when a consumer is going to place the image itself, its
+  ## placement decides, through context.decodeTargetScalingMode. The frame's
+  ## mode says nothing about what a particular node wants.
   if frameConfig.isNil:
     return fitCover
-  case frameConfig.scalingMode
-  of "contain": fitContain
-  of "stretch": fitStretch
-  else: fitCover
+  scaledDecodeFit(frameConfig.scalingMode)
 
 proc downloadImageForTarget*(url: string, maxBytes: int, target: Image = nil,
     headers: seq[SimpleHttpHeader] = @[], fit = fitCover): Image =
@@ -68,13 +77,43 @@ proc downloadImageForTarget*(url: string, maxBytes: int, target: Image = nil,
 proc downloadImageWithDataForContext*(self: AppRoot, context: ExecutionContext, url: string,
     maxBytes = 0, headers: seq[SimpleHttpHeader] = @[], fallbackWidth = 0,
     fallbackHeight = 0): tuple[image: Image, data: string] =
+  ## Downloads an image for an app that produces one.
+  ##
+  ## On embedded this can decode straight into the consumer's canvas, which
+  ## keeps peak memory at the decode intermediates — but only when the
+  ## interpreter has said so by setting context.decodeTargetImage, because
+  ## only the interpreter knows what the consumer will do with the result.
+  ##
+  ## It used to decode into context.image unconditionally, with the fit taken
+  ## from the FRAME's scalingMode. That silently cropped: the XKCD scene asks
+  ## render/image for `placement: "contain"`, and got cover, because the frame
+  ## default (hardcoded "cover" on ESP32) decided instead of the node. The
+  ## image arrived pre-cropped and already canvas-sized, so render/image drew
+  ## it 1:1 and its placement did nothing. The same happened to any consumer
+  ## that was not a full-frame draw at all. Hosts never had the bug: they skip
+  ## decode-into-target entirely and let the consumer place the image.
+  ##
+  ## With no hint, decode to display bounds instead — aspect preserved, no
+  ## crop, and still bounded for a small device.
   let byteLimit =
     if maxBytes > 0: maxBytes
     else: self.maxImageResponseBytes()
+
+  # Consume the hint: it is for this decode only, and must not leak into a
+  # sibling producer that runs later under the same context.
+  let decodeTarget = context.decodeTargetImage
+  let decodeScalingMode = context.decodeTargetScalingMode
+  if not decodeTarget.isNil:
+    context.decodeTargetImage = nil
+    context.decodeTargetScalingMode = ""
+
+  if decodeTarget.isNil:
+    return downloadImageWithData(url, maxBytes = byteLimit, headers = headers)
+
   downloadImageWithDataInto(
     url,
-    self.contextImageTarget(context, fallbackWidth, fallbackHeight),
+    decodeTarget,
     maxBytes = byteLimit,
     headers = headers,
-    fit = scaledDecodeFitForFrame(self.frameConfig)
+    fit = scaledDecodeFit(decodeScalingMode)
   )


### PR DESCRIPTION
The bundled XKCD scene renders as **cover on an ESP32 and contain on a Pi**, from the same scene — one that explicitly asks `render/image` for `placement: "contain"`.

## What was happening

On embedded, an image producer may decode straight into the consumer's canvas so peak memory stays at the decode intermediates — that is what makes big downloads survive on a small board. The interpreter owns that decision and hands it over through `context.decodeTargetImage` / `decodeTargetScalingMode`, because only it knows what the consumer will do with the result.

`downloadImageWithDataForContext` never used that hint. It decoded into `context.image` unconditionally, with the fit taken from **the frame's** `scalingMode` — hardcoded `"cover"` in the embedded runtime. So the image arrived pre-cropped and already canvas-sized; `render/image` saw that source and target matched, drew it 1:1, and its `placement` did nothing. The same applied to any consumer that was not a full-frame draw at all.

Hosts never had the bug: `downloadImageInto` ignores the target off-device and lets the consumer place the image. That is exactly why the Pi is correct and the ESP32 is not.

## The fix

- `downloadImageWithDataForContext` consumes the hint and uses **its** placement. With no hint it decodes to display bounds — aspect preserved, no crop, still bounded for a small device. This fixes six apps at once: `downloadImage`, `unsplash`, `immich`, `googlePhotos`, `openaiImage`, `wikicommons`.
- `data/frameOSGallery` had its own copy of the same mistake; same fix.
- All seven join `decodeTargetProducers`, so the memory optimisation still applies when the consumer is a full-frame `render/image` — now with that node's placement instead of the frame default.
- `scaledDecodeFit(mode)` splits out of `scaledDecodeFitForFrame`, which stays the fallback it always should have been.

`render/image` already had `if sourceImage == image: return` for the decode-into-canvas case, so the protocol was fully designed — these producers just weren't following it.

## Verified on hardware

ESP32-S3 PhotoPainter, 7.3" panel. I pulled the rendered frame back over USB and measured it rather than looking at it:

```
canvas 800x480, background (178,193,192)
image cell: content x 286..514  ->  286px left / 285px right margins
non-background pixels outside the letterbox: 0
334 rows of content between y=20 and y=368
```

Centred, letterboxed, nothing bleeding to the edges — contain.

## Tests

New tests pin the protocol: the hint's placement beats the frame's scaling mode, the hint is cleared after one decode (so a sibling producer cannot inherit the canvas), and no hint means no decode into the canvas. Green: frameOSGallery, interpreter errors, localImage, render/image, host compile.

## Not fixed here

`FrameConfig.scalingMode` is still **hardcoded to `"cover"`** in the embedded runtime, where a Pi reads it from `frame.json`. After this change it no longer affects placement, but it is a real gap and wants the same config path `rotate` already has.