### PR TITLE
Per-scene deploy tracking, runtime scene origin, and never-error image decodes

### DIFF
--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -664,6 +664,12 @@ def test_embedded_hardware_preset_for_waveshare_13in3e6():
     assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_SCK 6" in header
     assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_MISO 5" in header
     assert "#define FRAMEOS_DEFAULT_ASSETS_SD_PIN_MOSI 7" in header
+    # Battery: VBAT on ADC1_CH7 = GPIO8 through a 1/3 divider (vendor ADC
+    # examples read CHANNEL_7 and multiply the calibrated voltage by 3).
+    assert frame.device_config["batteryPin"] == 8
+    assert frame.device_config["batteryDivider"] == 3.0
+    assert "#define FRAMEOS_DEFAULT_BATTERY_PIN 8" in header
+    assert "#define FRAMEOS_DEFAULT_BATTERY_DIVIDER 3.0f" in header
 
 
 def test_embedded_hardware_preset_for_waveshare_photopainter():

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -319,6 +319,11 @@ EMBEDDED_HARDWARE_PRESETS: dict[str, dict[str, Any]] = {
         "flashSize": "32MB",
         "psramMB": 16,
         "pins": EMBEDDED_WAVESHARE_13IN3E6_PINS,
+        # VBAT taps ADC1_CH7 = GPIO8 through a 1/3 divider; Waveshare's own
+        # ADC examples (01_ADC_Test, Arduino + IDF) read CHANNEL_7 and
+        # multiply the calibrated pin voltage by 3.
+        "batteryPin": 8,
+        "batteryDivider": 3.0,
         "sdCardAssets": {
             "enabled": True,
             "preset": "waveshare_esp32_s3_epaper_13_3e6",
@@ -1018,6 +1023,12 @@ def apply_embedded_hardware_preset(frame: Frame) -> str:
         }
     else:
         device_config.pop("sdCardAssets", None)
+    # Battery sensing defaults, same policy as pins: the preset knows the
+    # board's divider, and the device can still override via console/NVS.
+    if "batteryPin" in preset:
+        device_config["batteryPin"] = preset["batteryPin"]
+    if "batteryDivider" in preset:
+        device_config["batteryDivider"] = preset["batteryDivider"]
     frame.device_config = device_config
     return preset_key
 

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
@@ -264,6 +264,10 @@ export async function POST(
     .update(frames)
     .set({
       assignedChecksum: payload.checksum,
+      // Per-scene slices of the same payload. The hub promotes this map to
+      // deployed_scene_state when the device acks payload.checksum, so the
+      // workspace can name the scene that is not on the frame yet.
+      assignedSceneState: payload.sceneStates,
       serviceSettingGroups,
       updatedAt: new Date(),
     })

--- a/cloud/apps/auth-web/src/lib/frames.ts
+++ b/cloud/apps/auth-web/src/lib/frames.ts
@@ -426,11 +426,17 @@ export function frameSummary(
     // provider-owned fields below always win, `name` above all.
     ...readFrameSettings(frame.settings),
     assigned_checksum: frame.assignedChecksum,
+    // Per-scene deploy ledger ({storeSceneId: {version, checksum}}): what
+    // the last assignment push contained vs what the device has acked. NULL
+    // on frames that predate the columns — the SPA then falls back to the
+    // all-or-nothing checksum comparison.
+    assigned_scene_state: frame.assignedSceneState,
     connected: frame.connected,
     created_at: frame.createdAt,
     frameos_version: frame.frameosVersion,
     hardware: frame.hardware,
     id: frame.id,
+    deployed_scene_state: frame.deployedSceneState,
     last_seen_at: frame.lastSeenAt,
     linked_client_id: frame.linkedClientId,
     name: frame.name,
@@ -774,14 +780,26 @@ export async function pinnedSceneVersion(
   return row;
 }
 
+// One store scene's slice of an assignment push: the version that produced
+// the bytes and the checksum of just that scene's runtime scenes. Stored on
+// the frame as assigned_scene_state / deployed_scene_state so sync state can
+// be answered per scene, not only for the set as a whole.
+export type SceneDeployState = { version: number; checksum: string };
+
 // Build the interpreted-scene payload for a frame from its assignments. The
 // payload shape matches the device's uploaded-scenes path ({"scenes": […]});
-// the checksum lets the device and the fleet UI agree on sync state.
+// the checksum lets the device and the fleet UI agree on sync state, and
+// sceneStates carries the same information per store scene.
 export async function buildScenesPayloadForFrame(
   db: FramesDatabase,
   frameId: string,
 ): Promise<
-  | { scenes: unknown[]; checksum: string; sceneNames: string[] }
+  | {
+      scenes: unknown[];
+      checksum: string;
+      sceneNames: string[];
+      sceneStates: Record<string, SceneDeployState>;
+    }
   | { error: string }
 > {
   const assignments = await db
@@ -798,6 +816,7 @@ export async function buildScenesPayloadForFrame(
 
   const scenes: unknown[] = [];
   const sceneNames: string[] = [];
+  const sceneStates: Record<string, SceneDeployState> = {};
   let rawBytes = 0;
   for (const assignment of assignments) {
     if (assignment.sceneStatus !== "active") {
@@ -845,6 +864,15 @@ export async function buildScenesPayloadForFrame(
     }
     scenes.push(...extracted.scenes);
     sceneNames.push(assignment.sceneName);
+    // The digest of just this assignment's slice of the payload. Comparing
+    // it against the copy stored at the last device-acked push is what lets
+    // the workspace flag the one edited scene instead of all of them.
+    sceneStates[assignment.sceneId] = {
+      checksum: createHash("sha256")
+        .update(JSON.stringify(extracted.scenes))
+        .digest("hex"),
+      version: versionRow.version,
+    };
   }
 
   const serialized = JSON.stringify(scenes);
@@ -852,7 +880,7 @@ export async function buildScenesPayloadForFrame(
     return { error: "scenes_payload_too_large" };
   }
   const checksum = createHash("sha256").update(serialized).digest("hex");
-  return { checksum, sceneNames, scenes };
+  return { checksum, sceneNames, sceneStates, scenes };
 }
 
 // Store one batch of shipped logs, enforcing the per-frame retention cap in

--- a/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
@@ -1030,6 +1030,22 @@ describe("frame management API", () => {
     expect(commandPayload.checksum).toBe(assignPayload.assigned_checksum);
     expect(commandPayload.scenes).toHaveLength(1);
 
+    // The per-scene ledger: one slice per assigned store scene, stamped with
+    // the version that produced the bytes. deployed_scene_state stays empty
+    // until the hub sees the device ack this checksum.
+    const [frameRow] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frame_id));
+    const sceneStates = frameRow?.assignedSceneState as Record<
+      string,
+      { version: number; checksum: string }
+    >;
+    expect(Object.keys(sceneStates ?? {})).toEqual([scene.id]);
+    expect(sceneStates[scene.id]?.version).toBe(1);
+    expect(sceneStates[scene.id]?.checksum).toMatch(/^[0-9a-f]{64}$/);
+    expect(frameRow?.deployedSceneState).toBeNull();
+
     const listed = await getFrameScenes(
       getRequest(`/api/frames/${frame_id}/scenes`),
       routeParams(frame_id),

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-scene-deploy-state.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-scene-deploy-state.test.ts
@@ -66,6 +66,107 @@ describe("undeployedSceneIdsFor — cloud", () => {
     expect(ids.size).toBe(0);
   });
 
+  it("flags only the scene whose assigned slice differs from the acked push", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({
+        assigned_checksum: "new",
+        scenes_checksum: "old",
+        assigned_scene_state: {
+          "store-a": { version: 2, checksum: "aaa2" },
+          "store-b": { version: 1, checksum: "bbb1" },
+        },
+        deployed_scene_state: {
+          "store-a": { version: 1, checksum: "aaa1" },
+          "store-b": { version: 1, checksum: "bbb1" },
+        },
+        cloud_scene_sources: {
+          "scene-a": { scene_id: "store-a", scene_version: null },
+          "scene-b": { scene_id: "store-b", scene_version: null },
+        },
+      }),
+      scenesEqual,
+    });
+    expect([...ids]).toEqual(["scene-a"]);
+  });
+
+  it("counts a scene the device never acked as pending", () => {
+    // store-b was assigned for the first time; the deployed ledger has no
+    // entry for it yet.
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({
+        assigned_checksum: "new",
+        scenes_checksum: "old",
+        assigned_scene_state: {
+          "store-a": { version: 1, checksum: "aaa1" },
+          "store-b": { version: 1, checksum: "bbb1" },
+        },
+        deployed_scene_state: {
+          "store-a": { version: 1, checksum: "aaa1" },
+        },
+        cloud_scene_sources: {
+          "scene-a": { scene_id: "store-a", scene_version: null },
+          "scene-b": { scene_id: "store-b", scene_version: null },
+        },
+      }),
+      scenesEqual,
+    });
+    expect([...ids]).toEqual(["scene-b"]);
+  });
+
+  it("counts a runtime scene with no known store source as pending", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({
+        assigned_checksum: "new",
+        scenes_checksum: "old",
+        assigned_scene_state: { "store-a": { version: 1, checksum: "aaa1" } },
+        deployed_scene_state: { "store-a": { version: 1, checksum: "aaa1" } },
+        cloud_scene_sources: { "scene-a": { scene_id: "store-a", scene_version: null } },
+      }),
+      scenesEqual,
+    });
+    expect([...ids]).toEqual(["scene-b"]);
+  });
+
+  it("falls back to all-or-nothing when the ledger predates the columns", () => {
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({
+        assigned_checksum: "new",
+        scenes_checksum: "old",
+        assigned_scene_state: null,
+        deployed_scene_state: null,
+      }),
+      scenesEqual,
+    });
+    expect([...ids].sort()).toEqual(["scene-a", "scene-b"]);
+  });
+
+  it("trusts the set checksum over a stale ledger once the device is in sync", () => {
+    // scene_ack promotes the ledger in the same UPDATE that stores the
+    // checksum, but a hello-path race must never make an in-sync frame look
+    // dirty: equal checksums win outright.
+    const ids = undeployedSceneIdsFor({
+      mode: "cloud",
+      scenes,
+      frame: frame({
+        assigned_checksum: "abc",
+        scenes_checksum: "abc",
+        assigned_scene_state: { "store-a": { version: 2, checksum: "aaa2" } },
+        deployed_scene_state: { "store-a": { version: 1, checksum: "aaa1" } },
+        cloud_scene_sources: { "scene-a": { scene_id: "store-a", scene_version: null } },
+      }),
+      scenesEqual,
+    });
+    expect(ids.size).toBe(0);
+  });
+
   it("ignores last_successful_deploy, which the cloud never writes", () => {
     // The old code path: with this field absent every scene looked undeployed.
     // Present-but-stale must not override the checksums either.

--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -531,7 +531,10 @@ export async function startFrameHub(
           ? { lastState: hello.states }
           : {}),
         ...(isAcceptableChecksum(hello.scenes_checksum)
-          ? { scenesChecksum: hello.scenes_checksum }
+          ? {
+              scenesChecksum: hello.scenes_checksum,
+              deployedSceneState: promotedSceneState(hello.scenes_checksum),
+            }
           : {}),
         // The device reports its hardware facts (panel, memory, partition
         // sizes) on every hello; without this refresh the enrollment-time
@@ -675,6 +678,16 @@ export async function startFrameHub(
     return false;
   }
 
+  // Promote the last assignment push's per-scene ledger to "deployed" the
+  // moment the device reports the matching set checksum. Any other reported
+  // checksum — an ad-hoc preview push, a stale set — leaves the ledger
+  // untouched: deployed_scene_state always describes the last ACKED
+  // assignment push, the cloud's equivalent of the backend's
+  // last_successful_deploy.scenes.
+  function promotedSceneState(reportedChecksum: string) {
+    return sql`case when ${reportedChecksum} = ${frames.assignedChecksum} then ${frames.assignedSceneState} else ${frames.deployedSceneState} end`;
+  }
+
   // Checksums are hex digests; an over-long one is malformed, and storing a
   // truncated copy would leave the frame permanently "out of sync" in the UI.
   function acceptChecksum(frameId: string, value: unknown) {
@@ -705,7 +718,12 @@ export async function startFrameHub(
       .set({
         lastSeenAt: now,
         updatedAt: now,
-        ...(checksum !== undefined ? { scenesChecksum: checksum } : {}),
+        ...(checksum !== undefined
+          ? {
+              scenesChecksum: checksum,
+              deployedSceneState: promotedSceneState(checksum),
+            }
+          : {}),
         ...(activeScene !== undefined
           ? {
               lastState: sql`coalesce(${frames.lastState}, '{}'::jsonb) || jsonb_build_object('active_scene', ${activeScene}::text)`,
@@ -735,7 +753,12 @@ export async function startFrameHub(
         ...(typeof rest.frameos_version === "string"
           ? { frameosVersion: rest.frameos_version.slice(0, 64) }
           : {}),
-        ...(checksum !== undefined ? { scenesChecksum: checksum } : {}),
+        ...(checksum !== undefined
+          ? {
+              scenesChecksum: checksum,
+              deployedSceneState: promotedSceneState(checksum),
+            }
+          : {}),
       })
       .where(eq(frames.id, session.frame.id));
     await broadcastFrameUpdate(session.frame.id);

--- a/cloud/apps/frame-hub/src/protocol.test.ts
+++ b/cloud/apps/frame-hub/src/protocol.test.ts
@@ -332,6 +332,8 @@ describe("browser event shaping", () => {
       publicKey: "pk",
       schedule: { events: [] },
       scenesChecksum: "have",
+      assignedSceneState: { "store-a": { checksum: "aaa", version: 1 } },
+      deployedSceneState: { "store-a": { checksum: "aaa", version: 1 } },
       // Denormalized scene-declared service settings groups. Group NAMES
       // travel to the browser (so the workspace can say which keys this
       // frame's scenes want); no field or value ever does.
@@ -342,8 +344,10 @@ describe("browser event shaping", () => {
     } satisfies FrameRow;
     expect(frameUpdateEvent(frame)).toEqual({
       assigned_checksum: "want",
+      assigned_scene_state: { "store-a": { checksum: "aaa", version: 1 } },
       connected: true,
       created_at: now,
+      deployed_scene_state: { "store-a": { checksum: "aaa", version: 1 } },
       frameos_version: "2026.8.1",
       hardware: { platform: "pi-zero2w" },
       id: "frame-uuid",
@@ -382,6 +386,8 @@ describe("browser event shaping", () => {
       publicKey: "pk",
       schedule: null,
       scenesChecksum: null,
+      assignedSceneState: null,
+      deployedSceneState: null,
       serviceSettingGroups: null,
       settings: null,
       status: "active",

--- a/cloud/apps/frame-hub/src/test/integration/frame-hub.integration.test.ts
+++ b/cloud/apps/frame-hub/src/test/integration/frame-hub.integration.test.ts
@@ -656,6 +656,48 @@ describe("command redelivery", () => {
     second.ws.close();
   });
 
+  it("promotes the per-scene ledger only on an ack of the assigned checksum", async () => {
+    const { frame, privateKey, token } = await createFrameFixture();
+    const ledger = {
+      "store-a": { checksum: "aaa", version: 3 },
+      "store-b": { checksum: "bbb", version: 1 },
+    };
+    await db
+      .update(frames)
+      .set({ assignedChecksum: "sum-assigned", assignedSceneState: ledger })
+      .where(eq(frames.id, frame.id));
+
+    const device = await openDevice(token);
+    await handshake(device, privateKey);
+
+    // An ack for some other payload (an ad-hoc preview push, a stale set)
+    // must not claim the assigned scenes were delivered.
+    device.send({ checksum: "sum-preview", id: randomUUID(), type: "scene_ack" });
+    await waitFor(async () => {
+      const [row] = await db
+        .select()
+        .from(frames)
+        .where(eq(frames.id, frame.id));
+      return row?.scenesChecksum === "sum-preview" ? row : undefined;
+    }, "preview checksum stored");
+    let [row] = await db.select().from(frames).where(eq(frames.id, frame.id));
+    expect(row?.deployedSceneState).toBeNull();
+
+    // The matching ack copies the assigned ledger to deployed in the same
+    // UPDATE that stores the checksum.
+    device.send({ checksum: "sum-assigned", id: randomUUID(), type: "scene_ack" });
+    await waitFor(async () => {
+      const [updated] = await db
+        .select()
+        .from(frames)
+        .where(eq(frames.id, frame.id));
+      return updated?.scenesChecksum === "sum-assigned" ? updated : undefined;
+    }, "assigned checksum stored");
+    [row] = await db.select().from(frames).where(eq(frames.id, frame.id));
+    expect(row?.deployedSceneState).toEqual(ledger);
+    device.ws.close();
+  });
+
   it("expires a sent command whose TTL passed instead of redelivering it", async () => {
     const { frame, privateKey, token } = await createFrameFixture();
     // Straight into the table as "sent": a five-minute-old reboot the device

--- a/cloud/docs/cloud-frames.md
+++ b/cloud/docs/cloud-frames.md
@@ -308,11 +308,28 @@ about. `frame.json` is still read as a fallback so frames elevated before the
 setting moved keep working; on ESP32 the equivalent store is NVS, which deploys
 do not touch either.
 
-Still open: cloud-installed scenes are not yet distinguished from local ones at
-runtime, so the `"shell"` risk-flag refusal and any origin-specific profile
-have nothing to key off. A frame demoted out of the managed state also loses
-the deny while still running the provider's last-pushed scenes — true on both
-platforms, and worth closing in one place.
+Scene origin is now tracked at runtime, on both platforms, and the device
+stamps it itself — a payload key is never trusted. On Pi/Linux the hub
+client's `set_scenes` handler marks the uploadScenes event `source: "cloud"`;
+the payload persists verbatim to `state/uploaded.json`, so the stamp survives
+reboots, and every rehydrate funnels through the same
+`updateUploadedScenesFromPayload` chokepoint. On ESP32 the scene index
+(`/state/scene-index.json`) records a top-level `source` of
+`local` / `backend` / `cloud`. Two things key off it:
+
+- **The private-network deny follows the scenes, not the link.** A frame
+  demoted out of the managed state keeps rendering the provider's last-pushed
+  scenes, and now keeps the deny with them (`refreshLocalNetworkPolicy` on
+  Pi, `apply_network_policy` on ESP32). Replacing the scenes locally or via a
+  backend deploy is what lifts it; the local elevation ceremony still
+  overrides.
+- **The refused-app check runs at load time, not only at transport time.** A
+  persisted cloud-origin payload is re-checked against
+  `CLOUD_REFUSED_APP_KEYWORDS` (`cloud/scene_guard.nim`) on every load, so a
+  file edited on disk — or written before a keyword joined the list — cannot
+  reach those apps by being replayed at boot. (On ESP32 the two refused apps
+  are not compiled into the firmware at all, so transport/load refusal is
+  structural there.)
 
 ### Signed OTA
 

--- a/cloud/docs/esp32-large-image-spill.md
+++ b/cloud/docs/esp32-large-image-spill.md
@@ -1,8 +1,17 @@
 # ESP32 large-image spill-to-storage
 
-Status: prototype merged to main (C glue + Nim reader + stub no-op,
-runtime-inert). Remaining: firmware wiring in `main.c` + bench validation —
-tracked in `docs/todo.md`.
+Status: shipped and bench-validated. The firmware wiring landed (spill dir
+in `main.c`, SD `.cache` preferred, `/state` fallback, boot sweep, the
+`set spill_force <bytes>` test knob), and the 13.3E6 forced-spill bench ran
+2026-08-13: a 4.4 MB baseline JPEG spilled to SD in ~24 s and streamed
+through the windowed decoder with a ~5.2 MB PSRAM floor. The bench also
+exposed that the decode-budget arithmetic — not memory — was the limiting
+factor (min(largest-block, headroom)/2 refused a 1.87 MB plan a fragmented
+heap easily held); the budget is now headroom-based, into-target decodes get
+the full headroom, and budget refusals degrade to a reduced-resolution
+decode instead of surfacing as error frames (`decodeIntoTargetWithDegrade`).
+Remaining nice-to-haves are in `docs/todo.md` (proactive Content-Length
+trigger, URL+ETag decode cache).
 
 ## The failure this fixes
 

--- a/cloud/packages/db/drizzle/0029_frame_scene_deploy_state.sql
+++ b/cloud/packages/db/drizzle/0029_frame_scene_deploy_state.sql
@@ -1,0 +1,13 @@
+-- Per-scene deploy tracking for cloud-managed frames. assigned_checksum /
+-- scenes_checksum cover the WHOLE assigned set, so the workspace could only
+-- say "something differs", never which scene. assigned_scene_state records,
+-- per store scene, {version, checksum} of the slice the last assignment push
+-- contained; the hub copies it into deployed_scene_state the moment the
+-- device acknowledges the matching set checksum. deployed_scene_state is the
+-- cloud's equivalent of the self-hosted backend's
+-- last_successful_deploy.scenes: what the device is actually running, per
+-- scene. NULL on frames that predate the column; the UI falls back to the
+-- old all-or-nothing behavior until the next push backfills it.
+ALTER TABLE "frames"
+  ADD COLUMN "assigned_scene_state" jsonb,
+  ADD COLUMN "deployed_scene_state" jsonb;

--- a/cloud/packages/db/src/schema.ts
+++ b/cloud/packages/db/src/schema.ts
@@ -661,6 +661,15 @@ export const frames = pgTable(
     // Desired vs device-acked interpreted-scene payload checksums.
     assignedChecksum: text("assigned_checksum"),
     scenesChecksum: text("scenes_checksum"),
+    // Per-scene deploy ledger: {storeSceneId: {version, checksum}}.
+    // assigned_scene_state is rewritten with every assignment push (the
+    // per-scene slices of the payload assigned_checksum covers);
+    // deployed_scene_state is the hub's copy of it, taken when the device
+    // acks the matching set checksum — the cloud's equivalent of the
+    // backend's last_successful_deploy.scenes, so the workspace can say
+    // WHICH scene is not on the frame yet instead of flagging all of them.
+    assignedSceneState: jsonb("assigned_scene_state"),
+    deployedSceneState: jsonb("deployed_scene_state"),
     ...timestamps,
   },
   (table) => ({

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -340,7 +340,7 @@ lines), nothing retained across disconnects, and error acks are ignored.
 | `state` | `hello`-shaped | sent on scene change / significant events |
 | `log_batch` | `{"logs": [{"timestamp", "scene"?, "payload"}…]}` | only with `telemetry:logs`; batched (device: ≤2 s / ≤100 lines); provider stores with a hard per-frame retention cap and counts retained bytes toward the account's storage usage |
 | `metrics` | `{"metrics": {…}}` | only with `telemetry:metrics` |
-| `scene_ack` | `{"checksum", "active_scene"}` | after a successful `set_scenes`, drives provider-side sync state |
+| `scene_ack` | `{"checksum", "active_scene"}` | after a successful `set_scenes`, drives provider-side sync state. When the acked checksum matches the provider's current assigned set, the provider also promotes its per-scene deploy ledger (`assigned_scene_state` → `deployed_scene_state` on the frame row) so the workspace can name WHICH scene is still pending on later edits |
 | `assets` | `{"id", "assets": […], "truncated"?}` | reply to `assets_list`; the provider caches the latest listing per frame (the reference provider rejects listings over **256 KiB** of JSON rather than truncating them) |
 | `asset_chunk` | `{"id", "seq", "data", "done", …}` | reply stream to `asset_get`; the provider reassembles in order, bounds the total at its per-file cap, and discards the partial file on a chunk carrying `"error"` or on disconnect |
 
@@ -801,8 +801,17 @@ in the scene logs. Two exceptions:
   elevation for scenes that legitimately need LAN access (e.g. Home
   Assistant).
 
-Standalone and backend-managed frames are unaffected; the deny is active only
-in managed mode.
+Standalone and backend-managed frames are unaffected. The deny keys on
+*provider-origin scenes*, not on the link alone: the device stamps every
+`set_scenes` payload with a runtime origin as it stores it (Pi/Linux:
+`"source": "cloud"` persisted with `state/uploaded.json`; ESP32: a top-level
+`"source"` in `/state/scene-index.json`), and a frame demoted out of the
+managed state keeps the deny for as long as those scenes remain resident.
+Replacing them — a local upload, a backend deploy — lifts it; the
+`allowLocalNetworkAccess` elevation above overrides in either state. The
+origin stamp is also re-checked at scene load time against the refused-app
+list, so a persisted cloud payload can never reach a process-spawning app by
+being replayed at boot.
 
 ## Compatibility
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,7 @@
 # FrameOS — consolidated remaining work
 
 One tracker for everything still open across the repo (last swept
-2026-08-10). Reference material — principles, permission scopes, store
+2026-08-13). Reference material — principles, permission scopes, store
 decisions, threat models, wire protocols — stays in the linked docs; this
 file only lists what is left to do. When an item ships, delete it here.
 
@@ -52,21 +52,6 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
   completes; composite over an opaque background at capture, reject
   fully-transparent uploads at publish, and backfill or gallery-fall-through
   the existing rows.
-- **Cloud "not on the frame yet" is all-or-nothing.** #323 reads the
-  assigned_checksum/scenes_checksum pair, which covers the whole assigned set
-  and cannot say WHICH scene differs. Per-scene granularity needs the cloud to
-  record what it last pushed — its equivalent of the backend's
-  `last_successful_deploy.scenes`.
-- **Scene origin is not tracked at runtime** — the JS-runtime capability
-  audit is done and written up in `cloud/docs/cloud-frames.md`, "sandbox
-  posture": bindings enumerated, JS time/heap/stack ceilings landed, the
-  asset sandbox made symlink-safe with an opt-in per-scene mode, RFC1918
-  blocking ported to ESP32, elevation moved behind an on-panel code. What is
-  left is the thing all of those wanted and none could have: a frame cannot
-  tell a cloud-installed scene from a locally authored one, so the store's
-  `"shell"` risk flag has nothing to refuse, and a frame demoted out of the
-  managed state keeps running the provider's last-pushed scenes with the LAN
-  deny switched off.
 - **Account hardening** — passkeys/TOTP 2FA, re-authentication for
   sensitive actions (revoking frames, bulk assignment changes, scope
   grants), per-frame audit trail surfaced in the UI.
@@ -82,25 +67,12 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
 - **Fleet extras** (design phase 4): offline alerting/notifications,
   backups integration, paid-tier gating.
 
-## Value pipeline (design + phased tracker in docs/value-pipeline.md)
-
-Replace the interpreter's single-shape decode-target fusion with declared
-per-port capabilities + a load-time planner with tiered fallback
-(fuse-into-target > canvas-sized scratch > materialize; bytes may spool to
-SD as a last-resort tier). Invisible in the editor. Phase 0 (per-node
-memory profiling on the 13.3E6) gates the ordering of the rest; the phase
-checklists live in the linked doc, not here.
-
 ## ESP32
 
-- **Large-image spill: bench validation** — a forced-spill render on the
-  13.3E6 (`set spill_force <bytes>`, ~3 MB gallery JPEG) confirming the PSRAM
-  floor during spill+decode. Measure fresh: the original premise, a 12-scene
-  workload eating the headroom, died when scenes stopped being resident.
-  Design: `cloud/docs/esp32-large-image-spill.md`.
-- Spill follow-ups (optional): proactive Content-Length trigger;
-  file-backed `InflateSegment` source in the pixie fork so spilled PNGs
-  stream too; URL+ETag decode cache.
+- Spill follow-ups (optional): proactive Content-Length trigger; URL+ETag
+  decode cache. (Spilled PNGs stream already; the 13.3E6 forced-spill bench
+  ran 2026-08-13 — 4.4 MB JPEG spilled to SD `.cache` and decoded with a
+  ~5.2 MB PSRAM floor after the decode-budget fixes.)
 
 ### Board follow-ups (rolled in from docs/esp32-photopainter-todo.md)
 
@@ -109,20 +81,6 @@ and the `image_get` cloud verb, all hardware-verified — so the file is gone
 and its board facts now live in `embedded/esp32/README.md` next to the preset
 table. What was still open there, mostly nice-to-have:
 
-- **The 13.3E6's internal-RAM figure is stale.** It was measured at ~16-19 KB
-  free with a dozen scenes, before the Nim heap moved to PSRAM explicitly and
-  before scenes became one-file-per-scene with only the active one resident.
-  Those two changes took a PhotoPainter from ~12.5 KB to ~109 KB. Nobody has
-  re-measured the 13.3E6; do that before drawing any conclusion from the old
-  number.
-- **Battery telemetry on the 13.3E6** — it has a battery header but no
-  telemetry IC. Check the schematic for a voltage-divider ADC pin and set
-  `battery_pin` if one is there.
-- **API-key rotation without reflash.** Check first whether `set api_key ""`
-  already clears it: the console has since grown an empty-value convention
-  for `gpio_buttons` and `cloud_wsurl`, so the original "cannot unset a
-  value" may no longer be true. Not tested here — it would wipe a live
-  frame's key.
 - **Parallel firmware builds.** Build directories are per-profile now, but
   `main/generated_config.h` and the Nim `nimcache` are still shared in-tree,
   so builds serialise under the global build lock.

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -125,10 +125,16 @@ Board facts worth knowing before reading a schematic (from the Waveshare docs),
 for the two Spectra boards most of the bench work runs on:
 
 - **13.3E6** — 32 MB flash, 16 MB PSRAM, TF slot on SPI3, MX1.25 battery
-  header. The charge IC is an ETA6098, *not* an I2C PMIC, so there is no
-  battery telemetry unless the schematic turns out to expose a voltage-divider
-  ADC pin. No RTC chip. No user buttons: BOOT and Reset only, which is why
-  GPIO wake has nothing to wake on.
+  header. The charge IC is an ETA6098, *not* an I2C PMIC, but VBAT is on
+  **ADC1_CH7 = GPIO8 through a 1/3 divider** (Waveshare's own `01_ADC_Test`
+  examples read CHANNEL_7 and multiply the calibrated voltage by 3), so
+  `battery_pin 8` + `battery_divider 3` gives voltage telemetry; the backend
+  preset bakes both. No RTC chip. No user buttons: BOOT and Reset only,
+  which is why GPIO wake has nothing to wake on. Internal RAM on 2026.8.17
+  firmware idles at **~103 KB free** (47 KB largest block) with a scene
+  resident and the cloud link up — the old ~16-19 KB figure predates the
+  PSRAM Nim heap and one-file-per-scene. `set api_key ""` clears a stored
+  key (the console's empty-value convention covers it now).
 - **PhotoPainter 7.3"** — 8 MB PSRAM, PMIC power-up, TF socket, and a KEY
   button next to BOOT (`0:BOOT`, `4:KEY1` in the preset's `gpio_buttons`).
 | `seeed_reterminal_sticky` | S3 | EPD_3in97 3.97" | reTerminal Sticky, 32MB flash |
@@ -279,7 +285,13 @@ into `/state/scene-<slot>.json` plus `/state/scene-index.json`, the combined
 file is deleted (the `state` partition is 1M and a payload may be 512K, so
 both do not fit), and only the **active** scene is parsed and resident. The
 index carries ids, names and refresh intervals, so the frame can list and
-switch scenes without holding them.
+switch scenes without holding them. It also carries a top-level
+`"source": "local" | "backend" | "cloud"` key recording who installed the
+payload (missing = `local` on pre-upgrade stores); `fos_cloud.c` keys the
+private-network egress deny on it, so provider-pushed scenes stay fenced off
+the owner's LAN even after the frame is demoted from cloud management. The
+source is mirrored in NVS so it survives the store→apply window across a
+reboot.
 
 Slot numbers rather than scene ids, because `CONFIG_SPIFFS_OBJ_NAME_LEN` is
 32 and a scene id is a 36-character uuid: `/<uuid>.json` cannot be opened at

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -408,8 +408,13 @@ const char *fos_cloud_ws_url(void) { return s_ws_url; }
  * runtime's utils/http_client.nim); this file owns the *trigger*, because this
  * is the only place that knows whether we are cloud-managed.
  *
- * Off whenever the frame is not enrolled. A standalone or backend-managed
- * frame runs the owner's own scenes, where reaching the LAN is the point. */
+ * Off whenever the frame is not enrolled AND not rendering provider scenes. A
+ * standalone or backend-managed frame runs the owner's own scenes, where
+ * reaching the LAN is the point. But enrollment alone is the wrong key: a
+ * demotion (cloud_demote) keeps rendering the last provider-pushed scenes, and
+ * those must not gain LAN access just because the link died — so the deny also
+ * keys on fos_scenes_from_cloud(), the persisted record of who installed the
+ * resident scenes (see fos_scenes.h). */
 
 /* Exempt one provider endpoint, as "host:port" with the scheme's default port
  * filled in — the same shape fos_netguard_url_allowed() derives from a request
@@ -447,13 +452,16 @@ static void netguard_exempt_provider_url(const char *url, bool ws)
  * of `allow_local_network` live without a restart. */
 static void apply_network_policy(void)
 {
-    static int logged_active = -1; /* -1 = nothing logged yet */
+    /* 0 = deny off, 1 = deny on (enrolled), 2 = deny on (demoted but still
+     * rendering cloud scenes), -1 = nothing logged yet. */
+    static int logged_state = -1;
     const fos_config_t *config = fos_config();
     const bool managed = (s_state == FOS_CLOUD_ENROLLED);
-    const bool active = managed && !config->allow_local_network;
+    const bool cloud_scenes = fos_scenes_from_cloud();
+    const bool active = (managed || cloud_scenes) && !config->allow_local_network;
 
     fos_netguard_clear_exempt();
-    if (active) {
+    if (active && managed) {
         /* The local admin linked this provider deliberately — possibly a dev
          * provider on the LAN — so the provider's own endpoints must not be
          * collateral damage. Both the API base URL and the optional ws_url
@@ -461,14 +469,25 @@ static void apply_network_policy(void)
         netguard_exempt_provider_url(config->cloud_url, false);
         netguard_exempt_provider_url(s_ws_url, true);
     }
+    /* Not enrolled but still holding cloud scenes: the link (and its URLs)
+     * are gone, so there is no provider host to exempt — exempts stay clear
+     * and the deny covers everything private. */
     fos_netguard_set_policy(active);
 
-    if ((int)active != logged_active) {
-        logged_active = (int)active;
-        if (active) {
+    const int state = active ? (managed ? 1 : 2) : 0;
+    if (state != logged_state) {
+        logged_state = state;
+        if (state == 1) {
             ESP_LOGW(TAG, "scene HTTP to private/link-local addresses is now blocked "
                           "(cloud-managed frame); override locally with "
                           "`set allow_local_network 1`");
+        } else if (state == 2) {
+            /* ESP_LOGW, not LOGI: LOGI is compiled out in every profile and
+             * this state must be visible on the serial stream. */
+            ESP_LOGW(TAG, "scene HTTP to private/link-local addresses stays blocked: "
+                          "frame is no longer cloud-managed but the resident scenes "
+                          "were pushed by the provider; upload scenes locally, sync "
+                          "from a backend, or `set allow_local_network 1` to lift");
         } else if (managed) {
             ESP_LOGW(TAG, "scene HTTP to private/link-local addresses is ALLOWED on this "
                           "cloud-managed frame (allow_local_network=1)");
@@ -1647,7 +1666,11 @@ static void ws_handle_set_scenes(const cJSON *root, const cJSON *id)
         return;
     }
     uint32_t generation = fos_scenes_apply_generation();
-    esp_err_t err = fos_scenes_set_json(payload, strlen(payload));
+    /* Declared CLOUD so the store remembers who installed these scenes:
+     * apply_network_policy() keeps the RFC1918 deny alive on that flag even
+     * after a demotion drops FOS_CLOUD_ENROLLED. */
+    esp_err_t err = fos_scenes_set_json_from(payload, strlen(payload),
+                                             FOS_SCENES_SOURCE_CLOUD);
     cJSON_free(payload);
     if (err != ESP_OK) {
         const char *detail = fos_scenes_last_error();
@@ -2414,7 +2437,15 @@ static void ws_clear_demote_request(void) {}
 /* Return to standalone: drop the provider credentials, keep the device key
  * (docs/cloud-frames.md — a revoked frame still needs a fresh claim token to
  * re-enroll) and keep rendering the last pushed scenes. Local admin surfaces
- * are untouched, so this can never lock the owner out of the device. */
+ * are untouched, so this can never lock the owner out of the device.
+ *
+ * The RFC1918 LAN deny intentionally SURVIVES this: the scenes still rendering
+ * were installed by the provider, and losing the link must not hand them the
+ * owner's LAN. apply_network_policy() keys on fos_scenes_from_cloud() as well
+ * as enrollment, and the scene source is persisted, so the deny holds across
+ * reboots too. Pushing scenes locally (HTTP/USB upload) or a backend sync
+ * replaces the cloud-sourced store and lifts the deny on the next policy
+ * tick; `set allow_local_network 1` overrides it immediately. */
 static void cloud_demote(const char *reason)
 {
     ws_stop();

--- a/embedded/esp32/main/fos_scenes.c
+++ b/embedded/esp32/main/fos_scenes.c
@@ -52,6 +52,17 @@ static const char *TAG = "fos_scenes";
 
 static bool s_mounted = false;
 static volatile bool s_pending = false;
+/* Who installed the scenes. s_source is the RESIDENT store's source (what the
+ * index on flash says, i.e. what the frame is rendering); s_pending_source is
+ * the source declared by the producer of a stored-but-not-yet-applied payload,
+ * promoted into s_source (and the index) when the apply succeeds. Plain
+ * volatile ints, like the rest of the cross-task flags here: they change only
+ * when a payload is stored/applied and single-word reads are atomic. The
+ * pending source is mirrored to NVS so a reboot inside the store→apply window
+ * (or before a combined scenes.json is first split) cannot launder a cloud
+ * payload into "local" — fos_cloud.c keys the LAN deny on this. */
+static volatile int s_source = FOS_SCENES_SOURCE_LOCAL;
+static volatile int s_pending_source = FOS_SCENES_SOURCE_LOCAL;
 /* Bumped once per pending-payload apply attempt by the render task; producers
  * poll it to learn whether their payload went live (see fos_scenes.h). */
 static volatile uint32_t s_apply_generation = 0;
@@ -389,6 +400,53 @@ static void persist_last_scene(const char *scene_id)
     nvs_close(nvs);
 }
 
+/* ----------------------------------------------------------- scene source */
+
+#define SCENE_SOURCE_NVS_KEY "scene_source"
+
+static const char *scene_source_str(int source)
+{
+    switch (source) {
+    case FOS_SCENES_SOURCE_BACKEND: return "backend";
+    case FOS_SCENES_SOURCE_CLOUD: return "cloud";
+    default: return "local";
+    }
+}
+
+/* Unknown or missing means LOCAL: pre-upgrade index files carry no "source"
+ * key, and those frames were never under cloud management on this firmware. */
+static int scene_source_from_str(const char *s)
+{
+    if (s != NULL) {
+        if (strcmp(s, "backend") == 0) return FOS_SCENES_SOURCE_BACKEND;
+        if (strcmp(s, "cloud") == 0) return FOS_SCENES_SOURCE_CLOUD;
+    }
+    return FOS_SCENES_SOURCE_LOCAL;
+}
+
+static void persist_scene_source(int source)
+{
+    nvs_handle_t nvs;
+    if (nvs_open("frameos", NVS_READWRITE, &nvs) != ESP_OK) return;
+    uint8_t current = 0xff;
+    if (nvs_get_u8(nvs, SCENE_SOURCE_NVS_KEY, &current) != ESP_OK ||
+        current != (uint8_t)source) {
+        nvs_set_u8(nvs, SCENE_SOURCE_NVS_KEY, (uint8_t)source);
+        nvs_commit(nvs);
+    }
+    nvs_close(nvs);
+}
+
+fos_scenes_source_t fos_scenes_source(void)
+{
+    return (fos_scenes_source_t)s_source;
+}
+
+bool fos_scenes_from_cloud(void)
+{
+    return s_source == FOS_SCENES_SOURCE_CLOUD;
+}
+
 /* True once the boot-time restore succeeded or an explicit selection made
  * it moot. Until then every scene load retries: the first payload after
  * boot can be the baked single-scene default (fresh /state), and the
@@ -548,6 +606,9 @@ static esp_err_t split_scenes(const char *json, size_t len)
         return ESP_ERR_NO_MEM;
     }
     cJSON_AddItemToObject(index, "scenes", scenes);
+    /* The producer declared this when it stored the payload; the index is
+     * written at apply time, so the value rode across in s_pending_source. */
+    cJSON_AddStringToObject(index, "source", scene_source_str(s_pending_source));
 
     esp_err_t err = ESP_OK;
     int written = 0;
@@ -618,6 +679,12 @@ static int load_scene_index(void)
         return 0;
     }
     cJSON *index = cJSON_ParseWithLength(index_json, len);
+    if (index != NULL) {
+        /* Missing key = pre-upgrade index = local. */
+        const cJSON *source = cJSON_GetObjectItem(index, "source");
+        s_source = scene_source_from_str(
+            cJSON_IsString(source) ? source->valuestring : NULL);
+    }
     const cJSON *scenes = cJSON_GetObjectItem(index, "scenes");
     if (cJSON_IsArray(scenes)) {
         const cJSON *entry = NULL;
@@ -748,6 +815,9 @@ static bool load_into_nim(const char *json, size_t len, const char *origin)
     size_t internal_cost = internal_before > internal_after
                                ? internal_before - internal_after : 0;
     s_loaded = count;
+    /* Whole-payload path (no index to carry it): the loaded payload's source
+     * becomes the resident source. The split path does this via the index. */
+    s_source = s_pending_source;
     ESP_LOGI(TAG, "%d scene(s) live; internal RAM %u -> %u (%u B for %d scenes, ~%u B each)",
              count, (unsigned)internal_before, (unsigned)internal_after,
              (unsigned)internal_cost, count,
@@ -965,6 +1035,25 @@ esp_err_t fos_scenes_init(void)
     esp_err_t err = mount_state();
     if (err != ESP_OK) return err;
     load_etag();
+    /* Restore the stored scenes' source BEFORE any task can ask: main() calls
+     * fos_cloud_start() after this, and its boot-time apply_network_policy()
+     * must see "cloud" on a demoted frame that still holds provider-pushed
+     * scenes — the LAN deny has to come up armed, not after the first apply.
+     * NVS is written at store time and always matches what the index (or the
+     * still-pending combined payload) carries; the first apply re-reads the
+     * index and corrects any divergence. Missing key = pre-upgrade = local. */
+    {
+        nvs_handle_t nvs;
+        if (nvs_open("frameos", NVS_READONLY, &nvs) == ESP_OK) {
+            uint8_t stored = 0;
+            if (nvs_get_u8(nvs, SCENE_SOURCE_NVS_KEY, &stored) == ESP_OK &&
+                stored <= FOS_SCENES_SOURCE_CLOUD) {
+                s_source = (int)stored;
+                s_pending_source = (int)stored;
+            }
+            nvs_close(nvs);
+        }
+    }
     struct stat st;
     if (stat(SCENES_PATH, &st) == 0 && st.st_size > 2) {
         ESP_LOGI(TAG, "cached scenes.json (%ld bytes, etag %s)", (long)st.st_size,
@@ -984,8 +1073,10 @@ esp_err_t fos_scenes_init(void)
 
 /* ------------------------------------------------------------ local push */
 
-esp_err_t fos_scenes_set_json(const char *json, size_t len)
+esp_err_t fos_scenes_set_json_from(const char *json, size_t len,
+                                   fos_scenes_source_t source)
 {
+    const char *origin = scene_source_str((int)source);
     s_last_error[0] = '\0';
     if (json == NULL || len == 0 || len > SCENES_MAX_BYTES) {
         set_scene_simple_error("invalid scenes payload length", len);
@@ -995,18 +1086,30 @@ esp_err_t fos_scenes_set_json(const char *json, size_t len)
     if (err != ESP_OK) return err;
     err = write_file_replace(SCENES_PATH, SCENES_TMP_PATH, json, len);
     if (err != ESP_OK) {
-        log_scene_event("event:uploadScenes", "error", "local", "",
+        log_scene_event("event:uploadScenes", "error", origin, "",
                         s_last_error[0] ? s_last_error : "store-failed",
                         len, 0, 0, err);
         return err;
     }
     s_last_error[0] = '\0';
+    /* "local" etag for cloud pushes too: it means "not the backend's payload,
+     * do not clobber on the next backend sync pass" (see fos_scenes_sync). */
     save_etag("local");
+    /* Recorded only after the payload is on flash, so a failed store cannot
+     * relabel whatever is still resident. */
+    s_pending_source = (int)source;
+    persist_scene_source((int)source);
     s_pending = true;
-    ESP_LOGI(TAG, "scenes payload stored (%u bytes), pending apply", (unsigned)len);
-    log_scene_event("event:uploadScenes", "stored", "local", "", "pending-apply",
+    ESP_LOGI(TAG, "scenes payload stored (%u bytes, source %s), pending apply",
+             (unsigned)len, origin);
+    log_scene_event("event:uploadScenes", "stored", origin, "", "pending-apply",
                     len, 0, 0, ESP_OK);
     return ESP_OK;
+}
+
+esp_err_t fos_scenes_set_json(const char *json, size_t len)
+{
+    return fos_scenes_set_json_from(json, len, FOS_SCENES_SOURCE_LOCAL);
 }
 
 /* ------------------------------------------------------------- backend */
@@ -1154,6 +1257,12 @@ esp_err_t fos_scenes_sync(bool force)
     err = write_file_replace(SCENES_PATH, SCENES_TMP_PATH, buf, total);
     if (err == ESP_OK) {
         save_etag(response_etag);
+        /* Backend-served payload: declare it before load_into_nim promotes
+         * the pending source, and persist it so the boot-time split (this
+         * path leaves the combined file for the next apply to split) records
+         * "backend" in the index. */
+        s_pending_source = FOS_SCENES_SOURCE_BACKEND;
+        persist_scene_source(FOS_SCENES_SOURCE_BACKEND);
         ESP_LOGI(TAG, "scenes updated from backend (%u bytes, etag %s)",
                  (unsigned)total, response_etag[0] ? response_etag : "none");
         log_scene_event("scenes:sync", "updated", "backend", "", "stored",

--- a/embedded/esp32/main/fos_scenes.h
+++ b/embedded/esp32/main/fos_scenes.h
@@ -16,6 +16,17 @@
 #include <stdint.h>
 #include "esp_err.h"
 
+/* Who installed the scenes a frame is holding. Not cosmetic: fos_cloud.c keys
+ * the RFC1918 LAN deny (fos_netguard) on this, so provider-pushed scenes stay
+ * fenced off the owner's LAN even after the frame is demoted from cloud
+ * management. Persisted in /state/scene-index.json (top-level "source") and
+ * mirrored in NVS so the answer survives reboots and the store→apply window. */
+typedef enum {
+    FOS_SCENES_SOURCE_LOCAL = 0,   /* HTTP POST /uploadScenes, USB console, portal */
+    FOS_SCENES_SOURCE_BACKEND,     /* fos_scenes_sync() from the configured backend */
+    FOS_SCENES_SOURCE_CLOUD,       /* cloud provider's set_scenes over the WS link */
+} fos_scenes_source_t;
+
 /* Mount /state and mark any cached scenes.json for loading. */
 esp_err_t fos_scenes_init(void);
 
@@ -25,8 +36,19 @@ esp_err_t fos_scenes_sync(bool force);
 bool fos_scenes_state_mounted(void);
 
 /* Persist a scenes JSON payload (local push, e.g. POST /api/scenes) and mark
- * it pending. Safe from any task; trigger a render to apply. */
+ * it pending. Safe from any task; trigger a render to apply.
+ * fos_scenes_set_json() means FOS_SCENES_SOURCE_LOCAL; every non-local caller
+ * must declare itself via fos_scenes_set_json_from(). */
 esp_err_t fos_scenes_set_json(const char *json, size_t len);
+esp_err_t fos_scenes_set_json_from(const char *json, size_t len,
+                                   fos_scenes_source_t source);
+
+/* Source of the stored scenes. Safe to read from any task (plain volatile
+ * int, same convention as the other fos_scenes flags; it changes only when a
+ * new payload is stored or applied). Defaults to LOCAL on a pre-upgrade
+ * store whose index has no "source" key. */
+fos_scenes_source_t fos_scenes_source(void);
+bool fos_scenes_from_cloud(void);
 
 /* Last storage/sync error detail, suitable for HTTP/USB responses. */
 const char *fos_scenes_last_error(void);

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -66,7 +66,12 @@ import frameos/utils/http_client
 import ./enrollment
 import ./identity
 import ./link_state
+import ./scene_guard
 import ./service_settings
+
+# Tests and other importers keep reaching CLOUD_REFUSED_APP_KEYWORDS /
+# refusedCloudAppKeyword through this module.
+export scene_guard
 
 const
   HubBackoffMinSeconds = 3.0
@@ -131,27 +136,10 @@ const CLOUD_SETTINGS_ALLOWLIST* = [
   "name", "rotate", "interval", "scaling_mode", "timezone", "debug",
 ]
 
-# Built-in apps a provider-pushed scene may not reference. Everything else on a
-# managed frame reaches the network through utils/http_client, where
-# `enforceLocalNetworkPolicy` denies private addresses; these two do not, so a
-# `set_scenes` push naming them would walk straight around that chokepoint.
-# Locally authored scenes are unaffected — this list is only consulted by the
-# cloud verb dispatcher (handleSetScenes).
-#
-# Derived by grepping src/apps for child-process spawning
-# (`utils/process`, `hal/processes`, `runProcess`, `osproc`): those two files
-# are the complete set on this branch. Legacy apps that call std/httpclient
-# directly (apps/legacy/openai*) are not listed because they are not in the
-# compiled registry (src/apps/apps.nim) and therefore cannot be reached by any
-# keyword at all.
-const CLOUD_REFUSED_APP_KEYWORDS* = [
-  # apt-get install (privileged!) plus a headless Chromium pointed at a
-  # configured URL: a package installer and an SSRF pivot in one node.
-  "chromiumScreenshot",
-  # ffmpeg -i <url>: another attacker-chosen target fetched by a child process
-  # rather than by the bounded HTTP client.
-  "rstpSnapshot",
-]
+# CLOUD_REFUSED_APP_KEYWORDS / refusedCloudAppKeyword moved to
+# cloud/scene_guard.nim (re-exported below): the scene registry now re-checks
+# persisted cloud-origin payloads at load time, and scenes.nim cannot import
+# this module.
 
 type
   CloudHubAuthError* = object of CatchableError
@@ -306,11 +294,19 @@ initLock(policyCacheLock)
 
 proc refreshLocalNetworkPolicy*(frameConfig: FrameConfig) {.gcsafe.} =
   ## Recomputes the managed-frame private-network HTTP deny
-  ## (utils/http_client.nim): active iff the frame is cloud-managed and the
+  ## (utils/http_client.nim): active iff the frame is cloud-managed — or
+  ## still running provider-pushed scenes after losing the link — and the
   ## local admin has not set `network.allowLocalNetworkAccess` in frame.json.
-  ## Called at startup and whenever the hub thread observes link-state or
-  ## config changes; standalone and backend-managed frames always end up with
-  ## the policy off.
+  ## Called at startup, whenever the hub thread observes link-state or config
+  ## changes, and (via uploadedScenesChangedHook) whenever the uploaded scene
+  ## set is replaced; standalone and backend-managed frames always end up
+  ## with the policy off.
+  ##
+  ## The scene-origin term closes the demotion hole: demoteManagedLink keeps
+  ## rendering the provider's last-pushed scenes, and before origin was
+  ## recorded that meant those scenes kept running with the deny switched
+  ## off. Now the deny follows the scenes, not the link — replacing them
+  ## locally (or via a backend deploy) is what lifts it.
   {.gcsafe.}:
     # Sampled before the (possibly cached) read so a save that races us always
     # leaves the cache key behind the state file, never ahead of it.
@@ -331,11 +327,17 @@ proc refreshLocalNetworkPolicy*(frameConfig: FrameConfig) {.gcsafe.} =
       exempt = policyCacheExempt
     let localOverride = frameConfig != nil and frameConfig.network != nil and
       frameConfig.network.allowLocalNetworkAccess
-    setLocalNetworkPolicy(managed and not localOverride, exempt)
+    # Computed outside the generation cache: the uploaded scene set changes
+    # independently of the link state.
+    let providerScenes = cloudUploadedScenesResident()
+    setLocalNetworkPolicy((managed or providerScenes) and not localOverride, exempt)
 
 proc demoteManagedLink(reason: string) {.gcsafe.} =
   ## Persistent 401: the provider revoked this frame. Return to standalone —
-  ## keep rendering the last pushed scenes, never touch them.
+  ## keep rendering the last pushed scenes, never touch them. The LAN deny
+  ## deliberately survives this: refreshLocalNetworkPolicy keys on the
+  ## persisted scene origin, so provider-pushed scenes keep their network
+  ## restrictions until the local admin (or a backend deploy) replaces them.
   {.gcsafe.}:
     withLock cloudLinkLock:
       let state = loadCloudLinkState()
@@ -559,38 +561,6 @@ proc validateInterpretedScenesPayload*(scenes: JsonNode): tuple[ok: bool, error:
       return (false, "invalid_scenes")
   (true, "")
 
-proc refusedCloudAppKeyword*(scenes: JsonNode): string {.gcsafe.} =
-  ## "" when the payload references no app from CLOUD_REFUSED_APP_KEYWORDS,
-  ## otherwise the offending keyword. Cloud-pushed scenes only: a scene the
-  ## local admin wrote may still use these apps, which is why this check lives
-  ## in the verb dispatcher and not in the scene parser.
-  if scenes == nil or scenes.kind != JArray:
-    return ""
-  for scene in scenes:
-    if scene == nil or scene.kind != JObject:
-      continue
-    let nodes = scene{"nodes"}
-    if nodes == nil or nodes.kind != JArray:
-      continue
-    for node in nodes:
-      if node == nil or node.kind != JObject:
-        continue
-      if node{"type"}.getStr("") != "app":
-        continue
-      let data = node{"data"}
-      if data == nil or data.kind != JObject:
-        continue
-      let keyword = data{"keyword"}.getStr("")
-      if keyword.len == 0:
-        continue
-      # Compare on the trailing segment ("data/rstpSnapshot" → "rstpSnapshot")
-      # so a category rename cannot quietly reopen the hole.
-      let leaf = keyword.rsplit('/', maxsplit = 1)[^1]
-      for refused in CLOUD_REFUSED_APP_KEYWORDS:
-        if cmpIgnoreCase(leaf, refused) == 0:
-          return keyword
-  ""
-
 proc expectedUploadedSceneId(scenes: JsonNode, requestedSceneId = ""): string =
   ## updateUploadedScenesFromPayload prefixes every scene id with "uploaded/",
   ## and activates the payload's `sceneId` when it names one of the pushed
@@ -643,7 +613,14 @@ proc handleSetScenes(ctx: CloudVerbContext, id: JsonNode, msg: JsonNode): CloudV
   # The workspace's "preview on frame" flow names which pushed scene to
   # activate and seeds its public state; the runtime's uploadScenes handler
   # honors both keys (runner.nim), so pass them through untouched.
-  var eventPayload = %*{"scenes": scenes}
+  #
+  # "source" is the runtime origin stamp: the DEVICE marks everything that
+  # arrives over this verb as provider-pushed — never trusting a key inside
+  # the payload — and updateUploadedScenesFromPayload persists it with the
+  # scenes. It is what keeps the LAN deny up after a demotion and what the
+  # load-time refused-app re-check keys on. Local admin uploads carry no
+  # source and read back as "local".
+  var eventPayload = %*{"scenes": scenes, "source": "cloud"}
   let requestedSceneId = msg{"scene_id"}.getStr("")
   if requestedSceneId.len > 0:
     eventPayload["sceneId"] = %requestedSceneId
@@ -1642,6 +1619,11 @@ proc startCloudManagement*(frameConfig: FrameConfig) {.gcsafe.} =
   ## the frame is enrolled (mode=managed in cloud_link.json) or a pending
   ## claim-token enrollment file appears at boot.
   {.gcsafe.}:
+    # A local upload replacing provider scenes must lift (or a rehydrate must
+    # raise) the deny without waiting for a hub tick — the hub thread idles
+    # on a standalone or demoted frame.
+    uploadedScenesChangedHook = proc() {.gcsafe.} =
+      refreshLocalNetworkPolicy(frameConfig)
     # Policy is correct from the first render onwards, not only once the
     # thread has spun up.
     refreshLocalNetworkPolicy(frameConfig)

--- a/frameos/src/frameos/cloud/scene_guard.nim
+++ b/frameos/src/frameos/cloud/scene_guard.nim
@@ -1,0 +1,62 @@
+# Shared guard for provider-pushed scene payloads. Lives in its own leaf
+# module (stdlib only) because both the cloud verb dispatcher
+# (cloud/hub_client.nim, transport time) and the scene registry
+# (frameos/scenes.nim, load time) consult it — scenes.nim cannot import
+# hub_client, which imports it back.
+import std/[json, strutils]
+
+# Built-in apps a provider-pushed scene may not reference. Everything else on a
+# managed frame reaches the network through utils/http_client, where
+# `enforceLocalNetworkPolicy` denies private addresses; these two do not, so a
+# `set_scenes` push naming them would walk straight around that chokepoint.
+# Locally authored scenes are unaffected — this list is only consulted for
+# payloads whose recorded source is the cloud.
+#
+# Derived by grepping src/apps for child-process spawning
+# (`utils/process`, `hal/processes`, `runProcess`, `osproc`): those two files
+# are the complete set on this branch. Legacy apps that call std/httpclient
+# directly (apps/legacy/openai*) are not listed because they are not in the
+# compiled registry (src/apps/apps.nim) and therefore cannot be reached by any
+# keyword at all.
+const CLOUD_REFUSED_APP_KEYWORDS* = [
+  # apt-get install (privileged!) plus a headless Chromium pointed at a
+  # configured URL: a package installer and an SSRF pivot in one node.
+  "chromiumScreenshot",
+  # ffmpeg -i <url>: another attacker-chosen target fetched by a child process
+  # rather than by the bounded HTTP client.
+  "rstpSnapshot",
+]
+
+proc refusedCloudAppKeyword*(scenes: JsonNode): string {.gcsafe.} =
+  ## "" when the payload references no app from CLOUD_REFUSED_APP_KEYWORDS,
+  ## otherwise the offending keyword. Cloud-pushed scenes only: a scene the
+  ## local admin wrote may still use these apps. Checked twice on purpose —
+  ## at transport time by the verb dispatcher, and again at load time for any
+  ## persisted payload whose source is the cloud, so a file edited on disk or
+  ## written before a keyword was added still cannot reach these apps.
+  if scenes == nil or scenes.kind != JArray:
+    return ""
+  for scene in scenes:
+    if scene == nil or scene.kind != JObject:
+      continue
+    let nodes = scene{"nodes"}
+    if nodes == nil or nodes.kind != JArray:
+      continue
+    for node in nodes:
+      if node == nil or node.kind != JObject:
+        continue
+      if node{"type"}.getStr("") != "app":
+        continue
+      let data = node{"data"}
+      if data == nil or data.kind != JObject:
+        continue
+      let keyword = data{"keyword"}.getStr("")
+      if keyword.len == 0:
+        continue
+      # Compare on the trailing segment ("data/rstpSnapshot" → "rstpSnapshot")
+      # so a category rename cannot quietly reopen the hole.
+      let leaf = keyword.rsplit('/', maxsplit = 1)[^1]
+      for refused in CLOUD_REFUSED_APP_KEYWORDS:
+        if cmpIgnoreCase(leaf, refused) == 0:
+          return keyword
+  ""

--- a/frameos/src/frameos/cloud/tests/test_hub_verbs.nim
+++ b/frameos/src/frameos/cloud/tests/test_hub_verbs.nim
@@ -278,6 +278,9 @@ suite "cloud hub verb dispatcher":
     check recorded.events.len == 1
     check recorded.events[0][0] == "uploadScenes"
     check recorded.events[0][1]{"scenes"}.kind == JArray
+    # The device stamps the runtime origin itself — this is what persists to
+    # state/uploaded.json and keeps the LAN deny alive after a demotion.
+    check recorded.events[0][1]{"source"}.getStr("") == "cloud"
     check recorded.persistedChecksums == @["sum-1"]
     check ctx.scenesChecksum == "sum-1"
     check reply.extra.len == 1

--- a/frameos/src/frameos/scenes.nim
+++ b/frameos/src/frameos/scenes.nim
@@ -4,6 +4,7 @@ import checksums/md5
 import scenes/scenes
 import system/scenes as systemScenesRegistry
 import frameos/channels
+import frameos/cloud/scene_guard
 import frameos/hal/files as halFiles
 import frameos/types
 import frameos/interpreter
@@ -263,11 +264,37 @@ var
   lastPersistedSceneId: Option[SceneId] = none(SceneId)
   uploadedScenePayloadLock: Lock
   uploadedScenePayload {.guard: uploadedScenePayloadLock.} = ""
+  # Runtime origin of the uploaded scene set: "cloud" when the payload came in
+  # over the provider's set_scenes verb (hub_client stamps it, the payload is
+  # persisted verbatim so the stamp survives reboots), "" for local admin
+  # uploads. Trust-boundary metadata, not the template-provenance
+  # `scene.origin` the editor writes.
+  uploadedScenesSource {.guard: uploadedScenePayloadLock.} = ""
   uploadedStateCleanupRan = false
+
+# Lets the cloud module recompute the LAN-deny policy when the uploaded scene
+# set (and with it the recorded origin) changes — scenes.nim cannot import
+# hub_client, which imports this module. Registered by startCloudManagement.
+var uploadedScenesChangedHook*: proc() {.gcsafe.} = nil
 
 proc setUploadedScenePayload*(payload: string) =
   withLock uploadedScenePayloadLock:
     uploadedScenePayload = payload
+
+proc setUploadedScenesSource(source: string) =
+  withLock uploadedScenePayloadLock:
+    uploadedScenesSource = source
+
+proc cloudUploadedScenesResident*(): bool =
+  ## True while the resident uploaded scene set was pushed by a cloud
+  ## provider. Keeps the private-network deny keyed to the scenes themselves:
+  ## a frame demoted out of the managed state still runs them, so it keeps
+  ## the deny until they are replaced.
+  {.gcsafe.}:
+    var isCloud = false
+    withLock uploadedScenePayloadLock:
+      isCloud = uploadedScenesSource == "cloud"
+    isCloud
 
 proc getUploadedScenePayload*(): JsonNode =
   withLock uploadedScenePayloadLock:
@@ -376,6 +403,21 @@ proc updateUploadedScenesFromPayload*(
   else:
     return (none(SceneId), @[])
 
+  # Runtime origin stamp (hub_client sets "cloud" on the set_scenes verb; the
+  # payload round-trips through state/uploaded.json, so the stamp survives a
+  # reboot). Cloud-origin payloads repeat the refused-app check the verb
+  # dispatcher already ran at transport time: a payload edited on disk, or
+  # persisted before a keyword joined the list, must not reach those apps by
+  # being replayed at boot.
+  let payloadSource = payload{"source"}.getStr("")
+  if payloadSource == "cloud":
+    let refused = refusedCloudAppKeyword(scenePayload)
+    if refused.len > 0:
+      log(%*{"event": "uploadScenes:refused", "source": payloadSource,
+             "keyword": refused,
+             "message": "Cloud-origin scene payload references a refused app; not loading it."})
+      return (none(SceneId), @[])
+
   # nim json -> jsony -> FrameSceneInput
   # clunky but works...
   let payloadString = $scenePayload
@@ -394,6 +436,11 @@ proc updateUploadedScenesFromPayload*(
     oldUploaded = uploadedScenes
   updateUploadedScenes(newScenes)
   setUploadedScenePayload(payloadString)
+  setUploadedScenesSource(payloadSource)
+  # The LAN-deny policy keys on the recorded origin; recompute it now rather
+  # than on the next hub tick (the hub thread idles on a demoted frame).
+  if not uploadedScenesChangedHook.isNil:
+    uploadedScenesChangedHook()
   for sceneId in oldUploaded.keys:
     if sceneId.string.startsWith("uploaded/") and not newScenes.hasKey(sceneId):
       removePersistedState(sceneId)

--- a/frameos/src/frameos/tests/test_decode_degrade.nim
+++ b/frameos/src/frameos/tests/test_decode_degrade.nim
@@ -1,0 +1,75 @@
+# The decode-budget plan check must never surface as an error frame when a
+# degraded decode would fit: decodeIntoTargetWithDegrade retries a refused
+# into-target decode at reduced resolution and upscales. These tests drive
+# the ladder with a scripted decode proc so the mechanics are pinned without
+# depending on a real decoder's plan arithmetic.
+import std/[strutils, unittest]
+import pixie
+import ../utils/image
+
+proc budgetRefusal(): ref PixieError =
+  newException(PixieError,
+    "JPEG decode of 2048x3072 needs 1869K of decode buffers, over the " &
+    "1807K memory budget")
+
+suite "decodeIntoTargetWithDegrade":
+  test "a decode that fits runs once, straight into the target":
+    let target = newImage(120, 160)
+    var calls: seq[(int, int)] = @[]
+    let got = decodeIntoTargetWithDegrade(target, fitCover,
+      proc(dst: Image) =
+        calls.add((dst.width, dst.height))
+        dst.fill(rgbx(10, 20, 30, 255)))
+    check got == target
+    check calls == @[(120, 160)]
+    check target[0, 0] == rgbx(10, 20, 30, 255)
+
+  test "a budget refusal retries at half resolution and upscales":
+    let target = newImage(120, 160)
+    var calls: seq[(int, int)] = @[]
+    let got = decodeIntoTargetWithDegrade(target, fitCover,
+      proc(dst: Image) =
+        calls.add((dst.width, dst.height))
+        if dst.width == target.width:
+          raise budgetRefusal()
+        dst.fill(rgbx(200, 100, 50, 255)))
+    check got == target
+    check calls == @[(120, 160), (60, 80)]
+    # The degraded decode's pixels were stretched over the full target.
+    check target[0, 0] == rgbx(200, 100, 50, 255)
+    check target[119, 159] == rgbx(200, 100, 50, 255)
+
+  test "keeps halving while the plan still refuses":
+    let target = newImage(120, 160)
+    var calls: seq[(int, int)] = @[]
+    discard decodeIntoTargetWithDegrade(target, fitCover,
+      proc(dst: Image) =
+        calls.add((dst.width, dst.height))
+        if dst.width > 30:
+          raise budgetRefusal()
+        dst.fill(rgbx(1, 2, 3, 255)))
+    check calls == @[(120, 160), (60, 80), (30, 40)]
+    check target[64, 64] == rgbx(1, 2, 3, 255)
+
+  test "re-raises the original refusal when every rung is refused":
+    let target = newImage(120, 160)
+    var calls = 0
+    expect PixieError:
+      discard decodeIntoTargetWithDegrade(target, fitCover,
+        proc(dst: Image) =
+          inc calls
+          raise budgetRefusal())
+    check calls == 3
+
+  test "non-budget errors pass through without any retry":
+    let target = newImage(120, 160)
+    var calls = 0
+    try:
+      discard decodeIntoTargetWithDegrade(target, fitCover,
+        proc(dst: Image) =
+          inc calls
+          raise newException(PixieError, "progressive JPEGs cannot stream"))
+      check false
+    except PixieError as e:
+      check "progressive" in e.msg
+    check calls == 1

--- a/frameos/src/frameos/tests/test_scenes_persistence.nim
+++ b/frameos/src/frameos/tests/test_scenes_persistence.nim
@@ -127,3 +127,49 @@ suite "scene persistence helpers":
     let first = getFirstSceneId()
     check first != missingUploaded
     check first.string.len > 0
+
+  test "uploaded payloads record their runtime origin":
+    # hub_client stamps source=cloud on the set_scenes verb; a local admin
+    # upload carries no source. The stamp keys the post-demotion LAN deny.
+    let scenes = %*[{
+      "id": "origin-test", "name": "Origin",
+      "nodes": [{"id": "1", "type": "app", "data": {"keyword": "data/clock"}}],
+      "edges": [],
+    }]
+    var hookFired = 0
+    uploadedScenesChangedHook = proc() {.gcsafe.} = inc hookFired
+    defer: uploadedScenesChangedHook = nil
+
+    let (cloudMain, _) = updateUploadedScenesFromPayload(
+      %*{"scenes": scenes, "source": "cloud"}, persistPayload = true)
+    check cloudMain.isSome
+    check cloudUploadedScenesResident()
+    check hookFired == 1
+    # The stamp survives in the persisted payload (what a reboot rehydrates).
+    check parseJson(readFile(uploadedFile)){"source"}.getStr("") == "cloud"
+
+    let (localMain, _) = updateUploadedScenesFromPayload(
+      %*{"scenes": scenes}, persistPayload = false)
+    check localMain.isSome
+    check not cloudUploadedScenesResident()
+    check hookFired == 2
+
+  test "cloud-origin payloads are re-checked for refused apps at load time":
+    # The verb dispatcher refuses these at transport time; the load-time
+    # re-check covers payloads edited on disk or persisted before a keyword
+    # joined the list. Local payloads with the same app still load.
+    let scenes = %*[{
+      "id": "refused-test", "name": "Refused",
+      "nodes": [{"id": "1", "type": "app",
+                 "data": {"keyword": "data/chromiumScreenshot"}}],
+      "edges": [],
+    }]
+    let (cloudMain, cloudIds) = updateUploadedScenesFromPayload(
+      %*{"scenes": scenes, "source": "cloud"}, persistPayload = false)
+    check cloudMain.isNone
+    check cloudIds.len == 0
+    check not cloudUploadedScenesResident()
+
+    let (localMain, _) = updateUploadedScenesFromPayload(
+      %*{"scenes": scenes}, persistPayload = false)
+    check localMain.isSome

--- a/frameos/src/frameos/utils/image.nim
+++ b/frameos/src/frameos/utils/image.nim
@@ -666,6 +666,45 @@ proc scalingModeToFit(scalingMode: string): Option[ScaledDecodeFit] =
   of "stretch": some(fitStretch)
   else: none(ScaledDecodeFit)
 
+proc decodeIntoTargetWithDegrade*(target: Image, fit: ScaledDecodeFit,
+    decode: proc(dst: Image)): Image =
+  ## Runs an into-target decode; when the decoder's plan check refuses for
+  ## lack of memory ("over the … memory budget"), retries the same decode at
+  ## reduced resolution into a temporary image and upscales the result onto
+  ## the target. A blurrier render always beats an error frame — the budget
+  ## refusal is a planning answer, so degrading the plan is the fix, not
+  ## surfacing the message. Non-budget errors pass through untouched.
+  try:
+    decode(target)
+    return target
+  except PixieError as refusal:
+    if not refusal.msg.contains("memory budget"):
+      raise
+    let refusalMsg = refusal.msg
+    # Halving the target quarters the plan's channel buffers; two rungs cover
+    # everything short of a heap that cannot hold even a quarter-res frame.
+    for divisor in [2, 4]:
+      var temp: Image
+      try:
+        temp = newImage(max(1, target.width div divisor),
+                        max(1, target.height div divisor))
+      except CatchableError:
+        continue
+      # The temp allocation itself changed the heap; re-plan against it.
+      refreshDecodeBudgetInto()
+      try:
+        decode(temp)
+        # temp shares the target's aspect and the fit was applied during the
+        # decode, so the upscale is a pure stretch.
+        target.scaleAndDrawImage(temp, "stretch")
+        refreshDecodeBudgetInto()
+        return target
+      except PixieError as retryRefusal:
+        if not retryRefusal.msg.contains("memory budget"):
+          raise
+        continue
+    raise newException(PixieError, refusalMsg)
+
 proc readImageIntoTarget*(path: string, target: Image, scalingMode: string): bool =
   ## Decodes an image file directly into an existing target image (usually
   ## the render canvas) with aspect-correct fit, keeping peak memory at the
@@ -683,7 +722,9 @@ proc readImageIntoTarget*(path: string, target: Image, scalingMode: string): boo
     return false
   let fit = fitOption.get()
 
-  refreshDecodeBudget()
+  # Into-target decode: the output is the pre-allocated canvas, so the
+  # decode plan may use the whole headroom (see refreshDecodeBudgetInto).
+  refreshDecodeBudgetInto()
   let fileSize = getFileSize(path)
   var header = probeImageFileHeader(path)
 
@@ -728,14 +769,21 @@ proc readImageIntoTarget*(path: string, target: Image, scalingMode: string): boo
     raise newException(PixieError, "Cannot open image file: " & path)
   try:
     if jpeg:
-      decodeJpegStreamScaledInto(fileJpegSource(file), fileSize.int, target, fit)
+      # A budget refusal degrades to a reduced-resolution decode inside the
+      # helper; only non-budget errors (progressive JPEGs) reach the buffered
+      # retry below.
+      discard decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+        file.setFilePos(0)
+        decodeJpegStreamScaledInto(fileJpegSource(file), fileSize.int, dst, fit))
       return true
     if streamablePng:
       when compiles(decodePngStreamScaledInto(fileJpegSource(file), fileSize.int, target, fit)):
         # Row-streamed: the compressed body is read incrementally and never held
         # whole, so this needs a fixed inflate window plus a row, not a block the
         # size of the file. Interlaced and 16-bit PNGs raise here and fall back.
-        decodePngStreamScaledInto(fileJpegSource(file), fileSize.int, target, fit)
+        discard decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+          file.setFilePos(0)
+          decodePngStreamScaledInto(fileJpegSource(file), fileSize.int, dst, fit))
         return true
     if streamableBmp:
       when compiles(decodeBmpStreamScaledInto(fileJpegSource(file), fileSize.int, target, fit)):
@@ -903,23 +951,24 @@ when defined(frameosEmbedded):
     header.setLen(max(0, got))
     let format = embeddedImageFormat(header.cstring, header.len)
     if format == "JPEG" and not target.isNil and target.width > 0 and target.height > 0:
-      file.setFilePos(0)
-      GC_fullCollect()
       when compiles(decodeJpegStreamScaledInto(fileJpegSource(file), totalLen, target, fit)):
         # Progressive JPEGs raise here; the buffered retry other paths use is
         # exactly the allocation that could not be made, so let it surface.
-        decodeJpegStreamScaledInto(fileJpegSource(file), totalLen, target, fit)
-        return target
+        # Budget refusals degrade to a reduced-resolution decode instead.
+        return decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+          file.setFilePos(0)
+          GC_fullCollect()
+          decodeJpegStreamScaledInto(fileJpegSource(file), totalLen, dst, fit))
     if format == "PNG" and not target.isNil and target.width > 0 and target.height > 0:
-      file.setFilePos(0)
-      GC_fullCollect()
       when compiles(decodePngStreamScaledInto(fileJpegSource(file), totalLen, target, fit)):
         # Row-streamed chunk walk over the spilled file: a small read buffer
         # plus pixie's fixed inflate window, never the whole compressed body.
         # Interlaced/16-bit PNGs raise here — decoding those would need the
         # buffered copy the spill exists to avoid, so let it surface.
-        decodePngStreamScaledInto(fileJpegSource(file), totalLen, target, fit)
-        return target
+        return decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+          file.setFilePos(0)
+          GC_fullCollect()
+          decodePngStreamScaledInto(fileJpegSource(file), totalLen, dst, fit))
     if format == "BMP" and not target.isNil and target.width > 0 and target.height > 0:
       file.setFilePos(0)
       GC_fullCollect()
@@ -936,15 +985,16 @@ when defined(frameosEmbedded):
         decodePpmStreamScaledInto(fileJpegSource(file), totalLen, target, fit)
         return target
     if format == "WEBP" and not target.isNil and target.width > 0 and target.height > 0:
-      file.setFilePos(0)
-      GC_fullCollect()
       when compiles(decodeWebpStreamScaledInto(fileJpegSource(file), totalLen, target, fit)):
         # A WebP bitstream cannot be windowed (VP8 partitions interleave
         # macroblock rows; VP8L's LZ77 window is the whole image), so pixie
         # holds the compressed body — budget-checked, refusing catchably —
-        # while the full-size RGBA intermediate still never exists.
-        decodeWebpStreamScaledInto(fileJpegSource(file), totalLen, target, fit)
-        return target
+        # while the full-size RGBA intermediate still never exists. Budget
+        # refusals degrade to a reduced-resolution decode.
+        return decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+          file.setFilePos(0)
+          GC_fullCollect()
+          decodeWebpStreamScaledInto(fileJpegSource(file), totalLen, dst, fit))
     raise newException(PixieError,
       &"Spilled {format} download ({totalLen div 1024}K) has no file-backed streaming decoder")
 
@@ -1006,15 +1056,30 @@ when defined(frameosEmbedded):
     # budget" plan check ran against a stale number — and a progressive JPEG
     # that passed it then OOM-aborted the render on a fragmented heap where
     # the largest free block was 1,668 bytes smaller than its allocation.
-    refreshDecodeBudget()
+    # With a target the decode streams into the existing canvas, so the
+    # output half of the budget split does not apply.
+    if not target.isNil and target.width > 0 and target.height > 0:
+      refreshDecodeBudgetInto()
+    else:
+      refreshDecodeBudget()
     try:
       if response.code >= 400:
         raise newException(HttpRequestError, "HTTP " & response.status & httpErrorDetail(response))
+      let intoTarget = not target.isNil and target.width > 0 and target.height > 0
       let image =
         if response.spillPath.len > 0:
           decodeSpilledImageInto(response.spillPath, response.bodyLen, target, fit)
         elif response.chunks.len > 1:
-          decodeImageChunks(response.chunks, response.bodyLen, target, fit)
+          if intoTarget:
+            # Budget refusals degrade to a reduced-resolution decode rather
+            # than reaching the scene as an error frame.
+            decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+              discard decodeImageChunks(response.chunks, response.bodyLen, dst, fit))
+          else:
+            decodeImageChunks(response.chunks, response.bodyLen, target, fit)
+        elif intoTarget:
+          decodeIntoTargetWithDegrade(target, fit, proc(dst: Image) =
+            discard decodeImageWithFallback(response.body, response.bodyLen, dst, fit))
         elif not target.isNil:
           decodeImageWithFallback(response.body, response.bodyLen, target, fit)
         elif boundWidth > 0 and boundHeight > 0:

--- a/frameos/src/frameos/utils/memory.nim
+++ b/frameos/src/frameos/utils/memory.nim
@@ -122,10 +122,28 @@ proc availableRenderHeadroomBytes*(): int =
 proc refreshDecodeBudget*() =
   ## Updates pixie's per-decode budget from live memory. Decode
   ## intermediates may take roughly half of what is available, leaving the
-  ## other half for the decoded output and the canvas.
-  let available = availableRenderBytes()
+  ## other half for the decoded output and the canvas. The intermediates are
+  ## many separate buffers (channel bands, accumulator rows, block streams),
+  ## so this is the headroom question — can the allocations coexist — not
+  ## the contiguous-block one: with the render canvas allocated the 13.3E6
+  ## sits at ~5.2MB free with a ~2.7MB largest block, and halving the block
+  ## answer refused a 1.4MB streamed-JPEG working set the heap held with
+  ## room to spare (spill bench, 2026-08). Single image-sized buffers keep
+  ## checking availableRenderBytes at their own call sites.
+  let available = availableRenderHeadroomBytes()
   if available > 0:
     setDecodeBudgetBytes(available div 2)
+
+proc refreshDecodeBudgetInto*() =
+  ## refreshDecodeBudget for decodes that stream into an existing target
+  ## (readImageIntoTarget, the spilled/chunked download paths): the decoded
+  ## output already exists as the canvas, so no second half needs reserving
+  ## and the whole headroom may hold the decode plan. The emergency reserve
+  ## sits outside the headroom either way. On the 13.3E6 the halved budget
+  ## refused a spilled 4.4MB JPEG whose ~1.8MB plan fit the heap twice over.
+  let available = availableRenderHeadroomBytes()
+  if available > 0:
+    setDecodeBudgetBytes(available)
 
 proc ensureRenderAllocation*(bytes: int64, what: string) =
   ## Raises a catchable error when an allocation plan clearly exceeds the

--- a/frontend/src/models/framesModel.tsx
+++ b/frontend/src/models/framesModel.tsx
@@ -1,6 +1,6 @@
 import { actions, afterMount, beforeUnmount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { FrameScene, FrameType, FrameId } from '../types'
+import { CloudSceneSource, FrameScene, FrameType, FrameId } from '../types'
 import { socketLogic } from '../scenes/socketLogic'
 import type { framesModelType } from './framesModelType'
 import { router } from 'kea-router'
@@ -145,9 +145,16 @@ export function clearCloudSceneJsonCache(storeSceneId: string): void {
   }
 }
 
-async function fetchCloudFrameScenes(frameId: FrameId): Promise<FrameScene[]> {
+async function fetchCloudFrameScenes(
+  frameId: FrameId
+): Promise<{ scenes: FrameScene[]; sources: Record<string, CloudSceneSource> }> {
   const rows = await listCloudFrameScenes(frameId)
   const scenes: FrameScene[] = []
+  // Runtime scene id → the store-scene assignment it came from. This is the
+  // only place both id spaces are visible at once, and the per-scene deploy
+  // ledger (assigned_scene_state / deployed_scene_state) is keyed by store
+  // scene id while the tiles are runtime scenes.
+  const sources: Record<string, CloudSceneSource> = {}
   for (const row of rows) {
     const cacheKey = cloudSceneCacheKey(row)
     let sceneJson = cloudSceneJsonCache.get(cacheKey)
@@ -164,9 +171,13 @@ async function fetchCloudFrameScenes(frameId: FrameId): Promise<FrameScene[]> {
         // a transient error heals on the next hydration pass.
       }
     }
-    scenes.push(...(sceneJson ?? [cloudSceneStub(row)]))
+    const rowScenes = sceneJson ?? [cloudSceneStub(row)]
+    for (const scene of rowScenes) {
+      sources[scene.id] = { scene_id: row.scene_id, scene_version: row.scene_version ?? null }
+    }
+    scenes.push(...rowScenes)
   }
-  return scenes
+  return { scenes, sources }
 }
 
 /**
@@ -179,7 +190,9 @@ function withStoredCloudScenes(next: FrameType, previous?: FrameType): FrameType
   if (!isCloudMode() || next.scenes?.length || !previous?.scenes?.length) {
     return next
   }
-  return { ...next, scenes: previous.scenes }
+  // cloud_scene_sources is hydration-owned client state; a frameSummary
+  // refetch never carries it, so keep it alongside the scenes it describes.
+  return { ...next, scenes: previous.scenes, cloud_scene_sources: previous.cloud_scene_sources }
 }
 
 const pendingSdCardImageDownloads = new Set<FrameId>()
@@ -591,7 +604,11 @@ export const framesModel = kea<framesModelType>([
     // frame.scenes so the tiles survive a reload. `force` skips the
     // once-a-minute throttle (used right after an install).
     hydrateCloudFrameScenes: (id: FrameId, force?: boolean) => ({ id, force: force || false }),
-    setCloudFrameScenes: (id: FrameId, scenes: FrameScene[]) => ({ id, scenes }),
+    setCloudFrameScenes: (id: FrameId, scenes: FrameScene[], sources?: Record<string, CloudSceneSource>) => ({
+      id,
+      scenes,
+      sources,
+    }),
     deployRemote: (id: FrameId, recompile?: boolean, transport: RemoteTaskTransport = 'auto') => ({
       id,
       recompile: recompile || false,
@@ -698,12 +715,16 @@ export const framesModel = kea<framesModelType>([
           ...state,
           [frame.id]: sanitizeFrameForStore(frame),
         }),
-        setCloudFrameScenes: (state, { id, scenes }) => {
+        setCloudFrameScenes: (state, { id, scenes, sources }) => {
           const frame = state[id]
           if (!frame) return state
           return {
             ...state,
-            [id]: sanitizeFrameForStore({ ...frame, scenes }),
+            [id]: sanitizeFrameForStore({
+              ...frame,
+              scenes,
+              ...(sources ? { cloud_scene_sources: sources } : {}),
+            }),
           }
         },
         setDeployWithAgent: (state, { id, deployWithAgent }) => {
@@ -1388,7 +1409,7 @@ export const framesModel = kea<framesModelType>([
       }
       cloudFrameSceneHydrationsInFlight.add(id)
       try {
-        const scenes = await fetchCloudFrameScenes(id)
+        const { scenes, sources } = await fetchCloudFrameScenes(id)
         cloudFrameScenesHydratedAt.set(id, Date.now())
         const frame = values.frames[id]
         if (!frame) {
@@ -1399,8 +1420,11 @@ export const framesModel = kea<framesModelType>([
         // reset) and re-renders every tile — needless churn on a poll where
         // nothing moved.
         const sanitized = scenes.map((scene) => sanitizeScene(scene, frame))
-        if (JSON.stringify(frame.scenes ?? []) !== JSON.stringify(sanitized)) {
-          actions.setCloudFrameScenes(id, scenes)
+        if (
+          JSON.stringify(frame.scenes ?? []) !== JSON.stringify(sanitized) ||
+          JSON.stringify(frame.cloud_scene_sources ?? {}) !== JSON.stringify(sources)
+        ) {
+          actions.setCloudFrameScenes(id, scenes, sources)
         }
       } catch (error) {
         console.error(error)

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -37,6 +37,20 @@ export interface FrameErrorBehavior {
   show_error_retry_seconds?: number
 }
 
+/** One store scene's slice of a cloud assignment push: the version that
+ * produced the bytes and the checksum of just that scene's runtime scenes
+ * (cloud/apps/auth-web/src/lib/frames.ts buildScenesPayloadForFrame). */
+export interface CloudSceneDeployState {
+  version?: number | null
+  checksum?: string
+}
+
+/** Which store-scene assignment a hydrated runtime scene came from. */
+export interface CloudSceneSource {
+  scene_id: string
+  scene_version?: number | null
+}
+
 export interface FrameType {
   id: FrameId
   project_id: number
@@ -220,6 +234,17 @@ export interface FrameType {
    * last_successful_deploy_at on this control plane). */
   assigned_checksum?: string | null
   scenes_checksum?: string | null
+  /** Cloud only: per-STORE-scene deploy ledger ({storeSceneId: {version,
+   * checksum}}). assigned_scene_state describes the last assignment push;
+   * deployed_scene_state is the hub's copy of it from the moment the device
+   * acked the matching set checksum. Null/absent on frames that predate the
+   * ledger — per-scene sync state then falls back to all-or-nothing. */
+  assigned_scene_state?: Record<string, CloudSceneDeployState> | null
+  deployed_scene_state?: Record<string, CloudSceneDeployState> | null
+  /** Cloud only, client-side: which store scene each hydrated RUNTIME scene
+   * came from, recorded while fetching scenes.json per assignment
+   * (framesModel.hydrateCloudFrameScenes). Keyed by runtime scene id. */
+  cloud_scene_sources?: Record<string, CloudSceneSource>
   /** Cloud only: the newest metrics sample the device sent. Read for the
    * memory advisory (utils/frameMemory.ts) — an embedded frame can render
    * fine while having too little internal RAM left to open its TLS link. */

--- a/frontend/src/utils/sceneDeployState.ts
+++ b/frontend/src/utils/sceneDeployState.ts
@@ -10,14 +10,17 @@ import type { WorkspaceMode } from '../scenes/workspace/workspaceSurfaces'
 //
 //   * backend  — the frame row carries `last_successful_deploy.scenes`, the
 //     exact graphs SSH last installed, so the comparison is per scene.
-//   * cloud    — there is no such field, and nothing writes one. A cloud
-//     deploy is a checksummed `set_scenes` push: `assigned_checksum` is what
-//     the account assigned, `scenes_checksum` is what the device acknowledged
-//     (the same pair the account frames table renders as "in sync" /
-//     "sync pending"). Reading `last_successful_deploy` there compared every
-//     scene against an empty list, so all of them were permanently pending.
-//     A single checksum covers the whole set, so this is all-or-nothing: it
-//     cannot say WHICH scene differs, only that the device is behind.
+//   * cloud    — a cloud deploy is a checksummed `set_scenes` push:
+//     `assigned_checksum` is what the account assigned, `scenes_checksum` is
+//     what the device acknowledged (the same pair the account frames table
+//     renders as "in sync" / "sync pending"). When they differ, the
+//     per-scene ledger narrows the blame: `assigned_scene_state` holds each
+//     store scene's slice of the last push, `deployed_scene_state` the copy
+//     the hub took when the device last acked a push, and
+//     `cloud_scene_sources` (hydration-owned) maps runtime scene ids back to
+//     their store scenes. Only scenes whose slice changed are flagged.
+//     Frames that predate the ledger (null maps) fall back to the old
+//     all-or-nothing answer: every scene pending until the checksums agree.
 //   * frameAdmin — the frame is the thing being edited; there is nowhere to
 //     deploy to.
 export function undeployedSceneIdsFor({
@@ -48,6 +51,24 @@ export function undeployedSceneIdsFor({
     // dirty before the user has done anything.
     if (!assigned && !reported) {
       return new Set<string>()
+    }
+    // Per-scene ledger: flag only the store scenes whose assigned slice
+    // differs from the last device-acked push. Needs the hydration-recorded
+    // runtime→store mapping; a runtime scene with no known source (a stub
+    // tile, an ad-hoc preview) counts as pending.
+    const assignedState = frame?.assigned_scene_state
+    const sources = frame?.cloud_scene_sources
+    if (assignedState && sources) {
+      const deployedState = frame?.deployed_scene_state ?? {}
+      const undeployed = new Set<string>()
+      scenes.forEach((scene) => {
+        const source = sources[scene.id]
+        const assignedSlice = source ? assignedState[source.scene_id] : undefined
+        if (!assignedSlice || assignedSlice.checksum !== deployedState[source!.scene_id]?.checksum) {
+          undeployed.add(scene.id)
+        }
+      })
+      return undeployed
     }
     return new Set(scenes.map((scene) => scene.id))
   }


### PR DESCRIPTION
Three long-standing tracker items closed in one branch, plus a bench session on the 13.3E6 that found and fixed a real rendering bug.

## Per-scene deploy tracking (cloud)

`assigned_checksum`/`scenes_checksum` covered the whole assigned set, so a device that was behind flagged *every* scene as "not on the frame yet". The cloud now keeps a per-scene ledger — its equivalent of the backend's `last_successful_deploy.scenes`:

- `buildScenesPayloadForFrame` digests each assignment's slice; `POST /frames/{id}/scenes` stores `frames.assigned_scene_state` (`{storeSceneId: {version, checksum}}`, migration `0029`).
- The hub promotes it to `deployed_scene_state` atomically wherever it stores a reported checksum (hello / state / scene_ack) — and only when the ack matches the current assigned set, so an ad-hoc preview push never claims the assignment was delivered.
- The SPA records a runtime→store scene-id map during hydration and flags only the scenes whose assigned slice differs from the acked one. Frames predating the ledger keep the old all-or-nothing answer.

## Runtime scene origin (both platforms)

A frame could not tell a cloud-installed scene from a locally authored one, so a frame demoted out of managed state kept running the provider's scenes with the LAN deny off. The device now stamps origin itself (payload keys are never trusted):

- **Pi/Linux**: the `set_scenes` verb marks the upload `source: "cloud"`, persisted verbatim in `state/uploaded.json`. `refreshLocalNetworkPolicy` keys on *(managed OR cloud scenes resident)*; a hook recomputes it when the scene set changes (the hub thread idles on a demoted frame). Cloud-origin payloads are re-checked against `CLOUD_REFUSED_APP_KEYWORDS` at **load** time (new leaf module `cloud/scene_guard.nim`), so an edited or pre-list persisted payload cannot reach process-spawning apps at boot.
- **ESP32**: `scene-index.json` carries a top-level `"source"` (`local`/`backend`/`cloud`), mirrored in NVS so the deny arms at boot before the cloud task starts. `apply_network_policy` keys the netguard on *(enrolled OR cloud scenes resident)*, with a visible log when a demoted frame keeps the deny.

Replacing the scenes (local upload, backend sync) lifts the deny; the local elevation ceremony still overrides. Docs updated (`docs/cloud-frames.md`, `cloud/docs/cloud-frames.md` sandbox posture).

## Decode budget: degrade, never error (found by the bench)

The 13.3E6 kept logging `JPEG decode of 2048x3072 needs 1869K of decode buffers, over the 1807K memory budget` while 5+ MB sat free. Fixed on principle — a budget refusal must never surface as an error frame:

- budget derives from **headroom** (free − reserve), not the halved contiguous-block answer — decode intermediates are many separate buffers;
- into-target decodes get the **full** headroom (their output is the pre-allocated canvas);
- if a plan still refuses, `decodeIntoTargetWithDegrade` retries at half/quarter resolution and upscales — blur beats an error frame.

Hardware-verified: a forced-spill 4.4 MB baseline JPEG now spills to SD and renders cleanly (~6.9 MB PSRAM floor, deterministic output) where it previously error-framed.

## Bench session (13.3E6, frame 59)

- Internal RAM re-measured: **~103 KB free** idle, ~104 KB with all 13 scenes loaded (the stale ~16-19 KB figure is dead).
- Battery: VBAT = ADC1_CH7 = **GPIO8, ÷3 divider** (vendor examples), baked into the hardware preset — hardware-confirmed at 4194 mV / 99% on the attached pack.
- `set api_key ""` clears a stored key now (empty-value convention).
- Forced-spill validation ran end-to-end; `docs/todo.md` swept accordingly (also removes the shipped value-pipeline and blank-tile items).

## Tests

- cloud: 476 auth-web unit tests, 45 frames + 31 frame-hub integration tests (new: ledger write, hub promotion, per-scene deploy-state cases)
- Nim: hub verbs (source stamp), scenes persistence (origin round-trip + load-time refusal), decode-degrade ladder, spilled-stream, image-spool, repo-scenes, network-policy — all green
- backend: 66 embedded-firmware tests (new battery-preset assertions)
- ESP32: esp32-s3-32mb firmware builds clean; all of the above hardware-checked on the bench 13.3E6

🤖 Generated with [Claude Code](https://claude.com/claude-code)