### PR TITLE
Read the device's log ring from the logs panel; hand back idle JS interpreters

### DIFF
--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -243,6 +243,7 @@ proc cleanupScene(scene: FrameScene) =
   interpreted.cacheValues = initTable[NodeId, Value]()
   interpreted.cacheTimes = initTable[NodeId, float]()
   interpreted.cacheKeys = initTable[NodeId, JsonNode]()
+  interpreted.cacheExprs = initTable[NodeId, JsonNode]()
   when defined(memProbe): memProbe("  cleanupScene: tables cleared")
   cleanupSceneJs(interpreted)
   when defined(memProbe): memProbe("  cleanupScene: js closed")

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -454,6 +454,11 @@ proc renderCurrentScene*(): Option[Image] =
     nextSleep: -1
   )
   let image = interpreter.render(currentScene, context)
+  # The scene is done with its JS nodes until the next render, which on this
+  # board is minutes away. Hand their interpreters back now so the packing and
+  # display work below — and the next render's image decodes — see the memory.
+  releaseIdleJsAppRuntimes()
+  when defined(memProbe): memProbe("  renderCurrentScene: idle js runtimes released")
   if image.isNil:
     log("render returned no image")
     return none(Image)

--- a/frameos/src/frameos/js_runtime/app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/app_runtime.nim
@@ -91,6 +91,24 @@ when defined(frameosEmbedded):
       if other != keep and other.ready and not jsRuntimeStack.contains(other):
         teardownJsRuntime(other)
 
+proc releaseIdleJsAppRuntimes*() =
+  ## Drop every JS app interpreter that is not mid-call. Called when a render
+  ## finishes.
+  ##
+  ## Eviction otherwise only ever runs from ensureReady — that is, when ANOTHER
+  ## JS node is about to be built. Nothing on the image path triggers it, so a
+  ## decode could be refused for want of memory that was sitting in idle
+  ## interpreters the whole time, and a frame that sleeps for five minutes
+  ## between renders sleeps holding all of them.
+  ##
+  ## Cheap to undo: teardownJsRuntime keeps transpiledCode, so rebuilding
+  ## re-evaluates the module without re-transpiling — the expensive part, ~22 s
+  ## for the bundled Weather app.
+  when defined(frameosEmbedded):
+    for runtime in liveJsRuntimes:
+      if runtime.ready and not jsRuntimeStack.contains(runtime):
+        teardownJsRuntime(runtime)
+
 proc jsFetchMaxBytes(e: JsAppEvalEnv): int =
   if e != nil:
     frameos_apps.maxHttpResponseBytes(e.owner)

--- a/frameos/src/frameos/scenes.nim
+++ b/frameos/src/frameos/scenes.nim
@@ -102,6 +102,7 @@ proc cleanupSceneRuntime*(scene: FrameScene) =
     interpreted.cacheValues = initTable[NodeId, Value]()
     interpreted.cacheTimes = initTable[NodeId, float]()
     interpreted.cacheKeys = initTable[NodeId, JsonNode]()
+    interpreted.cacheExprs = initTable[NodeId, JsonNode]()
     cleanupSceneJs(interpreted)
 
 proc cleanupSceneTableRuntime*(scenes: Table[SceneId, FrameScene]) =

--- a/frontend/src/models/embeddedUsbLogsModel.ts
+++ b/frontend/src/models/embeddedUsbLogsModel.ts
@@ -98,26 +98,32 @@ function serialErrorMessage(error: unknown): string {
   return detail || 'USB serial log stream failed.'
 }
 
-function usbLog(line: string, frameId: FrameId, type = 'usb'): LogType {
+function usbLog(line: string, frameId: FrameId, type = 'usb', timestamp?: string): LogType {
   return {
     id: nextUsbLogId--,
     frame_id: frameId,
     ip: 'usb',
     line,
-    timestamp: new Date().toISOString(),
+    timestamp: timestamp ?? new Date().toISOString(),
     type,
   }
 }
 
-function appendUsbLine(frameId: FrameId, line: string, type = 'usb'): void {
+function appendUsbLine(frameId: FrameId, line: string, type = 'usb', timestamp?: string): void {
   if (line.length === 0) {
     return
   }
-  embeddedUsbLogsModel.actions.appendUsbLog(usbLog(line, frameId, type))
+  embeddedUsbLogsModel.actions.appendUsbLog(usbLog(line, frameId, type, timestamp))
 }
 
-export function appendEmbeddedUsbLogLine(frameId: FrameId, line: string, type = 'usb'): void {
-  appendUsbLine(frameId, line, type)
+/**
+ * Append a line to a frame's USB log view. `timestamp` overrides "now", which
+ * matters for replayed history: the device's log ring carries the epoch each
+ * line was written at, and stamping those with the fetch time would file
+ * yesterday's boot under this minute.
+ */
+export function appendEmbeddedUsbLogLine(frameId: FrameId, line: string, type = 'usb', timestamp?: string): void {
+  appendUsbLine(frameId, line, type, timestamp)
 }
 
 /** Append a line that came off the device's console, minus the wire protocol. */
@@ -1263,6 +1269,52 @@ export async function usbLogsTail(frameId: FrameId): Promise<EmbeddedUsbLogEntry
       }
       return { epoch: match[1] === '-' ? null : Number(match[1]), line: match[2] }
     })
+}
+
+/**
+ * Fetch the device's own log ring and replay it into this frame's USB log view.
+ *
+ * The serial stream only carries what the board printed while a browser was
+ * attached, which is never the interesting part: by the time anyone opens the
+ * logs, whatever went wrong has already scrolled past — or happened before the
+ * cable was plugged in. The firmware keeps the last FOS_NIM_LOG_RING_CAP lines
+ * regardless of who is listening, and `usb_api logs` is the only way to read
+ * them. It needs an explicit request because it is a point-in-time snapshot,
+ * not a stream.
+ *
+ * Lines are stamped with the epoch the DEVICE recorded, so replayed history
+ * files itself under when it happened. Entries from before the board had a
+ * synced clock come back with no epoch; those keep the fetch time, which is
+ * wrong but monotonic, and the marker lines around the batch say so.
+ */
+export async function loadEmbeddedUsbLogHistory(frameId: FrameId): Promise<number> {
+  appendUsbLine(frameId, '[USB API] reading the device log ring')
+  let entries: EmbeddedUsbLogEntry[]
+  try {
+    entries = await usbLogsTail(frameId)
+  } catch (error) {
+    appendUsbLine(frameId, `[USB API] could not read the device log ring: ${serialErrorMessage(error)}`)
+    throw error
+  }
+  if (entries.length === 0) {
+    appendUsbLine(frameId, '[USB API] the device log ring is empty')
+    return 0
+  }
+  let undated = 0
+  for (const entry of entries) {
+    const timestamp = entry.epoch === null ? undefined : new Date(entry.epoch * 1000).toISOString()
+    if (entry.epoch === null) {
+      undated += 1
+    }
+    appendUsbLine(frameId, entry.line, 'usb-history', timestamp)
+  }
+  appendUsbLine(
+    frameId,
+    undated > 0
+      ? `[USB API] replayed ${entries.length} line(s) from the device log ring; ${undated} predate its clock sync and show the time they were read`
+      : `[USB API] replayed ${entries.length} line(s) from the device log ring`
+  )
+  return entries.length
 }
 
 /**

--- a/frontend/src/scenes/frame/panels/Logs/Logs.tsx
+++ b/frontend/src/scenes/frame/panels/Logs/Logs.tsx
@@ -8,13 +8,15 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 import { DropdownMenu } from '../../../../components/DropdownMenu'
 import { Spinner } from '../../../../components/Spinner'
 import { ArrowDownTrayIcon, ArrowUpTrayIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/solid'
-import { ChevronRightIcon, CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
+import { ChevronRightIcon, ClockIcon, CommandLineIcon, StopCircleIcon } from '@heroicons/react/24/outline'
 import { EMBEDDED_ESP32_S3 } from '../../../../devices'
 import { workspaceLogic, type WorkspaceTheme } from '../../../workspace/workspaceLogic'
 import { frameSupportsUsbSerialConsole, workspaceMode } from '../../../workspace/workspaceSurfaces'
 import {
   embeddedUsbLogsModel,
+  ensureEmbeddedUsbApiPort,
   isEmbeddedUsbLogStreamOpen,
+  loadEmbeddedUsbLogHistory,
   sendEmbeddedUsbConsoleCommand,
   startEmbeddedUsbLogStream,
 } from '../../../../models/embeddedUsbLogsModel'
@@ -316,6 +318,12 @@ function logTypeClassName(type: string, theme: WorkspaceTheme): string {
   if (type === 'usb') {
     return theme === 'dark' ? 'text-emerald-200' : 'text-emerald-700'
   }
+  if (type === 'usb-history') {
+    // Dimmer than live output on purpose: these lines were replayed out of the
+    // device's ring, so they sit in the list at the time they HAPPENED, which
+    // is usually well above whatever was streaming when they arrived.
+    return theme === 'dark' ? 'text-emerald-400/80' : 'text-emerald-800/80'
+  }
   return theme === 'dark' ? 'text-slate-100' : 'text-slate-900'
 }
 
@@ -327,6 +335,7 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
   const { usbLogStreamStatesByFrameId } = useValues(embeddedUsbLogsModel)
   const { stopUsbLogStream } = useActions(embeddedUsbLogsModel)
   const [atBottom, setAtBottom] = useState(true)
+  const [historyLoading, setHistoryLoading] = useState(false)
   const [expandedMetricLogIds, setExpandedMetricLogIds] = useState<number[]>([])
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const shouldStickToBottomRef = useRef(true)
@@ -481,6 +490,27 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
     await startEmbeddedUsbLogStream(frameId)
   }
 
+  // The device remembers its last lines whether or not anyone was attached;
+  // the live stream only shows what it printed since we connected. This is
+  // how you find out what happened before the cable went in.
+  const loadUsbLogHistory = async (): Promise<void> => {
+    if (historyLoading) {
+      return
+    }
+    setHistoryLoading(true)
+    try {
+      if (await ensureEmbeddedUsbApiPort(frameId)) {
+        await loadEmbeddedUsbLogHistory(frameId)
+        scrollToLatest()
+      }
+    } catch (error) {
+      // loadEmbeddedUsbLogHistory already put the reason in the log view,
+      // which is where someone reading logs will look for it.
+    } finally {
+      setHistoryLoading(false)
+    }
+  }
+
   const submitCommand = async (): Promise<void> => {
     const line = command.trim()
     if (!line || commandSending) {
@@ -501,6 +531,16 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
   }
 
   const menuItems = [
+    ...(showUsbLogControls
+      ? [
+          {
+            label: 'Load device log history',
+            onClick: loadUsbLogHistory,
+            icon: historyLoading ? <Spinner color="white" className="w-4 h-4" /> : <ClockIcon className="w-5 h-5" />,
+            loading: historyLoading,
+          },
+        ]
+      : []),
     {
       label: 'Download log',
       onClick: downloadLog,
@@ -811,6 +851,13 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
             logLine = (
               <>
                 <span className={renderTheme === 'dark' ? 'text-emerald-300' : 'text-emerald-700'}>{'[USB]'}</span>{' '}
+                {logLine}
+              </>
+            )
+          } else if (log.type === 'usb-history') {
+            logLine = (
+              <>
+                <span className={renderTheme === 'dark' ? 'text-emerald-500' : 'text-emerald-800'}>{'[USB ring]'}</span>{' '}
                 {logLine}
               </>
             )


### PR DESCRIPTION
Follow-ups to #325.

## The device's log ring was unreachable from the UI

The USB serial stream only carries what the board printed while a browser was attached, which is never the interesting part — by the time anyone opens the logs the failure has scrolled past, or happened before the cable went in. The firmware keeps its last lines regardless of who is listening, and `usb_api logs` reads them back, but nothing called it: `usbLogsTail()` had sat unused since it was written, and typing `usb_api logs` into the console box showed nothing, because the stream's protocol filter drops payload bodies for every command except `status`.

**Load device log history** in the logs menu now fetches that ring and replays it. It goes through the command path (`mirrorOutput: false`), so the payload is parsed rather than filtered.

Replayed lines carry the epoch the *device* recorded rather than the fetch time, so they file themselves under when they happened — which means they land above whatever is streaming now. They are dimmer and prefixed `[USB ring]` so that reads as deliberate rather than confusing. Lines from before the board synced its clock have no epoch; those keep the fetch time and the summary says how many.

## Idle JS interpreters are handed back when a render ends

Eviction only ever ran from `ensureReady` — when *another JS node* was about to be built. Nothing on the image path triggered it, so an image decode could be refused for want of memory sitting in idle interpreters, and a frame that sleeps five minutes between renders slept holding all of them.

`renderCurrentScene` now releases every JS app runtime that is not mid-call once the scene is done with them. Rebuilding on the next render re-evaluates the module but does not re-transpile (`teardownJsRuntime` keeps `transpiledCode`), which is why it costs nothing measurable.

Measured on an ESP32-S3 with the bundled Weather scene:

| | before | after |
|---|---|---|
| free PSRAM after render | 4157K | **4429K** (+272K) |
| render time | 72,704 ms | 72,819 ms (noise) |

Counter is unchanged, as expected — its JS is scene-level code nodes, a different runtime that lives as long as the scene.

## Also

`cacheExprs` is now cleared in both scene teardown paths. It was the one cache table neither cleared. Not a leak — no cycle, so ORC collects it with the scene — but the omission reads as a bug sitting next to the three tables that are.

## Testing

Nim suites pass (`test_scene_runtime_cleanup`, `test_js_app_runtime`, `test_repo_scenes_esp32`, `test_interpreter_cache`, `test_scenes_persistence`), ESP32 cross-compile is clean, frontend typechecks. The memory and render-time numbers above are from the frame, not estimates.

**Untested:** the log-history UI has no automated coverage — the frontend has no unit test runner, and Web Serial is not drivable from the existing Playwright setup. I exercised the underlying `usb_api logs` path against the board by hand during this work; the React wiring on top of it is typechecked only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)