### PR TITLE
Stop allocating to read bytes we already have in the transpiler

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -127,17 +127,41 @@ table. What was still open there, mostly nice-to-have:
 
 ### Startup cost
 
-- **Parse and transpile scenes at deploy time, not on every boot.** After
-  #322 one app transpile is 3.3 s (11 KB source) or 10.2 s (36 KB) on an
-  ESP32-S3, and a frame pays it again on every boot and every scene reload
-  for sources that never change — it is what makes the first render after a
-  boot the worst one. Doing it upstream (the frontend already bundles
-  esbuild, the cloud has typescript) would also let the transpiler be
-  compiled out of the firmware: transpiler + tokens + parser + source_map +
-  token_processor are ~92 KB of object code, against ~420 KB left in the OTA
-  slot. Cheaper interim with no format change: cache the transpiled output on
-  flash keyed by a hash of the source, so the cost is once-ever rather than
-  once-per-boot.
+- **`-d:memProbe` prints nothing on the ESP32 — fix this before trusting any
+  transpile number below.** Built the 7.3" PhotoPainter firmware with
+  `FRAMEOS_EXTRA_NIM_FLAGS="-d:memProbe"` (2026-08-10) and got zero MEMPROBE
+  lines over a cold boot and three Weather-scene renders, despite the
+  generated C carrying 15 resolved calls to `memProbe__...` and the probe
+  strings from `app_runtime.nim:1038/1042`. Plain `printf` from C reaches the
+  console fine (`fos_client.c:447` "render #N started" shows up), so this is
+  not the console. Either the JS-app path is never entered on that scene — no
+  `NEW JsAppRuntime` probe fires either, which would mean `app:weatherPanel`
+  resolves to something other than a JS app runtime on device — or Nim's
+  `c_printf` in `utils/memory.nim:54` is being swallowed. Until this is
+  answered, the repo has no working way to time a transpile on hardware, and
+  the numbers in the next item are unverified.
+- **Parse and transpile scenes at deploy time, not on every boot.** The
+  3.3 s (11 KB) / 10.2 s (36 KB) figures quoted here since #322 are **not
+  reproducible as stated** and should be treated as suspect. On the bench
+  7.3" PhotoPainter the cold-boot Weather render minus the warm render is
+  24.8 s, but that delta is network-dominated: it is unchanged (24.7 s) after
+  a transpiler fix that cut host transpile time 3.2x, so it is not measuring
+  transpilation at all. Fix the probe above, then re-measure before using any
+  of this to justify a format change. What *is* measured: the erasure passes
+  made 724,572 heap allocations for the 36 KB `weatherPanel/app.ts` — 19.9
+  per source byte, all through ESP-IDF multi_heap against PSRAM — because
+  `startsWordAt` allocated a slice per keyword probe and the copy helpers
+  allocated per literal per pass. Removing that took it to 16,709 allocations
+  (0.46/byte) and 14.2 ms -> 4.5 ms on host, with byte-identical output.
+  If a real device measurement still shows seconds, deploy-time
+  transpilation remains the answer, and doing it upstream (the frontend
+  already bundles esbuild, the cloud has typescript) would also let the
+  transpiler be compiled out of the firmware: transpiler + tokens + parser +
+  source_map + token_processor are ~92 KB of object code (unverified — one
+  reading of `frameos_esp32.map` put the five modules at ~78 KB), against
+  ~420 KB left in the OTA slot. Cheaper interim with no format change: cache
+  the transpiled output on flash keyed by a hash of the source, so the cost
+  is once-ever rather than once-per-boot.
 - **`compileToBytecode` serialises the wrong object.** It asked for
   `JS_EVAL_FLAG_COMPILE_ONLY`, which burrito.nim declared one bit too high —
   that value is `JS_EVAL_FLAG_BACKTRACE_BARRIER` in the bundled quickjs.h — so

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -127,41 +127,47 @@ table. What was still open there, mostly nice-to-have:
 
 ### Startup cost
 
-- **`-d:memProbe` prints nothing on the ESP32 — fix this before trusting any
-  transpile number below.** Built the 7.3" PhotoPainter firmware with
-  `FRAMEOS_EXTRA_NIM_FLAGS="-d:memProbe"` (2026-08-10) and got zero MEMPROBE
-  lines over a cold boot and three Weather-scene renders, despite the
-  generated C carrying 15 resolved calls to `memProbe__...` and the probe
-  strings from `app_runtime.nim:1038/1042`. Plain `printf` from C reaches the
-  console fine (`fos_client.c:447` "render #N started" shows up), so this is
-  not the console. Either the JS-app path is never entered on that scene — no
-  `NEW JsAppRuntime` probe fires either, which would mean `app:weatherPanel`
-  resolves to something other than a JS app runtime on device — or Nim's
-  `c_printf` in `utils/memory.nim:54` is being swallowed. Until this is
-  answered, the repo has no working way to time a transpile on hardware, and
-  the numbers in the next item are unverified.
-- **Parse and transpile scenes at deploy time, not on every boot.** The
-  3.3 s (11 KB) / 10.2 s (36 KB) figures quoted here since #322 are **not
-  reproducible as stated** and should be treated as suspect. On the bench
-  7.3" PhotoPainter the cold-boot Weather render minus the warm render is
-  24.8 s, but that delta is network-dominated: it is unchanged (24.7 s) after
-  a transpiler fix that cut host transpile time 3.2x, so it is not measuring
-  transpilation at all. Fix the probe above, then re-measure before using any
-  of this to justify a format change. What *is* measured: the erasure passes
-  made 724,572 heap allocations for the 36 KB `weatherPanel/app.ts` — 19.9
-  per source byte, all through ESP-IDF multi_heap against PSRAM — because
-  `startsWordAt` allocated a slice per keyword probe and the copy helpers
-  allocated per literal per pass. Removing that took it to 16,709 allocations
-  (0.46/byte) and 14.2 ms -> 4.5 ms on host, with byte-identical output.
-  If a real device measurement still shows seconds, deploy-time
-  transpilation remains the answer, and doing it upstream (the frontend
-  already bundles esbuild, the cloud has typescript) would also let the
-  transpiler be compiled out of the firmware: transpiler + tokens + parser +
-  source_map + token_processor are ~92 KB of object code (unverified — one
-  reading of `frameos_esp32.map` put the five modules at ~78 KB), against
-  ~420 KB left in the OTA slot. Cheaper interim with no format change: cache
-  the transpiled output on flash keyed by a hash of the source, so the cost
-  is once-ever rather than once-per-boot.
+- **Flashing the bench 7.3" PhotoPainter: use 0x10000, not 0x20000.** That
+  board carries the **8 MB** layout (`partitions.csv`: otadata 0xd000, ota_0
+  0x10000, ota_1 0x380000) while `build-pp73` is configured for
+  `partitions_ota_16mb.csv` (otadata 0xf000, ota_0 0x20000). An app-only
+  `write_flash 0x20000` lands in the middle of ota_0, the image is never
+  found, and the bootloader silently keeps running the *old* app from ota_1 —
+  esptool reports "Hash of data verified" either way. This cost a full day of
+  measurement in 2026-08: two firmwares were "flashed" and compared, and both
+  runs were the same untouched binary, which then read as "the fix does
+  nothing" and "`-d:memProbe` is broken". **After every flash, check the boot
+  log for `boot: Loaded app from partition at offset ...` and confirm the
+  slot.** `esp_image: image at 0x10000 has invalid magic byte` in that log
+  means the write went to the wrong offset.
+- **Serial drops output during CPU-bound bursts.** The USB-Serial-JTAG
+  console loses lines while `fos_client` holds the CPU — the transpile window
+  in a cold boot comes back as a 16 s gap with corrupted joins
+  (`MEMMEMPROBE`, `MEMrender`). Absence of a probe line is not evidence the
+  probe did not fire. Read with a tight poll loop and expect to repeat the
+  capture.
+- **Parse and transpile scenes at deploy time, not on every boot.** Measured
+  on the bench 7.3" PhotoPainter with `-d:memProbe`, after the allocation fix
+  (#329): weatherIcons 11 KB = **0.55 s**, weatherPanel 36 KB = **1.38 s**,
+  and the panel is transpiled twice because each node builds its own runtime
+  — **~3.3 s per boot**, then `transpile CACHED` on every later render. The
+  older 3.3 s / 10.2 s figures look like genuine measurements of the *pre-fix*
+  transpiler (2 x 10.2 + 3.3 lands on the ~24 s cold-vs-warm delta that
+  firmware showed), so the fix appears to be worth roughly 7x on device — but
+  the old binary was overwritten before it could be re-instrumented, so treat
+  the comparison as inferred rather than measured. What is measured on the
+  host: 724,572 heap allocations for the 36 KB app (19.9 per source byte, all
+  through ESP-IDF multi_heap against PSRAM) down to 16,709 (0.46/byte), and
+  14.2 ms -> 4.5 ms, with byte-identical output.
+  **This changes the case for deploy-time transpilation**: it now saves ~3 s
+  per boot, not ~24 s, against ~92 KB of transpiler object code (unverified —
+  one reading of `frameos_esp32.map` put the five modules nearer 78 KB) and
+  ~420 KB left in the OTA slot. Cheapest win left is free: the two
+  weatherPanel nodes transpile the same source twice, so caching per source
+  hash halves what remains. For scale, a cold boot only costs ~6 s more than a
+  warm render (3.3 s transpile + ~1.7 s Open-Meteo fetch + ~0.6 s scene load);
+  the real per-render costs are SVG rasterization (7-8 s for the two weather
+  SVGs), dither+pack (3.2 s) and the panel refresh (~29 s).
 - **`compileToBytecode` serialises the wrong object.** It asked for
   `JS_EVAL_FLAG_COMPILE_ONLY`, which burrito.nim declared one bit too high —
   that value is `JS_EVAL_FLAG_BACKTRACE_BARRIER` in the bundled quickjs.h — so

--- a/frameos/src/frameos/js_runtime/transpiler.nim
+++ b/frameos/src/frameos/js_runtime/transpiler.nim
@@ -125,12 +125,22 @@ proc decodeJsxEntities(s: string): string =
     i = semi + 1
 
 proc startsWordAt(code: string, i: int, word: string): bool =
-  if i < 0 or i + word.len > code.len:
+  ## Hot: the erasure passes probe this at nearly every byte, and
+  ## stripTypeScriptModifiers alone probes seven words per byte. It used to
+  ## compare with `code.substr(...) != word`, which heap-allocates the slice
+  ## before looking at a single character — 698k malloc/free pairs for one
+  ## 36 KB app. On the ESP32 those go through ESP-IDF multi_heap against PSRAM,
+  ## which is what made a transpile cost seconds rather than milliseconds.
+  ## Compare in place instead, cheapest discriminator first.
+  if word.len == 0 or i < 0 or i + word.len > code.len:
     return false
-  if code.substr(i, i + word.len - 1) != word:
+  if code[i] != word[0]:
     return false
   if i > 0 and isIdentPart(code[i - 1]):
     return false
+  for k in 1 ..< word.len:
+    if code[i + k] != word[k]:
+      return false
   let after = i + word.len
   after >= code.len or not isIdentPart(code[after])
 
@@ -142,8 +152,22 @@ proc readIdentifier(code: string, i: var int): string =
       inc i
   code[start..<i]
 
-proc copyQuoted(code: string, i: var int, quote: char): string =
-  let start = i
+proc addSpan(dest: var string, code: string, start, finish: int) =
+  ## Append `code[start ..< finish]` without materialising a temporary slice.
+  ## The erasure passes copy every string, comment and template literal through
+  ## on their way to the output; going via a fresh string each time is one heap
+  ## allocation per literal, per pass.
+  if finish <= start:
+    return
+  let count = finish - start
+  let at = dest.len
+  dest.setLen(at + count)
+  copyMem(addr dest[at], unsafeAddr code[start], count)
+
+# The scan* procs only advance `i`. copy*/add*/skip* are the three things the
+# callers actually want, and none of them needs to allocate to find the end.
+
+proc scanQuoted(code: string, i: var int, quote: char) =
   inc i
   while i < code.len:
     if code[i] == '\\':
@@ -153,36 +177,21 @@ proc copyQuoted(code: string, i: var int, quote: char): string =
       break
     else:
       inc i
-  code[start..<i]
 
-proc skipQuoted(code: string, i: var int, quote: char) =
-  discard copyQuoted(code, i, quote)
-
-proc copyLineComment(code: string, i: var int): string =
-  let start = i
+proc scanLineComment(code: string, i: var int) =
   i += 2
   while i < code.len and code[i] notin {'\n', '\r'}:
     inc i
-  code[start..<i]
 
-proc skipLineComment(code: string, i: var int) =
-  discard copyLineComment(code, i)
-
-proc copyBlockComment(code: string, i: var int): string =
-  let start = i
+proc scanBlockComment(code: string, i: var int) =
   i += 2
   while i + 1 < code.len:
     if code[i] == '*' and code[i + 1] == '/':
       i += 2
       break
     inc i
-  code[start..<i]
 
-proc skipBlockComment(code: string, i: var int) =
-  discard copyBlockComment(code, i)
-
-proc copyTemplate(code: string, i: var int): string =
-  let start = i
+proc scanTemplate(code: string, i: var int) =
   inc i
   while i < code.len:
     if code[i] == '\\':
@@ -192,10 +201,58 @@ proc copyTemplate(code: string, i: var int): string =
       break
     else:
       inc i
+
+proc copyQuoted(code: string, i: var int, quote: char): string =
+  let start = i
+  scanQuoted(code, i, quote)
   code[start..<i]
 
+proc addQuoted(dest: var string, code: string, i: var int, quote: char) =
+  let start = i
+  scanQuoted(code, i, quote)
+  dest.addSpan(code, start, i)
+
+proc skipQuoted(code: string, i: var int, quote: char) =
+  scanQuoted(code, i, quote)
+
+proc copyLineComment(code: string, i: var int): string =
+  let start = i
+  scanLineComment(code, i)
+  code[start..<i]
+
+proc addLineComment(dest: var string, code: string, i: var int) =
+  let start = i
+  scanLineComment(code, i)
+  dest.addSpan(code, start, i)
+
+proc skipLineComment(code: string, i: var int) =
+  scanLineComment(code, i)
+
+proc copyBlockComment(code: string, i: var int): string =
+  let start = i
+  scanBlockComment(code, i)
+  code[start..<i]
+
+proc addBlockComment(dest: var string, code: string, i: var int) =
+  let start = i
+  scanBlockComment(code, i)
+  dest.addSpan(code, start, i)
+
+proc skipBlockComment(code: string, i: var int) =
+  scanBlockComment(code, i)
+
+proc copyTemplate(code: string, i: var int): string =
+  let start = i
+  scanTemplate(code, i)
+  code[start..<i]
+
+proc addTemplate(dest: var string, code: string, i: var int) =
+  let start = i
+  scanTemplate(code, i)
+  dest.addSpan(code, start, i)
+
 proc skipTemplate(code: string, i: var int) =
-  discard copyTemplate(code, i)
+  scanTemplate(code, i)
 
 proc findMatching(code: string, openIndex: int, openCh: char, closeCh: char): int =
   var i = openIndex
@@ -453,19 +510,20 @@ proc lowerEnumDeclaration(code: string, start: int): tuple[code: string, next: i
   result.next = close + 1
 
 proc lowerEnums(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if startsWordAt(code, i, "enum") or
@@ -641,17 +699,17 @@ proc stripParamTypes(params: string): string =
   while i < params.len:
     case params[i]
     of '\'', '"':
-      result.add(copyQuoted(params, i, params[i]))
+      result.addQuoted(params, i, params[i])
       continue
     of '`':
-      result.add(copyTemplate(params, i))
+      result.addTemplate(params, i)
       continue
     of '/':
       if i + 1 < params.len and params[i + 1] == '/':
-        result.add(copyLineComment(params, i))
+        result.addLineComment(params, i)
         continue
       if i + 1 < params.len and params[i + 1] == '*':
-        result.add(copyBlockComment(params, i))
+        result.addBlockComment(params, i)
         continue
     of '{':
       inc braceDepth
@@ -678,19 +736,20 @@ proc stripParamTypes(params: string): string =
     inc i
 
 proc stripFunctionAndArrowTypes(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if startsWordAt(code, i, "function"):
@@ -727,6 +786,7 @@ proc stripFunctionAndArrowTypes(code: string): string =
     inc i
 
 proc stripTypeParametersAndArguments(code: string): string =
+  result = newStringOfCap(code.len)
   proc isLikelyTypeList(raw: string): bool =
     let content = raw.strip()
     if content.len == 0:
@@ -741,16 +801,16 @@ proc stripTypeParametersAndArguments(code: string): string =
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if code[i] == '<':
@@ -779,20 +839,21 @@ proc stripTypeParametersAndArguments(code: string): string =
     inc i
 
 proc stripTypeScriptModifiers(code: string): string =
+  result = newStringOfCap(code.len)
   let modifiers = ["public", "private", "protected", "abstract", "readonly", "override", "declare"]
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
     var removed = false
     for modifier in modifiers:
@@ -809,6 +870,7 @@ proc stripTypeScriptModifiers(code: string): string =
     inc i
 
 proc stripMethodAndMemberTypes(code: string): string =
+  result = newStringOfCap(code.len)
   proc isLikelyMemberTypeColon(colonIndex: int): bool =
     var lineStart = colonIndex - 1
     while lineStart >= 0 and code[lineStart] notin {'\n', '\r', '{', ';'}:
@@ -875,16 +937,16 @@ proc stripMethodAndMemberTypes(code: string): string =
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if code[i] == '(' and isLikelyMethodParen(i):
@@ -928,6 +990,7 @@ proc stripMethodAndMemberTypes(code: string): string =
     inc i
 
 proc stripVarTypes(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   var inVarDecl = false
   var inInitializer = false
@@ -936,16 +999,16 @@ proc stripVarTypes(code: string): string =
   var parenDepth = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if startsWordAt(code, i, "const") or startsWordAt(code, i, "let") or startsWordAt(code, i, "var"):
@@ -1001,6 +1064,7 @@ proc stripVarTypes(code: string): string =
     inc i
 
 proc stripAsAssertions(code: string): string =
+  result = newStringOfCap(code.len)
   proc isLikelyAssertionTypeStart(code: string, i: int): bool =
     i < code.len and (isIdentStart(code[i]) or code[i] in {'{', '[', '(', '\'', '"'})
 
@@ -1013,16 +1077,16 @@ proc stripAsAssertions(code: string): string =
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
     if startsWordAt(code, i, "import"):
       let endStmt = findStatementEnd(code, i)
@@ -1093,19 +1157,20 @@ proc copyTemplateWithTransformedExpressions(code: string, i: var int): string =
     inc i
 
 proc transformTemplateLiteralTypes(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
       result.add(copyTemplateWithTransformedExpressions(code, i))
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
     result.add(code[i])
     inc i
@@ -1157,19 +1222,20 @@ proc looksLikeInterfaceDeclarationAt(code: string, i: int): bool =
   j < code.len and code[j] == '{'
 
 proc stripTypeOnlyStatements(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
-      result.add(copyTemplate(code, i))
+      result.addTemplate(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if looksLikeInterfaceDeclarationAt(code, i) or
@@ -1198,19 +1264,20 @@ proc stripTypeOnlyStatements(code: string): string =
     inc i
 
 proc stripDeclareStatements(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
       result.add(copyTemplateWithTransformedExpressions(code, i))
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if startsWordAt(code, i, "declare"):
@@ -1240,6 +1307,7 @@ proc stripDeclareStatements(code: string): string =
     inc i
 
 proc transformConstructorParameterProperties(code: string): string =
+  result = newStringOfCap(code.len)
   proc transformParams(params: string): tuple[code: string, assignments: seq[string]] =
     let parts = splitTopLevelCommaList(params)
     for index, part in parts:
@@ -1282,16 +1350,16 @@ proc transformConstructorParameterProperties(code: string): string =
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
       result.add(copyTemplateWithTransformedExpressions(code, i))
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if startsWordAt(code, i, "constructor"):
@@ -1432,19 +1500,20 @@ proc tokenStripTypeScriptErasure(code: string): string =
   processor.finish().code
 
 proc stripAbstractMembers(code: string): string =
+  result = newStringOfCap(code.len)
   var i = 0
   while i < code.len:
     if code[i] in {'\'', '"'}:
-      result.add(copyQuoted(code, i, code[i]))
+      result.addQuoted(code, i, code[i])
       continue
     if code[i] == '`':
       result.add(copyTemplateWithTransformedExpressions(code, i))
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '/':
-      result.add(copyLineComment(code, i))
+      result.addLineComment(code, i)
       continue
     if code[i] == '/' and i + 1 < code.len and code[i + 1] == '*':
-      result.add(copyBlockComment(code, i))
+      result.addBlockComment(code, i)
       continue
 
     if startsWordAt(code, i, "abstract"):


### PR DESCRIPTION
The TypeScript erasure passes spent their time in the allocator, not in scanning. One 36 KB app transpile made **724,572 malloc/free pairs** — 19.9 heap allocations per source byte. On the ESP32 those go through ESP-IDF `multi_heap` against PSRAM, which is why the same work costs milliseconds on a laptop and seconds on a frame.

## The fix

Three changes, all the same shape — the passes were allocating in order to look at bytes they already held:

- **`startsWordAt` compared with `code.substr(...) != word`**, heap-allocating the slice before looking at a single character. It is the keyword probe, called at nearly every byte across 13 passes, and `stripTypeScriptModifiers` alone probes seven words per byte. Now compares in place, cheapest discriminator first (length → first char → prev-char boundary → rest).
- **`copyQuoted`/`copyLineComment`/`copyBlockComment`/`copyTemplate`** each built a fresh string that the caller appended and dropped — one allocation per literal, per comment, per template, per pass. Split into `scan*` (advance only), `add*` (append the span straight into the output via `copyMem`), and `copy*` (kept for the two callers that need a string). The `skip*` variants were allocating and `discard`ing outright; they now just scan.
- **Twelve passes grew their output from an empty string.** Pre-sized with `newStringOfCap`.

## Measured

On device — bench 7.3" PhotoPainter (`waveshare_esp32_s3_photopainter`, EPD_7in3e), built with `-d:memProbe`:

| transpile | after fix |
|---|---:|
| `weatherIcons/app.ts`, 11 KB | **0.55 s** |
| `weatherPanel/app.ts`, 36 KB | **1.38 s** |
| per boot (panel runs twice, one runtime per node) | **~3.3 s**, cached thereafter |

Host, and the number that explains it:

| | before | after | |
|---|---:|---:|---|
| Allocations, 36 KB app | 724,572 | **16,709** | 43x fewer |
| Per source byte | 19.9 | 0.46 | |
| Host, 36 KB | 14.22 ms | **4.50 ms** | 3.2x |
| Host, 11 KB | 4.45 ms | **1.37 ms** | 3.2x |
| Firmware size | 3,188,208 B | **3,184,224 B** | −3,984 B |

The pre-fix figures in `docs/todo.md` were 3.3 s / 10.2 s, so this looks like roughly a 7x device win — but the old binary was overwritten before it could be re-instrumented, so treat that specific comparison as inferred rather than measured.

## Verified as a pure refactor

- All 6 Nim `js_runtime` suites pass; 23 sucrase parity tests pass.
- Built the CLI before and after and compared all 30 sucrase parity fixtures plus every repo app source across all six modes (`script`, `module`, `script-json`, `module-json`, `tokens`, `parse`) — **180 comparisons, byte-identical output**.
- Flashed and cold-booted on hardware; Weather scene renders correctly across multiple boots and renders.

## Second commit: two hardware traps, written down

The `docs/todo.md` commit records what nearly sank this measurement, because both traps produce confident-looking wrong answers:

- **This board is 8 MB (`partitions.csv`: ota_0 at 0x10000), but `build-pp73` targets `partitions_ota_16mb.csv` (ota_0 at 0x20000).** An app-only `write_flash 0x20000` lands mid-partition, the image is never found, and the bootloader silently keeps running the old app from ota_1 — while esptool reports "Hash of data verified". My first round of measurements compared two "different" firmwares that were the same untouched binary, which read as "the fix does nothing" and "`-d:memProbe` is broken". Always check the boot log for `Loaded app from partition at offset ...`.
- **The USB-Serial-JTAG console drops lines during CPU-bound bursts.** The transpile window comes back as a 16 s gap with corrupted joins (`MEMMEMPROBE`). Absence of a probe line is not evidence the probe did not fire.

It also revises the case for deploy-time transpilation: that now saves ~3 s per boot rather than ~24 s, against ~92 KB of transpiler object code. The cheapest remaining win is free — the two weatherPanel nodes transpile the same source twice, so caching per source hash halves what is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)