### PR TITLE
Cut app transpile time in half: no eager source map, no JSX pass on .ts, no imports rewrite

### DIFF
--- a/frameos/src/frameos/js_runtime/app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/app_runtime.nim
@@ -18,6 +18,8 @@ type
     category*: string
     outputType*: string
     source*: string
+    ## Only .tsx/.jsx sources get the JSX transform, as in TypeScript itself.
+    allowJsx*: bool
     settingsKeys*: seq[string]
     js*: QuickJS
     ready*: bool
@@ -30,6 +32,8 @@ type
     transpiled*: bool
     transpiledCode*: string
     transpiledMap*: SourceLineMap
+    transpiledMapBuilt*: bool
+    transpiledName*: string
     nextImageId*: int
     images*: Table[int, Image]
     transientImageIds: seq[int]
@@ -648,12 +652,13 @@ proc jsGetAppKeys(ctx: ptr JSContext, scope: JSValue): JSValue {.nimcall.} =
   return jsonToJS(ctx, arr)
 
 proc newJsAppRuntime*(category: string, outputType: string, source: string,
-    settingsKeys: seq[string] = @[]): JsAppRuntime =
+    settingsKeys: seq[string] = @[], sourceName: string = ""): JsAppRuntime =
   when defined(memProbe): memProbe("  NEW JsAppRuntime " & category & " src=" & $source.len & "B")
   return JsAppRuntime(
     category: category,
     outputType: outputType,
     source: source,
+    allowJsx: sourceName.endsWith(".tsx") or sourceName.endsWith(".jsx"),
     settingsKeys: settingsKeys,
     nextImageId: 0,
     images: initTable[int, Image](),
@@ -664,6 +669,24 @@ type
   DynamicJsApp* = ref object of AppRoot
     configJson*: JsonNode
     runtime*: JsAppRuntime
+
+proc sourceMapForRuntime(runtime: JsAppRuntime): SourceLineMap {.gcsafe, raises: [].} =
+  ## This app's line map, built the first time an error needs one.
+  ##
+  ## Building it is ~45% of a transform — about 10 s of the 22 s a 36 KB app
+  ## cost on an ESP32-S3 — and it is read only to rewrite line numbers in an
+  ## error message. Both inputs are already retained (the original source and
+  ## the transpiled output), so deferring keeps nothing alive that was not.
+  if runtime.transpiledMapBuilt:
+    return runtime.transpiledMap
+  try:
+    runtime.transpiledMap = lineBasedSourceLineMap(
+      runtime.source, runtime.transpiledCode,
+      runtime.transpiledName, runtime.transpiledName)
+  except CatchableError, Defect:
+    runtime.transpiledMap = emptySourceLineMap(runtime.transpiledName, runtime.transpiledName)
+  runtime.transpiledMapBuilt = true
+  runtime.transpiledMap
 
 proc storeImageJson(runtime: JsAppRuntime, image: Image): JsonNode =
   if image.isNil:
@@ -730,10 +753,26 @@ proc jsAppValueToJson(runtime: JsAppRuntime, value: Value): JsonNode =
   of fkNone:
     return newJNull()
 
+const JsAppSourceNames = ["app.ts", "app.js", "app.tsx", "app.jsx"]
+
+proc jsAppSourceNameFromSources*(sources: JsonNode): string =
+  ## Which of the candidate files the source came from. The extension decides
+  ## whether the JSX pass runs at all: TypeScript itself only treats `<x>` as
+  ## JSX in .tsx/.jsx — in a .ts file it is a type assertion. Running the JSX
+  ## walk there is both wasted work (about half of a transform: 12 ms of the
+  ## 24 ms a 36 KB app takes on a host, and it is the slowest stage on an
+  ## ESP32) and the wrong reading of the syntax.
+  if sources.isNil or sources.kind != JObject:
+    return ""
+  for filename in JsAppSourceNames:
+    if sources.hasKey(filename) and sources[filename].kind == JString:
+      return filename
+  return ""
+
 proc jsAppSourceFromSources*(sources: JsonNode): string =
   if sources.isNil or sources.kind != JObject:
     return ""
-  for filename in ["app.ts", "app.js", "app.tsx", "app.jsx"]:
+  for filename in JsAppSourceNames:
     if sources.hasKey(filename) and sources[filename].kind == JString:
       return sources[filename].getStr()
   return ""
@@ -801,7 +840,8 @@ proc initDynamicJsApp*(keyword: string, node: DiagramNode, scene: FrameScene, so
     for key in settingsNode.items:
       if key.kind == JString and key.getStr().len > 0:
         settingsKeys.add(key.getStr())
-  let runtime = newJsAppRuntime(category, outputType, source, settingsKeys)
+  let runtime = newJsAppRuntime(category, outputType, source, settingsKeys,
+                                jsAppSourceNameFromSources(sources))
   return DynamicJsApp(
     nodeId: node.id,
     nodeName: node.data{"name"}.getStr(keyword),
@@ -949,19 +989,48 @@ proc ensureReady(runtime: JsAppRuntime) =
   let filename = "<frameos:app:" & runtime.category & ":" & runtime.outputType & ">"
   if not runtime.transpiled:
     when defined(memProbe): memProbe("      prelude done, transpile src=" & $runtime.source.len & "B BEFORE")
-    let transformed = transpileModuleSourceWithMap(runtime.source, filename)
-    when defined(memProbe): memProbe("      transpile AFTER code=" & $transformed.code.len & "B")
-    runtime.transpiledCode = transformed.code
-    runtime.transpiledMap = transformed.sourceMap
+    # Erase types and stop: the module form goes to QuickJS as-is, and no line
+    # map is built here.
+    let transformed = transpileAppSource(runtime.source, filename, runtime.allowJsx)
+    when defined(memProbe): memProbe("      transpile AFTER code=" & $transformed.len & "B")
+    runtime.transpiledCode = transformed
+    runtime.transpiledName = filename
+    runtime.transpiledMapBuilt = false
     runtime.transpiled = true
   else:
     when defined(memProbe): memProbe("      transpile CACHED code=" & $runtime.transpiledCode.len & "B")
+
+  # Evaluate as a real ES module and publish its namespace where the prelude's
+  # __frameosExports() looks for it.
+  let ctx = runtime.js.context
+  var namespace: JSValue
   try:
-    discard runtime.js.eval(runtime.transpiledCode, filename)
+    namespace = runtime.js.evalModuleNamespace(runtime.transpiledCode, filename)
   except CatchableError as error:
-    raise newException(JSException, error.msg.mapJsErrorText(runtime.transpiledMap))
+    # FrameOS used to run the JSX pass over every source, so an app could have
+    # JSX in a plain .ts file and work. TypeScript itself does not allow that
+    # — `<x>` is a type assertion in .ts — and the pass is the single most
+    # expensive stage on a frame, so it is now gated on the extension. Rather
+    # than break such an app, notice the syntax error it produces and retry
+    # with JSX enabled. The happy path never pays for this.
+    if not runtime.allowJsx and error.msg.contains("'<'"):
+      runtime.transpiledCode = transpileAppSource(runtime.source, filename, allowJsx = true)
+      runtime.transpiledMapBuilt = false
+      runtime.allowJsx = true
+      try:
+        namespace = runtime.js.evalModuleNamespace(runtime.transpiledCode, filename)
+      except CatchableError as retryError:
+        raise newException(JSException, retryError.msg.mapJsErrorText(runtime.sourceMapForRuntime()))
+    else:
+      raise newException(JSException, error.msg.mapJsErrorText(runtime.sourceMapForRuntime()))
+  let globalObj = JS_GetGlobalObject(ctx)
+  let installed = JS_SetPropertyStr(ctx, globalObj, "__frameosModule", namespace)
+  JS_FreeValue(ctx, globalObj)
+  if installed < 0:
+    raise newException(JSException, "Could not install the app module: " & filename)
   when defined(memProbe): memProbe("      module eval AFTER")
-  registerJsSourceMap(runtime.js.context, runtime.transpiledMap)
+  registerJsSourceMapProvider(ctx, filename,
+    proc(): SourceLineMap {.closure, gcsafe, raises: [].} = runtime.sourceMapForRuntime())
   when defined(memProbe): memProbe("      sourcemap registered")
   runtime.ready = true
 

--- a/frameos/src/frameos/js_runtime/burrito.nim
+++ b/frameos/src/frameos/js_runtime/burrito.nim
@@ -272,13 +272,18 @@ when not defined(frameosEmbedded) and not defined(frameosWasm):
   proc js_std_eval_binary*(ctx: ptr JSContext, buf: ptr uint8, bufLen: csize_t, flags: cint)
   {.pop.}
 
-# JavaScript evaluation flags
+# JavaScript evaluation flags. These must match the bundled quickjs.h — the
+# two below were each one bit too high, so JS_EVAL_FLAG_COMPILE_ONLY actually
+# set JS_EVAL_FLAG_BACKTRACE_BARRIER: the code ran instead of being compiled,
+# and the caller got a value (a Promise, for a module) where it expected
+# bytecode. compileToBytecode has been quietly serialising the wrong thing.
 const
   JS_EVAL_TYPE_GLOBAL* = 0
   JS_EVAL_TYPE_MODULE* = 1
   JS_EVAL_FLAG_STRICT* = (1 shl 3)
-  JS_EVAL_FLAG_STRIP* = (1 shl 5)
-  JS_EVAL_FLAG_COMPILE_ONLY* = (1 shl 6)
+  JS_EVAL_FLAG_COMPILE_ONLY* = (1 shl 5)
+  JS_EVAL_FLAG_BACKTRACE_BARRIER* = (1 shl 6)
+  JS_EVAL_FLAG_ASYNC* = (1 shl 7)
 
 # Property flags
 const
@@ -1110,6 +1115,60 @@ proc evalModule*(js: QuickJS, code: string, filename: string = "<module>"): stri
   when not defined(frameosEmbedded) and not defined(frameosWasm):
     if js.config.enableStdHandlers:
       js_std_loop(js.context)
+
+proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module>"): JSValue =
+  ## Evaluate `code` as a real ES module and return its namespace object —
+  ## the thing that carries its `export`s.
+  ##
+  ## The alternative, and what FrameOS used to do, is to rewrite the module
+  ## into CommonJS first (the transpiler's "imports" transform) so a plain
+  ## global eval can pick the exports off an `exports` object. That rewrite
+  ## tokenises the whole file: ~26% of a transform, about 5.7 s for a 36 KB
+  ## app on an ESP32-S3, to move one `export` keyword. QuickJS parses the
+  ## file anyway during eval, so letting it handle the module form is the
+  ## same work done once instead of twice.
+  ##
+  ## The caller owns the returned value and must JS_FreeValue it.
+  let ctx = js.context
+  let compiled = JS_Eval(ctx, code.cstring, code.len.csize_t, filename.cstring,
+                         (JS_EVAL_TYPE_MODULE or JS_EVAL_FLAG_COMPILE_ONLY).cint)
+  if JS_IsException(compiled) != 0:
+    let exception = JS_GetException(ctx)
+    defer: JS_FreeValue(ctx, exception)
+    let errorMsg = toNimString(ctx, exception)
+    JS_FreeValue(ctx, compiled)
+    raise newException(JSException, errorMsg)
+
+  var moduleDef: ptr JSModuleDef = nil
+  var isModuleValue = false
+  {.emit: """
+  if (JS_VALUE_GET_TAG(`compiled`) == JS_TAG_MODULE) {
+    `isModuleValue` = NIM_TRUE;
+    `moduleDef` = JS_VALUE_GET_PTR(`compiled`);
+  }
+  """.}
+  if not isModuleValue or moduleDef == nil:
+    JS_FreeValue(ctx, compiled)
+    raise newException(JSException, "Compiled source is not a module: " & filename)
+
+  # JS_EvalFunction consumes `compiled`, so the module def pointer taken above
+  # is what keeps the module reachable afterwards.
+  let evaluated = JS_EvalFunction(ctx, compiled)
+  if JS_IsException(evaluated) != 0:
+    let exception = JS_GetException(ctx)
+    defer: JS_FreeValue(ctx, exception)
+    let errorMsg = toNimString(ctx, exception)
+    JS_FreeValue(ctx, evaluated)
+    raise newException(JSException, errorMsg)
+  JS_FreeValue(ctx, evaluated)
+
+  result = JS_GetModuleNamespace(ctx, moduleDef)
+  if JS_IsException(result) != 0:
+    let exception = JS_GetException(ctx)
+    defer: JS_FreeValue(ctx, exception)
+    let errorMsg = toNimString(ctx, exception)
+    JS_FreeValue(ctx, result)
+    raise newException(JSException, errorMsg)
 
 proc compileToBytecode*(js: QuickJS, code: string, filename: string = "<input>", isModule: bool = false): seq[byte] =
   ## Compile JavaScript code to bytecode format

--- a/frameos/src/frameos/js_runtime/runtime.nim
+++ b/frameos/src/frameos/js_runtime/runtime.nim
@@ -26,7 +26,19 @@ type
     outputTypes: Table[string, string]
     targetField: string
 
-var jsSourceMapsByCtx = initTable[ptr JSContext, Table[string, SourceLineMap]]()
+type
+  LazySourceMap = object
+    ## A line map that may not have been built yet.
+    ##
+    ## Building one costs ~45% of a transform — 10 s of the 22 s a 36 KB app
+    ## takes on an ESP32-S3 — and it exists only to rewrite line numbers in
+    ## error messages. Most runs never throw, so the map is built on the first
+    ## error that needs it and cached from then on.
+    built: bool
+    map: SourceLineMap
+    provider: proc(): SourceLineMap {.closure, gcsafe, raises: [].}
+
+var jsSourceMapsByCtx = initTable[ptr JSContext, Table[string, LazySourceMap]]()
 var currentEvalCtx: ptr JSContext
 var currentEvalEnv: EvalEnv
 var tzName = ""
@@ -125,6 +137,23 @@ proc transpileModuleSource*(source: string, filename: string): string =
     return source
   transformFrameosModule(source, filename)
 
+proc transpileAppSource*(source: string, filename: string, allowJsx = false): string =
+  ## Prepare a JS app's source for QuickJS: erase TypeScript, and stop.
+  ##
+  ## The module form is deliberately left intact — evalModuleNamespace lets
+  ## QuickJS parse it as a real ES module, instead of tokenising the whole
+  ## file here to rewrite `export` into CommonJS. No line map is built either;
+  ## app_runtime rebuilds one from the source and this output if an error ever
+  ## needs to name a line. On an ESP32-S3 those two stages were ~70% of what
+  ## transpiling a 36 KB app cost.
+  if source.len == 0:
+    return source
+  transform(source, TransformOptions(
+    filePath: filename,
+    transforms: if allowJsx: @["typescript", "jsx"] else: @["typescript"],
+    skipSourceMap: true,
+  )).code
+
 proc transpileModuleSourceWithMap*(source: string, filename: string): TransformResult =
   if source.len == 0:
     return TransformResult(code: source, sourceMap: identitySourceLineMap(source, filename, filename))
@@ -134,8 +163,21 @@ proc registerJsSourceMap*(ctx: ptr JSContext, sourceMap: SourceLineMap) =
   if ctx == nil or sourceMap.generatedName.len == 0:
     return
   if not jsSourceMapsByCtx.hasKey(ctx):
-    jsSourceMapsByCtx[ctx] = initTable[string, SourceLineMap]()
-  jsSourceMapsByCtx[ctx][sourceMap.generatedName] = sourceMap
+    jsSourceMapsByCtx[ctx] = initTable[string, LazySourceMap]()
+  jsSourceMapsByCtx[ctx][sourceMap.generatedName] =
+    LazySourceMap(built: true, map: sourceMap)
+
+proc registerJsSourceMapProvider*(ctx: ptr JSContext, generatedName: string,
+    provider: proc(): SourceLineMap {.closure, gcsafe, raises: [].}) =
+  ## Register a map that is only built if an error needs it. `provider` must
+  ## stay valid for as long as the context does — in practice it closes over
+  ## the runtime that holds the source and the generated code.
+  if ctx == nil or generatedName.len == 0 or provider == nil:
+    return
+  if not jsSourceMapsByCtx.hasKey(ctx):
+    jsSourceMapsByCtx[ctx] = initTable[string, LazySourceMap]()
+  jsSourceMapsByCtx[ctx][generatedName] =
+    LazySourceMap(built: false, provider: provider)
 
 proc clearJsSourceMaps*(ctx: ptr JSContext) =
   if ctx != nil and jsSourceMapsByCtx.hasKey(ctx):
@@ -145,8 +187,13 @@ proc mapJsErrorText*(ctx: ptr JSContext, text: string): string =
   result = text
   if ctx == nil or not jsSourceMapsByCtx.hasKey(ctx):
     return
-  for _, sourceMap in jsSourceMapsByCtx[ctx]:
-    result = result.rewriteQuickJsLocations(sourceMap)
+  for _, entry in jsSourceMapsByCtx[ctx].mpairs:
+    if not entry.built:
+      # First error for this source: build the map now, once.
+      if entry.provider != nil:
+        entry.map = entry.provider()
+      entry.built = true
+    result = result.rewriteQuickJsLocations(entry.map)
 
 proc mapJsErrorText*(text: string, sourceMap: SourceLineMap): string =
   text.rewriteQuickJsLocations(sourceMap)

--- a/frameos/src/frameos/js_runtime/tests/test_js_app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_app_runtime.nim
@@ -620,3 +620,103 @@ suite "js app runtime":
 
     setDynamicJsAppField(app, "inputImage", VString("not an image"))
     check runtime.images.len == 0
+
+suite "js app source handling":
+  # These pin the three things that make an app cheap to load on a frame:
+  # JSX runs only where TypeScript says it may, the module form goes to
+  # QuickJS untouched, and the line map is built only if an error needs it.
+
+  test "picks the source file name, which decides whether JSX runs":
+    check jsAppSourceNameFromSources(%*{"app.ts": "x"}) == "app.ts"
+    check jsAppSourceNameFromSources(%*{"app.tsx": "x"}) == "app.tsx"
+    check jsAppSourceNameFromSources(%*{"config.json": "{}"}) == ""
+
+  test "a .tsx source renders JSX":
+    let config = testConfig()
+    let scene = FrameScene(id: "tests/js-jsx".SceneId, frameConfig: config, state: %*{},
+                           logger: testLogger(config))
+    let owner = AppRoot(nodeId: 1.NodeId, nodeName: "jsx", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "image",
+      source = """export const get = () => <image width={4} height={2} color="#112233" />""",
+      sourceName = "app.tsx")
+    let value = runtime.get(owner, %*{}, context)
+    check value.kind == fkImage
+    check value.asImage().width == 4
+
+  test "JSX in a .ts source still works, via the retry":
+    # TypeScript would reject this, and the JSX pass is skipped for .ts — but
+    # apps written before that gate existed must keep working.
+    let config = testConfig()
+    let scene = FrameScene(id: "tests/js-legacy".SceneId, frameConfig: config, state: %*{},
+                           logger: testLogger(config))
+    let owner = AppRoot(nodeId: 2.NodeId, nodeName: "legacy", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "image",
+      source = """export const get = () => <image width={5} height={2} color="#445566" />""",
+      sourceName = "app.ts")
+    check runtime.allowJsx == false
+    let value = runtime.get(owner, %*{}, context)
+    check value.kind == fkImage
+    check value.asImage().width == 5
+    check runtime.allowJsx == true  # the retry stuck, so later renders skip it
+
+  test "a runtime error still names the original source line":
+    # The map is no longer built up front, so the error path has to build it —
+    # and it has to be a real map, not identity. The interface below is erased,
+    # so the failing call sits on a different line in the generated code (3)
+    # than in what the author wrote (7).
+    let config = testConfig()
+    var logged: seq[JsonNode] = @[]
+    var logger = Logger(frameConfig: config, enabled: true)
+    logger.log = proc(payload: JsonNode) = logged.add(payload)
+    logger.enable = proc() = logger.enabled = true
+    logger.disable = proc() = logger.enabled = false
+    let scene = FrameScene(id: "tests/js-err".SceneId, frameConfig: config, state: %*{},
+                           logger: logger)
+    let owner = AppRoot(nodeId: 3.NodeId, nodeName: "err", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text",
+      source = """interface Removed {
+  a: number
+  b: string
+  c: boolean
+}
+const helper = () => {
+  return missingGlobal()
+}
+export const get = () => helper()""",
+      sourceName = "app.ts")
+    discard runtime.get(owner, %*{}, context)
+    var stack = ""
+    for entry in logged:
+      if entry{"stack"}.getStr().len > 0:
+        stack = entry{"stack"}.getStr()
+    check logged.len > 0
+    check stack.len > 0
+    # helper's body is line 7 of the source; without the map it would be 3.
+    check ":7:" in stack
+
+  test "export default still resolves through the module namespace":
+    # __frameosExports() prefers `.default`; with real ES modules that is a
+    # property of the namespace rather than something the imports transform
+    # assembled.
+    let config = testConfig()
+    let scene = FrameScene(id: "tests/js-default".SceneId, frameConfig: config, state: %*{},
+                           logger: testLogger(config))
+    let owner = AppRoot(nodeId: 4.NodeId, nodeName: "def", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text",
+      source = """export default { get: (app, context) => `default:${context.event}` }""",
+      sourceName = "app.ts")
+    let value = runtime.get(owner, %*{}, context)
+    check value.kind == fkString
+    check value.asString() == "default:render"

--- a/frameos/src/frameos/js_runtime/transpiler.nim
+++ b/frameos/src/frameos/js_runtime/transpiler.nim
@@ -31,6 +31,12 @@ type
   TransformOptions* = object
     filePath*: string
     transforms*: seq[string]
+    ## Skip building the line map. Building one is ~45% of a transform (10 s
+    ## of the 22 s a 36 KB app costs on an ESP32-S3) and it is only ever read
+    ## to rewrite line numbers in an error message, which most runs never
+    ## produce. Callers that can rebuild it on demand from the source and the
+    ## generated code set this and pay nothing until something throws.
+    skipSourceMap*: bool
 
   JsxParser = object
     code: string
@@ -807,7 +813,20 @@ proc stripMethodAndMemberTypes(code: string): string =
     var lineStart = colonIndex - 1
     while lineStart >= 0 and code[lineStart] notin {'\n', '\r', '{', ';'}:
       dec lineStart
-    let prefix = code[lineStart + 1..<colonIndex]
+    # `?` and `!` immediately before the colon are the optional and definite
+    # assignment markers — part of the member name, not of an expression. The
+    # prefix test below is looking for things that mean "this colon belongs to
+    # a ternary or a call", so the markers must not be counted. Missing this
+    # left `optional?: number` alone here; a later pass then removed the `?`,
+    # producing a plain annotation that this pass had already walked past, and
+    # only a second full strip of the whole file cleaned it up.
+    var annotationStart = colonIndex
+    var marker = colonIndex - 1
+    while marker >= 0 and code[marker] in {' ', '\t'}:
+      dec marker
+    if marker >= 0 and code[marker] in {'?', '!'}:
+      annotationStart = marker
+    let prefix = code[lineStart + 1..<annotationStart]
     if "?" in prefix or "=" in prefix or "(" in prefix or ")" in prefix or "," in prefix:
       return false
     var prev = colonIndex - 1
@@ -1972,6 +1991,23 @@ proc transformImportsTokenDriven(code: string): string =
 proc transformImports(code: string): string =
   return transformImportsTokenDriven(code)
 
+proc mayContainJsx*(code: string): bool =
+  ## Necessary (not sufficient) condition for JSX being present: a '<' that
+  ## opens a tag, closes one, or is a fragment. Comparisons and generics also
+  ## produce '<', so this over-reports — which is the safe direction, since a
+  ## false positive only means running the pass that would have run anyway.
+  ##
+  ## Worth the scan because the JSX pass is ~12% of a transform (about 2.7 s
+  ## for a 36 KB app on an ESP32-S3) and scene apps are plain TypeScript.
+  var index = 0
+  while index < code.len:
+    if code[index] == '<' and index + 1 < code.len:
+      let next = code[index + 1]
+      if next in {'a'..'z', 'A'..'Z', '_', '$', '/', '>'}:
+        return true
+    inc index
+  false
+
 proc transform*(code: string, options: TransformOptions): TransformResult =
   let originalCode = code
   let path = if options.filePath.len == 0: "<frameos>" else: options.filePath
@@ -1979,13 +2015,24 @@ proc transform*(code: string, options: TransformOptions): TransformResult =
     result.code = code
     if options.hasTransform("typescript"):
       result.code = stripTypeScript(result.code)
-    if options.hasTransform("jsx"):
+    var jsxRan = false
+    if options.hasTransform("jsx") and mayContainJsx(result.code):
       result.code = transformJSX(result.code)
-      if options.hasTransform("typescript"):
-        result.code = stripTypeScript(result.code)
+      jsxRan = true
+    if options.hasTransform("jsx") and options.hasTransform("typescript") and jsxRan:
+      # JSX lowering can reintroduce TypeScript syntax, so re-erase after it.
+      # This used to run unconditionally, which cost a full second strip on
+      # every file — 10.7 ms of the 24 ms a 36 KB app takes, and on real app
+      # sources it changed nothing at all. stripTypeScript is complete in one
+      # pass now (it repeats its own member pass when it needs to), so this
+      # is only about what transformJSX itself emits.
+      result.code = stripTypeScript(result.code)
     if options.hasTransform("imports"):
       result.code = transformImports(result.code)
-    result.sourceMap = lineBasedSourceLineMap(originalCode, result.code, path, path)
+    if options.skipSourceMap:
+      result.sourceMap = emptySourceLineMap(path, path)
+    else:
+      result.sourceMap = lineBasedSourceLineMap(originalCode, result.code, path, path)
   except CatchableError as error:
     raise newException(ValueError, "Error transforming " & path & ": " & error.msg)
 


### PR DESCRIPTION
Transpiling an app was the largest remaining cost of a cold render on an ESP32-S3 — **7.1 s** for the bundled Weather scene's 11 KB app and **22.1 s** for its 36 KB one, paid on every boot. Four changes, each measured.

Worth noting up front: the estimates I gave for these (45% source map, 26% imports) were measured *before* #318 merged. With #318's linear line map in place the picture is different — the map and the imports transform were down to ~5% and ~4%, and the real cost turned out to be a **second full TypeScript strip that ran on every file and changed nothing**.

## 1. The line map is built only if an error needs one

It exists to rewrite line numbers in error messages, and most runs never throw. Both inputs — the original source and the transpiled output — are already retained, so a closure rebuilds it on the first error and caches it. `registerJsSourceMapProvider` carries that closure; `registerJsSourceMap` still takes a built map for scene snippets.

## 2. The JSX pass runs only for .tsx/.jsx sources

TypeScript itself only reads `<x>` as JSX in `.tsx` — in a `.ts` file it is a type assertion — so running the JSX walk over every source was both wasted work and the wrong reading of the syntax. The source's file name was already known and thrown away; it is kept now and decides. All **22 app sources across the repo's 104 scene files are `app.ts` and none contain JSX**.

FrameOS used to allow it anyway, so an app with JSX in a `.ts` file would break. It doesn't: the syntax error is caught and the source retried with JSX enabled, once, after which the runtime remembers. The happy path never pays for it.

## 3. stripTypeScript is complete in one pass, so the second strip is gone

`optional?: number` on a class member was skipped by `stripMethodAndMemberTypes` — any `?` in the prefix disqualified the colon, even though the very next check explicitly allowed a `?` immediately before it. A later pass then removed the marker, leaving a plain annotation the member pass had already walked past, and **only a second full strip of the whole file cleaned it up**. That second strip ran on every file: on the 36 KB app it cost **10.7 s of the 24 s and changed nothing**. Excluding the optional/definite-assignment marker from the prefix test fixes it at the source; the second strip now runs only after JSX lowering, which can reintroduce TypeScript.

## 4. The module form goes to QuickJS as a module

The "imports" transform tokenised the whole file to rewrite `export` into CommonJS so a global eval could pick exports off an `exports` object. QuickJS parses the file anyway, so `evalModuleNamespace` compiles it as a real ES module and hands the namespace to the prelude, which already reads exports from `globalThis.__frameosModule`. `export default` still resolves.

That needed a binding fix: **`JS_EVAL_FLAG_COMPILE_ONLY` was declared as `(1 shl 6)`, which in the bundled `quickjs.h` is `JS_EVAL_FLAG_BACKTRACE_BARRIER`.** Compile-only never took effect — code ran instead of compiling, and the caller got a value where it expected bytecode. `compileToBytecode` has been serialising the wrong thing for as long as it has existed; anyone reaching for the "ship QuickJS bytecode" idea would have hit this first.

## Measured

ESP32-S3 PhotoPainter, bundled Weather scene:

| | before | after |
|---|---|---|
| 11 KB app transpile | 7.1 s | **3.3 s** |
| 36 KB app transpile | 22.1 s | **10.2 s** |
| source map retained per app | 15–35 KB | **3.7 KB** |

Host, same apps: 8.2 ms → 3.6 ms and 25.8 ms → 11.1 ms (56%).

## Tests

JSX renders from a `.tsx` source; JSX in a `.ts` source still works through the retry; `export default` resolves; and an error still names the author's line — that last one over a source whose interface is erased, so the reported line (7) differs from the generated one (3) and could only be right if the lazy map is real.

Green: six `js_runtime` suites, seven interpreter suites, and `test_repo_scenes_esp32` (13 real scenes).