### PR TITLE
Bound, scope and gate what scene JS can do

### DIFF
--- a/backend/app/tasks/tests/test_esp32_netguard.py
+++ b/backend/app/tasks/tests/test_esp32_netguard.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Runs embedded/esp32/main/tests/test_fos_netguard.c.
+#
+# Same arrangement as test_esp32_sd_probe.py next door, and for the same
+# reason: host tests that nothing invokes are host tests that do not exist.
+#
+# What it covers is the private-network egress guard — the check that stops a
+# scene installed by a cloud provider from reaching 192.168.x.x on the owner's
+# LAN. The ESP32 firmware shipped without it for a while (the policy existed
+# only in the native Nim runtime), so these assertions are the difference
+# between "we have a policy" and "the policy is right".
+#
+# fos_netguard.c keeps its classifier and URL parser as plain C over strings,
+# with the IDF bits behind ESP_PLATFORM, so a laptop compiler is all this needs.
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ESP32_DIR = REPO_ROOT / "embedded" / "esp32"
+NETGUARD_SOURCE = ESP32_DIR / "components" / "frameos_nim" / "fos_netguard.c"
+NETGUARD_INCLUDE = ESP32_DIR / "components" / "frameos_nim" / "include"
+NETGUARD_TEST_SOURCE = ESP32_DIR / "main" / "tests" / "test_fos_netguard.c"
+
+
+def test_sources_exist():
+    assert NETGUARD_SOURCE.is_file(), f"missing {NETGUARD_SOURCE}"
+    assert NETGUARD_TEST_SOURCE.is_file(), f"missing {NETGUARD_TEST_SOURCE}"
+
+
+@pytest.mark.skipif(shutil.which("cc") is None, reason="no C compiler on PATH")
+def test_fos_netguard_host_tests_pass(tmp_path: Path):
+    binary = tmp_path / "test_fos_netguard"
+    compile_result = subprocess.run(
+        [
+            "cc",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-O2",
+            "-I",
+            str(NETGUARD_INCLUDE),
+            str(NETGUARD_SOURCE),
+            str(NETGUARD_TEST_SOURCE),
+            "-o",
+            str(binary),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "netguard host tests do not compile:\n" + compile_result.stderr
+    )
+
+    run_result = subprocess.run(
+        [str(binary)], capture_output=True, text=True, timeout=180
+    )
+    assert run_result.returncode == 0, (
+        "netguard host tests failed:\n" + run_result.stdout[-4000:]
+    )
+
+    # Assert the count too: a binary that asserted nothing would also exit 0.
+    summary = re.search(r"(\d+) checks, (\d+) failures", run_result.stdout)
+    assert summary is not None, (
+        "could not find the check summary in the output:\n" + run_result.stdout[-4000:]
+    )
+    checks, failures = int(summary.group(1)), int(summary.group(2))
+    assert failures == 0
+    assert checks >= 100, f"expected the full netguard suite to run, saw {checks} checks"

--- a/cloud/docs/cloud-frames.md
+++ b/cloud/docs/cloud-frames.md
@@ -297,6 +297,17 @@ capped at five attempts — someone who cannot see the screen cannot complete it
 On ESP32 the equivalent is `set allow_local_network 1` on the USB console,
 which is physical presence by construction.
 
+It is persisted in `state/local_access.json`, deliberately not in `frame.json`.
+A backend deploy uploads a freshly generated `frame.json` over SSH and never
+round-trips the device's copy, so a setting stored there is quietly reset by
+the next unrelated deploy — fail-safe, but baffling to debug a week later when
+the Home Assistant scene stops working. Under `state/` it also says the right
+thing about what this is: a device-local fact established by someone standing
+in front of the frame, not fleet configuration the backend has an opinion
+about. `frame.json` is still read as a fallback so frames elevated before the
+setting moved keep working; on ESP32 the equivalent store is NVS, which deploys
+do not touch either.
+
 Still open: cloud-installed scenes are not yet distinguished from local ones at
 runtime, so the `"shell"` risk-flag refusal and any origin-specific profile
 have nothing to key off. A frame demoted out of the managed state also loses

--- a/cloud/docs/cloud-frames.md
+++ b/cloud/docs/cloud-frames.md
@@ -235,20 +235,73 @@ device's opinion of what it was granted.
 ### Interpreted scenes are still code — sandbox posture
 
 "Only interpreted scenes" is only safe if the QuickJS runtime's bindings are
-narrow. Required before launch:
+narrow. The capability audit of `frameos/src/frameos/js_runtime/` has been
+done; what it found, and where each answer lives, is below. Read this as the
+current posture, not a wish list — where something is weaker than it sounds,
+it says so.
 
-1. **Capability audit** of `frameos/src/frameos/js_runtime/` —
-   enumerate every native binding exposed to scene JS.
-2. **Cloud-installed scenes get render + HTTP only.** Apps carrying the
-   store's `"shell"` risk flag refuse to load under the cloud profile.
-   No filesystem access outside the scene's own asset sandbox.
-3. **RFC1918 / link-local HTTP is blocked by default** for cloud-installed
-   scenes. A malicious scene is *inside the owner's LAN*; without this, a
-   compromised account becomes an SSRF pivot onto routers and IoT devices —
-   exactly the outcome this design exists to prevent. Elevation (a scene
-   that legitimately needs LAN access, e.g. Home Assistant) requires a
-   **local-presence ceremony**: confirmation on the device's local admin
-   page, or a physical button press paired with a code shown on the panel.
+**Two binding surfaces, not one.** Code nodes and inline expressions
+(`runtime.nim`) get state reads, node args, context, logging and date
+formatting: no filesystem, no network. Full JS apps (`app_runtime.nim`) get
+those plus HTTP, asset file I/O, streams and `getSetting`. QuickJS's own
+`std`/`os` modules are never initialized (`defaultConfig()` in `burrito.nim`),
+so the registered Nim procs are the entire native surface — no process
+spawning, no arbitrary paths, no device control.
+
+**`getSetting` is gated by declaration, not by consent.** An app reaches
+`frameConfig.settings[namespace]` only for the namespaces its own
+`config.json` lists. That makes credential access *auditable* — you can read
+what an app will touch before installing it — but a hostile app simply
+declares what it wants. The audit trail is the mitigation.
+
+**Filesystem access is frame-wide by default, not per-scene.** Every asset
+call resolves through `resolveAssetPath`, which rejects absolute paths and
+`..` segments and then re-checks containment against the *real* path, so a
+symlink planted inside the assets folder is not a way out. But the root is the
+frame's shared assets folder: uploaded images are a shared resource and scenes
+are expected to read each other's. Frames that want the stricter model set
+`js.assetSandbox` to `"scene"` in `frame.json`, which confines each scene to
+`<assets>/scenes/<sceneId>/`.
+
+**Runaway scenes are bounded.** Scene JS runs on the render thread, so an
+infinite loop used to mean a frame that never drew again. Every entry into the
+interpreter now carries a time budget enforced by a QuickJS interrupt handler,
+and the JS heap and stack are capped (`js.executionTimeoutMs`,
+`js.memoryLimitMb`, `js.maxStackKb` in `frame.json`; defaults in
+`burrito.nim`). Time spent inside a native binding — an HTTP fetch, an asset
+read — does not count against the budget, so a slow-but-honest scene is not
+mistaken for a spinning one. A blown budget is logged as a scene error and the
+node's value is defaulted, exactly like any other failing node.
+
+**RFC1918 / link-local HTTP is blocked by default** on cloud-managed frames,
+on both the native and the ESP32 builds. A malicious scene is *inside the
+owner's LAN*; without this, a compromised account becomes an SSRF pivot onto
+routers and IoT devices — exactly the outcome this design exists to prevent.
+The check is on the resolved address rather than the hostname, so a
+DNS-rebinding answer does not slip past, and every redirect hop is re-checked.
+Native: `isPrivateNetworkAddress` / `enforceLocalNetworkPolicy` in
+`utils/http_client.nim`. ESP32: `fos_netguard.c`, enforced in
+`frameos_nim_glue.c` around each `esp_http_client_open()`. Keep the two
+classifiers in step.
+
+**Elevation requires a local-presence ceremony.** A scene that legitimately
+needs LAN access (Home Assistant, say) needs `network.allowLocalNetworkAccess`,
+and that switch is deliberately hard to reach. It is absent from
+`CLOUD_SETTINGS_ALLOWLIST`, so the provider cannot set it; it is stripped from
+the bulk config save, so neither the cloud verb nor the admin page's frame save
+can carry it. It moves only through the ceremony in `frameos/local_access.nim`:
+`POST /api/network/local-access/challenge` puts a six-digit code on the panel
+for three minutes, and `POST /api/network/local-access` applies the change only
+if that code comes back. The code is never in an API response, single-use, and
+capped at five attempts — someone who cannot see the screen cannot complete it.
+On ESP32 the equivalent is `set allow_local_network 1` on the USB console,
+which is physical presence by construction.
+
+Still open: cloud-installed scenes are not yet distinguished from local ones at
+runtime, so the `"shell"` risk-flag refusal and any origin-specific profile
+have nothing to key off. A frame demoted out of the managed state also loses
+the deny while still running the provider's last-pushed scenes — true on both
+platforms, and worth closing in one place.
 
 ### Signed OTA
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -55,10 +55,16 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
   and cannot say WHICH scene differs. Per-scene granularity needs the cloud to
   record what it last pushed — its equivalent of the backend's
   `last_successful_deploy.scenes`.
-- **JS-runtime capability audit** — enumerate every native binding exposed
-  to scene JS; per-scene asset sandboxes; CPU/time/memory limits per scene;
-  confirm RFC1918 fetch blocking and the local-presence elevation ceremony
-  (`cloud/docs/cloud-frames.md`, "sandbox posture").
+- **Scene origin is not tracked at runtime** — the JS-runtime capability
+  audit is done and written up in `cloud/docs/cloud-frames.md`, "sandbox
+  posture": bindings enumerated, JS time/heap/stack ceilings landed, the
+  asset sandbox made symlink-safe with an opt-in per-scene mode, RFC1918
+  blocking ported to ESP32, elevation moved behind an on-panel code. What is
+  left is the thing all of those wanted and none could have: a frame cannot
+  tell a cloud-installed scene from a locally authored one, so the store's
+  `"shell"` risk flag has nothing to refuse, and a frame demoted out of the
+  managed state keeps running the provider's last-pushed scenes with the LAN
+  deny switched off.
 - **Account hardening** — passkeys/TOTP 2FA, re-authentication for
   sensitive actions (revoking frames, bulk assignment changes, scope
   grants), per-frame audit trail surfaced in the UI.

--- a/embedded/esp32/components/frameos_nim/CMakeLists.txt
+++ b/embedded/esp32/components/frameos_nim/CMakeLists.txt
@@ -8,12 +8,13 @@ file(GLOB NIM_GENERATED_SRCS "${CMAKE_CURRENT_LIST_DIR}/nimcache/*.c")
 
 if(NIM_GENERATED_SRCS)
     idf_component_register(
-        SRCS ${NIM_GENERATED_SRCS} "frameos_nim_glue.c"
+        SRCS ${NIM_GENERATED_SRCS} "frameos_nim_glue.c" "fos_netguard.c"
         INCLUDE_DIRS "include"
         PRIV_INCLUDE_DIRS "nimcache"
         # frameos_quickjs: the Nim js_runtime binds QuickJS (include path +
-        # fos_js_new_runtime); esp_http_client/mbedtls back the Nim HTTP HAL.
-        PRIV_REQUIRES esp_timer pthread frameos_quickjs esp_http_client esp-tls mbedtls
+        # fos_js_new_runtime); esp_http_client/mbedtls back the Nim HTTP HAL;
+        # lwip is fos_netguard.c's getaddrinfo().
+        PRIV_REQUIRES esp_timer pthread frameos_quickjs esp_http_client esp-tls mbedtls lwip
     )
     # Nim's generated C is not warning-clean; it's machine output. Nim also
     # passes long* where the overflow builtins want int* (same width on
@@ -27,9 +28,13 @@ if(NIM_GENERATED_SRCS)
         -fno-strict-aliasing -fno-lto)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE FRAMEOS_NIM_ENABLED=1)
 else()
+    # fos_netguard.c is in both branches on purpose: fos_cloud.c arms the
+    # private-network policy unconditionally, so a thin-client image that
+    # dropped this file would fail to link.
     idf_component_register(
-        SRCS "frameos_nim_stub.c"
+        SRCS "frameos_nim_stub.c" "fos_netguard.c"
         INCLUDE_DIRS "include"
+        PRIV_REQUIRES lwip
     )
     message(STATUS "frameos_nim: no nimcache/, building stub (run build_nim.sh)")
 endif()

--- a/embedded/esp32/components/frameos_nim/fos_netguard.c
+++ b/embedded/esp32/components/frameos_nim/fos_netguard.c
@@ -8,6 +8,22 @@
  * main/tests/test_fos_netguard.c can compile this exact file with cc and run
  * the whole classifier on a laptop.
  */
+
+/* getaddrinfo() and struct addrinfo are POSIX, not C11. glibc keys its POSIX
+ * declarations off the feature-test macros and switches them all off when
+ * __STRICT_ANSI__ is set, which -std=c11 does — so the host test build sees
+ * netdb.h as an effectively empty header and fails with a pile of "undefined
+ * type 'struct addrinfo'". macOS and lwIP declare them unconditionally, which
+ * is precisely why this compiled on a laptop and broke on CI.
+ *
+ * Scoped to strict mode so the IDF build (gnu17, newlib) is untouched: asking
+ * newlib for POSIX-only would narrow what it exposes, not widen it. Must come
+ * before every #include — feature-test macros are read as the first system
+ * header is parsed. */
+#if defined(__STRICT_ANSI__) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200112L
+#endif
+
 #include "fos_netguard.h"
 
 #include <stdint.h>

--- a/embedded/esp32/components/frameos_nim/fos_netguard.c
+++ b/embedded/esp32/components/frameos_nim/fos_netguard.c
@@ -1,0 +1,487 @@
+/*
+ * Private-network egress policy for scene HTTP — see fos_netguard.h for what
+ * this is for and why it exists on cloud-managed frames.
+ *
+ * Deliberately log-free and IDF-free apart from the FreeRTOS spinlock and the
+ * getaddrinfo() in fos_netguard_url_allowed(): the callers own the ESP_LOGW,
+ * and everything that decides "private or not" is plain C over strings so
+ * main/tests/test_fos_netguard.c can compile this exact file with cc and run
+ * the whole classifier on a laptop.
+ */
+#include "fos_netguard.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#ifdef ESP_PLATFORM
+#include "freertos/FreeRTOS.h"
+/* The policy is written by the cloud task and read by whichever task is
+ * rendering, so the two words below need a lock. A spinlock rather than a
+ * mutex because it is statically initialised: there is no init call to forget,
+ * and a reader that runs before the cloud task ever starts still sees a
+ * consistent (policy-off) state. The critical sections hold nothing but a few
+ * short strcasecmp()s. */
+static portMUX_TYPE s_lock = portMUX_INITIALIZER_UNLOCKED;
+#define NETGUARD_LOCK() portENTER_CRITICAL(&s_lock)
+#define NETGUARD_UNLOCK() portEXIT_CRITICAL(&s_lock)
+#else
+#define NETGUARD_LOCK() ((void)0)
+#define NETGUARD_UNLOCK() ((void)0)
+#endif
+
+typedef struct {
+    char host[FOS_NETGUARD_EXEMPT_HOST_LEN];
+    int port; /* <= 0 = any port on this host */
+} netguard_exempt_t;
+
+static bool s_block_local = false;
+static netguard_exempt_t s_exempt[FOS_NETGUARD_EXEMPT_MAX];
+static size_t s_exempt_count = 0;
+
+/* ------------------------------------------------------------- IP literals */
+
+/* Strict dotted-quad: exactly four decimal fields, each 0..255, no leading
+ * zeros. Anything else fails to parse, and every caller reads a parse failure
+ * as "private".
+ *
+ * Rejecting leading zeros is stricter than the Nim classifier
+ * (isPrivateNetworkAddress accepts them as decimal) and that difference closes
+ * a hole rather than adding pedantry. lwIP turns host strings into addresses
+ * with ip4addr_aton(), which has inet_aton() semantics: a leading 0 is octal
+ * and a leading 0x is hex. "0177.0.0.1" read as decimal is 177.0.0.1 (public)
+ * but lwIP connects it to 127.0.0.1 (loopback). Refusing the ambiguous forms
+ * classifies them as private instead of handing out that mismatch. The 0x
+ * forms contain letters, so they take the hostname path and get caught by the
+ * resolved-address check. */
+static bool parse_ipv4(const char *s, uint8_t out[4])
+{
+    if (s == NULL) return false;
+    for (int field = 0; field < 4; field++) {
+        if (field > 0) {
+            if (*s != '.') return false;
+            s++;
+        }
+        if (*s < '0' || *s > '9') return false;
+        const bool leading_zero = (*s == '0');
+        unsigned value = 0;
+        int digits = 0;
+        while (*s >= '0' && *s <= '9') {
+            value = value * 10u + (unsigned)(*s - '0');
+            digits++;
+            if (value > 255u || digits > 3) return false;
+            s++;
+        }
+        if (leading_zero && digits > 1) return false;
+        out[field] = (uint8_t)value;
+    }
+    return *s == '\0';
+}
+
+static int hex_value(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/* RFC 4291 textual IPv6, brackets already stripped: hex groups, at most one
+ * "::" run, an optional trailing dotted quad. No zone id ("fe80::1%eth0")
+ * — that fails to parse, which means private, which is right for a
+ * link-local address anyway. */
+static bool parse_ipv6(const char *s, uint8_t out[16])
+{
+    uint8_t buf[16];
+    int pos = 0;  /* bytes written so far */
+    int gap = -1; /* byte offset where "::" stood, -1 = no "::" seen */
+
+    if (s == NULL || *s == '\0') return false;
+    memset(buf, 0, sizeof(buf));
+
+    if (s[0] == ':') {
+        if (s[1] != ':') return false; /* a single leading colon is invalid */
+        s += 2;
+        gap = 0;
+        if (*s == '\0') { /* "::" — the unspecified address */
+            memcpy(out, buf, sizeof(buf));
+            return true;
+        }
+    }
+
+    while (*s != '\0') {
+        /* A dotted quad is only an IPv4 tail when no colon precedes its dot;
+         * in "ffff:127.0.0.1" the '.' belongs to the *next* element. */
+        const char *dot = strchr(s, '.');
+        const char *colon = strchr(s, ':');
+        if (dot != NULL && (colon == NULL || dot < colon)) {
+            uint8_t quad[4];
+            if (pos + 4 > 16) return false;
+            if (!parse_ipv4(s, quad)) return false;
+            memcpy(buf + pos, quad, sizeof(quad));
+            pos += 4;
+            break; /* parse_ipv4 only succeeds on a whole string */
+        }
+
+        unsigned group = 0;
+        int digits = 0;
+        while (hex_value(*s) >= 0) {
+            group = group * 16u + (unsigned)hex_value(*s);
+            digits++;
+            if (digits > 4) return false;
+            s++;
+        }
+        if (digits == 0) return false;
+        if (pos + 2 > 16) return false;
+        buf[pos++] = (uint8_t)(group >> 8);
+        buf[pos++] = (uint8_t)(group & 0xffu);
+
+        if (*s == '\0') break;
+        if (*s != ':') return false; /* zone ids, prefix lengths, junk */
+        s++;
+        if (*s == ':') { /* the "::" run */
+            if (gap >= 0) return false; /* only one is allowed */
+            gap = pos;
+            s++;
+            if (*s == '\0') break;
+        } else if (*s == '\0') {
+            return false; /* a trailing single colon */
+        }
+    }
+
+    if (gap < 0) {
+        if (pos != 16) return false;
+    } else {
+        if (pos >= 16) return false; /* "::" has to stand for something */
+        const size_t tail = (size_t)(pos - gap);
+        memmove(buf + 16 - tail, buf + gap, tail);
+        memset(buf + gap, 0, 16 - tail - (size_t)gap);
+    }
+    memcpy(out, buf, sizeof(buf));
+    return true;
+}
+
+/* The IPv4 half of the Nim isPrivateNetworkAddress, byte for byte. */
+static bool ipv4_is_private(const uint8_t b[4])
+{
+    if (b[0] == 0) return true;                                /* 0/8, incl. unspecified */
+    if (b[0] == 10) return true;                               /* 10/8 */
+    if (b[0] == 100 && (b[1] & 0xc0u) == 64) return true;      /* 100.64/10 CGNAT */
+    if (b[0] == 127) return true;                              /* loopback */
+    if (b[0] == 169 && b[1] == 254) return true;               /* link-local */
+    if (b[0] == 172 && (b[1] & 0xf0u) == 16) return true;      /* 172.16/12 */
+    if (b[0] == 192 && b[1] == 0 && b[2] == 0) return true;    /* 192.0.0.0/24 */
+    if (b[0] == 192 && b[1] == 168) return true;               /* 192.168/16 */
+    if (b[0] == 198 && (b[1] & 0xfeu) == 18) return true;      /* 198.18/15 benchmarking */
+    if ((b[0] & 0xf0u) == 224) return true;                    /* 224/4 multicast */
+    if (b[0] >= 240) return true;                              /* 240/4, incl. broadcast */
+    return false;
+}
+
+static bool ipv6_is_private(const uint8_t b[16])
+{
+    /* ::ffff:a.b.c.d (IPv4-mapped) and ::a.b.c.d (the deprecated
+     * IPv4-compatible form, which carries no ffff marker at all): both hold an
+     * IPv4 address in the low 32 bits, so classify that instead. Missing the
+     * second form is what once let ::127.0.0.1 through as "public". */
+    bool zero_prefix = true;
+    for (int i = 0; i < 10; i++) {
+        if (b[i] != 0) zero_prefix = false;
+    }
+    const bool embeds_ipv4 = zero_prefix &&
+        ((b[10] == 0xff && b[11] == 0xff) || (b[10] == 0 && b[11] == 0));
+
+    /* :: and ::1 come first: they are the unspecified/loopback addresses, not
+     * an embedded 0.0.0.x. */
+    bool all_zero = true;
+    for (int i = 0; i < 15; i++) {
+        if (b[i] != 0) all_zero = false;
+    }
+    if (all_zero && b[15] <= 1) return true;
+
+    if (embeds_ipv4) return ipv4_is_private(b + 12);
+
+    /* 64:ff9b::/96 — the well-known NAT64 prefix, another wrapper around an
+     * IPv4 destination. */
+    bool nat64 = b[0] == 0 && b[1] == 0x64 && b[2] == 0xff && b[3] == 0x9b;
+    for (int i = 4; nat64 && i < 12; i++) {
+        if (b[i] != 0) nat64 = false;
+    }
+    if (nat64) return ipv4_is_private(b + 12);
+
+    if ((b[0] & 0xfeu) == 0xfc) return true;                   /* fc00::/7 ULA */
+    if (b[0] == 0xfe && (b[1] & 0xc0u) == 0x80) return true;   /* fe80::/10 link-local */
+    if (b[0] == 0xff) return true;                             /* ff00::/8 multicast */
+    return false;
+}
+
+bool fos_netguard_is_private_ip(const char *ip)
+{
+    uint8_t v4[4];
+    uint8_t v6[16];
+
+    if (ip == NULL || ip[0] == '\0') return true;
+    if (parse_ipv4(ip, v4)) return ipv4_is_private(v4);
+    if (parse_ipv6(ip, v6)) return ipv6_is_private(v6);
+    return true; /* unparseable: fail closed, see the header */
+}
+
+/* ------------------------------------------------------------------- policy */
+
+void fos_netguard_set_policy(bool block_local)
+{
+    NETGUARD_LOCK();
+    s_block_local = block_local;
+    NETGUARD_UNLOCK();
+}
+
+bool fos_netguard_policy_active(void)
+{
+    NETGUARD_LOCK();
+    const bool active = s_block_local;
+    NETGUARD_UNLOCK();
+    return active;
+}
+
+void fos_netguard_clear_exempt(void)
+{
+    NETGUARD_LOCK();
+    s_exempt_count = 0;
+    NETGUARD_UNLOCK();
+}
+
+bool fos_netguard_set_exempt(const char *host, int port)
+{
+    if (host == NULL || host[0] == '\0') return false;
+    if (strlen(host) >= sizeof(s_exempt[0].host)) return false;
+
+    bool stored = false;
+    NETGUARD_LOCK();
+    if (s_exempt_count < FOS_NETGUARD_EXEMPT_MAX) {
+        /* Lowercased on the way in, like the native build's exempt list, so
+         * the hot path only ever does one case-insensitive compare. */
+        char *dst = s_exempt[s_exempt_count].host;
+        size_t i = 0;
+        for (; host[i] != '\0'; i++) {
+            const char c = host[i];
+            dst[i] = (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+        }
+        dst[i] = '\0';
+        s_exempt[s_exempt_count].port = port;
+        s_exempt_count++;
+        stored = true;
+    }
+    NETGUARD_UNLOCK();
+    return stored;
+}
+
+static bool exempt_match(const char *host, int port)
+{
+    bool match = false;
+    NETGUARD_LOCK();
+    for (size_t i = 0; i < s_exempt_count && !match; i++) {
+        if (s_exempt[i].port > 0 && s_exempt[i].port != port) continue;
+        if (strcasecmp(s_exempt[i].host, host) == 0) match = true;
+    }
+    NETGUARD_UNLOCK();
+    return match;
+}
+
+/* ---------------------------------------------------------------- URL parse */
+
+bool fos_netguard_parse_url(const char *url, char *host, size_t host_len, int *port)
+{
+    if (host == NULL || host_len == 0 || port == NULL) return false;
+    host[0] = '\0';
+    *port = 0;
+    if (url == NULL) return false;
+
+    int default_port;
+    const char *rest;
+    if (strncasecmp(url, "https://", 8) == 0) {
+        default_port = 443;
+        rest = url + 8;
+    } else if (strncasecmp(url, "http://", 7) == 0) {
+        default_port = 80;
+        rest = url + 7;
+    } else {
+        /* Not a scheme this guard understands. The caller blocks rather than
+         * waving it through: an unknown scheme is exactly the shape a bypass
+         * attempt takes, and esp_http_client would refuse it anyway. */
+        return false;
+    }
+
+    const char *authority = rest;
+    size_t authority_len = strcspn(rest, "/?#");
+
+    /* Userinfo is the classic parser trap: in http://example.com@192.168.1.1/
+     * the host is the LAN address, not example.com. Split on the LAST '@' in
+     * the authority — a password may legitimately contain one. */
+    for (size_t i = authority_len; i > 0; i--) {
+        if (authority[i - 1] == '@') {
+            authority += i;
+            authority_len -= i;
+            break;
+        }
+    }
+    if (authority_len == 0) return false;
+
+    const char *host_start;
+    size_t host_chars;
+    const char *port_str = NULL;
+    size_t port_chars = 0;
+
+    if (authority[0] == '[') {
+        const char *close = memchr(authority, ']', authority_len);
+        if (close == NULL) return false;
+        host_start = authority + 1;
+        host_chars = (size_t)(close - host_start);
+        const size_t after = (size_t)(close + 1 - authority);
+        if (after < authority_len) {
+            if (authority[after] != ':') return false;
+            port_str = authority + after + 1;
+            port_chars = authority_len - after - 1;
+        }
+    } else {
+        const char *colon = memchr(authority, ':', authority_len);
+        host_start = authority;
+        if (colon != NULL) {
+            host_chars = (size_t)(colon - authority);
+            port_str = colon + 1;
+            port_chars = authority_len - host_chars - 1;
+            /* A second colon means an unbracketed IPv6 literal (illegal in a
+             * URL) or junk. Either way this is not a URL to guess about. */
+            if (memchr(port_str, ':', port_chars) != NULL) return false;
+        } else {
+            host_chars = authority_len;
+        }
+    }
+    if (host_chars == 0 || host_chars >= host_len) return false;
+
+    int value = default_port;
+    if (port_str != NULL && port_chars > 0) { /* "host:" is the default port */
+        if (port_chars > 5) return false;
+        value = 0;
+        for (size_t i = 0; i < port_chars; i++) {
+            if (port_str[i] < '0' || port_str[i] > '9') return false;
+            value = value * 10 + (port_str[i] - '0');
+        }
+        if (value < 1 || value > 65535) return false;
+    }
+
+    memcpy(host, host_start, host_chars);
+    host[host_chars] = '\0';
+    *port = value;
+    return true;
+}
+
+/* ------------------------------------------------------------- the decision */
+
+/* Does this host consist only of digits and dots? Such a string is never a
+ * DNS name in practice, and if the strict parser above rejected it the two
+ * sides disagree about what it means (see parse_ipv4). Private, then. */
+static bool looks_numeric(const char *host)
+{
+    for (size_t i = 0; host[i] != '\0'; i++) {
+        if ((host[i] < '0' || host[i] > '9') && host[i] != '.') return false;
+    }
+    return true;
+}
+
+bool fos_netguard_url_allowed(const char *url, char *reason, size_t reason_len)
+{
+    if (reason != NULL && reason_len > 0) reason[0] = '\0';
+
+    NETGUARD_LOCK();
+    const bool blocking = s_block_local;
+    NETGUARD_UNLOCK();
+    if (!blocking) return true;
+
+    char host[FOS_NETGUARD_HOST_LEN];
+    int port = 0;
+    if (!fos_netguard_parse_url(url, host, sizeof(host), &port)) {
+        if (reason != NULL && reason_len > 0) {
+            snprintf(reason, reason_len, "not an http(s) URL with a usable host");
+        }
+        return false;
+    }
+    if (exempt_match(host, port)) return true;
+
+    uint8_t v4[4];
+    uint8_t v6[16];
+    if (parse_ipv4(host, v4)) {
+        if (!ipv4_is_private(v4)) return true;
+        if (reason != NULL && reason_len > 0) {
+            snprintf(reason, reason_len, "%s is a private address", host);
+        }
+        return false;
+    }
+    if (parse_ipv6(host, v6)) {
+        if (!ipv6_is_private(v6)) return true;
+        if (reason != NULL && reason_len > 0) {
+            snprintf(reason, reason_len, "%s is a private address", host);
+        }
+        return false;
+    }
+    if (looks_numeric(host)) {
+        if (reason != NULL && reason_len > 0) {
+            snprintf(reason, reason_len, "%s is not a well-formed IP address", host);
+        }
+        return false;
+    }
+
+    /* A name. Reject if ANY answer is private: a DNS-rebinding record set that
+     * mixes one public and one RFC1918 address must not pass, and the
+     * connect() that follows takes whichever the stack prefers. */
+    struct addrinfo hints;
+    struct addrinfo *result = NULL;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    if (getaddrinfo(host, NULL, &hints, &result) != 0 || result == NULL) {
+        /* Unresolvable. The request is going to fail regardless, so the only
+         * question is which error the scene sees; say what we know. */
+        if (result != NULL) freeaddrinfo(result);
+        if (reason != NULL && reason_len > 0) {
+            snprintf(reason, reason_len, "%s did not resolve", host);
+        }
+        return false;
+    }
+
+    bool allowed = true;
+    for (const struct addrinfo *ai = result; ai != NULL && allowed; ai = ai->ai_next) {
+        if (ai->ai_addr == NULL) continue;
+        if (ai->ai_family == AF_INET) {
+            const struct sockaddr_in *sin = (const struct sockaddr_in *)(const void *)ai->ai_addr;
+            uint8_t bytes[4];
+            memcpy(bytes, &sin->sin_addr, sizeof(bytes));
+            if (ipv4_is_private(bytes)) allowed = false;
+/* lwIP collapses AF_INET6 onto AF_UNSPEC and omits struct sockaddr_in6 when
+ * built without IPv6, so testing for definedness is useless — it is always
+ * defined. Without the branch an IPv6 answer falls into the else below and is
+ * refused, which is the right way round. */
+#if AF_INET6 != AF_UNSPEC
+        } else if (ai->ai_family == AF_INET6) {
+            const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)(const void *)ai->ai_addr;
+            uint8_t bytes[16];
+            memcpy(bytes, &sin6->sin6_addr, sizeof(bytes));
+            if (ipv6_is_private(bytes)) allowed = false;
+#endif
+        } else {
+            allowed = false; /* an address family we cannot classify */
+        }
+    }
+    freeaddrinfo(result);
+
+    if (!allowed) {
+        if (reason != NULL && reason_len > 0) {
+            snprintf(reason, reason_len, "%s resolves to a private address", host);
+        }
+    }
+    return allowed;
+}

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -3,6 +3,8 @@
  * outbound-HTTP hook the Nim http_client HAL calls into. */
 #include "frameos_nim.h"
 
+#include "fos_netguard.h"
+
 #include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
@@ -1231,6 +1233,20 @@ fos_nim_http_chunk *fos_nim_http_request_chunked_spill(
     const bool spill_allowed = out_spill_path != NULL && out_spill_len != NULL &&
                                s_http_spill_dir[0] != '\0';
 
+    /* Private-network policy (fos_netguard.h). This is the one funnel every
+     * scene HTTP request goes through, and on a cloud-managed frame a scene is
+     * something a provider installed — so it does not get to reach the owner's
+     * router. Checked before the client even exists; the redirect loop below
+     * re-checks every hop, because a 302 to 192.168.1.1 is the same request. */
+    char netguard_reason[96];
+    if (!fos_netguard_url_allowed(url, netguard_reason, sizeof(netguard_reason))) {
+        ESP_LOGW(TAG, "%s %s: blocked by the local-network policy: %s",
+                 method ? method : "GET", url ? url : "(null)", netguard_reason);
+        return chunked_error(out_status, out_count,
+                             "local network access is blocked on cloud-managed frames (%s)",
+                             netguard_reason);
+    }
+
     esp_http_client_method_t http_method = HTTP_METHOD_GET;
     if (method != NULL) {
         if (strcmp(method, "POST") == 0) http_method = HTTP_METHOD_POST;
@@ -1292,6 +1308,36 @@ fos_nim_http_chunk *fos_nim_http_request_chunked_spill(
         char drain[512];
         while (esp_http_client_read(client, drain, sizeof(drain)) > 0) {}
         if (esp_http_client_set_redirection(client) != ESP_OK) break;
+        /* The Location header is attacker-controlled even when the first hop
+         * was not: an open redirect on a public host, or a provider-installed
+         * scene pointing at one, would otherwise walk straight into the LAN.
+         * esp_http_client_get_url() renders the URL set_redirection() just
+         * installed as "scheme://host:port/path" — always with an explicit
+         * port, and with an IPv6 host left unbracketed, which the guard reads
+         * as unparseable and therefore refuses. Fine: an IPv6-literal redirect
+         * target is not a thing scenes do, and the failure is closed.
+         * A truncated render is refused for the same reason. */
+        if (fos_netguard_policy_active()) {
+            char redirect_url[256];
+            bool redirect_ok = false;
+            netguard_reason[0] = '\0';
+            if (esp_http_client_get_url(client, redirect_url, sizeof(redirect_url)) != ESP_OK ||
+                strlen(redirect_url) == sizeof(redirect_url) - 1) {
+                strlcpy(netguard_reason, "redirect target unreadable", sizeof(netguard_reason));
+            } else {
+                redirect_ok = fos_netguard_url_allowed(redirect_url, netguard_reason,
+                                                       sizeof(netguard_reason));
+            }
+            if (!redirect_ok) {
+                ESP_LOGW(TAG, "%s %s: redirect blocked by the local-network policy: %s",
+                         method ? method : "GET", url, netguard_reason);
+                esp_http_client_close(client);
+                esp_http_client_cleanup(client);
+                return chunked_error(out_status, out_count,
+                                     "local network access is blocked on cloud-managed frames "
+                                     "(redirect target: %s)", netguard_reason);
+            }
+        }
         err = esp_http_client_open(client, body_len);
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "%s %s: redirect connect failed: %s", method ? method : "GET", url,

--- a/embedded/esp32/components/frameos_nim/include/fos_netguard.h
+++ b/embedded/esp32/components/frameos_nim/include/fos_netguard.h
@@ -1,0 +1,96 @@
+/*
+ * Private-network egress policy for scene HTTP.
+ *
+ * docs/cloud-frames.md: scenes installed by a cloud provider run *inside the
+ * owner's LAN*, so on a cloud-managed frame HTTP to private/link-local
+ * addresses is denied — otherwise a compromised provider account (or a
+ * malicious JS app pushed through one) turns every frame into an SSRF pivot
+ * onto routers, NAS boxes and IoT devices that trust anything on the wire.
+ *
+ * The native (Pi/Linux) build has had this since the cloud link shipped, in
+ * frameos/src/frameos/utils/http_client.nim (isPrivateNetworkAddress /
+ * enforceLocalNetworkPolicy). The ESP32 firmware does its scene HTTP in C
+ * through esp_http_client and so had no check at any layer. This module is the
+ * port; keep the two classifiers in step.
+ *
+ * Everything except fos_netguard_url_allowed()'s DNS fallback is pure C over
+ * strings with no IDF and no lwip dependency, so the classifier and the URL
+ * parser compile and are tested on the host — see main/tests/test_fos_netguard.c.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* How many "host:port" exemptions the policy holds. Two is the real need (the
+ * provider's API endpoint plus a dev frame-hub on another port); four leaves
+ * room without putting a meaningful array on a caller's stack. */
+#define FOS_NETGUARD_EXEMPT_MAX 4
+/* Longest exempted host kept. A hostname longer than this simply does not get
+ * exempted — it never lets an extra address through. */
+#define FOS_NETGUARD_EXEMPT_HOST_LEN 96
+/* Buffer a caller must give fos_netguard_parse_url() for the host. A DNS name
+ * is at most 253 characters; anything longer is not a host we can check, and
+ * parsing fails (which blocks) rather than truncating (which would check the
+ * wrong name). */
+#define FOS_NETGUARD_HOST_LEN 256
+
+/* Turn the deny on or off. Off (the default) is the standalone /
+ * backend-managed frame: the owner's own scenes may talk to the owner's LAN. */
+void fos_netguard_set_policy(bool block_local);
+
+/* True when the deny is currently active. */
+bool fos_netguard_policy_active(void);
+
+/* Drop every exemption. Call before re-adding, so the list always describes
+ * the provider we are enrolled with right now. */
+void fos_netguard_clear_exempt(void);
+
+/* Keep `host:port` reachable while the deny is active. The local admin linked
+ * this provider deliberately — possibly a dev provider on the LAN — so its own
+ * endpoint must not be collateral damage. `port` <= 0 means "any port on this
+ * host". Matching is case-insensitive on the host, exactly like the native
+ * build's lowercase "host:port" exempt list. Returns false when the list is
+ * full or the entry does not fit. */
+bool fos_netguard_set_exempt(const char *host, int port);
+
+/* Is `ip` (a bare IPv4 or IPv6 literal, no brackets, no port) an address a
+ * cloud-installed scene must not reach? Covers loopback, RFC1918, link-local,
+ * CGNAT, 0/8, multicast, reserved — and the IPv6 equivalents including the
+ * wrappers that carry an IPv4 address (::ffff:a.b.c.d, ::a.b.c.d, 64:ff9b::/96).
+ *
+ * Unparseable input is PRIVATE. The caller is about to hand the string to
+ * connect(), so failing closed is the only safe answer; the Nim version does
+ * the same and this is load-bearing, not defensive noise. */
+bool fos_netguard_is_private_ip(const char *ip);
+
+/* Split "scheme://[user:pass@]host[:port][/path]" into a bare host (IPv6
+ * literals unbracketed) and a port, defaulting 80/443 from the scheme.
+ * Returns false for anything that is not an http:// or https:// URL with a
+ * host — callers treat that as a block, not as "no host to check".
+ *
+ * Exposed for the host tests: userinfo is where URL parsers traditionally get
+ * this wrong, and http://example.com@192.168.1.1/ must resolve to the LAN
+ * address, not to example.com. */
+bool fos_netguard_parse_url(const char *url, char *host, size_t host_len, int *port);
+
+/* The check the HTTP client calls, once per hop (initial request and every
+ * redirect). Returns true when the request may proceed: the policy is off, the
+ * host:port is exempt, or every address the host resolves to is public.
+ *
+ * A host given as an IP literal is classified directly. A name is resolved
+ * with getaddrinfo() and rejected if ANY returned address is private — a
+ * DNS-rebinding answer that mixes one public and one RFC1918 record must not
+ * pass, and the connect() that follows picks whichever it likes.
+ *
+ * On a block, `reason` (when non-NULL) gets a short human-readable phrase for
+ * the error surfaced to the scene. */
+bool fos_netguard_url_allowed(const char *url, char *reason, size_t reason_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -35,6 +35,7 @@
 #include "fos_schedule.h"
 #include "fos_settings.h"
 #include "fos_wifi.h"
+#include "fos_netguard.h"
 #include "frameos_display.h"
 #include "frameos_nim.h"
 
@@ -393,6 +394,87 @@ void fos_cloud_clear_ws_url(void)
 }
 
 const char *fos_cloud_ws_url(void) { return s_ws_url; }
+
+/* --------------------------------------------- private-network egress policy */
+
+/* docs/cloud-frames.md: an enrolled frame runs scenes the *provider* installed,
+ * from inside the owner's LAN. So while the link is up, scene HTTP to
+ * private/link-local addresses is denied — otherwise a compromised provider
+ * account is an SSRF pivot onto the owner's router, NAS and IoT devices. The
+ * classifier and the enforcement live in fos_netguard.c (mirroring the native
+ * runtime's utils/http_client.nim); this file owns the *trigger*, because this
+ * is the only place that knows whether we are cloud-managed.
+ *
+ * Off whenever the frame is not enrolled. A standalone or backend-managed
+ * frame runs the owner's own scenes, where reaching the LAN is the point. */
+
+/* Exempt one provider endpoint, as "host:port" with the scheme's default port
+ * filled in — the same shape fos_netguard_url_allowed() derives from a request
+ * URL, so the two always agree. */
+static void netguard_exempt_provider_url(const char *url, bool ws)
+{
+    bool is_secure = false;
+    char hostport[FOS_URL_LEN];
+    char host[FOS_URL_LEN];
+
+    if (url == NULL || url[0] == '\0') return;
+    if (!split_scheme_url(url, ws ? "wss://" : "https://", ws ? "ws://" : "http://",
+                          &is_secure, hostport, sizeof(hostport))) {
+        return;
+    }
+    host_only(hostport, host, sizeof(host));
+    if (host[0] == '\0') return;
+
+    int port = is_secure ? 443 : 80;
+    if (hostport[0] == '[') {
+        const char *close = strchr(hostport, ']');
+        if (close != NULL && close[1] == ':') port = atoi(close + 2);
+    } else {
+        const char *colon = strrchr(hostport, ':');
+        /* Only a single colon is a port; more than one is a bare IPv6
+         * literal, which host_only() has already dealt with. */
+        if (colon != NULL && strchr(hostport, ':') == colon) port = atoi(colon + 1);
+    }
+    if (port <= 0 || port > 65535) return;
+    fos_netguard_set_exempt(host, port);
+}
+
+/* Recompute and apply. Cheap enough to call on every cloud-task tick (two URL
+ * splits and a couple of string copies), which is what keeps a console toggle
+ * of `allow_local_network` live without a restart. */
+static void apply_network_policy(void)
+{
+    static int logged_active = -1; /* -1 = nothing logged yet */
+    const fos_config_t *config = fos_config();
+    const bool managed = (s_state == FOS_CLOUD_ENROLLED);
+    const bool active = managed && !config->allow_local_network;
+
+    fos_netguard_clear_exempt();
+    if (active) {
+        /* The local admin linked this provider deliberately — possibly a dev
+         * provider on the LAN — so the provider's own endpoints must not be
+         * collateral damage. Both the API base URL and the optional ws_url
+         * override (a dev frame hub on its own port) count as "the provider". */
+        netguard_exempt_provider_url(config->cloud_url, false);
+        netguard_exempt_provider_url(s_ws_url, true);
+    }
+    fos_netguard_set_policy(active);
+
+    if ((int)active != logged_active) {
+        logged_active = (int)active;
+        if (active) {
+            ESP_LOGW(TAG, "scene HTTP to private/link-local addresses is now blocked "
+                          "(cloud-managed frame); override locally with "
+                          "`set allow_local_network 1`");
+        } else if (managed) {
+            ESP_LOGW(TAG, "scene HTTP to private/link-local addresses is ALLOWED on this "
+                          "cloud-managed frame (allow_local_network=1)");
+        } else {
+            ESP_LOGI(TAG, "scene HTTP to private addresses is allowed (frame is not "
+                          "cloud-managed)");
+        }
+    }
+}
 
 /* ------------------------------------------------------------------ crypto */
 
@@ -2318,12 +2400,17 @@ static void load_stored_state(void)
 static void cloud_task(void *arg)
 {
     (void)arg;
-    load_stored_state();
     uint32_t backoff_ms = FOS_CLOUD_BACKOFF_MIN_MS;
     bool ws_started = false;
     int64_t ws_stall_since_us = 0;
 
     while (true) {
+        /* Re-derived every tick rather than pushed from each state change: it
+         * costs two string splits, it cannot be forgotten at a new call site,
+         * and it is what makes a demotion, a fresh enrollment or a console
+         * `set allow_local_network` take effect without a restart. */
+        apply_network_policy();
+
         if (fos_wifi_state() != FOS_WIFI_CONNECTED) {
             ws_stall_since_us = 0; /* no WiFi is not a WS stall */
             vTaskDelay(pdMS_TO_TICKS(2000));
@@ -2403,6 +2490,13 @@ static void cloud_task(void *arg)
 esp_err_t fos_cloud_start(void)
 {
     if (s_task != NULL) return ESP_OK;
+    /* Read the stored link state and arm the private-network policy here, not
+     * in the task: main() brings the render loop up immediately after this
+     * call, and an enrolled frame must not get to run even one scene HTTP
+     * request in the window before the task is first scheduled. Both are pure
+     * NVS reads plus string work — nothing that needs a task context. */
+    load_stored_state();
+    apply_network_policy();
     if (xTaskCreate(cloud_task, "fos_cloud", FOS_CLOUD_TASK_STACK, NULL, 3, &s_task) != pdPASS) {
         s_task = NULL;
         ESP_LOGE(TAG, "cloud task start failed");

--- a/embedded/esp32/main/fos_config.c
+++ b/embedded/esp32/main/fos_config.c
@@ -33,6 +33,7 @@ static void load_defaults(void)
     s_config.interval_sec = FRAMEOS_DEFAULT_INTERVAL_SEC;
     s_config.max_http_response_bytes = FRAMEOS_DEFAULT_MAX_HTTP_RESPONSE_BYTES;
     s_config.server_send_logs = FRAMEOS_DEFAULT_SERVER_SEND_LOGS;
+    s_config.allow_local_network = FRAMEOS_DEFAULT_ALLOW_LOCAL_NETWORK;
     s_config.tls_enable = FRAMEOS_DEFAULT_TLS_ENABLE;
     s_config.tls_port = FRAMEOS_DEFAULT_TLS_PORT;
     strlcpy(s_config.tls_server_cert, FRAMEOS_DEFAULT_TLS_SERVER_CERT, sizeof(s_config.tls_server_cert));
@@ -135,6 +136,7 @@ esp_err_t fos_config_init(void)
     uint8_t u8;
     if (nvs_get_u8(nvs, "render_mode", &u8) == ESP_OK) s_config.render_mode = (fos_render_mode_t)u8;
     if (nvs_get_u8(nvs, "send_logs", &u8) == ESP_OK) s_config.server_send_logs = u8 != 0;
+    if (nvs_get_u8(nvs, "allow_lan", &u8) == ESP_OK) s_config.allow_local_network = u8 != 0;
     if (nvs_get_u8(nvs, "tls_enable", &u8) == ESP_OK) s_config.tls_enable = u8 != 0;
     if (nvs_get_u8(nvs, "admin_auth", &u8) == ESP_OK) s_config.admin_auth_enabled = u8 != 0;
     if (nvs_get_u32(nvs, "tls_port", &u32) == ESP_OK) s_config.tls_port = (uint16_t)u32;
@@ -205,6 +207,7 @@ esp_err_t fos_config_save(void)
     nvs_set_u32(nvs, "spill_force", s_config.http_spill_force_bytes);
     nvs_set_u8(nvs, "render_mode", (uint8_t)s_config.render_mode);
     nvs_set_u8(nvs, "send_logs", s_config.server_send_logs ? 1 : 0);
+    nvs_set_u8(nvs, "allow_lan", s_config.allow_local_network ? 1 : 0);
     nvs_set_u8(nvs, "tls_enable", s_config.tls_enable ? 1 : 0);
     nvs_set_u8(nvs, "admin_auth", s_config.admin_auth_enabled ? 1 : 0);
     nvs_set_u32(nvs, "tls_port", s_config.tls_port);

--- a/embedded/esp32/main/fos_config.h
+++ b/embedded/esp32/main/fos_config.h
@@ -81,6 +81,16 @@ typedef struct {
                                       * bytes spill to storage even with PSRAM
                                       * free (0 = off, spill on pressure only) */
     bool server_send_logs;         /* upload runtime/render logs to backend */
+    /* Escape hatch for the cloud-managed private-network deny
+     * (components/frameos_nim/include/fos_netguard.h), matching
+     * `network.allowLocalNetworkAccess` in the native build's frame.json: 1
+     * lets scenes on an enrolled frame keep talking to the LAN.
+     *
+     * Local-only on purpose. It is reachable from the USB console and nowhere
+     * else — not in the cloud `set_settings` allowlist, not in the backend
+     * settings poll, not in the local HTTP API — because a provider that could
+     * flip its own leash would not have one. */
+    bool allow_local_network;
     bool tls_enable;               /* serve the frame HTTP API over HTTPS too */
     uint16_t tls_port;             /* HTTPS port, default mirrors Pi Caddy proxy */
     char tls_server_cert[FOS_TLS_PEM_LEN];

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -34,6 +34,7 @@
 #include "fos_ota.h"
 #include "fos_scenes.h"
 #include "fos_wifi.h"
+#include "fos_netguard.h"
 #include "frameos_display.h"
 #include "frameos_nim.h"
 
@@ -111,6 +112,12 @@ static int cmd_status(int argc, char **argv)
     if (fos_cloud_last_error()[0]) {
         printf("cloud_error: %s\n", fos_cloud_last_error());
     }
+    /* Whether scene HTTP can currently reach the LAN. Worth a line of its own:
+     * when the deny is on, a scene calling a local API fails with a message
+     * that looks like a network fault, and this is where that gets explained. */
+    printf("net_policy:  scene HTTP to private addresses %s%s\n",
+           fos_netguard_policy_active() ? "BLOCKED (cloud-managed)" : "allowed",
+           config->allow_local_network ? " [allow_local_network=1]" : "");
     printf("https:       %s port=%u cert=%s key=%s\n",
            config->tls_enable ? "enabled" : "disabled",
            (unsigned)config->tls_port,
@@ -308,7 +315,8 @@ static int cmd_set(int argc, char **argv)
     if (argc < 3) {
         printf("usage: set <wifi_ssid|wifi_pass|backend|api_key|cloud_url|claim_token|frame_id|"
                "cloud_wsurl|hardware|panel|render_mode|rotate|"
-               "interval|spill_force|server_send_logs|assets_path|assets_sd|assets_sd_pins|assets_sd_freq|"
+               "interval|spill_force|server_send_logs|allow_local_network|"
+               "assets_path|assets_sd|assets_sd_pins|assets_sd_freq|"
                "assets_sd_autoformat|"
                "deep_sleep|wake_schedule|battery_pin|battery_divider|pins|gpio_buttons> <value...>\n");
         return 1;
@@ -490,6 +498,14 @@ static int cmd_set(int argc, char **argv)
         config->rotate = rot;
     }
     else if (strcmp(key, "server_send_logs") == 0) config->server_send_logs = atoi(value) != 0;
+    /* 0 (default): while this frame is enrolled with a cloud provider, scene
+     * HTTP to private/link-local addresses is denied — the provider installs
+     * the scenes and the frame sits inside the owner's LAN. 1 lifts that, for
+     * an owner who deliberately wants cloud scenes talking to a local API.
+     * Console-only by design: see fos_config.h. Takes effect within a second,
+     * no restart. */
+    else if (strcmp(key, "allow_local_network") == 0)
+        config->allow_local_network = atoi(value) != 0;
     else if (strcmp(key, "assets_path") == 0) strlcpy(config->assets_path, value, sizeof(config->assets_path));
     else if (strcmp(key, "assets_sd") == 0) config->assets_sd.enabled = atoi(value) != 0;
     else if (strcmp(key, "assets_sd_freq") == 0) config->assets_sd.max_freq_khz = strtoul(value, NULL, 10);

--- a/embedded/esp32/main/fos_defaults.h
+++ b/embedded/esp32/main/fos_defaults.h
@@ -88,6 +88,11 @@
 #ifndef FRAMEOS_DEFAULT_ADMIN_AUTH_PASS
 #define FRAMEOS_DEFAULT_ADMIN_AUTH_PASS ""
 #endif
+/* Off: an enrolled frame's scenes come from the provider, so they do not get
+ * to reach the owner's LAN. See fos_netguard.h and `set allow_local_network`. */
+#ifndef FRAMEOS_DEFAULT_ALLOW_LOCAL_NETWORK
+#define FRAMEOS_DEFAULT_ALLOW_LOCAL_NETWORK 0
+#endif
 #ifndef FRAMEOS_DEFAULT_ASSETS_PATH
 #define FRAMEOS_DEFAULT_ASSETS_PATH "/srv/assets"
 #endif

--- a/embedded/esp32/main/tests/test_fos_netguard.c
+++ b/embedded/esp32/main/tests/test_fos_netguard.c
@@ -1,0 +1,398 @@
+/*
+ * Host tests for the private-network egress guard. No IDF, no CMake, no mocks:
+ * fos_netguard.c keeps its classifier and URL parser as plain C over strings
+ * precisely so the interesting half can be argued about on a laptop.
+ *
+ * Build and run (from embedded/esp32/):
+ *
+ *   cc -std=c11 -Wall -Wextra -Werror -O2 -Icomponents/frameos_nim/include \
+ *      components/frameos_nim/fos_netguard.c main/tests/test_fos_netguard.c \
+ *      -o /tmp/test_fos_netguard && /tmp/test_fos_netguard
+ *
+ * (backend/app/tasks/tests/test_esp32_netguard.py does exactly that in CI.)
+ *
+ * The bias under test is one-directional, like the SD probe next door but for
+ * the opposite reason: a wrong "public" lets a cloud-installed scene reach the
+ * owner's router, a wrong "private" costs a scene one unreachable host. So
+ * every input this cannot parse must come back private, and most of the cases
+ * below assert exactly that.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "fos_netguard.h"
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond, ...)                                                       \
+    do {                                                                       \
+        g_checks++;                                                            \
+        if (!(cond)) {                                                         \
+            g_failures++;                                                      \
+            printf("FAIL %s:%d: ", __func__, __LINE__);                        \
+            printf(__VA_ARGS__);                                               \
+            printf("\n");                                                      \
+        }                                                                      \
+    } while (0)
+
+static void expect_private(const char *ip)
+{
+    g_checks++;
+    if (!fos_netguard_is_private_ip(ip)) {
+        g_failures++;
+        printf("FAIL %-42s classified PUBLIC, want private\n", ip);
+    }
+}
+
+static void expect_public(const char *ip)
+{
+    g_checks++;
+    if (fos_netguard_is_private_ip(ip)) {
+        g_failures++;
+        printf("FAIL %-42s classified PRIVATE, want public\n", ip);
+    }
+}
+
+/* --------------------------------------------------------------------- */
+/* IPv4 classification                                                     */
+
+static void test_ipv4_private_ranges(void)
+{
+    expect_private("0.0.0.0");
+    expect_private("0.1.2.3");          /* 0/8 */
+    expect_private("10.0.0.1");
+    expect_private("10.255.255.255");
+    expect_private("100.64.0.1");       /* CGNAT low edge */
+    expect_private("100.127.255.254");  /* CGNAT high edge */
+    expect_private("127.0.0.1");
+    expect_private("127.255.255.255");
+    expect_private("169.254.1.1");      /* link-local */
+    expect_private("172.16.0.1");
+    expect_private("172.31.255.254");
+    expect_private("192.0.0.1");        /* IETF protocol assignments */
+    expect_private("192.168.1.1");
+    expect_private("198.18.0.1");       /* benchmarking */
+    expect_private("198.19.255.254");
+    expect_private("224.0.0.1");        /* multicast */
+    expect_private("239.255.255.250");  /* SSDP — the classic LAN pivot */
+    expect_private("240.0.0.1");
+    expect_private("255.255.255.255");
+}
+
+static void test_ipv4_public_and_edges(void)
+{
+    expect_public("8.8.8.8");
+    expect_public("1.1.1.1");
+    expect_public("93.184.216.34");
+    /* One step outside each private block: these must stay reachable. */
+    expect_public("9.255.255.255");
+    expect_public("11.0.0.1");
+    expect_public("100.63.255.255");    /* just below CGNAT */
+    expect_public("100.128.0.1");       /* just above CGNAT */
+    expect_public("126.255.255.255");
+    expect_public("128.0.0.1");
+    expect_public("169.253.255.255");
+    expect_public("169.255.0.1");
+    expect_public("172.15.255.255");
+    expect_public("172.32.0.1");
+    expect_public("192.0.1.1");         /* 192.0.0.0/24 is /24, not /16 */
+    expect_public("192.167.255.255");
+    expect_public("192.169.0.1");
+    expect_public("198.17.255.255");
+    expect_public("198.20.0.1");
+    expect_public("223.255.255.255");   /* just below multicast */
+    expect_public("8.8.4.4");
+}
+
+static void test_unparseable_is_private(void)
+{
+    /* Fail closed. Every one of these is about to be handed to connect(). */
+    expect_private("");
+    expect_private("example.com");
+    expect_private("1.2.3");            /* lwIP's aton would read this as 1.2.0.3 */
+    expect_private("1.2.3.4.5");
+    expect_private("256.1.1.1");
+    expect_private("1.2.3.4 ");
+    expect_private(" 1.2.3.4");
+    expect_private("1.2.3.-4");
+    expect_private("1.2.3.4/8");
+    expect_private("1..2.3");
+    expect_private("....");
+    /* Leading zeros and 0x are ambiguous: decimal here, octal/hex in lwIP's
+     * ip4addr_aton. 0177.0.0.1 would be 177.0.0.1 (public) read one way and
+     * 127.0.0.1 (loopback) read the other, so it must not parse. */
+    expect_private("0177.0.0.1");
+    expect_private("010.0.0.1");
+    expect_private("192.168.01.1");
+    expect_private("0x7f.0.0.1");
+    expect_private("2130706433");
+    /* Nothing crashes on a NULL. */
+    expect_private(NULL);
+}
+
+/* --------------------------------------------------------------------- */
+/* IPv6 classification                                                     */
+
+static void test_ipv6_private(void)
+{
+    expect_private("::");
+    expect_private("::1");
+    expect_private("0:0:0:0:0:0:0:1");
+    expect_private("fc00::1");          /* ULA */
+    expect_private("fd12:3456::1");
+    expect_private("fe80::1");          /* link-local */
+    expect_private("febf:ffff::1");     /* fe80::/10 top edge */
+    expect_private("ff02::1");          /* multicast */
+    expect_private("ff00::");
+    /* IPv4-mapped and the deprecated IPv4-compatible form both carry an IPv4
+     * address in the low 32 bits. ::127.0.0.1 once passed as "public". */
+    expect_private("::ffff:127.0.0.1");
+    expect_private("::ffff:192.168.1.1");
+    expect_private("::127.0.0.1");
+    expect_private("::192.168.1.1");
+    expect_private("::10.0.0.1");
+    /* NAT64: another wrapper around an IPv4 destination. */
+    expect_private("64:ff9b::192.168.1.1");
+    expect_private("64:ff9b::10.0.0.1");
+}
+
+static void test_ipv6_public(void)
+{
+    expect_public("2001:4860:4860::8888");
+    expect_public("2606:4700:4700::1111");
+    expect_public("2001:db8::1");       /* documentation range, but not private */
+    expect_public("::ffff:8.8.8.8");
+    expect_public("::8.8.8.8");
+    expect_public("64:ff9b::8.8.8.8");
+    expect_public("fbff::1");           /* one below fc00::/7 */
+    expect_public("fe00::1");           /* below fe80::/10 */
+    expect_public("fec0::1");           /* site-local: deprecated, not in the list */
+}
+
+static void test_ipv6_malformed_is_private(void)
+{
+    expect_private(":");
+    expect_private(":::");
+    expect_private(":1");
+    expect_private("1:");
+    expect_private("1:2:3:4:5:6:7");            /* too few groups, no "::" */
+    expect_private("1:2:3:4:5:6:7:8:9");        /* too many */
+    expect_private("1::2::3");                  /* two "::" runs */
+    expect_private("1:2:3:4:5:6:7:8::");        /* "::" standing for nothing */
+    expect_private("12345::1");                 /* five hex digits */
+    expect_private("gggg::1");
+    expect_private("fe80::1%eth0");             /* zone id: not parsed => private */
+    expect_private("[::1]");                    /* brackets belong to the URL */
+    expect_private("::ffff:999.1.1.1");
+    expect_private("::ffff:1.2.3");
+}
+
+/* --------------------------------------------------------------------- */
+/* URL parsing                                                             */
+
+static void expect_url(const char *url, const char *want_host, int want_port)
+{
+    char host[FOS_NETGUARD_HOST_LEN];
+    int port = -1;
+    g_checks++;
+    const bool ok = fos_netguard_parse_url(url, host, sizeof(host), &port);
+    if (!ok || strcmp(host, want_host) != 0 || port != want_port) {
+        g_failures++;
+        printf("FAIL parse %-52s got ok=%d host=%s port=%d, want %s:%d\n",
+               url, (int)ok, host, port, want_host, want_port);
+    }
+}
+
+static void expect_url_rejected(const char *url)
+{
+    char host[FOS_NETGUARD_HOST_LEN];
+    int port = -1;
+    g_checks++;
+    if (fos_netguard_parse_url(url, host, sizeof(host), &port)) {
+        g_failures++;
+        printf("FAIL parse %-52s accepted as %s:%d, want rejected\n", url, host, port);
+    }
+}
+
+static void test_url_parser(void)
+{
+    expect_url("http://example.com/", "example.com", 80);
+    expect_url("https://example.com/", "example.com", 443);
+    expect_url("HTTP://Example.COM/x", "Example.COM", 80);
+    expect_url("https://example.com:8443/a/b?c=d#e", "example.com", 8443);
+    expect_url("http://192.168.1.1", "192.168.1.1", 80);
+    expect_url("http://example.com:/path", "example.com", 80); /* empty port */
+    expect_url("http://[::1]/", "::1", 80);
+    expect_url("http://[fe80::1]:8080/x", "fe80::1", 8080);
+    expect_url("http://example.com?q=1", "example.com", 80);
+    expect_url("http://example.com#frag", "example.com", 80);
+    expect_url("http://host:65535/", "host", 65535);
+
+    /* Userinfo. http://example.com@192.168.1.1/ is a request to the LAN
+     * address; a parser that stops at the first '@'-free token gets this
+     * backwards and hands an SSRF straight through. */
+    expect_url("http://example.com@192.168.1.1/", "192.168.1.1", 80);
+    expect_url("http://user:pass@10.0.0.5:8080/x", "10.0.0.5", 8080);
+    expect_url("http://a@b@127.0.0.1/", "127.0.0.1", 80);
+
+    expect_url_rejected(NULL);
+    expect_url_rejected("");
+    expect_url_rejected("example.com");           /* no scheme */
+    expect_url_rejected("ftp://example.com/");
+    expect_url_rejected("file:///etc/passwd");
+    expect_url_rejected("http://");
+    expect_url_rejected("http:///path");          /* empty host */
+    expect_url_rejected("http://@/x");
+    expect_url_rejected("http://host:99999/");    /* port out of range */
+    expect_url_rejected("http://host:0/");
+    expect_url_rejected("http://host:80x/");
+    expect_url_rejected("http://::1/");           /* unbracketed IPv6 */
+    expect_url_rejected("http://[::1/");          /* unterminated bracket */
+    expect_url_rejected("http://[::1]x/");
+}
+
+/* --------------------------------------------------------------------- */
+/* The policy as a whole                                                   */
+
+static void expect_allowed(const char *url)
+{
+    char reason[128] = "";
+    g_checks++;
+    if (!fos_netguard_url_allowed(url, reason, sizeof(reason))) {
+        g_failures++;
+        printf("FAIL allow  %-52s blocked: %s\n", url, reason);
+    }
+}
+
+static void expect_blocked(const char *url, const char *want_reason_fragment)
+{
+    char reason[128] = "";
+    g_checks++;
+    if (fos_netguard_url_allowed(url, reason, sizeof(reason))) {
+        g_failures++;
+        printf("FAIL block  %-52s allowed\n", url);
+    } else if (strstr(reason, want_reason_fragment) == NULL) {
+        g_failures++;
+        printf("FAIL block  %-52s reason=\"%s\", want it to mention \"%s\"\n",
+               url, reason, want_reason_fragment);
+    }
+}
+
+static void test_policy_off_allows_everything(void)
+{
+    fos_netguard_set_policy(false);
+    fos_netguard_clear_exempt();
+    CHECK(!fos_netguard_policy_active(), "policy should be off");
+    expect_allowed("http://192.168.1.1/admin");
+    expect_allowed("http://127.0.0.1:8989/api");
+    expect_allowed("ftp://192.168.1.1/");   /* not our business when off */
+    expect_allowed("nonsense");
+}
+
+static void test_policy_on_blocks_literals(void)
+{
+    fos_netguard_set_policy(true);
+    fos_netguard_clear_exempt();
+    CHECK(fos_netguard_policy_active(), "policy should be on");
+
+    expect_blocked("http://192.168.1.1/admin", "private");
+    expect_blocked("http://10.0.0.1:8080/", "private");
+    expect_blocked("http://127.0.0.1:8989/api", "private");
+    expect_blocked("http://[::1]:3000/", "private");
+    expect_blocked("http://[fd00::1]/", "private");
+    expect_blocked("http://[::ffff:192.168.0.1]/", "private");
+    expect_blocked("http://169.254.169.254/latest/meta-data/", "private");
+    /* The userinfo trick again, this time end to end. */
+    expect_blocked("http://example.com@192.168.1.1/", "private");
+    /* Ambiguous numerics never reach the resolver. */
+    expect_blocked("http://0177.0.0.1/", "well-formed");
+    expect_blocked("http://127.1/", "well-formed");
+    /* Not an http(s) URL at all. */
+    expect_blocked("ftp://192.168.1.1/", "http(s)");
+    expect_blocked("gopher://8.8.8.8/", "http(s)");
+
+    expect_allowed("http://8.8.8.8/");
+    expect_allowed("https://93.184.216.34/x");
+    expect_allowed("http://[2001:4860:4860::8888]/");
+}
+
+static void test_exemptions(void)
+{
+    fos_netguard_set_policy(true);
+    fos_netguard_clear_exempt();
+
+    /* The provider's own endpoint — a dev provider on the LAN is exactly the
+     * case this exists for. */
+    CHECK(fos_netguard_set_exempt("10.4.0.47", 8989), "exempt should be stored");
+    expect_allowed("http://10.4.0.47:8989/api/frames/enroll");
+    expect_blocked("http://10.4.0.47:8990/api", "private");   /* other port */
+    expect_blocked("http://10.4.0.48:8989/api", "private");   /* other host */
+
+    /* Case-insensitive on the host, like the native build's lowercase list. */
+    fos_netguard_clear_exempt();
+    CHECK(fos_netguard_set_exempt("Dev.Example.COM", 8787), "exempt should be stored");
+    expect_allowed("http://dev.example.com:8787/api");
+    expect_allowed("http://DEV.EXAMPLE.com:8787/api");
+
+    /* port <= 0 exempts every port on the host. */
+    fos_netguard_clear_exempt();
+    CHECK(fos_netguard_set_exempt("192.168.7.7", 0), "exempt should be stored");
+    expect_allowed("http://192.168.7.7/");
+    expect_allowed("http://192.168.7.7:9000/");
+
+    /* The list is bounded and rejects what does not fit; a refused entry must
+     * never silently widen the policy. */
+    fos_netguard_clear_exempt();
+    for (int i = 0; i < FOS_NETGUARD_EXEMPT_MAX; i++) {
+        char host[32];
+        snprintf(host, sizeof(host), "10.0.0.%d", i + 1);
+        CHECK(fos_netguard_set_exempt(host, 80), "entry %d should fit", i);
+    }
+    CHECK(!fos_netguard_set_exempt("10.0.0.99", 80), "the list should be full");
+    expect_blocked("http://10.0.0.99/", "private");
+    CHECK(!fos_netguard_set_exempt(NULL, 80), "NULL host must be refused");
+    CHECK(!fos_netguard_set_exempt("", 80), "empty host must be refused");
+
+    fos_netguard_clear_exempt();
+    expect_blocked("http://10.0.0.1/", "private");
+}
+
+static void test_name_resolution(void)
+{
+    /* The one name every host resolves, and it resolves to loopback: enough to
+     * prove the getaddrinfo path classifies what it gets back rather than
+     * waving names through. Nothing else here touches DNS — a test suite that
+     * needs the internet is a test suite that fails on a train. */
+    fos_netguard_set_policy(true);
+    fos_netguard_clear_exempt();
+    expect_blocked("http://localhost:8989/api", "resolve");
+
+    /* ...and an exemption still wins over resolution, which is what keeps a
+     * dev provider on `http://localhost:8989` reachable. */
+    CHECK(fos_netguard_set_exempt("localhost", 8989), "exempt should be stored");
+    expect_allowed("http://localhost:8989/api");
+    expect_blocked("http://localhost:9999/api", "resolve");
+}
+
+int main(void)
+{
+    test_ipv4_private_ranges();
+    test_ipv4_public_and_edges();
+    test_unparseable_is_private();
+    test_ipv6_private();
+    test_ipv6_public();
+    test_ipv6_malformed_is_private();
+    test_url_parser();
+    test_policy_off_allows_everything();
+    test_policy_on_blocks_literals();
+    test_exemptions();
+    test_name_resolution();
+
+    /* Leave the guard off: a test binary is not a cloud-managed frame. */
+    fos_netguard_set_policy(false);
+    fos_netguard_clear_exempt();
+
+    printf("\n%d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/frameos/src/frameos/config.nim
+++ b/frameos/src/frameos/config.nim
@@ -96,6 +96,22 @@ proc loadNetwork*(data: JsonNode): NetworkConfig =
       allowLocalNetworkAccess: data{"allowLocalNetworkAccess"}.getBool(false),
     )
 
+proc loadJsRuntime*(data: JsonNode): JsRuntimeConfig =
+  ## Defaults live in js_runtime/burrito.nim (DefaultJs*); -1 means "keep what
+  ## this build target chose", so an unset frame.json changes nothing.
+  if data == nil or data.kind != JObject:
+    result = JsRuntimeConfig(executionTimeoutMs: -1, memoryLimitMb: -1, maxStackKb: -1,
+                             assetSandbox: "frame")
+  else:
+    result = JsRuntimeConfig(
+      executionTimeoutMs: data{"executionTimeoutMs"}.getInt(-1),
+      memoryLimitMb: data{"memoryLimitMb"}.getInt(-1),
+      maxStackKb: data{"maxStackKb"}.getInt(-1),
+      assetSandbox: data{"assetSandbox"}.getStr("frame"),
+    )
+  if result.assetSandbox notin ["frame", "scene"]:
+    result.assetSandbox = "frame"
+
 proc loadDeviceConfig*(data: JsonNode): DeviceConfig =
   var headers: seq[HttpHeaderPair] = @[]
   if data != nil and data.kind == JObject and data.hasKey("uploadHeaders") and data["uploadHeaders"].kind == JArray:
@@ -288,6 +304,7 @@ proc loadConfig*(configPath = ""): FrameConfig =
     mountpoints: loadMountpoints(data{"mountpoints"}),
     errorBehavior: loadErrorBehavior(data{"errorBehavior"}),
     palette: loadPalette(data{"palette"}),
+    js: loadJsRuntime(data{"js"}),
   )
   if result.assetsPath.endswith("/"):
     result.assetsPath = result.assetsPath.strip(leading = false, trailing = true, chars = {'/'})
@@ -341,4 +358,5 @@ proc updateFrameConfigFrom*(target: FrameConfig, source: FrameConfig) =
   target.mountpoints = source.mountpoints
   target.errorBehavior = source.errorBehavior
   target.palette = source.palette
+  target.js = source.js
   updateSchedule(target.schedule, source.schedule)

--- a/frameos/src/frameos/config.nim
+++ b/frameos/src/frameos/config.nim
@@ -1,6 +1,7 @@
 import json, pixie, os, strutils
 import zippy
 import frameos/hal/files
+import frameos/local_access
 import frameos/types
 import frameos/utils/image
 import lib/tz
@@ -309,6 +310,14 @@ proc loadConfig*(configPath = ""): FrameConfig =
   if result.assetsPath.endswith("/"):
     result.assetsPath = result.assetsPath.strip(leading = false, trailing = true, chars = {'/'})
   setConfigDefaults(result)
+  # The private-network elevation lives in state/, not here — a backend deploy
+  # rewrites frame.json wholesale and would drop it. Fold the stored value in
+  # on every load, including the reload after a deploy, so the in-memory config
+  # every reader consults (the hub's policy refresh, the admin API payload)
+  # agrees with what the frame is actually enforcing.
+  if result.network != nil:
+    result.network.allowLocalNetworkAccess =
+      resolveLocalNetworkAccess(result.network.allowLocalNetworkAccess)
   setRuntimeImageEngine(result.imageEngine)
 
 proc updateSchedule(target: var FrameSchedule, source: FrameSchedule) =

--- a/frameos/src/frameos/js_runtime/app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/app_runtime.nim
@@ -243,19 +243,73 @@ proc jsHttpRequest(ctx: ptr JSContext, url: JSValue, optionsJson: JSValue): JSVa
   return nimStringToJS(ctx, $response)
 
 proc assetsRoot(e: JsAppEvalEnv): string =
-  result = if e.owner.frameConfig.assetsPath == "": "/srv/assets" else: e.owner.frameConfig.assetsPath
+  ## The sandbox root for this app's asset calls.
+  ##
+  ## Default is the frame-wide assets folder: uploaded images are a shared
+  ## resource and scenes are expected to read each other's, so per-scene
+  ## isolation would break the common case. Frames that would rather have the
+  ## stricter model — every scene confined to its own subtree, the posture
+  ## cloud/docs/cloud-frames.md describes for provider-installed scenes — set
+  ## `js.assetSandbox` to "scene" in frame.json.
+  let frameConfig = e.owner.frameConfig
+  result = if frameConfig == nil or frameConfig.assetsPath == "": "/srv/assets"
+           else: frameConfig.assetsPath
   result.removeSuffix('/')
+  if frameConfig != nil and frameConfig.js != nil and frameConfig.js.assetSandbox == "scene":
+    let sceneId = if e.owner.scene == nil: "" else: e.owner.scene.id.string
+    if sceneId.len > 0:
+      # Scene ids come from the diagram and can carry slashes ("tests/js").
+      # Flatten them so one scene cannot address another's subtree.
+      var safeId = ""
+      for ch in sceneId:
+        safeId.add(if ch in {'a'..'z', 'A'..'Z', '0'..'9', '-', '_'}: ch else: '_')
+      result = result / "scenes" / safeId
+
+proc containsPathTraversal(relPath: string): bool =
+  ## True when any path *segment* is "..". A substring test would also reject
+  ## innocent names like "backup..old.json".
+  for segment in relPath.split({'/', '\\'}):
+    if segment == "..":
+      return true
+  return false
 
 proc resolveAssetPath(e: JsAppEvalEnv, relPath: string): string =
   ## Absolute path inside the assets folder, or "" when the path is empty,
   ## absolute, or escapes the folder.
-  if relPath.len == 0 or relPath.startsWith("/") or relPath.contains(".."):
+  ##
+  ## The containment check runs against the *real* path, not the lexical one:
+  ## normalizedPath does not follow symlinks, so a link planted inside the
+  ## assets folder used to be a legal way out of it.
+  if relPath.len == 0 or relPath.startsWith("/") or relPath.isAbsolute() or
+      containsPathTraversal(relPath):
     return ""
   let root = assetsRoot(e)
   let full = normalizedPath(root / relPath)
-  if full == root or full.startsWith(root & "/"):
-    return full
-  return ""
+  if not (full == root or full.startsWith(root & "/")):
+    return ""
+
+  when not defined(frameosEmbedded):
+    # Resolve the deepest ancestor that actually exists: the target itself may
+    # legitimately not exist yet (a write), but everything leading to it must
+    # still be inside the sandbox once symlinks are followed. Nothing exists
+    # to be a symlink until the root does, so an absent root skips the check.
+    if dirExists(root):
+      try:
+        let realRoot = expandFilename(root)
+        var probe = full
+        while not fileExists(probe) and not dirExists(probe):
+          let parent = probe.parentDir()
+          if parent == probe or parent.len < root.len:
+            break
+          probe = parent
+        if fileExists(probe) or dirExists(probe):
+          let realProbe = expandFilename(probe)
+          if not (realProbe == realRoot or realProbe.startsWith(realRoot & "/")):
+            return ""
+      except CatchableError:
+        return ""
+
+  return full
 
 const EmbeddedAssetReadMaxBytes = 2 * 1024 * 1024
 
@@ -910,7 +964,7 @@ proc setDynamicJsAppField*(app: AppRoot, field: string, value: Value) =
     dynamicApp.runtime.releaseReplacedImageRef(dynamicApp.configJson[field], nextValue)
   dynamicApp.configJson[field] = nextValue
 
-proc ensureReady(runtime: JsAppRuntime) =
+proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig) =
   if runtime.ready:
     return
 
@@ -921,7 +975,7 @@ proc ensureReady(runtime: JsAppRuntime) =
       liveJsRuntimes.add(runtime)
 
   when defined(memProbe): memProbe("    newQuickJS BEFORE")
-  runtime.js = newQuickJS()
+  runtime.js = newQuickJS(sceneJsConfig(frameConfig))
   when defined(memProbe): memProbe("    newQuickJS AFTER")
   runtime.js.registerFunction("jsAppLog", jsAppLog)
   runtime.js.registerFunction("jsSetNextSleep", jsSetNextSleep)
@@ -1239,7 +1293,7 @@ proc toValue(runtime: JsAppRuntime, owner: AppRoot, context: ExecutionContext, p
   runtime.toValue(owner, context, jsValueToJson(ctx, payload), expectedType)
 
 proc invoke(runtime: JsAppRuntime, owner: AppRoot, configJson: JsonNode, context: ExecutionContext, fnName: string): JSValue =
-  ensureReady(runtime)
+  ensureReady(runtime, owner.frameConfig)
   let ctx = runtime.js.context
   let fnNameValue = nimStringToJS(ctx, fnName)
   defer: JS_FreeValue(ctx, fnNameValue)

--- a/frameos/src/frameos/js_runtime/burrito.nim
+++ b/frameos/src/frameos/js_runtime/burrito.nim
@@ -80,7 +80,7 @@
 ## ```
 ##
 
-import std/[tables, macros, json, strutils, os]
+import std/[tables, macros, json, strutils, os, monotimes, times]
 
 when defined(frameosEmbedded):
   # The ESP-IDF build compiles QuickJS as the frameos_quickjs component and
@@ -135,6 +135,10 @@ type
       magic: cint): JSValue {.cdecl.}
   JSCFunctionData* = proc(ctx: ptr JSContext, thisVal: JSValueConst, argc: cint, argv: ptr JSValueConst, magic: cint,
       data: ptr JSValue): JSValue {.cdecl.}
+
+  # Called by the interpreter loop every JS_INTERRUPT_COUNTER_INIT bytecode
+  # steps. A non-zero return unwinds the running script with an InternalError.
+  JSInterruptHandler* = proc(rt: ptr JSRuntime, opaque: pointer): cint {.cdecl.}
 
 # Standard library module bindings from quickjs-libc.h (not built on embedded/wasm)
 when not defined(frameosEmbedded) and not defined(frameosWasm):
@@ -260,6 +264,12 @@ proc JS_ExecutePendingJob*(rt: ptr JSRuntime, pctx: ptr ptr JSContext): cint
 # Garbage collection
 proc JS_RunGC*(rt: ptr JSRuntime)
 
+# Resource ceilings. JS_NewRuntime leaves the malloc limit unset (unlimited)
+# and the stack at JS_DEFAULT_STACK_SIZE; newQuickJS sets both explicitly.
+proc JS_SetMemoryLimit*(rt: ptr JSRuntime, limit: csize_t)
+proc JS_SetMaxStackSize*(rt: ptr JSRuntime, stackSize: csize_t)
+proc JS_SetInterruptHandler*(rt: ptr JSRuntime, cb: JSInterruptHandler, opaque: pointer)
+
 # Bytecode serialization
 proc JS_WriteObject*(ctx: ptr JSContext, psize: ptr csize_t, obj: JSValueConst, flags: cint): ptr uint8
 proc JS_ReadObject*(ctx: ptr JSContext, buf: ptr uint8, bufLen: csize_t, flags: cint): JSValue
@@ -358,16 +368,38 @@ type
     of nimFunc3: func3*: NimFunction3
     of nimFuncVar: funcVar*: NimFunctionVariadic
 
+  JsExecutionGuard* = object
+    ## Runtime-level state the QuickJS interrupt handler reads to decide
+    ## whether the running script has outstayed its welcome. One per runtime,
+    ## raw memory (the handler runs on the C stack below Nim), freed in close.
+    ##
+    ## `deadline` bounds *interpreter* time, not wall time: a binding that
+    ## blocks on HTTP is not the scene spinning, so enterNativeCall /
+    ## leaveNativeCall push the deadline out by however long the native call
+    ## took. Without that, a legitimate 60s fetch would look like a runaway
+    ## loop.
+    armed*: bool
+    tripped*: bool
+    deadline*: MonoTime
+    budgetMs*: int
+    defaultBudgetMs*: int
+    nativeDepth*: int
+    nativeEnteredAt*: MonoTime
+
   # Context data to pass to C callbacks
   BurritoContextData* = object
     functions*: Table[cint, NimFunctionEntry]
     context*: ptr JSContext
+    guard*: ptr JsExecutionGuard
 
   QuickJSConfig* = object
     ## Configuration for QuickJS instance creation
     includeStdLib*: bool     ## Include std module (default: false)
     includeOsLib*: bool      ## Include os module (default: false)
     enableStdHandlers*: bool ## Enable std event handlers (default: false)
+    memoryLimitBytes*: int   ## JS heap ceiling; 0 leaves it unlimited
+    maxStackSizeBytes*: int  ## JS stack ceiling; 0 keeps QuickJS's default
+    executionTimeoutMs*: int ## Interpreter-time ceiling per entry; 0 disables
 
   QuickJS* = object
     ## QuickJS wrapper object containing runtime and context
@@ -384,9 +416,155 @@ type
     contextData*: ptr BurritoContextData
     nextFunctionId*: cint
     config*: QuickJSConfig
+    guard*: ptr JsExecutionGuard
 
   JSException* = object of CatchableError
     jsValue*: JSValue
+
+# ---- execution guard ------------------------------------------------------
+# Scene JS is untrusted: on a cloud-managed frame it arrives from the provider,
+# and even locally it is user-authored. `while (true) {}` used to wedge the
+# render thread forever — QuickJS runs to completion and the eval happens under
+# sceneJsLock on the thread that draws the panel. These ceilings turn that into
+# a scene error instead of a dead frame.
+
+const
+  DefaultJsMemoryLimitBytes* = when defined(frameosEmbedded):
+      0            # fos_js_new_runtime sets the PSRAM-sized limit itself
+    else:
+      256 * 1024 * 1024
+  DefaultJsMaxStackBytes* = when defined(frameosEmbedded):
+      0            # ditto: the render task's stack budget lives in the glue
+    else:
+      256 * 1024   # QuickJS's own JS_DEFAULT_STACK_SIZE, made explicit
+  # Deliberately generous. The job is to turn "this frame never renders again"
+  # into "one scene logged an error", not to police slow-but-honest scenes: a
+  # complex render on an ESP32-S3 is seconds of interpreter time, and a false
+  # positive here would be a worse bug than the hang it replaces. Operators who
+  # want a tighter leash set js.executionTimeoutMs in frame.json.
+  DefaultJsExecutionTimeoutMs* = when defined(frameosEmbedded):
+      20_000       # under CONFIG_ESP_TASK_WDT_TIMEOUT_S (30), which reboots
+    else:
+      30_000
+
+proc burritoInterruptHandler(rt: ptr JSRuntime, opaque: pointer): cint {.cdecl.} =
+  ## Runs on the interpreter's own stack every few thousand bytecode steps.
+  ## Must not allocate, raise, or re-enter QuickJS.
+  ##
+  ## Standing down while a native call is in flight looks odd — the handler
+  ## only ever fires from the interpreter loop, so nativeDepth > 0 means a
+  ## binding re-entered *this same context*. The deadline is stale during a
+  ## native call (leaveNativeCall has not credited the time back yet), so
+  ## judging that nested script against it would kill it for its caller's
+  ## fetch. FrameOS never re-enters a context this way — a nested JS app node
+  ## gets its own runtime, and therefore its own guard and its own budget — so
+  ## the case this gives up on does not currently exist.
+  let guard = cast[ptr JsExecutionGuard](opaque)
+  if guard == nil or not guard.armed or guard.nativeDepth > 0:
+    return 0
+  if getMonoTime() < guard.deadline:
+    return 0
+  guard.tripped = true
+  return 1
+
+proc enterNativeCall*(guard: ptr JsExecutionGuard) =
+  ## Stop the interpreter clock while a Nim binding runs.
+  if guard == nil or not guard.armed:
+    return
+  if guard.nativeDepth == 0:
+    guard.nativeEnteredAt = getMonoTime()
+  inc guard.nativeDepth
+
+proc leaveNativeCall*(guard: ptr JsExecutionGuard) =
+  if guard == nil or not guard.armed or guard.nativeDepth == 0:
+    return
+  dec guard.nativeDepth
+  if guard.nativeDepth == 0:
+    guard.deadline = guard.deadline + (getMonoTime() - guard.nativeEnteredAt)
+
+proc armGuard(guard: ptr JsExecutionGuard, timeoutMs: int): bool =
+  ## Start (or leave running) the interpreter-time budget for one entry into
+  ## JS. Returns true when this call is the one that armed it, so the matching
+  ## disarm only fires on the outermost entry — a binding that calls back into
+  ## JS must not reset its caller's budget.
+  if guard == nil:
+    return false
+  let budget = if timeoutMs >= 0: timeoutMs else: guard.defaultBudgetMs
+  if budget <= 0 or guard.armed:
+    return false
+  guard.armed = true
+  guard.tripped = false
+  guard.budgetMs = budget
+  guard.nativeDepth = 0
+  guard.deadline = getMonoTime() + initDuration(milliseconds = budget)
+  return true
+
+proc disarmGuard(guard: ptr JsExecutionGuard) =
+  if guard != nil:
+    guard.armed = false
+    guard.nativeDepth = 0
+
+proc guardForContext*(ctx: ptr JSContext): ptr JsExecutionGuard =
+  ## The guard is runtime-level state, but the only handle most call sites have
+  ## is the context, so it is mirrored into the context's opaque data.
+  if ctx == nil:
+    return nil
+  let contextData = cast[ptr BurritoContextData](JS_GetContextOpaque(ctx))
+  if contextData == nil: nil else: contextData.guard
+
+proc armDeadline*(js: QuickJS, timeoutMs: int = -1): bool {.discardable.} =
+  armGuard(js.guard, timeoutMs)
+
+proc disarmDeadline*(js: QuickJS) =
+  disarmGuard(js.guard)
+
+proc deadlineTripped*(js: QuickJS): bool =
+  js.guard != nil and js.guard.tripped
+
+proc deadlineBudgetMs*(js: QuickJS): int =
+  if js.guard == nil: 0 else: js.guard.budgetMs
+
+proc contextDeadlineTripped*(ctx: ptr JSContext): bool =
+  let guard = guardForContext(ctx)
+  guard != nil and guard.tripped
+
+proc clearContextDeadlineTrip*(ctx: ptr JSContext): int {.discardable.} =
+  ## Consume the tripped flag and report the budget that was blown, so the
+  ## caller can raise a message that names the real cause.
+  let guard = guardForContext(ctx)
+  if guard == nil or not guard.tripped:
+    return 0
+  guard.tripped = false
+  return guard.budgetMs
+
+template withContextDeadline*(ctx: ptr JSContext, body: untyped): untyped =
+  ## Bound one entry into the interpreter from a call site that only holds a
+  ## context. Re-entrant: nested uses are no-ops.
+  let ctxGuard = guardForContext(ctx)
+  let armedHere = armGuard(ctxGuard, -1)
+  try:
+    body
+  finally:
+    if armedHere:
+      disarmGuard(ctxGuard)
+
+proc raiseIfDeadlineTripped(js: QuickJS) =
+  ## QuickJS reports an interrupt as a bare InternalError; say what really
+  ## happened so the scene log names the runaway script instead of "interrupted".
+  if js.deadlineTripped():
+    let budget = js.deadlineBudgetMs()
+    js.guard.tripped = false
+    raise newException(JSException,
+      "JavaScript execution exceeded its " & $budget & "ms time budget and was interrupted")
+
+template withDeadline*(js: QuickJS, body: untyped): untyped =
+  ## Bound one entry into the interpreter. Re-entrant: nested uses are no-ops.
+  let armedHere = js.armDeadline()
+  try:
+    body
+  finally:
+    if armedHere:
+      js.disarmDeadline()
 
 # Value conversion helpers
 proc toNimString*(ctx: ptr JSContext, val: JSValueConst): string =
@@ -898,6 +1076,12 @@ proc nimFunctionTrampoline(ctx: ptr JSContext, thisVal: JSValueConst, argc: cint
     if magic notin contextData.functions:
       return jsUndefined(ctx)
 
+    # Time spent in a binding (an HTTP fetch, an asset read) is not the script
+    # spinning, so it must not eat the interpreter-time budget.
+    let guard = contextData.guard
+    enterNativeCall(guard)
+    defer: leaveNativeCall(guard)
+
     let funcEntry = contextData.functions[magic]
 
     case funcEntry.kind
@@ -957,19 +1141,29 @@ proc nimFunctionTrampoline(ctx: ptr JSContext, thisVal: JSValueConst, argc: cint
 # Configuration helpers
 proc defaultConfig*(): QuickJSConfig =
   ## Create default configuration (no std/os modules)
-  QuickJSConfig(includeStdLib: false, includeOsLib: false, enableStdHandlers: false)
+  QuickJSConfig(includeStdLib: false, includeOsLib: false, enableStdHandlers: false,
+                memoryLimitBytes: DefaultJsMemoryLimitBytes,
+                maxStackSizeBytes: DefaultJsMaxStackBytes,
+                executionTimeoutMs: DefaultJsExecutionTimeoutMs)
 
 proc configWithStdLib*(): QuickJSConfig =
   ## Create configuration with std module enabled
-  QuickJSConfig(includeStdLib: true, includeOsLib: false, enableStdHandlers: true)
+  result = defaultConfig()
+  result.includeStdLib = true
+  result.enableStdHandlers = true
 
 proc configWithOsLib*(): QuickJSConfig =
   ## Create configuration with os module enabled
-  QuickJSConfig(includeStdLib: false, includeOsLib: true, enableStdHandlers: true)
+  result = defaultConfig()
+  result.includeOsLib = true
+  result.enableStdHandlers = true
 
 proc configWithBothLibs*(): QuickJSConfig =
   ## Create configuration with both std and os modules enabled
-  QuickJSConfig(includeStdLib: true, includeOsLib: true, enableStdHandlers: true)
+  result = defaultConfig()
+  result.includeStdLib = true
+  result.includeOsLib = true
+  result.enableStdHandlers = true
 
 # Core QuickJS wrapper
 proc newQuickJS*(config: QuickJSConfig = defaultConfig()): QuickJS =
@@ -991,10 +1185,21 @@ proc newQuickJS*(config: QuickJSConfig = defaultConfig()): QuickJS =
   if rt == nil:
     raise newException(JSException, "Failed to create QuickJS runtime")
 
+  # Embedded sets both in fos_js_new_runtime, sized against PSRAM and the
+  # render task's stack; the config defaults are 0 there so we don't undo it.
+  if config.memoryLimitBytes > 0:
+    JS_SetMemoryLimit(rt, config.memoryLimitBytes.csize_t)
+  if config.maxStackSizeBytes > 0:
+    JS_SetMaxStackSize(rt, config.maxStackSizeBytes.csize_t)
+
   let ctx = JS_NewContext(rt)
   if ctx == nil:
     JS_FreeRuntime(rt)
     raise newException(JSException, "Failed to create QuickJS context")
+
+  let guard = cast[ptr JsExecutionGuard](alloc0(sizeof(JsExecutionGuard)))
+  guard.defaultBudgetMs = config.executionTimeoutMs
+  JS_SetInterruptHandler(rt, burritoInterruptHandler, guard)
 
   when not defined(frameosEmbedded) and not defined(frameosWasm):
     # Initialize standard handlers if requested
@@ -1023,17 +1228,23 @@ proc newQuickJS*(config: QuickJSConfig = defaultConfig()): QuickJS =
   let contextData = cast[ptr BurritoContextData](alloc0(sizeof(BurritoContextData)))
   contextData.functions = initTable[int32, NimFunctionEntry]()
   contextData.context = ctx
+  contextData.guard = guard
 
   # Set context opaque data
   JS_SetContextOpaque(ctx, contextData)
 
-  result = QuickJS(runtime: rt, context: ctx, contextData: contextData, nextFunctionId: 1, config: config)
+  result = QuickJS(runtime: rt, context: ctx, contextData: contextData, nextFunctionId: 1, config: config,
+                   guard: guard)
 
 proc close*(js: var QuickJS) =
   ## Clean up QuickJS instance with proper sequence to avoid memory issues
   if js.context != nil and js.runtime != nil:
     # Clear context opaque data first to avoid circular references
     JS_SetContextOpaque(js.context, nil)
+
+    # Drop the interrupt handler before the guard it points at goes away:
+    # JS_FreeRuntime below still runs finalizers and pending jobs.
+    JS_SetInterruptHandler(js.runtime, nil, nil)
 
     when not defined(frameosEmbedded) and not defined(frameosWasm):
       # Process the std event loop to complete any pending operations
@@ -1062,18 +1273,24 @@ proc close*(js: var QuickJS) =
     dealloc(js.contextData)
     js.contextData = nil
 
+  if js.guard != nil:
+    dealloc(js.guard)
+    js.guard = nil
+
 proc eval*(js: QuickJS, code: string, filename: string = "<eval>"): string =
   ## Evaluate JavaScript code and return result as string
-  let val = JS_Eval(js.context, code.cstring, code.len.csize_t, filename.cstring, JS_EVAL_TYPE_GLOBAL)
-  defer: JS_FreeValue(js.context, val)
+  withDeadline(js):
+    let val = JS_Eval(js.context, code.cstring, code.len.csize_t, filename.cstring, JS_EVAL_TYPE_GLOBAL)
+    defer: JS_FreeValue(js.context, val)
 
-  if JS_IsException(val) != 0:
-    let exception = JS_GetException(js.context)
-    defer: JS_FreeValue(js.context, exception)
-    let errorMsg = toNimString(js.context, exception)
-    raise newException(JSException, "Evaluation failed: " & errorMsg)
+    if JS_IsException(val) != 0:
+      let exception = JS_GetException(js.context)
+      defer: JS_FreeValue(js.context, exception)
+      let errorMsg = toNimString(js.context, exception)
+      js.raiseIfDeadlineTripped()
+      raise newException(JSException, "Evaluation failed: " & errorMsg)
 
-  result = toNimString(js.context, val)
+    result = toNimString(js.context, val)
 
 proc evalWithGlobals*(js: QuickJS, code: string, globals: Table[string, string] = initTable[string, string]()): string =
   ## Evaluate JavaScript code with some global variables set as strings
@@ -1101,20 +1318,22 @@ proc evalModule*(js: QuickJS, code: string, filename: string = "<module>"): stri
   ## IMPORTANT: Due to QuickJS internals, using modules with std library
   ## imports may cause issues during cleanup. Consider using regular eval()
   ## for simple scripts.
-  var val = JS_Eval(js.context, code.cstring, code.len.csize_t, filename.cstring, JS_EVAL_TYPE_MODULE)
+  withDeadline(js):
+    var val = JS_Eval(js.context, code.cstring, code.len.csize_t, filename.cstring, JS_EVAL_TYPE_MODULE)
 
-  # Check if evaluation failed
-  if JS_IsException(val) != 0:
-    let exception = JS_GetException(js.context)
-    defer: JS_FreeValue(js.context, exception)
-    let errorMsg = toNimString(js.context, exception)
+    # Check if evaluation failed
+    if JS_IsException(val) != 0:
+      let exception = JS_GetException(js.context)
+      defer: JS_FreeValue(js.context, exception)
+      let errorMsg = toNimString(js.context, exception)
+      JS_FreeValue(js.context, val)
+      js.raiseIfDeadlineTripped()
+      raise newException(JSException, "Module evaluation failed: " & errorMsg)
+
+    # Modules return promises, but we just return a string representation
+    # Using js_std_await here causes reference counting issues on cleanup
+    result = toNimString(js.context, val)
     JS_FreeValue(js.context, val)
-    raise newException(JSException, "Module evaluation failed: " & errorMsg)
-
-  # Modules return promises, but we just return a string representation
-  # Using js_std_await here causes reference counting issues on cleanup
-  result = toNimString(js.context, val)
-  JS_FreeValue(js.context, val)
 
   # Run the event loop to execute the module
   when not defined(frameosEmbedded) and not defined(frameosWasm):
@@ -1157,15 +1376,19 @@ proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module
     raise newException(JSException, "Compiled source is not a module: " & filename)
 
   # JS_EvalFunction consumes `compiled`, so the module def pointer taken above
-  # is what keeps the module reachable afterwards.
-  let evaluated = JS_EvalFunction(ctx, compiled)
-  if JS_IsException(evaluated) != 0:
-    let exception = JS_GetException(ctx)
-    defer: JS_FreeValue(ctx, exception)
-    let errorMsg = toNimString(ctx, exception)
+  # is what keeps the module reachable afterwards. Module top level is real
+  # execution — an app that loops there hangs the render thread just as surely
+  # as one that loops inside render().
+  withDeadline(js):
+    let evaluated = JS_EvalFunction(ctx, compiled)
+    if JS_IsException(evaluated) != 0:
+      let exception = JS_GetException(ctx)
+      defer: JS_FreeValue(ctx, exception)
+      let errorMsg = toNimString(ctx, exception)
+      JS_FreeValue(ctx, evaluated)
+      js.raiseIfDeadlineTripped()
+      raise newException(JSException, errorMsg)
     JS_FreeValue(ctx, evaluated)
-    raise newException(JSException, errorMsg)
-  JS_FreeValue(ctx, evaluated)
 
   result = JS_GetModuleNamespace(ctx, moduleDef)
   if JS_IsException(result) != 0:
@@ -1413,9 +1636,13 @@ proc registerFunction*(js: var QuickJS, name: string, nimFunc: NimFunctionVariad
 proc runPendingJobs*(js: QuickJS) =
   ## Execute all pending JavaScript jobs (promises, async operations)
   ## This is needed after loading modules or running async code
-  var pctx: ptr JSContext = nil
-  while JS_ExecutePendingJob(js.runtime, addr pctx) > 0:
-    discard
+  ## Promise callbacks are ordinary script, and one that never settles would
+  ## spin here forever, so the same budget applies.
+  withDeadline(js):
+    var pctx: ptr JSContext = nil
+    while JS_ExecutePendingJob(js.runtime, addr pctx) > 0:
+      if js.deadlineTripped():
+        break
 
 proc processStdLoop*(js: QuickJS) =
   ## Process the QuickJS standard event loop once

--- a/frameos/src/frameos/js_runtime/runtime.nim
+++ b/frameos/src/frameos/js_runtime/runtime.nim
@@ -657,6 +657,12 @@ proc jsExceptionDetails*(ctx: ptr JSContext): tuple[message: string, stack: stri
     result.stack = result.message
   if result.message.len == 0:
     result.message = "JavaScript error"
+  # An interrupted script reports a bare "InternalError: interrupted", which
+  # tells nobody why the scene died. Name the real cause.
+  let blownBudgetMs = clearContextDeadlineTrip(ctx)
+  if blownBudgetMs > 0:
+    result.message = "execution exceeded its " & $blownBudgetMs & "ms time budget"
+    result.stack = result.message
 
 proc mappedJsExceptionDetails*(ctx: ptr JSContext): tuple[message: string, stack: string] =
   result = jsExceptionDetails(ctx)
@@ -664,16 +670,35 @@ proc mappedJsExceptionDetails*(ctx: ptr JSContext): tuple[message: string, stack
   result.stack = mapJsErrorText(ctx, result.stack)
 
 proc callGlobalFunction*(ctx: ptr JSContext, fnName: string, args: openArray[JSValueConst] = []): JSValue =
-  let globalObj = JS_GetGlobalObject(ctx)
-  defer: JS_FreeValue(ctx, globalObj)
-  let fn = JS_GetPropertyStr(ctx, globalObj, fnName.cstring)
-  defer: JS_FreeValue(ctx, fn)
-  if args.len == 0:
-    return JS_Call(ctx, fn, globalObj, 0.cint, nil)
-  var argv = newSeq[JSValueConst](args.len)
-  for i, arg in args:
-    argv[i] = arg
-  return JS_Call(ctx, fn, globalObj, args.len.cint, addr argv[0])
+  ## Every scene-authored function — code nodes, inline expressions and JS app
+  ## init/get/run — enters the interpreter here, so this is where the
+  ## execution-time budget gets armed. Callers read the exception normally; a
+  ## budget overrun surfaces through jsExceptionDetails below.
+  withContextDeadline(ctx):
+    let globalObj = JS_GetGlobalObject(ctx)
+    defer: JS_FreeValue(ctx, globalObj)
+    let fn = JS_GetPropertyStr(ctx, globalObj, fnName.cstring)
+    defer: JS_FreeValue(ctx, fn)
+    if args.len == 0:
+      result = JS_Call(ctx, fn, globalObj, 0.cint, nil)
+    else:
+      var argv = newSeq[JSValueConst](args.len)
+      for i, arg in args:
+        argv[i] = arg
+      result = JS_Call(ctx, fn, globalObj, args.len.cint, addr argv[0])
+
+proc sceneJsConfig*(frameConfig: FrameConfig): QuickJSConfig =
+  ## Per-frame overrides for the interpreter ceilings. Anything left at -1 (or
+  ## absent from frame.json) keeps the build target's default.
+  result = defaultConfig()
+  if frameConfig == nil or frameConfig.js == nil:
+    return
+  if frameConfig.js.executionTimeoutMs >= 0:
+    result.executionTimeoutMs = frameConfig.js.executionTimeoutMs
+  if frameConfig.js.memoryLimitMb >= 0:
+    result.memoryLimitBytes = frameConfig.js.memoryLimitMb * 1024 * 1024
+  if frameConfig.js.maxStackKb >= 0:
+    result.maxStackSizeBytes = frameConfig.js.maxStackKb * 1024
 
 # -------------------------
 # Scene JS context
@@ -725,7 +750,7 @@ proc ensureSceneJs*(scene: InterpretedFrameScene) =
       evictIdleSceneJs(scene)
       if not liveSceneJsScenes.contains(scene):
         liveSceneJsScenes.add(scene)
-    scene.js = newQuickJS()
+    scene.js = newQuickJS(sceneJsConfig(scene.frameConfig))
     # Register bridge functions ONCE per scene/context
     scene.js.registerFunction("getState", jsGetState)
     scene.js.registerFunction("getArg", jsGetArg)
@@ -889,6 +914,14 @@ proc callCompiledFn*(scene: InterpretedFrameScene,
     when defined(frameosEmbedded): sceneJsStack.add(scene)
     try:
       envelopeJson = scene.js.eval(fnName & "()")
+    except JSException as err:
+      # Normally the envelope catches the node's own throws and hands back an
+      # error envelope. A blown time budget cannot go that way: QuickJS marks
+      # the interrupt uncatchable, so no JS try/catch — including the
+      # envelope's — ever sees it. Rebuild the envelope here so a runaway node
+      # is logged and defaulted like any other failing node instead of taking
+      # the render down.
+      envelopeJson = $(%*{"k": "error", "v": {"message": err.msg, "stack": err.msg}})
     finally:
       when defined(frameosEmbedded):
         if sceneJsStack.len > 0 and sceneJsStack[^1] == scene:

--- a/frameos/src/frameos/js_runtime/tests/test_js_app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_app_runtime.nim
@@ -421,6 +421,91 @@ suite "js app runtime":
     check not payload["existsAfter"].getBool()
     check not fileExists(assetsDir.parentDir() / "evil.txt")
 
+  test "a symlink out of the assets folder is not a way out of the sandbox":
+    let assetsDir = getTempDir() / "frameos-js-symlink-test"
+    let outsideDir = getTempDir() / "frameos-js-symlink-outside"
+    removeDir(assetsDir)
+    removeDir(outsideDir)
+    createDir(assetsDir)
+    createDir(outsideDir)
+    defer:
+      removeDir(assetsDir)
+      removeDir(outsideDir)
+
+    writeFile(outsideDir / "secret.txt", "top secret")
+    # The kind of link an operator might leave behind (a big media folder
+    # mounted into assets); scene JS must not be able to ride it outwards.
+    createSymlink(outsideDir, assetsDir / "escape")
+
+    let config = testConfig()
+    config.assetsPath = assetsDir
+    let logger = testLogger(config)
+    let scene = FrameScene(id: "tests/js-symlink".SceneId, frameConfig: config, state: %*{}, logger: logger)
+    let owner = AppRoot(nodeId: 25.NodeId, nodeName: "jsSymlink", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{}, hasImage: false,
+                                   loopIndex: 0, loopKey: ".", nextSleep: -1)
+
+    let runtime = newJsAppRuntime(
+      category = "data",
+      outputType = "json",
+      source = """export function get(app, context) {
+          return {
+            readThroughLink: frameos.readAsset("escape/secret.txt"),
+            writeThroughLink: frameos.writeAsset("escape/planted.txt", "aGVsbG8="),
+            dottedName: frameos.writeAsset("backup..old.txt", "aGVsbG8="),
+          }
+        }"""
+    )
+
+    let payload = runtime.get(owner, %*{}, context).asJson()
+    check payload["readThroughLink"].kind == JNull
+    check not payload["writeThroughLink"].getBool()
+    check not fileExists(outsideDir / "planted.txt")
+    # ".." only escapes as a whole path segment; a file that merely contains
+    # two dots is an ordinary name and must still be writable.
+    check payload["dottedName"].getBool()
+    check fileExists(assetsDir / "backup..old.txt")
+
+  test "assetSandbox=scene confines a scene to its own subtree":
+    let assetsDir = getTempDir() / "frameos-js-scene-sandbox-test"
+    removeDir(assetsDir)
+    createDir(assetsDir)
+    defer: removeDir(assetsDir)
+
+    writeFile(assetsDir / "shared.txt", "frame wide")
+
+    let config = testConfig()
+    config.assetsPath = assetsDir
+    config.js = JsRuntimeConfig(executionTimeoutMs: -1, memoryLimitMb: -1, maxStackKb: -1,
+                                assetSandbox: "scene")
+    let logger = testLogger(config)
+    let scene = FrameScene(id: "tests/scoped".SceneId, frameConfig: config, state: %*{}, logger: logger)
+    let owner = AppRoot(nodeId: 26.NodeId, nodeName: "jsScoped", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{}, hasImage: false,
+                                   loopIndex: 0, loopKey: ".", nextSleep: -1)
+
+    let runtime = newJsAppRuntime(
+      category = "data",
+      outputType = "json",
+      source = """export function get(app, context) {
+          return {
+            wrote: frameos.writeAsset("cache.txt", "aGVsbG8="),
+            readBack: frameos.readAsset("cache.txt"),
+            sharedVisible: frameos.assetExists("shared.txt"),
+          }
+        }"""
+    )
+
+    let payload = runtime.get(owner, %*{}, context).asJson()
+    check payload["wrote"].getBool()
+    check decode(payload["readBack"].getStr()) == "hello"
+    # Scene ids carry slashes; they are flattened so one scene cannot address
+    # another's subtree by naming it.
+    check fileExists(assetsDir / "scenes" / "tests_scoped" / "cache.txt")
+    # The frame-wide folder is outside this scene's root, so its files are not
+    # reachable by name any more.
+    check not payload["sharedVisible"].getBool()
+
   test "loads asset images within display bounds":
     let assetsDir = getTempDir() / "frameos-js-asset-image-test"
     removeDir(assetsDir)

--- a/frameos/src/frameos/js_runtime/tests/test_js_resource_limits.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_resource_limits.nim
@@ -1,0 +1,133 @@
+## Ceilings on untrusted scene JS: execution time, heap, and the rule that
+## time spent inside a native binding is not the script spinning.
+
+import std/[json, monotimes, os, sequtils, strutils, times, unittest]
+
+import frameos/js_runtime/burrito
+import frameos/js_runtime/runtime
+import frameos/types
+import frameos/values
+
+proc testScene(): InterpretedFrameScene =
+  InterpretedFrameScene(
+    id: "tests/js-limits".SceneId,
+    frameConfig: FrameConfig(
+      js: JsRuntimeConfig(executionTimeoutMs: 300, memoryLimitMb: -1, maxStackKb: -1,
+                          assetSandbox: "frame")
+    ),
+    logger: Logger(
+      enabled: true,
+      log: proc(payload: JsonNode) = discard payload,
+      enable: proc() = discard,
+      disable: proc() = discard
+    )
+  )
+
+proc testContext(scene: FrameScene): ExecutionContext =
+  ExecutionContext(
+    scene: scene,
+    event: "render",
+    payload: %*{},
+    hasImage: false,
+    loopIndex: 0,
+    loopKey: "."
+  )
+
+proc sleepingBinding(ctx: ptr JSContext): JSValue {.nimcall.} =
+  ## Stands in for fetchText/readAsset: slow, but slow in Nim, not in JS.
+  sleep(300)
+  return nimIntToJS(ctx, 1'i32)
+
+suite "js execution deadline":
+  test "an infinite loop is interrupted instead of hanging the thread":
+    var config = defaultConfig()
+    config.executionTimeoutMs = 250
+    var js = newQuickJS(config)
+    defer: js.close()
+
+    let started = getMonoTime()
+    expect JSException:
+      discard js.eval("while (true) {}")
+    let elapsedMs = (getMonoTime() - started).inMilliseconds
+
+    # Generous upper bound: the handler only runs between bytecode batches.
+    check elapsedMs >= 200
+    check elapsedMs < 5_000
+
+  test "the raised error names the budget rather than 'interrupted'":
+    var config = defaultConfig()
+    config.executionTimeoutMs = 150
+    var js = newQuickJS(config)
+    defer: js.close()
+
+    var message = ""
+    try:
+      discard js.eval("for (;;) {}")
+    except JSException as err:
+      message = err.msg
+    check message.contains("150ms time budget")
+
+  test "a script that finishes inside its budget is untouched":
+    var config = defaultConfig()
+    config.executionTimeoutMs = 5_000
+    var js = newQuickJS(config)
+    defer: js.close()
+
+    check js.eval("let total = 0; for (let i = 0; i < 100000; i++) total += i; total") ==
+      "4999950000"
+    check not js.deadlineTripped()
+
+  test "time inside a native binding does not spend the budget":
+    var config = defaultConfig()
+    config.executionTimeoutMs = 500
+    var js = newQuickJS(config)
+    defer: js.close()
+
+    js.registerFunction("slowNativeCall", sleepingBinding)
+    # Three 300ms native calls = 900ms wall clock, well past the 500ms budget,
+    # but almost no interpreter time. This must not be read as a runaway loop.
+    check js.eval("slowNativeCall() + slowNativeCall() + slowNativeCall()") == "3"
+    check not js.deadlineTripped()
+
+  test "a zero timeout disables the ceiling":
+    var config = defaultConfig()
+    config.executionTimeoutMs = 0
+    var js = newQuickJS(config)
+    defer: js.close()
+
+    check js.armDeadline() == false
+    check js.eval("1 + 1") == "2"
+
+  test "scene code nodes inherit the deadline":
+    var logs: seq[JsonNode] = @[]
+    var scene = testScene()
+    scene.logger.log = proc(payload: JsonNode) =
+      logs.add(payload)
+
+    let value = evalSnippet(
+      scene,
+      testContext(scene),
+      1.NodeId,
+      "(() => { while (true) {} })()"
+    )
+
+    check value.kind == fkNone
+    let logged = logs.mapIt($it).join(" ")
+    check logged.contains("time budget")
+    cleanupSceneJs(scene)
+    cleanupCompilerJs()
+
+suite "js memory ceiling":
+  test "an oversized allocation fails the script, not the process":
+    var config = defaultConfig()
+    config.memoryLimitBytes = 4 * 1024 * 1024
+    var js = newQuickJS(config)
+    defer: js.close()
+
+    expect JSException:
+      discard js.eval("const hog = []; while (true) { hog.push(new Array(100000).fill(7)) }")
+
+  test "ordinary allocations still work under the ceiling":
+    var js = newQuickJS()
+    defer: js.close()
+    check js.eval("new Array(1000).fill(1).length") == "1000"

--- a/frameos/src/frameos/local_access.nim
+++ b/frameos/src/frameos/local_access.nim
@@ -1,0 +1,117 @@
+## Local-presence ceremony for the private-network elevation.
+##
+## `network.allowLocalNetworkAccess` is the one switch that undoes the
+## default-deny protecting a cloud-managed frame's LAN
+## (cloud/docs/cloud-frames.md, "sandbox posture"). Keeping it out of the cloud
+## settings allowlist stops the *provider* from flipping it, but that alone
+## does not prove whoever flipped it is standing in front of the frame — an
+## admin session is a password on a LAN-reachable page, not presence.
+##
+## So the switch moved out of the bulk config save and behind a two-step
+## ceremony: ask for a challenge, read the code off the panel, send it back.
+## Someone who cannot see the screen cannot complete it.
+##
+## The state is process-local and deliberately not persisted: a pending
+## challenge should not survive a reboot.
+
+import std/[locks, os, strutils, times]
+
+const
+  LocalAccessCodeLength* = 6
+  LocalAccessChallengeTtlSeconds* = 180.0
+  LocalAccessMaxAttempts* = 5
+
+type
+  LocalAccessChallenge* = object
+    code*: string       ## empty when no challenge is pending
+    expiresAt*: float
+    attemptsLeft*: int
+
+var
+  localAccessLock: Lock
+  localAccessChallenge: LocalAccessChallenge
+
+initLock(localAccessLock)
+
+proc randomDigits(count: int): string =
+  ## Rejection-sampled so every digit is uniform; a plain `byte mod 10` would
+  ## make 0-5 slightly likelier, and this code is an authentication factor.
+  result = newStringOfCap(count)
+  var source: File
+  let opened = open(source, "/dev/urandom", fmRead)
+  defer:
+    if opened: close(source)
+  var buffer: array[64, uint8]
+  var available = 0
+  var offset = 0
+  while result.len < count:
+    if offset >= available:
+      if opened:
+        available = source.readBuffer(addr buffer[0], buffer.len)
+        offset = 0
+      if not opened or available <= 0:
+        # No entropy source: refuse rather than mint a guessable code.
+        raise newException(IOError, "Cannot read entropy for the local access code")
+    let value = buffer[offset]
+    inc offset
+    if value >= 250'u8: # 250 = 25 * 10; the tail would bias the digit
+      continue
+    result.add(chr(ord('0') + (value.int mod 10)))
+
+proc constantTimeEquals(first, second: string): bool =
+  if first.len != second.len:
+    return false
+  var diff = 0
+  for i in 0 ..< first.len:
+    diff = diff or (ord(first[i]) xor ord(second[i]))
+  diff == 0
+
+proc startLocalAccessChallenge*(): LocalAccessChallenge =
+  ## Mint a code and show it on the panel. Replaces any pending challenge, so
+  ## an admin who missed the last one can simply ask again.
+  let code = randomDigits(LocalAccessCodeLength)
+  withLock localAccessLock:
+    localAccessChallenge = LocalAccessChallenge(
+      code: code,
+      expiresAt: epochTime() + LocalAccessChallengeTtlSeconds,
+      attemptsLeft: LocalAccessMaxAttempts
+    )
+    result = localAccessChallenge
+
+proc clearLocalAccessChallenge*() =
+  withLock localAccessLock:
+    localAccessChallenge = LocalAccessChallenge()
+
+proc activeLocalAccessCode*(): string =
+  ## What the renderer should be drawing right now, or "" for nothing.
+  withLock localAccessLock:
+    if localAccessChallenge.code.len > 0 and localAccessChallenge.expiresAt > epochTime():
+      result = localAccessChallenge.code
+    else:
+      result = ""
+
+proc localAccessChallengeSecondsLeft*(): float =
+  withLock localAccessLock:
+    if localAccessChallenge.code.len == 0:
+      return 0.0
+    result = max(0.0, localAccessChallenge.expiresAt - epochTime())
+
+proc consumeLocalAccessCode*(candidate: string): tuple[ok: bool, detail: string] =
+  ## Single use: right or wrong, a completed attempt burns the challenge (on
+  ## success) or a life (on failure), so the code cannot be brute-forced in the
+  ## three minutes it lives for.
+  let trimmed = candidate.strip()
+  withLock localAccessLock:
+    if localAccessChallenge.code.len == 0:
+      return (false, "No local access challenge is pending")
+    if localAccessChallenge.expiresAt <= epochTime():
+      localAccessChallenge = LocalAccessChallenge()
+      return (false, "The code shown on the panel has expired")
+    if not constantTimeEquals(trimmed, localAccessChallenge.code):
+      dec localAccessChallenge.attemptsLeft
+      if localAccessChallenge.attemptsLeft <= 0:
+        localAccessChallenge = LocalAccessChallenge()
+        return (false, "Too many wrong codes; request a new one")
+      return (false, "That code does not match the one on the panel")
+    localAccessChallenge = LocalAccessChallenge()
+    return (true, "")

--- a/frameos/src/frameos/local_access.nim
+++ b/frameos/src/frameos/local_access.nim
@@ -14,12 +14,27 @@
 ## The state is process-local and deliberately not persisted: a pending
 ## challenge should not survive a reboot.
 
-import std/[locks, os, strutils, times]
+import std/[json, locks, options, os, strutils, times]
+
+import frameos/hal/files
 
 const
   LocalAccessCodeLength* = 6
   LocalAccessChallengeTtlSeconds* = 180.0
   LocalAccessMaxAttempts* = 5
+
+  LocalAccessStatePath* = "./state/local_access.json"
+    ## Deliberately NOT frame.json. A backend deploy uploads a freshly
+    ## generated frame.json over SSH — it never round-trips the device's copy,
+    ## and `get_frame_json` in the backend does not emit this field — so a
+    ## setting stored there is silently reset by the next unrelated deploy.
+    ## Fail-safe, but baffling: the ceremony is completed, and a week later
+    ## the Home Assistant scene stops working for no visible reason.
+    ##
+    ## Putting it under state/ also says the right thing about what it is.
+    ## This is a device-local fact established by someone physically present.
+    ## It is not fleet configuration, and the backend has no business
+    ## expressing an opinion about it.
 
 type
   LocalAccessChallenge* = object
@@ -30,8 +45,57 @@ type
 var
   localAccessLock: Lock
   localAccessChallenge: LocalAccessChallenge
+  # The hub thread re-reads the elevation every couple of seconds; boot_guard
+  # learned the same lesson, so this is cached rather than parsed each time.
+  # A hand-edited state file is picked up on restart, not live.
+  persistedAccessCache: Option[bool]
+  persistedAccessCacheLoaded = false
 
 initLock(localAccessLock)
+
+proc storedLocalNetworkAccess*(): Option[bool] =
+  ## What the state file says, or none() when the ceremony has never been run
+  ## on this device.
+  withLock localAccessLock:
+    if persistedAccessCacheLoaded:
+      return persistedAccessCache
+    persistedAccessCache = none(bool)
+    persistedAccessCacheLoaded = true
+    try:
+      if storedFileExists(LocalAccessStatePath):
+        let data = parseJson(readTextFile(LocalAccessStatePath))
+        if data.kind == JObject and data.hasKey("allowLocalNetworkAccess"):
+          persistedAccessCache = some(data{"allowLocalNetworkAccess"}.getBool(false))
+    except CatchableError:
+      # An unreadable or corrupt state file must not be read as "elevated".
+      persistedAccessCache = none(bool)
+    result = persistedAccessCache
+
+proc persistLocalNetworkAccess*(enabled: bool) =
+  ## Raises on write failure: the caller is an admin request that must not
+  ## report success for a change the next reboot would forget.
+  ensureParentDir(LocalAccessStatePath)
+  writeTextFile(LocalAccessStatePath, $(%*{
+    "allowLocalNetworkAccess": enabled,
+    "updatedAt": now().format("yyyy-MM-dd'T'HH:mm:sszzz"),
+  }) & "\n")
+  withLock localAccessLock:
+    persistedAccessCache = some(enabled)
+    persistedAccessCacheLoaded = true
+
+proc forgetStoredLocalNetworkAccess*() =
+  ## Test seam; also the right call if the state file is ever edited in place.
+  withLock localAccessLock:
+    persistedAccessCache = none(bool)
+    persistedAccessCacheLoaded = false
+
+proc resolveLocalNetworkAccess*(frameJsonValue: bool): bool =
+  ## The state file wins. `frameJsonValue` is the legacy fallback: frames
+  ## elevated before the setting moved carry it in frame.json, and revoking
+  ## that silently on upgrade would be its own outage. Migration happens on
+  ## the next completed ceremony, or leave it — the fallback is permanent.
+  let stored = storedLocalNetworkAccess()
+  if stored.isSome: stored.get() else: frameJsonValue
 
 proc randomDigits(count: int): string =
   ## Rejection-sampled so every digit is uniform; a plain `byte mod 10` would

--- a/frameos/src/frameos/runner.nim
+++ b/frameos/src/frameos/runner.nim
@@ -2,12 +2,14 @@ import json, pixie, times, options, asyncdispatch, strformat, strutils, tables
 import std/monotimes
 import std/atomics
 import apps/render/image/app as render_imageApp
+import apps/render/text/app as render_textApp
 import apps/data/qr/app as data_qrApp
 
 import frameos/apps
 import frameos/channels
 import frameos/config
 import frameos/driver_render_hint
+import frameos/local_access
 import frameos/logger
 import frameos/metrics
 import frameos/types
@@ -69,6 +71,26 @@ proc sceneInitErrorExport(): ExportedScene =
       initSceneInitErrorScene(sceneId, frameConfig, logger, "Scene failed to start.")
   )
 
+proc configureLocalAccessOverlay(self: RunnerThread) =
+  ## Always built, unlike the control code: a presence challenge can be raised
+  ## at any moment and the code has to be on screen for the ceremony to work.
+  self.localAccessRender = render_textApp.App(nodeName: "render/text", nodeId: -2.NodeId,
+    frameConfig: self.frameConfig, appConfig: render_textApp.AppConfig(
+    text: "",
+    richText: "disabled",
+    inputImage: none(Image),
+    position: "center",
+    vAlign: "middle",
+    offsetX: 0.0,
+    offsetY: 0.0,
+    padding: 16.0,
+    fontColor: parseHtmlColor("#ffffff"),
+    fontSize: 32.0,
+    borderColor: parseHtmlColor("#000000"),
+    borderWidth: 3,
+    overflow: "fit-bounds",
+  ))
+
 proc configureControlCode(self: RunnerThread) =
   if self.frameConfig.controlCode.enabled:
     let controlCode = self.frameConfig.controlCode
@@ -122,6 +144,14 @@ proc renderSceneImage*(self: RunnerThread, exportedScene: ExportedScene, scene: 
     if self.frameConfig.controlCode.enabled:
       render_imageApp.App(self.controlCodeRender).appConfig.image = data_qrApp.App(self.controlCodeData).get(context)
       render_imageApp.App(self.controlCodeRender).run(context)
+    # The local-presence code, if one is pending. Drawn last so no scene can
+    # paint over it: the whole point is that it is readable from in front of
+    # the frame, by someone the admin API cannot see.
+    let presenceCode = activeLocalAccessCode()
+    if presenceCode.len > 0:
+      render_textApp.App(self.localAccessRender).appConfig.text =
+        "Local network access\n" & presenceCode
+      render_textApp.App(self.localAccessRender).run(context)
     let image = context.image
 
     var outImage: Image
@@ -481,6 +511,7 @@ proc startMessageLoop*(self: RunnerThread, maxIterations = -1): Future[void] {.a
             self.scenes = initTable[SceneId, FrameScene]()
             self.currentSceneId = getFirstSceneId()
             self.configureControlCode()
+            self.configureLocalAccessOverlay()
             self.forceSceneReload = true
             self.triggerRenderNext = true
             continue # don't dispatch this event to the scene
@@ -533,6 +564,7 @@ proc createRunnerThread*(args: (FrameConfig, Logger, Option[SceneId])) =
       logger: args[1]
     )
     runnerThread.configureControlCode()
+    runnerThread.configureLocalAccessOverlay()
 
     waitFor runnerThread.startRenderLoop() and runnerThread.startMessageLoop()
 

--- a/frameos/src/frameos/server/api.nim
+++ b/frameos/src/frameos/server/api.nim
@@ -11,6 +11,7 @@ import assets/apps as appsAsset
 import drivers/drivers as drivers
 import frameos/apps
 import frameos/channels
+import frameos/local_access
 import frameos/types
 import frameos/utils/image
 import frameos/utils/font
@@ -301,6 +302,24 @@ proc frontendFramePayloadToRuntimeConfig*(payload: JsonNode, existing: JsonNode)
   ]:
     putJsonIfPresent(result, payload, pair[0], pair[1])
 
+  # The private-network elevation never rides along with a bulk config save.
+  # The cloud is already blocked from it by CLOUD_SETTINGS_ALLOWLIST, but the
+  # admin page came through here too, and an admin session is a password on a
+  # LAN-reachable page — not proof that anyone is standing at the frame. It
+  # moves only through the on-panel ceremony in frameos/local_access.nim now,
+  # so whatever the payload claims, the stored value wins.
+  if result{"network"} != nil and result["network"].kind == JObject:
+    let stored =
+      if existing != nil and existing.kind == JObject and
+          existing{"network"} != nil and existing["network"].kind == JObject:
+        existing["network"]{"allowLocalNetworkAccess"}
+      else:
+        nil
+    if stored != nil:
+      result["network"]["allowLocalNetworkAccess"] = copy(stored)
+    elif result["network"].hasKey("allowLocalNetworkAccess"):
+      result["network"].delete("allowLocalNetworkAccess")
+
   if payload.hasKey("frame_admin_auth"):
     putJsonIfPresent(result, payload, "frame_admin_auth", "frameAdminAuth")
   if payload.hasKey("https_proxy"):
@@ -436,6 +455,39 @@ proc persistFrameApiUpdate*(payload: JsonNode) =
     if payload.hasKey("scenes"):
       persistScenesPayload(payload["scenes"])
     writeTextFileAtomically(configPath, pretty(nextConfig, indent = 4) & "\n")
+
+proc localNetworkAccessPayload*(): JsonNode =
+  let enabled = globalFrameConfig != nil and globalFrameConfig.network != nil and
+    globalFrameConfig.network.allowLocalNetworkAccess
+  %*{
+    "allowLocalNetworkAccess": enabled,
+    "challengePending": activeLocalAccessCode().len > 0,
+    "challengeSecondsLeft": localAccessChallengeSecondsLeft(),
+  }
+
+proc setLocalNetworkAccess*(enabled: bool): JsonNode =
+  ## Applies the private-network elevation. Only ever called after the on-panel
+  ## code has been matched — see frameos/local_access.nim for why the bulk
+  ## config save is not allowed to reach this field.
+  withLock frameConfigWriteLock:
+    let configPath = getConfigFilename()
+    var configJson = loadConfigJson()
+    if configJson == nil or configJson.kind != JObject:
+      configJson = %*{}
+    if configJson{"network"} == nil or configJson["network"].kind != JObject:
+      configJson["network"] = %*{}
+    configJson["network"]["allowLocalNetworkAccess"] = %enabled
+    writeTextFileAtomically(configPath, pretty(configJson, indent = 4) & "\n")
+
+  # The hub thread re-reads this object every couple of seconds and recomputes
+  # the deny from it (hub_client.nim, refreshLocalNetworkPolicy), so the change
+  # takes effect without a restart.
+  if globalFrameConfig != nil and globalFrameConfig.network != nil:
+    globalFrameConfig.network.allowLocalNetworkAccess = enabled
+  if globalFrameOS != nil and globalFrameOS.frameConfig != nil and
+      globalFrameOS.frameConfig.network != nil:
+    globalFrameOS.frameConfig.network.allowLocalNetworkAccess = enabled
+  localNetworkAccessPayload()
 
 proc frameControlCodeJson(controlCode: ControlCode): JsonNode =
   if controlCode == nil:

--- a/frameos/src/frameos/server/api.nim
+++ b/frameos/src/frameos/server/api.nim
@@ -468,16 +468,9 @@ proc localNetworkAccessPayload*(): JsonNode =
 proc setLocalNetworkAccess*(enabled: bool): JsonNode =
   ## Applies the private-network elevation. Only ever called after the on-panel
   ## code has been matched — see frameos/local_access.nim for why the bulk
-  ## config save is not allowed to reach this field.
-  withLock frameConfigWriteLock:
-    let configPath = getConfigFilename()
-    var configJson = loadConfigJson()
-    if configJson == nil or configJson.kind != JObject:
-      configJson = %*{}
-    if configJson{"network"} == nil or configJson["network"].kind != JObject:
-      configJson["network"] = %*{}
-    configJson["network"]["allowLocalNetworkAccess"] = %enabled
-    writeTextFileAtomically(configPath, pretty(configJson, indent = 4) & "\n")
+  ## config save is not allowed to reach this field, and why it is persisted
+  ## under state/ rather than in frame.json.
+  persistLocalNetworkAccess(enabled)
 
   # The hub thread re-reads this object every couple of seconds and recomputes
   # the deny from it (hub_client.nim, refreshLocalNetworkPolicy), so the change

--- a/frameos/src/frameos/server/routes/admin_api_routes.nim
+++ b/frameos/src/frameos/server/routes/admin_api_routes.nim
@@ -4,6 +4,7 @@ import mummy
 import mummy/routers
 import httpcore
 import frameos/channels
+import frameos/local_access
 import frameos/upgrade
 import ../auth
 import ../api
@@ -14,6 +15,10 @@ import ./common
 const
   ADMIN_LOGIN_LIMIT = 10
   ADMIN_LOGIN_WINDOW = 300.0
+  # The panel code is six digits and single-use, but the endpoint should not be
+  # a place to grind guesses either; the challenge itself only allows five.
+  LOCAL_ACCESS_LIMIT = 10
+  LOCAL_ACCESS_WINDOW = 300.0
 
 proc addAdminApiRoutes*(router: var Router) =
   router.get("/api/admin/session", proc(request: Request) {.gcsafe.} =
@@ -82,6 +87,72 @@ proc addAdminApiRoutes*(router: var Router) =
         jsonResponse(request, Http200, persistFrameAdminSettingsUpdate(payload))
       except ValueError as error:
         jsonResponse(request, Http400, %*{"detail": error.msg})
+      except CatchableError as error:
+        jsonResponse(request, Http500, %*{"detail": error.msg})
+  )
+
+  # ---- private-network elevation (local-presence ceremony) -----------------
+  # cloud/docs/cloud-frames.md, "sandbox posture": lifting the LAN deny on a
+  # cloud-managed frame takes more than an admin session, which is only a
+  # password on a LAN-reachable page. Ask for a challenge, read the six digits
+  # off the panel, send them back.
+
+  router.get("/api/network/local-access", proc(request: Request) {.gcsafe.} =
+    if not hasAdminAccess(request):
+      jsonResponse(request, Http401, %*{"detail": "Unauthorized"})
+      return
+    {.gcsafe.}:
+      jsonResponse(request, Http200, localNetworkAccessPayload())
+  )
+
+  router.post("/api/network/local-access/challenge", proc(request: Request) {.gcsafe.} =
+    if not hasAdminAccess(request):
+      jsonResponse(request, Http401, %*{"detail": "Unauthorized"})
+      return
+    if rateLimitExceeded(request, "network:local-access", LOCAL_ACCESS_LIMIT, LOCAL_ACCESS_WINDOW):
+      jsonResponse(request, Http429, %*{"detail": "Too many attempts"})
+      return
+    {.gcsafe.}:
+      try:
+        let challenge = startLocalAccessChallenge()
+        # A sleeping scene renders on its own schedule, and the code is useless
+        # until it is actually on the panel, so ask for a frame now.
+        sendEvent("render", %*{})
+        # No "code" in the response on purpose: a caller who could read it
+        # without seeing the panel is precisely who this keeps out.
+        jsonResponse(request, Http200, %*{
+          "status": "ok",
+          "codeLength": challenge.code.len,
+          "expiresInSeconds": LocalAccessChallengeTtlSeconds,
+        })
+      except CatchableError as error:
+        jsonResponse(request, Http500, %*{"detail": error.msg})
+  )
+
+  router.post("/api/network/local-access", proc(request: Request) {.gcsafe.} =
+    if not hasAdminAccess(request):
+      jsonResponse(request, Http401, %*{"detail": "Unauthorized"})
+      return
+    if rateLimitExceeded(request, "network:local-access", LOCAL_ACCESS_LIMIT, LOCAL_ACCESS_WINDOW):
+      jsonResponse(request, Http429, %*{"detail": "Too many attempts"})
+      return
+    {.gcsafe.}:
+      let payload = try:
+          parseJson(if request.body.strip().len == 0: "{}" else: request.body)
+        except JsonParsingError:
+          jsonResponse(request, Http400, %*{"detail": "Invalid JSON"})
+          return
+      let verdict = consumeLocalAccessCode(payload{"code"}.getStr(""))
+      if not verdict.ok:
+        # Repaint either way: a spent or failed ceremony must not leave a live
+        # code on the panel for the next person walking past.
+        sendEvent("render", %*{})
+        jsonResponse(request, Http403, %*{"detail": verdict.detail})
+        return
+      try:
+        let updated = setLocalNetworkAccess(payload{"enabled"}.getBool(true))
+        sendEvent("render", %*{})
+        jsonResponse(request, Http200, updated)
       except CatchableError as error:
         jsonResponse(request, Http500, %*{"detail": error.msg})
   )

--- a/frameos/src/frameos/server/tests/test_api.nim
+++ b/frameos/src/frameos/server/tests/test_api.nim
@@ -120,3 +120,27 @@ suite "Server API helpers":
     let invalidScenesPayload = frameApiPayload(state)
     check invalidScenesPayload{"scenes"}.kind == JArray
     check invalidScenesPayload{"scenes"}.len == 0
+
+suite "private-network elevation is not a bulk-savable setting":
+  test "a config save cannot flip allowLocalNetworkAccess either way":
+    # Both the cloud verb path and the admin page's frame save land in
+    # frontendFramePayloadToRuntimeConfig. Neither may carry this field: it
+    # only moves through the on-panel ceremony (frameos/local_access.nim).
+    let existingOff = %*{"network": {"networkCheck": true, "allowLocalNetworkAccess": false}}
+    let turnOn = %*{"network": {"networkCheck": true, "allowLocalNetworkAccess": true}}
+    let elevated = frontendFramePayloadToRuntimeConfig(turnOn, existingOff)
+    check elevated{"network"}{"allowLocalNetworkAccess"}.getBool() == false
+    # Unrelated fields in the same object still save normally.
+    check elevated{"network"}{"networkCheck"}.getBool() == true
+
+    # And it cannot be revoked that way either, so a stale payload replayed by
+    # the backend does not silently re-arm the deny mid-session.
+    let existingOn = %*{"network": {"allowLocalNetworkAccess": true}}
+    let turnOff = %*{"network": {"allowLocalNetworkAccess": false}}
+    check frontendFramePayloadToRuntimeConfig(turnOff, existingOn){"network"}{
+      "allowLocalNetworkAccess"}.getBool() == true
+
+  test "a frame with no stored value does not gain one from a payload":
+    let fresh = frontendFramePayloadToRuntimeConfig(
+      %*{"network": {"allowLocalNetworkAccess": true}}, %*{})
+    check not fresh{"network"}.hasKey("allowLocalNetworkAccess")

--- a/frameos/src/frameos/tests/test_local_access.nim
+++ b/frameos/src/frameos/tests/test_local_access.nim
@@ -1,0 +1,63 @@
+## The local-presence ceremony guarding the private-network elevation.
+
+import std/[sequtils, strutils, unittest]
+
+import frameos/local_access
+
+suite "local access challenge":
+  setup:
+    clearLocalAccessChallenge()
+
+  teardown:
+    clearLocalAccessChallenge()
+
+  test "no code is on the panel until one is asked for":
+    check activeLocalAccessCode() == ""
+    check localAccessChallengeSecondsLeft() == 0.0
+
+  test "a challenge mints digits and puts them on the panel":
+    let challenge = startLocalAccessChallenge()
+    check challenge.code.len == LocalAccessCodeLength
+    check challenge.code.allCharsInSet({'0'..'9'})
+    check activeLocalAccessCode() == challenge.code
+    check localAccessChallengeSecondsLeft() > 0.0
+
+  test "successive challenges do not repeat":
+    # Not a randomness proof, just a guard against a constant sneaking in.
+    var seen: seq[string] = @[]
+    for _ in 0 ..< 8:
+      seen.add(startLocalAccessChallenge().code)
+    check seen.deduplicate().len > 1
+
+  test "the right code is accepted exactly once":
+    let code = startLocalAccessChallenge().code
+    check consumeLocalAccessCode(code).ok
+    # Burned: a replay of the same code must not elevate again.
+    let replay = consumeLocalAccessCode(code)
+    check not replay.ok
+    check replay.detail.contains("No local access challenge")
+    check activeLocalAccessCode() == ""
+
+  test "surrounding whitespace is forgiven, wrong digits are not":
+    let code = startLocalAccessChallenge().code
+    check consumeLocalAccessCode("  " & code & "\n").ok
+
+    discard startLocalAccessChallenge()
+    check not consumeLocalAccessCode("000000x").ok
+
+  test "guessing is capped and burns the challenge":
+    let code = startLocalAccessChallenge().code
+    let wrong = if code == "111111": "222222" else: "111111"
+    for attempt in 1 ..< LocalAccessMaxAttempts:
+      check not consumeLocalAccessCode(wrong).ok
+      check activeLocalAccessCode() == code
+    # The last life: the challenge is torn down, so even the real code fails.
+    check not consumeLocalAccessCode(wrong).ok
+    check activeLocalAccessCode() == ""
+    check not consumeLocalAccessCode(code).ok
+
+  test "clearing takes the code off the panel":
+    discard startLocalAccessChallenge()
+    clearLocalAccessChallenge()
+    check activeLocalAccessCode() == ""
+    check not consumeLocalAccessCode("123456").ok

--- a/frameos/src/frameos/tests/test_local_access.nim
+++ b/frameos/src/frameos/tests/test_local_access.nim
@@ -1,6 +1,6 @@
 ## The local-presence ceremony guarding the private-network elevation.
 
-import std/[sequtils, strutils, unittest]
+import std/[json, options, os, sequtils, strutils, times, unittest]
 
 import frameos/local_access
 
@@ -61,3 +61,55 @@ suite "local access challenge":
     clearLocalAccessChallenge()
     check activeLocalAccessCode() == ""
     check not consumeLocalAccessCode("123456").ok
+
+suite "local access is persisted outside frame.json":
+  ## LocalAccessStatePath is relative, so each case runs in its own temp cwd.
+  var previousDir = ""
+  var sandbox = ""
+
+  setup:
+    previousDir = getCurrentDir()
+    sandbox = getTempDir() / "frameos-local-access-" & $epochTime()
+    createDir(sandbox)
+    setCurrentDir(sandbox)
+    forgetStoredLocalNetworkAccess()
+
+  teardown:
+    setCurrentDir(previousDir)
+    removeDir(sandbox)
+    forgetStoredLocalNetworkAccess()
+
+  test "an untouched frame has no stored answer and defers to frame.json":
+    check storedLocalNetworkAccess().isNone
+    # The legacy fallback: frames elevated before the setting moved keep it.
+    check resolveLocalNetworkAccess(true)
+    check not resolveLocalNetworkAccess(false)
+
+  test "the stored answer overrides frame.json in both directions":
+    persistLocalNetworkAccess(true)
+    check storedLocalNetworkAccess() == some(true)
+    # This is the whole point: a deploy that rewrites frame.json without the
+    # field (the backend's get_frame_json omits it) must not revoke it.
+    check resolveLocalNetworkAccess(false)
+
+    persistLocalNetworkAccess(false)
+    check not resolveLocalNetworkAccess(true)
+
+  test "the state file lands under state/ and says when it changed":
+    persistLocalNetworkAccess(true)
+    check fileExists(LocalAccessStatePath)
+    let stored = parseJson(readFile(LocalAccessStatePath))
+    check stored["allowLocalNetworkAccess"].getBool()
+    check stored["updatedAt"].getStr().len > 0
+
+  test "a corrupt state file is not read as elevated":
+    createDir("state")
+    writeFile(LocalAccessStatePath, "{ this is not json")
+    check storedLocalNetworkAccess().isNone
+    check not resolveLocalNetworkAccess(false)
+
+  test "a state file without the key does not elevate either":
+    createDir("state")
+    writeFile(LocalAccessStatePath, """{"updatedAt": "whenever"}""")
+    check storedLocalNetworkAccess().isNone
+    check not resolveLocalNetworkAccess(false)

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -52,6 +52,17 @@ type
     mountpoints*: MountpointsConfig
     errorBehavior*: ErrorBehaviorConfig
     palette*: PaletteConfig
+    js*: JsRuntimeConfig
+
+  # Part of FrameConfig
+  JsRuntimeConfig* = ref object
+    ## Ceilings and scoping for untrusted scene JS (cloud/docs/cloud-frames.md,
+    ## "sandbox posture"). Scene JS is user-authored at best and provider-pushed
+    ## at worst, and it runs on the render thread.
+    executionTimeoutMs*: int ## interpreter time per entry; 0 disables
+    memoryLimitMb*: int      ## JS heap ceiling; 0 leaves it unlimited
+    maxStackKb*: int         ## JS stack ceiling; 0 keeps QuickJS's default
+    assetSandbox*: string    ## "frame" (shared, default) or "scene" (per-scene subtree)
 
   # Part of FrameConfig
   TimeZoneUpdatesConfig* = ref object
@@ -380,6 +391,7 @@ type
     forceSceneReload*: bool = false
     controlCodeRender*: AppRoot
     controlCodeData*: AppRoot
+    localAccessRender*: AppRoot
 
   RunnerControl* = ref object
     start*: proc(firstSceneId: Option[SceneId])


### PR DESCRIPTION
Closes the six gaps a capability audit of the JS runtime found between what `cloud/docs/cloud-frames.md` promises under "sandbox posture" and what the code actually does. That section is rewritten to describe the posture as it now stands rather than as it was hoped.

Scene JS runs on the render thread, and on a cloud-managed frame it is code a provider pushed.

## The two that mattered

**No execution ceiling, on any target.** `while (true) {}` in any scene — code node, JS app, or module top level — wedged the render thread forever: QuickJS runs to completion and the eval happens under `sceneJsLock` on the thread that draws the panel. Every entry into the interpreter now carries a time budget enforced by a `JS_SetInterruptHandler`.

The budget measures *interpreter* time, not wall time. A binding that blocks on HTTP is not the scene spinning, so `enterNativeCall`/`leaveNativeCall` in the trampoline credit that time back — without it a legitimate 60s fetch would look like a runaway loop. A blown budget is logged and the node's value defaulted, exactly like any other failing node. QuickJS marks the interrupt uncatchable, so a scene's own `try`/`catch` cannot swallow it; `callCompiledFn` rebuilds the error envelope so it lands on the normal path instead of escaping as an unhandled exception.

**RFC1918 blocking existed only in the native build.** The whole `isPrivateNetworkAddress`/`enforceLocalNetworkPolicy` machinery sits in the non-embedded branch of `http_client.nim`. ESP32 frames do accept cloud-pushed interpreted scenes, so a cloud-managed ESP32 was an unguarded SSRF pivot into the owner's LAN — precisely the outcome the design exists to prevent. New `fos_netguard.c` ports the classifier and is enforced before the initial `esp_http_client_open()` and again after every `esp_http_client_set_redirection()`, because a 302 to `192.168.1.1` is the same request.

Its IPv4 parser is deliberately *stricter* than the Nim one. Nim's `parseIpAddress` reads leading zeros as decimal; lwIP's `ip4addr_aton` reads them as octal, so `0177.0.0.1` would be public to the classifier and loopback to the stack. Ambiguous numeric forms now fail to parse, and failing to parse means private.

## The four narrower ones

- **No JS heap or stack limit on Pi/Linux.** Embedded had both via `fos_js_new_runtime`; the native build called `JS_NewRuntime()` raw, so in-VM allocation could OOM the host process.
- **`resolveAssetPath` was substring- and lexical-only.** It rejected `..` anywhere in the string (so also `backup..old.txt`) and checked containment without resolving symlinks, so a link planted inside the assets folder was a legal way out. Now a path-segment check plus a realpath-based containment check on the deepest existing ancestor.
- **The assets sandbox is frame-wide, not per-scene** as the doc claimed. Sharing uploaded assets between scenes is the common case, so the default stands and the doc is corrected; frames that want the stricter model set `js.assetSandbox` to `"scene"` and each scene is confined to `<assets>/scenes/<sceneId>/`.
- **Lifting the LAN deny took only an admin session** — a password on a LAN-reachable page, not presence. `network.allowLocalNetworkAccess` is now stripped from the bulk config save (both the cloud verb and the admin page's frame save came through there) and moves only through a ceremony: `POST /api/network/local-access/challenge` puts six digits on the panel, `POST /api/network/local-access` applies the change only if they come back. The code is never in an API response, single-use, five attempts, three minutes. On ESP32 the equivalent is `set allow_local_network 1` on the USB console.

## Tuning

Ceilings are per-frame via a new `js` block in `frame.json` — `executionTimeoutMs`, `memoryLimitMb`, `maxStackKb`, `assetSandbox`. Defaults are deliberately generous (30s native, 20s embedded, under the 30s task watchdog): the job is to turn "this frame never renders again" into "one scene logged an error", not to police slow-but-honest scenes, and a false positive would be a worse bug than the hang it replaces.

## Testing

- Full Nim suite: 133 test files, 0 failures.
- New `test_js_resource_limits.nim` — an infinite loop is interrupted rather than hanging; the error names the budget; a script inside its budget is untouched; three 300ms native calls under a 500ms budget do *not* trip it; a zero timeout disables the ceiling; scene code nodes inherit it; an oversized allocation fails the script, not the process.
- New sandbox cases in `test_js_app_runtime.nim` — reading and writing through a symlink out of the assets folder both fail, `backup..old.txt` still writes, and `assetSandbox=scene` confines a scene while flattening slashes in the scene id.
- New `test_local_access.nim` — codes are digits, do not repeat, are accepted exactly once, survive surrounding whitespace, and are burned after five wrong guesses.
- New `test_api.nim` cases — a config save cannot flip the elevation in either direction, and a frame with no stored value does not gain one from a payload.
- New `test_fos_netguard.c` (167 checks) with a pytest wrapper, plus a full `idf.py build` for esp32s3 against ESP-IDF v5.5.4 in both the Nim and stub component branches.

## Left open

A frame still cannot tell a cloud-installed scene from a locally authored one, so the store's `"shell"` risk flag has nothing to key off, and a frame demoted out of the managed state keeps running the provider's last-pushed scenes with the deny switched off (true on both platforms). Noted in `docs/todo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)