### PR TITLE
Cloud: stop claiming every scene is undeployed; log GPIO button presses

### DIFF
--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-scene-deploy-state.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-scene-deploy-state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { undeployedSceneIdsFor } from "../../../../../../frontend/src/utils/sceneDeployState";
+import type { FrameScene, FrameType } from "../../../../../../frontend/src/types";
+
+// Bug: every scene in the cloud workspace claimed "This scene has changes that
+// are not on the frame yet", including immediately after a successful push.
+// The check read frame.last_successful_deploy.scenes — a backend field that
+// nothing in the cloud ever writes — so it compared each scene against an
+// empty list and marked them all pending, forever.
+//
+// The cloud's evidence is the checksum pair the account frames table already
+// renders as "in sync" / "sync pending": assigned_checksum (what the account
+// assigned) versus scenes_checksum (what the device acknowledged).
+
+const scenes = [
+  { id: "scene-a", name: "A", nodes: [], edges: [] },
+  { id: "scene-b", name: "B", nodes: [], edges: [] },
+] as unknown as FrameScene[];
+
+function frame(fields: Partial<FrameType>): FrameType {
+  return fields as FrameType;
+}
+
+// The cloud never has this field; a stub keeps the backend cases honest.
+const scenesEqual = (a: FrameScene, b: FrameScene) =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+describe("undeployedSceneIdsFor — cloud", () => {
+  it("reports nothing pending once the device acknowledges the assigned set", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({ assigned_checksum: "abc", scenes_checksum: "abc" }),
+      scenesEqual,
+    });
+    expect([...ids]).toEqual([]);
+  });
+
+  it("reports the whole set pending while the device is behind", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({ assigned_checksum: "new", scenes_checksum: "old" }),
+      scenesEqual,
+    });
+    expect([...ids].sort()).toEqual(["scene-a", "scene-b"]);
+  });
+
+  it("reports pending when the device has not acknowledged anything yet", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({ assigned_checksum: "abc", scenes_checksum: null }),
+      scenesEqual,
+    });
+    expect(ids.size).toBe(2);
+  });
+
+  it("leaves a frame with nothing assigned and nothing on the device alone", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes: [],
+      frame: frame({ assigned_checksum: null, scenes_checksum: null }),
+      scenesEqual,
+    });
+    expect(ids.size).toBe(0);
+  });
+
+  it("ignores last_successful_deploy, which the cloud never writes", () => {
+    // The old code path: with this field absent every scene looked undeployed.
+    // Present-but-stale must not override the checksums either.
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({
+        assigned_checksum: "abc",
+        scenes_checksum: "abc",
+        last_successful_deploy: { scenes: [] },
+      } as Partial<FrameType>),
+      scenesEqual,
+    });
+    expect(ids.size).toBe(0);
+  });
+});
+
+describe("undeployedSceneIdsFor — other modes", () => {
+  it("compares against last_successful_deploy on the backend", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "backend",
+      scenes,
+      frame: frame({
+        last_successful_deploy: { scenes: [scenes[0]] },
+      } as Partial<FrameType>),
+      scenesEqual,
+    });
+    expect([...ids]).toEqual(["scene-b"]);
+  });
+
+  it("has nothing to deploy in frame admin mode", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "frameAdmin",
+      scenes,
+      frame: frame({}),
+      scenesEqual,
+    });
+    expect(ids.size).toBe(0);
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/workspace-surfaces.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/workspace-surfaces.test.ts
@@ -9,6 +9,7 @@ import {
   allowedSceneToolPanels,
   allowedSceneUtilityPanels,
   frameCapabilities,
+  isEsp32Frame,
   frameMenuActionDisabledReason,
   frameMenuActionIsAllowed,
   frameSettingsSectionIsAllowed,
@@ -502,5 +503,33 @@ describe("Add frame opens the flow its control plane implements", () => {
   it("leaves the backend and the on-device panel on the creation form", () => {
     expect(addFrameFlows.backend).toBe("backendForm");
     expect(addFrameFlows.frameAdmin).toBe("backendForm");
+  });
+});
+
+describe("isEsp32Frame", () => {
+  // Callers that care about the DEVICE rather than the control plane: an
+  // esp32 serves its own asset thumbnails from a microcontroller, so the
+  // asset panel loads them one at a time instead of five.
+  it("recognises a cloud-enrolled esp32 from its hardware report", () => {
+    expect(isEsp32Frame({ hardware: { platform: "esp32-s3" } }, "cloud")).toBe(true);
+    expect(isEsp32Frame({ hardware: { platform: "esp32" } }, "cloud")).toBe(true);
+  });
+
+  it("recognises a backend/on-device esp32 from its embedded platform", () => {
+    expect(isEsp32Frame({ embedded: { platform: "esp32-s3" } }, "backend")).toBe(true);
+    expect(isEsp32Frame({ embedded: { platform: "esp32-c3" } }, "frameAdmin")).toBe(true);
+  });
+
+  it("is false for everything else", () => {
+    expect(isEsp32Frame({ embedded: { platform: "virtual" } }, "backend")).toBe(false);
+    expect(isEsp32Frame({ hardware: { platform: "pi-zero-2" } }, "cloud")).toBe(false);
+    expect(isEsp32Frame(null, "backend")).toBe(false);
+    expect(isEsp32Frame(undefined, "cloud")).toBe(false);
+  });
+
+  it("does not treat a cloud hardware report as esp32 outside cloud mode", () => {
+    // hardware.platform is the enrollment report; a backend frame's device
+    // identity is embedded.platform.
+    expect(isEsp32Frame({ hardware: { platform: "esp32-s3" } }, "backend")).toBe(false);
   });
 });

--- a/embedded/esp32/main/fos_buttons.c
+++ b/embedded/esp32/main/fos_buttons.c
@@ -61,6 +61,11 @@ static void enqueue_press(const fos_gpio_button_t *button, int level)
     strlcpy(event.label, button->label, sizeof(event.label));
     if (xQueueSend(s_queue, &event, 0) != pdTRUE) {
         ESP_LOGW(TAG, "button event queue full, dropping GPIO %d", button->pin);
+        char dropped[160];
+        snprintf(dropped, sizeof(dropped),
+                 "{\"event\":\"button:dropped\",\"source\":\"esp32\",\"pin\":%d,"
+                 "\"reason\":\"queue-full\"}", button->pin);
+        frameos_nim_log_hook(dropped);
         return;
     }
     fos_client_render_now();
@@ -140,6 +145,30 @@ esp_err_t fos_buttons_start(void)
         return ESP_ERR_INVALID_STATE;
     }
 
+    /* One line naming the pins and labels this frame is listening on. Half of
+     * "I pressed the button and nothing happened" is not knowing which pin the
+     * board actually wired, and which label a scene has to match. */
+    {
+        char list[256];
+        size_t used = 0;
+        list[0] = '\0';
+        for (size_t i = 0; i < config->gpio_button_count && used + 1 < sizeof(list); i++) {
+            if (!s_enabled[i]) continue;
+            char label[FOS_GPIO_BUTTON_LABEL_LEN * 2];
+            json_escape(config->gpio_buttons[i].label, label, sizeof(label));
+            int written = snprintf(list + used, sizeof(list) - used,
+                                   "%s{\"pin\":%d,\"label\":\"%s\"}",
+                                   used ? "," : "", config->gpio_buttons[i].pin, label);
+            if (written < 0 || (size_t)written >= sizeof(list) - used) break;
+            used += (size_t)written;
+        }
+        char line[320];
+        snprintf(line, sizeof(line),
+                 "{\"event\":\"buttons:listening\",\"source\":\"esp32\",\"buttons\":[%s]}",
+                 list);
+        frameos_nim_log_hook(line);
+    }
+
     BaseType_t created = xTaskCreate(buttons_task, "fos_buttons", 3072, NULL, 4, NULL);
     if (created != pdPASS) {
         vQueueDelete(s_queue);
@@ -161,7 +190,18 @@ void fos_buttons_process_events(void)
         char payload[96];
         snprintf(payload, sizeof(payload), "{\"pin\":%d,\"label\":\"%s\",\"level\":%d}",
                  event.pin, label, event.level);
-        if (!frameos_nim_send_event("button", payload)) {
+        bool dispatched = frameos_nim_send_event("button", payload);
+        /* Into the frame log, not just the serial console: a press used to
+         * leave no trace anywhere a user can see. When a scene ignores it the
+         * interpreter says so (runEvent:noListenerMatched), but that only
+         * helps if you can first tell the press was registered at all. */
+        char line[192];
+        snprintf(line, sizeof(line),
+                 "{\"event\":\"button\",\"source\":\"esp32\",\"pin\":%d,"
+                 "\"label\":\"%s\",\"level\":%d,\"dispatched\":%s}",
+                 event.pin, label, event.level, dispatched ? "true" : "false");
+        frameos_nim_log_hook(line);
+        if (!dispatched) {
             ESP_LOGW(TAG, "button event skipped: Nim runtime unavailable");
         }
     }

--- a/frontend/src/components/DeferredImage.tsx
+++ b/frontend/src/components/DeferredImage.tsx
@@ -28,12 +28,29 @@ class LoadLimiter {
     })
   }
 }
-const sharedLimiter = new LoadLimiter(5)
+// One pool per concurrency level, so a caller that needs a stricter cap gets
+// its own queue instead of quietly changing everyone else's.
+const limiters = new Map<number, LoadLimiter>()
+function limiterFor(max: number): LoadLimiter {
+  const key = Math.max(1, Math.floor(max))
+  const existing = limiters.get(key)
+  if (existing) return existing
+  const created = new LoadLimiter(key)
+  limiters.set(key, created)
+  return created
+}
+const defaultMaxConcurrent = 5
 
 export interface DeferredImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   url: string
   startWhenVisible?: boolean
   spinnerClassName?: string
+  /**
+   * How many of these may be in flight at once. Defaults to 5; an esp32 frame
+   * serves its asset thumbnails from the device itself, one small HTTP server
+   * on a microcontroller, so the asset panel asks for 1 there.
+   */
+  maxConcurrent?: number
 }
 
 /** DeferredImage with visibility gate + 5-at-a-time limiter + spinner */
@@ -41,6 +58,7 @@ export function DeferredImage({
   url,
   startWhenVisible = true,
   spinnerClassName,
+  maxConcurrent = defaultMaxConcurrent,
   className,
   onLoad,
   onError,
@@ -79,7 +97,7 @@ export function DeferredImage({
     let cancelled = false
     if (!started || actualSrc) return
     ;(async () => {
-      const release = await sharedLimiter.acquire()
+      const release = await limiterFor(maxConcurrent).acquire()
       if (cancelled) {
         release()
         return

--- a/frontend/src/scenes/frame/panels/Assets/Assets.tsx
+++ b/frontend/src/scenes/frame/panels/Assets/Assets.tsx
@@ -1,6 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import clsx from 'clsx'
 import { frameLogic } from '../../frameLogic'
+import { isEsp32Frame } from '../../../workspace/workspaceSurfaces'
 import {
   assetsLogic,
   isInThumbsFolder,
@@ -126,6 +127,11 @@ function TreeNode({
    * run-image-scene buttons stay. */
   readOnly: boolean
 }): JSX.Element {
+  // An esp32 serves these thumbnails from the device itself — one small HTTP
+  // server on a microcontroller that also has a render loop to run. Asking for
+  // five at once makes the whole panel slower than asking for one.
+  const { frame } = useValues(frameLogic)
+  const thumbnailConcurrency = isEsp32Frame(frame) ? 1 : undefined
   const expansionKey = frameAssetFolderExpansionKey(frameId, node.path)
   const expanded = frameAssetFolderExpansion[expansionKey] ?? node.path === ''
   const [isDragOver, setIsDragOver] = useState(false)

--- a/frontend/src/scenes/frame/panels/Scenes/scenesLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/scenesLogic.tsx
@@ -2,6 +2,8 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import type { scenesLogicType } from './scenesLogicType'
 import { FrameScene, SceneNodeData, FrameId } from '../../../../types'
 import { frameLogic, sanitizeScene, sceneEqualForComparison } from '../../frameLogic'
+import { undeployedSceneIdsFor } from '../../../../utils/sceneDeployState'
+import { workspaceMode } from '../../../workspace/workspaceSurfaces'
 import { appsModel } from '../../../../models/appsModel'
 import { sceneUpdatesLogic } from './sceneUpdatesLogic'
 import { forms } from 'kea-forms'
@@ -405,23 +407,13 @@ export const scenesLogic = kea<scenesLogicType>([
     rawScenes: [(s) => [s.editingFrame], (frame): FrameScene[] => frame?.scenes ?? []],
     undeployedSceneIds: [
       (s) => [s.rawScenes, s.frame, s.isFrameAdminMode],
-      (scenes, frame, isFrameAdminMode): Set<string> => {
-        if (isFrameAdminMode) {
-          return new Set<string>()
-        }
-
-        const deployedScenes: FrameScene[] = frame?.last_successful_deploy?.scenes ?? []
-        const undeployed = new Set<string>()
-
-        scenes.forEach((scene) => {
-          const deployed = deployedScenes.find((deployedScene) => deployedScene.id === scene.id)
-          if (!deployed || !sceneEqualForComparison(scene, deployed)) {
-            undeployed.add(scene.id)
-          }
-        })
-
-        return undeployed
-      },
+      (scenes, frame, isFrameAdminMode): Set<string> =>
+        undeployedSceneIdsFor({
+          mode: isFrameAdminMode ? 'frameAdmin' : workspaceMode(),
+          scenes,
+          frame,
+          scenesEqual: sceneEqualForComparison,
+        }),
     ],
     unsavedSceneIds: [
       (s) => [s.frame, s.frameForm],

--- a/frontend/src/scenes/workspace/workspaceSurfaces.ts
+++ b/frontend/src/scenes/workspace/workspaceSurfaces.ts
@@ -330,6 +330,20 @@ export function isEsp32CloudFrame(frame?: FrameCapabilityInput | null, mode: Wor
 }
 
 /**
+ * An esp32 frame under any control plane: enrolled into the cloud (its
+ * hardware report says esp32) or driven by a backend/on-device build (its
+ * embedded platform does). Callers that care about the DEVICE rather than
+ * the control plane want this — how much a microcontroller can be asked to
+ * do at once does not depend on who is asking.
+ */
+export function isEsp32Frame(
+  frame?: FrameCapabilityInput | null,
+  mode: WorkspaceMode = workspaceMode()
+): boolean {
+  return isEsp32CloudFrame(frame, mode) || isEsp32Platform(frame?.embedded?.platform)
+}
+
+/**
  * An embedded-mode frame on the "virtual" platform (devices.ts
  * EMBEDDED_VIRTUAL; string literal here so this module stays import-free):
  * no hardware at all — the backend renders the frame and serves it as an

--- a/frontend/src/utils/sceneDeployState.ts
+++ b/frontend/src/utils/sceneDeployState.ts
@@ -1,0 +1,64 @@
+import type { FrameScene, FrameType } from '../types'
+import type { WorkspaceMode } from '../scenes/workspace/workspaceSurfaces'
+
+// Which scenes are not on the frame yet — the input to the scene drawer's
+// "This scene has changes that are not on the frame yet" notice.
+//
+// The three control planes answer this from different evidence, and getting
+// the cloud one wrong is why every cloud scene claimed to be undeployed even
+// straight after a successful push:
+//
+//   * backend  — the frame row carries `last_successful_deploy.scenes`, the
+//     exact graphs SSH last installed, so the comparison is per scene.
+//   * cloud    — there is no such field, and nothing writes one. A cloud
+//     deploy is a checksummed `set_scenes` push: `assigned_checksum` is what
+//     the account assigned, `scenes_checksum` is what the device acknowledged
+//     (the same pair the account frames table renders as "in sync" /
+//     "sync pending"). Reading `last_successful_deploy` there compared every
+//     scene against an empty list, so all of them were permanently pending.
+//     A single checksum covers the whole set, so this is all-or-nothing: it
+//     cannot say WHICH scene differs, only that the device is behind.
+//   * frameAdmin — the frame is the thing being edited; there is nowhere to
+//     deploy to.
+export function undeployedSceneIdsFor({
+  mode,
+  scenes,
+  frame,
+  scenesEqual,
+}: {
+  mode: WorkspaceMode
+  scenes: readonly FrameScene[]
+  frame: FrameType | null | undefined
+  /** Injected so this module stays free of the frameLogic import cycle. */
+  scenesEqual: (a: FrameScene, b: FrameScene) => boolean
+}): Set<string> {
+  if (mode === 'frameAdmin') {
+    return new Set<string>()
+  }
+
+  if (mode === 'cloud') {
+    const assigned = frame?.assigned_checksum
+    const reported = frame?.scenes_checksum
+    // Both present and equal: the device has acknowledged exactly this set.
+    if (assigned && reported && assigned === reported) {
+      return new Set<string>()
+    }
+    // Nothing assigned yet and nothing on the device either — an empty frame
+    // has nothing pending, and claiming otherwise makes a fresh frame look
+    // dirty before the user has done anything.
+    if (!assigned && !reported) {
+      return new Set<string>()
+    }
+    return new Set(scenes.map((scene) => scene.id))
+  }
+
+  const deployedScenes: FrameScene[] = frame?.last_successful_deploy?.scenes ?? []
+  const undeployed = new Set<string>()
+  scenes.forEach((scene) => {
+    const deployed = deployedScenes.find((deployedScene) => deployedScene.id === scene.id)
+    if (!deployed || !scenesEqual(scene, deployed)) {
+      undeployed.add(scene.id)
+    }
+  })
+  return undeployed
+}


### PR DESCRIPTION
Two unrelated reports, both about something that happened being invisible or misreported.

## 1. "This scene has changes that are not on the frame yet" — on every scene, always

The check compared each scene against `frame.last_successful_deploy.scenes`. That field is written by the **backend's** SSH deploy; **nothing in the cloud writes it**, and it is not in the cloud's frame payload at all (`buildFrameSummary` in `src/lib/frames.ts` has no such key). So the comparison ran against an empty list and marked every scene pending — permanently, no matter how many times you pushed.

The cloud's actual evidence is the checksum pair its own account frames table already renders as "in sync" / "sync pending":

```tsx
frame.assignedChecksum === frame.scenesChecksum ? "in sync" : "sync pending"
```

`assigned_checksum` is what the account assigned; `scenes_checksum` is what the device acknowledged. Both are already in the frame payload and in `FrameType`.

The decision moves into `undeployedSceneIdsFor()` — a pure function the cloud's node suite can test — with one branch per control plane:

| mode | evidence |
|---|---|
| cloud | the checksum pair; **all-or-nothing**, since one checksum covers the whole set and cannot say *which* scene differs |
| backend | unchanged: per scene against `last_successful_deploy` |
| frameAdmin | nothing to deploy to; unchanged |

A frame with nothing assigned *and* nothing on the device reports nothing pending, so a fresh frame no longer looks dirty before you have done anything to it.

7 new tests cover the cloud branch (in sync, behind, never acknowledged, empty frame, and that a stray `last_successful_deploy` cannot override the checksums) plus the two other modes.

## 2. GPIO button presses left no trace

`fos_buttons` logged at `ESP_LOGI`, which the console hides at WARN and which never reaches the frame log the Logs panel shows. Three lines now go to the frame log:

```json
{"event":"button","source":"esp32","pin":4,"label":"B","level":0,"dispatched":true}
{"event":"buttons:listening","source":"esp32","buttons":[{"pin":0,"label":"A"},{"pin":4,"label":"B"}]}
{"event":"button:dropped","source":"esp32","pin":4,"reason":"queue-full"}
```

- `dispatched` separates "the board never saw it" from "the scene ignored it".
- The listening line names the pins and labels a scene must match — the half that was missing when these buttons turned out to be dead in #316.
- A dropped press was previously a serial-only warning, so a lost press left no trace at all.

**Verified on hardware** — both presses appear in the frame log after flashing:

```
{"event":"buttons:listening",...,"buttons":[{"pin":0,"label":"A"},{"pin":4,"label":"B"}]}
{"event":"button",...,"pin":0,"label":"A","level":0,"dispatched":true}
{"event":"button",...,"pin":4,"label":"B","level":0,"dispatched":true}
```

Together with `runEvent:noListenerMatched` (#316) the whole chain is visible: press → dispatched → matched, or filtered out and by which filter.

## Not in this PR

The blank scene tile is diagnosed but not fixed — see the PR discussion.