### PR TITLE
Copy store covers into the frame's snapshot cache when scenes are installed

### DIFF
--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
@@ -23,6 +23,7 @@ import {
   supersedePendingCommands,
 } from "../../../../../src/lib/frames";
 import { rateLimitResponse } from "../../../../../src/lib/rate-limit";
+import { copySceneCoversIntoFrameCache } from "../../../../../src/lib/scene-images";
 import { readSession } from "../../../../../src/lib/session";
 
 export const runtime = "nodejs";
@@ -316,6 +317,15 @@ export async function POST(
     },
     target: { commandId: command?.id, frameId: frame.id },
   });
+
+  // Install-time cover copy: without it a freshly assigned scene's tile
+  // stays blank until the device renders it and a snapshot fetch lands.
+  // Cosmetic, so a failure must not fail the push that just committed.
+  try {
+    await copySceneCoversIntoFrameCache(db, frame.id, requested);
+  } catch (error) {
+    console.error("install-time scene cover copy failed", error);
+  }
 
   return NextResponse.json({
     assigned_checksum: payload.checksum,

--- a/cloud/apps/auth-web/src/lib/scene-images.ts
+++ b/cloud/apps/auth-web/src/lib/scene-images.ts
@@ -19,7 +19,12 @@ import {
   storeScenes,
   storeSceneVersions,
 } from "@frameos-cloud/db";
-import { extractScenesJson, type FramesDatabase } from "./frames";
+import { cachedAssetFile, sceneSnapshotAssetPath } from "./frame-asset-cache";
+import {
+  extractScenesJson,
+  storeFrameAssetFile,
+  type FramesDatabase,
+} from "./frames";
 
 // (storeSceneId, version) → runtime scene ids in that version's scenes.json.
 // Bounded so a pathological fleet cannot grow it without limit; eviction is
@@ -195,6 +200,57 @@ export async function storeSceneCoverImage(
     };
   }
   return undefined;
+}
+
+// The explicit install-time cover copy (docs/todo.md, "a scene added from a
+// template shows a blank tile"): when an assignment set is pushed, each
+// installed scene's cover is written into frame_asset_files under the exact
+// paths the device's own snapshots will occupy — one row per runtime scene
+// id and thumb variant. The tile route then has bytes to serve from the
+// first request, and the first real snapshot replaces the cover through the
+// same upsert the asset_get chunk stream uses. Rows that already exist are
+// left alone: a device snapshot must never lose to a cover.
+export async function copySceneCoversIntoFrameCache(
+  db: Parameters<typeof storeFrameAssetFile>[0],
+  frameId: string,
+  assignments: readonly {
+    sceneId: string;
+    sceneVersion: number | null;
+  }[],
+): Promise<void> {
+  for (const assignment of assignments) {
+    const cover = await storeSceneCoverImage(db, assignment.sceneId);
+    if (!cover) {
+      continue;
+    }
+    const version = await pinnedVersionNumber(
+      db,
+      assignment.sceneId,
+      assignment.sceneVersion,
+    );
+    if (version === undefined) {
+      continue;
+    }
+    const runtimeIds = await runtimeIdsForVersion(
+      db,
+      assignment.sceneId,
+      version,
+    );
+    for (const runtimeId of runtimeIds) {
+      const path = sceneSnapshotAssetPath(runtimeId);
+      for (const thumb of [false, true]) {
+        if (await cachedAssetFile(db, frameId, path, thumb)) {
+          continue;
+        }
+        await storeFrameAssetFile(db, frameId, {
+          content: cover.content,
+          contentType: cover.contentType,
+          path,
+          thumb,
+        });
+      }
+    }
+  }
 }
 
 export function resetSceneImageCacheForTests() {

--- a/cloud/apps/auth-web/src/test/integration/frame-scene-images.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frame-scene-images.integration.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@frameos-cloud/db";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET as getSceneImage } from "../../../app/api/frames/[frameId]/scene_images/[sceneId]/route";
+import { POST as assignFrameScenes } from "../../../app/api/frames/[frameId]/scenes/route";
 import { sceneSnapshotAssetPath } from "../../lib/frame-asset-cache";
 import { resetRateLimitForTests } from "../../lib/rate-limit";
 import { resetSceneImageCacheForTests } from "../../lib/scene-images";
@@ -435,5 +436,125 @@ describe("GET /api/frames/{id}/scene_images/{sceneId}", () => {
       .from(frameCommands)
       .where(eq(frameCommands.frameId, frame.id));
     expect(queued.map((row) => row.type)).toEqual(["asset_get"]);
+  });
+});
+
+// The explicit install-time cover copy: POST /scenes writes each installed
+// scene's cover into frame_asset_files under the runtime scene ids, so a
+// tile has bytes to show before the device has ever rendered the scene.
+describe("POST /api/frames/{id}/scenes cover copy", () => {
+  function postScenes(frameId: string, sceneIds: string[]) {
+    return assignFrameScenes(
+      new NextRequest(new URL(`/api/frames/${frameId}/scenes`, baseUrl), {
+        body: JSON.stringify({
+          scenes: sceneIds.map((id) => ({ scene_id: id })),
+        }),
+        headers: { "content-type": "application/json", origin: baseUrl },
+        method: "POST",
+      }),
+      { params: Promise.resolve({ frameId }) },
+    );
+  }
+
+  async function assetRows(frameId: string) {
+    return await db
+      .select({
+        content: frameAssetFiles.content,
+        contentType: frameAssetFiles.contentType,
+        path: frameAssetFiles.path,
+        thumb: frameAssetFiles.thumb,
+      })
+      .from(frameAssetFiles)
+      .where(eq(frameAssetFiles.frameId, frameId));
+  }
+
+  it("copies the cover under every runtime scene id, full and thumb", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Installed",
+      previewImage: Buffer.from("cover-bytes"),
+      previewImageType: "image/jpeg",
+      runtimeSceneIds: ["runtime-a", "runtime-b"],
+    });
+
+    const response = await postScenes(frame.id, [scene.id]);
+    expect(response.status).toBe(200);
+
+    const rows = await assetRows(frame.id);
+    const expected = ["runtime-a", "runtime-b"].flatMap((id) =>
+      [false, true].map((thumb) => ({
+        path: sceneSnapshotAssetPath(id),
+        thumb,
+      })),
+    );
+    expect(
+      rows
+        .map((row) => ({ path: row.path, thumb: row.thumb }))
+        .sort((a, b) =>
+          `${a.path}:${a.thumb}`.localeCompare(`${b.path}:${b.thumb}`),
+        ),
+    ).toEqual(
+      expected.sort((a, b) =>
+        `${a.path}:${a.thumb}`.localeCompare(`${b.path}:${b.thumb}`),
+      ),
+    );
+    for (const row of rows) {
+      expect(Buffer.from(row.content).toString()).toBe("cover-bytes");
+      expect(row.contentType).toBe("image/jpeg");
+    }
+
+    // And the tile route serves the copy from the snapshot tier at once.
+    const tile = await getSceneImage(
+      getRequest(`/api/frames/${frame.id}/scene_images/runtime-a?thumb=1`),
+      routeParams(frame.id, "runtime-a"),
+    );
+    expect(tile.status).toBe(200);
+    expect(tile.headers.get("cache-control")).toBe("private, max-age=60");
+    expect(Buffer.from(await tile.arrayBuffer()).toString()).toBe(
+      "cover-bytes",
+    );
+  });
+
+  it("never overwrites an existing device snapshot", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Rendered before",
+      previewImage: Buffer.from("cover-bytes"),
+      previewImageType: "image/jpeg",
+      runtimeSceneIds: ["runtime-snapped"],
+    });
+    await db.insert(frameAssetFiles).values({
+      content: Buffer.from("device-render"),
+      contentType: "image/png",
+      frameId: frame.id,
+      path: sceneSnapshotAssetPath("runtime-snapped"),
+      sizeBytes: "device-render".length,
+      thumb: false,
+    });
+
+    const response = await postScenes(frame.id, [scene.id]);
+    expect(response.status).toBe(200);
+
+    const rows = await assetRows(frame.id);
+    const full = rows.find((row) => !row.thumb);
+    const thumb = rows.find((row) => row.thumb);
+    // The device's render survives; only the missing thumb slot is filled.
+    expect(Buffer.from(full!.content).toString()).toBe("device-render");
+    expect(Buffer.from(thumb!.content).toString()).toBe("cover-bytes");
+  });
+
+  it("copies nothing for a scene with no cover, without failing the push", async () => {
+    const accountId = await signIn();
+    const frame = await activeFrame(accountId);
+    const scene = await createStoreScene(accountId, {
+      name: "Coverless",
+      runtimeSceneIds: ["runtime-bare-install"],
+    });
+
+    const response = await postScenes(frame.id, [scene.id]);
+    expect(response.status).toBe(200);
+    expect(await assetRows(frame.id)).toEqual([]);
   });
 });

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -42,14 +42,16 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
 
 ## Cloud-managed frames
 
-- **A scene added from a template shows a blank tile.** Two independent
-  causes, both reproduced: `/api/frames/{id}/scene_images/{sceneId}` resolves
-  the runtime scene id through `frame_scene_assignments`, so a scene not yet
-  saved/pushed maps to nothing and 404s; and separately the template's own
-  stored `preview_image` is transparent, so even a successful lookup serves
-  nothing visible. Needs a decision: serve the store cover for unassigned
-  scenes, render a placeholder, or fix whatever writes transparent previews
-  at publish time.
+- **Transparent `preview_image` at publish time.** The surviving half of the
+  blank-tile bug: the decided fix (explicitly copy the store cover into
+  `frame_asset_files` when `POST /frames/{id}/scenes` installs an assignment
+  set — the backend's `assignSceneImages` pattern, now on the cloud too)
+  gives every installed scene's tile bytes to show, but a copy of a fully
+  transparent cover is still invisible. The auto-captured preview appears to
+  be grabbed from the wasm live-preview canvas before the first render
+  completes; composite over an opaque background at capture, reject
+  fully-transparent uploads at publish, and backfill or gallery-fall-through
+  the existing rows.
 - **Cloud "not on the frame yet" is all-or-nothing.** #323 reads the
   assigned_checksum/scenes_checksum pair, which covers the whole assigned set
   and cannot say WHICH scene differs. Per-scene granularity needs the cloud to


### PR DESCRIPTION
## What

Installing a scene onto a cloud-managed frame left its tile blank until the device first rendered the scene and the snapshot fetch landed (the first half of the "blank tile" entry in `docs/todo.md`).

The backend control plane has always handled this explicitly — `assignSceneImages` copies the template's cover the moment a scene is added — but the SPA skips that path in cloud mode, assuming the request-time store-cover fallback suffices. It doesn't: that fallback needs an assignment to resolve the runtime scene id, and even a successful lookup can serve a fully transparent preview.

## How

When `POST /api/frames/{id}/scenes` commits an assignment set, each installed scene's cover (gallery-first, the same pick as the request-time fallback) is copied into `frame_asset_files` under the exact paths the device's own snapshots will occupy — one row per runtime scene id, full and thumb variants:

- The tile route serves the copied bytes from its first (snapshot) tier immediately, before the scene has ever rendered.
- The first real device snapshot replaces the cover through the same upsert the `asset_get` chunk stream uses, and the per-frame LRU caps apply via `storeFrameAssetFile`.
- Existing rows are never overwritten — a device snapshot always wins over a cover.
- A copy failure only logs; covers are cosmetic and must not fail the push that just committed.

The other half of the bug — publishes that store a fully transparent `preview_image`, which copying cannot make visible — is now its own `docs/todo.md` entry (opaque-composite at capture, reject transparent uploads at publish, backfill existing rows).

## Testing

Three new integration tests in `frame-scene-images.integration.test.ts` (12/12 pass): covers land under every runtime id in both thumb variants and serve from the snapshot tier; an existing device snapshot survives a re-assignment while the missing thumb slot fills; a coverless scene copies nothing and the push still succeeds. `store.integration.test.ts` fails to import in a fresh worktree (unbuilt `frameos-wasm` artifact) — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)