### PR TITLE
Cloud workspace truthfulness for live frames: image, active scene, activity grouping

### DIFF
--- a/cloud/apps/auth-web/app/api/frames/[frameId]/image/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/image/route.ts
@@ -14,7 +14,12 @@ export const runtime = "nodejs";
 
 const fetchCommandTtlMs = 2 * 60 * 1000;
 // The preview panel wants "the current image" — anything older than a
-// render interval is history. Serve stale immediately, refresh behind it.
+// render interval is history. A passive load (?t=-1, a tile filling in)
+// serves stale immediately and refreshes behind it; an explicit refresh
+// (?t=<seconds> — the refresh button, or a render signal) waits for the
+// device's answer before falling back to the stale copy. Serving the same
+// stale bytes to the very click that asked for fresh ones is how the
+// refresh button reads as broken.
 const imageStaleAfterMs = 30_000;
 const longPollTotalMs = 25_000;
 const longPollStepMs = 750;
@@ -101,6 +106,10 @@ export async function GET(
 
   const cached = await cachedImage(db, frame.id);
   const now = Date.now();
+  // ?t=-1 is the tile's initial cache-only load (entityImagesModel); any
+  // real timestamp means someone deliberately asked for the current image.
+  const tParam = request.nextUrl.searchParams.get("t");
+  const wantsFresh = tParam !== null && tParam !== "-1";
   const needsFetch =
     !cached || now - cached.updatedAt.getTime() > imageStaleAfterMs;
   if (
@@ -115,18 +124,22 @@ export async function GET(
       type: "image_get",
     });
   }
-  if (cached) {
+  const canWaitForFresh = frame.status === "active";
+  if (cached && !(wantsFresh && needsFetch && canWaitForFresh)) {
     return imageResponse(cached);
   }
   if (frame.status !== "active") {
     return jsonError("frame_not_active", 409);
   }
 
+  // Long-poll for the image_get result: the first image ever, or one newer
+  // than the stale row an explicit refresh is trying to replace.
+  const previousUpdatedAt = cached?.updatedAt.getTime() ?? 0;
   const deadline = now + longPollTotalMs;
   while (Date.now() < deadline) {
     await sleep(longPollStepMs);
     const row = await cachedImage(db, frame.id);
-    if (row) {
+    if (row && row.updatedAt.getTime() > previousUpdatedAt) {
       return imageResponse(row);
     }
     const [refused] = await db
@@ -142,8 +155,17 @@ export async function GET(
       )
       .limit(1);
     if (refused) {
+      // The device could not serve a fresh image right now (busy mid-render,
+      // rebooting, nothing rendered yet). For a refresh of an existing image
+      // the stale copy beats an error page.
+      if (cached) {
+        return imageResponse(cached);
+      }
       return jsonError(refused.error ?? "image_unavailable", 404);
     }
+  }
+  if (cached) {
+    return imageResponse(cached);
   }
   return jsonError("image_unavailable", 504);
 }

--- a/cloud/apps/auth-web/src/test/integration/frame-image.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frame-image.integration.test.ts
@@ -1,0 +1,255 @@
+// GET /api/frames/{id}/image — the frame's current rendered image, backed by
+// the image_get verb and the frame_asset_files cache.
+//
+// The ?t= query param carries intent (entityImagesModel): t=-1 is a tile
+// filling in passively — serve whatever is cached immediately and refresh
+// behind it — while a real timestamp is a deliberate "give me the current
+// image" (the refresh button, a render signal), which must wait for the
+// device's answer instead of echoing the stale cache back at the click that
+// asked for fresh bytes. That echo is exactly how "the frame shows the new
+// render but Refresh shows the old image" happened on a live esp32 frame.
+import { generateKeyPairSync } from "node:crypto";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { NextRequest } from "next/server";
+import {
+  createDb,
+  frameAssetFiles,
+  frameCommands,
+  linkedClients,
+  frames,
+  upsertAccountFromIdentity,
+} from "@frameos-cloud/db";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET as getFrameImage } from "../../../app/api/frames/[frameId]/image/route";
+import { frameImageAssetPath } from "../../lib/frames";
+import { resetRateLimitForTests } from "../../lib/rate-limit";
+import { hashSecret } from "../../lib/secrets";
+import { createSession, sessionCookieName } from "../../lib/session";
+
+const cookieJar = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) => {
+      const value = cookieJar.get(name);
+      return value === undefined ? undefined : { name, value };
+    },
+  }),
+  headers: async () => new Headers(),
+}));
+
+const baseUrl = "http://localhost:3000";
+const issuer = "https://accounts.google.com";
+const db = createDb();
+let userCounter = 0;
+
+afterAll(async () => {
+  await db.$client.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  resetRateLimitForTests();
+  cookieJar.clear();
+  const tables = await db.execute<{ tablename: string }>(
+    sql`select tablename from pg_tables where schemaname = 'public'`,
+  );
+  const names = tables
+    .map((row) => row.tablename)
+    .filter((name) => name !== "schema_migrations")
+    .map((name) => `"${name}"`);
+  if (names.length > 0) {
+    await db.execute(sql.raw(`TRUNCATE TABLE ${names.join(", ")} CASCADE`));
+  }
+});
+
+function imageRequest(frameId: string, t?: string) {
+  const query = t === undefined ? "" : `?t=${t}`;
+  return new NextRequest(
+    new URL(`/api/frames/${frameId}/image${query}`, baseUrl),
+    { method: "GET" },
+  );
+}
+
+const routeParams = (frameId: string) => ({
+  params: Promise.resolve({ frameId }),
+});
+
+async function signIn() {
+  userCounter += 1;
+  const providerSubject = `frame-image-user-${userCounter}`;
+  const { accountId } = await upsertAccountFromIdentity(db, {
+    displayName: `Frame Image User ${userCounter}`,
+    email: `frame-image-${userCounter}@example.com`,
+    emailVerified: true,
+    providerIssuer: issuer,
+    providerKey: "google",
+    providerSubject,
+  });
+  const token = await createSession(db, {
+    accountId,
+    providerIssuer: issuer,
+    providerSubject,
+  });
+  cookieJar.set(sessionCookieName, token);
+  return accountId;
+}
+
+function rawPublicKeyBase64() {
+  const { publicKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  return Buffer.from(spki.subarray(spki.length - 32)).toString("base64");
+}
+
+async function createFrame(accountId: string, status = "active") {
+  const [client] = await db
+    .insert(linkedClients)
+    .values({
+      accountId,
+      clientKind: "frame",
+      providerClientMetadata: { requestedScopes: ["frame:managed"] },
+      publicDisplayName: "Frame image frame",
+      tokenReference: hashSecret(`fc_link_frame_image_${accountId}`),
+    })
+    .returning();
+  const [frame] = await db
+    .insert(frames)
+    .values({
+      accountId,
+      linkedClientId: client!.id,
+      name: "Frame image frame",
+      publicKey: rawPublicKeyBase64(),
+      status,
+    })
+    .returning();
+  return frame!;
+}
+
+async function cacheImage(frameId: string, bytes: string, ageMs: number) {
+  await db
+    .delete(frameAssetFiles)
+    .where(
+      and(
+        eq(frameAssetFiles.frameId, frameId),
+        eq(frameAssetFiles.path, frameImageAssetPath),
+      ),
+    );
+  await db.insert(frameAssetFiles).values({
+    content: Buffer.from(bytes),
+    contentType: "image/bmp",
+    frameId,
+    path: frameImageAssetPath,
+    sizeBytes: bytes.length,
+    thumb: false,
+    updatedAt: new Date(Date.now() - ageMs),
+  });
+}
+
+async function outstandingImageGets(frameId: string) {
+  return db
+    .select()
+    .from(frameCommands)
+    .where(
+      and(
+        eq(frameCommands.frameId, frameId),
+        eq(frameCommands.type, "image_get"),
+        inArray(frameCommands.status, ["pending", "sent"]),
+      ),
+    );
+}
+
+describe("GET /api/frames/{id}/image freshness", () => {
+  it("serves a stale image immediately on a passive load and refreshes behind it", async () => {
+    const accountId = await signIn();
+    const frame = await createFrame(accountId);
+    await cacheImage(frame.id, "old-render", 60_000);
+
+    const started = Date.now();
+    const response = await getFrameImage(
+      imageRequest(frame.id, "-1"),
+      routeParams(frame.id),
+    );
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "old-render",
+    );
+    // No long-poll on the passive path — the tile must fill in instantly.
+    expect(Date.now() - started).toBeLessThan(500);
+    // …but the stale copy still queues a device fetch behind it.
+    expect(await outstandingImageGets(frame.id)).toHaveLength(1);
+  });
+
+  it("waits for the device's fresh image on an explicit refresh", async () => {
+    const accountId = await signIn();
+    const frame = await createFrame(accountId);
+    await cacheImage(frame.id, "old-render", 60_000);
+
+    // The device answering the queued image_get, a moment after the request
+    // starts long-polling.
+    const deviceReply = setTimeout(() => {
+      void cacheImage(frame.id, "new-render", 0);
+    }, 1200);
+    try {
+      const response = await getFrameImage(
+        imageRequest(frame.id, String(Math.floor(Date.now() / 1000))),
+        routeParams(frame.id),
+      );
+      expect(response.status).toBe(200);
+      expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+        "new-render",
+      );
+    } finally {
+      clearTimeout(deviceReply);
+    }
+    expect(await outstandingImageGets(frame.id)).toHaveLength(1);
+  }, 15_000);
+
+  it("serves a fresh-enough cache immediately, even on an explicit refresh", async () => {
+    const accountId = await signIn();
+    const frame = await createFrame(accountId);
+    await cacheImage(frame.id, "recent-render", 5_000);
+
+    const response = await getFrameImage(
+      imageRequest(frame.id, String(Math.floor(Date.now() / 1000))),
+      routeParams(frame.id),
+    );
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "recent-render",
+    );
+    // Under the staleness window nothing needs re-fetching.
+    expect(await outstandingImageGets(frame.id)).toHaveLength(0);
+  });
+
+  it("falls back to the stale image when the device refuses the fetch", async () => {
+    const accountId = await signIn();
+    const frame = await createFrame(accountId);
+    await cacheImage(frame.id, "old-render", 60_000);
+    // A refusal from moments ago (busy mid-render, rebooting…).
+    await db.insert(frameCommands).values({
+      error: "busy",
+      frameId: frame.id,
+      status: "failed",
+      type: "image_get",
+    });
+
+    const response = await getFrameImage(
+      imageRequest(frame.id, String(Math.floor(Date.now() / 1000))),
+      routeParams(frame.id),
+    );
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      "old-render",
+    );
+  }, 15_000);
+
+  it("keeps answering 409 for a frame no board has enrolled as", async () => {
+    const accountId = await signIn();
+    const frame = await createFrame(accountId, "pending");
+
+    const response = await getFrameImage(
+      imageRequest(frame.id, String(Math.floor(Date.now() / 1000))),
+      routeParams(frame.id),
+    );
+    expect(response.status).toBe(409);
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/frame-status-groups.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/frame-status-groups.test.ts
@@ -1,0 +1,66 @@
+// The fleet sidebar/home grouping (Active / Inactive / Archived).
+//
+// frameIsActive grew up on backend fields — active_connections, last_log_at,
+// status "ready" — none of which a cloud frame carries. Its summary has the
+// hub-maintained `connected` flag, `last_seen_at` and status "active", so
+// every cloud frame used to land under "Inactive" while saying "last seen
+// just now" two lines below. Pure-function suite, tested from auth-web like
+// the other shared-SPA logic (frontend/ has no test runner).
+import { describe, expect, it } from "vitest";
+import { groupFramesByStatus } from "../../../../../../frontend/src/scenes/workspace/frameStatusGroups";
+import type { FrameType } from "../../../../../../frontend/src/types";
+
+function groupOf(frame: Partial<FrameType>): string {
+  const groups = groupFramesByStatus([
+    { id: "frame-1", name: "Frame", ...frame } as FrameType,
+  ]);
+  expect(groups).toHaveLength(1);
+  return groups[0]!.key;
+}
+
+const minutesAgo = (minutes: number) =>
+  new Date(Date.now() - minutes * 60_000).toISOString();
+
+describe("cloud frames in the status groups", () => {
+  it("counts a connected cloud frame as active", () => {
+    expect(
+      groupOf({ connected: true, last_seen_at: minutesAgo(0), status: "active" }),
+    ).toBe("active");
+  });
+
+  it("counts a recently-seen but momentarily disconnected frame as active", () => {
+    expect(
+      groupOf({ connected: false, last_seen_at: minutesAgo(5), status: "active" }),
+    ).toBe("active");
+  });
+
+  it("moves a frame not seen for over an hour to inactive", () => {
+    expect(
+      groupOf({ connected: false, last_seen_at: minutesAgo(90), status: "active" }),
+    ).toBe("inactive");
+  });
+
+  it("keeps a never-enrolled frame inactive", () => {
+    expect(groupOf({ status: "pending" })).toBe("inactive");
+  });
+});
+
+describe("backend frames in the status groups", () => {
+  it("keeps ready frames with fresh logs active", () => {
+    expect(groupOf({ last_log_at: minutesAgo(1), status: "ready" })).toBe(
+      "active",
+    );
+  });
+
+  it("keeps stale-logged frames inactive", () => {
+    expect(groupOf({ last_log_at: minutesAgo(120), status: "ready" })).toBe(
+      "inactive",
+    );
+  });
+
+  it("keeps archived frames archived, whatever else they report", () => {
+    expect(
+      groupOf({ archived: true, connected: true, status: "active" }),
+    ).toBe("archived");
+  });
+});

--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -32,6 +32,10 @@
     // Same story: mounts EmbeddedWebFlasher, whose import graph reaches the
     // legacy workspace components (bare JSX namespace, pre-strict typing).
     // Vitest still runs it; only tsc leaves it out.
-    "src/test/shared-spa/embedded-web-flasher.test.tsx"
+    "src/test/shared-spa/embedded-web-flasher.test.tsx",
+    // Same story: frameStatusGroups imports decorators/frame.tsx, which
+    // renders the legacy connection dot/spinner components (bare JSX
+    // namespace). Vitest still runs it; only tsc leaves it out.
+    "src/test/shared-spa/frame-status-groups.test.ts"
   ]
 }

--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -67,6 +67,7 @@ import {
   newMetricsEvent,
   parseJsonMessage,
   parseLogEntries,
+  stateWithActiveScene,
   uuidPattern,
   withinJsonByteLimit,
   type FrameRow,
@@ -517,6 +518,9 @@ export async function startFrameHub(
 
     const hello = session.hello ?? {};
     const now = new Date();
+    const helloState = isRecord(hello.states)
+      ? stateWithActiveScene(hello.states, hello.active_scene)
+      : undefined;
     await db
       .update(frames)
       .set({
@@ -527,8 +531,8 @@ export async function startFrameHub(
         ...(typeof hello.frameos_version === "string"
           ? { frameosVersion: hello.frameos_version.slice(0, 64) }
           : {}),
-        ...(isRecord(hello.states) && acceptState(frameId, hello.states)
-          ? { lastState: hello.states }
+        ...(helloState && acceptState(frameId, helloState)
+          ? { lastState: helloState }
           : {}),
         ...(isAcceptableChecksum(hello.scenes_checksum)
           ? {
@@ -740,8 +744,11 @@ export async function startFrameHub(
   ) {
     // `state` is hello-shaped; some payloads nest scene state under `states`,
     // so prefer that and fall back to the whole payload minus the envelope.
+    // Either way the top-level active_scene must survive into last_state.
     const { id: _id, type: _type, ...rest } = msg;
-    const lastState = isRecord(rest.states) ? rest.states : rest;
+    const lastState = isRecord(rest.states)
+      ? stateWithActiveScene(rest.states, rest.active_scene)
+      : rest;
     const checksum = acceptChecksum(session.frame.id, rest.scenes_checksum);
     const now = new Date();
     await db

--- a/cloud/apps/frame-hub/src/protocol.test.ts
+++ b/cloud/apps/frame-hub/src/protocol.test.ts
@@ -16,6 +16,7 @@ import {
   parseJsonMessage,
   parseLogEntries,
   parseLogTimestamp,
+  stateWithActiveScene,
   withinJsonByteLimit,
   type FrameRow,
 } from "./protocol";
@@ -257,6 +258,35 @@ describe("persisted-value size caps", () => {
     expect(isAcceptableChecksum("a".repeat(maxChecksumChars + 1))).toBe(false);
     expect(isAcceptableChecksum(undefined)).toBe(false);
     expect(isAcceptableChecksum(12345)).toBe(false);
+  });
+});
+
+describe("folding the top-level active_scene into last_state", () => {
+  // hello/state carry active_scene as a SIBLING of `states`, but only the
+  // `states` object is stored — without the fold the id is lost and the
+  // workspace cannot name the frame's active scene until a scene_ack.
+  it("copies the sibling active_scene into the stored states", () => {
+    expect(stateWithActiveScene({ brightness: 1 }, "df0e3976")).toEqual({
+      active_scene: "df0e3976",
+      brightness: 1,
+    });
+  });
+
+  it("leaves the states alone when the device put the id inside them", () => {
+    const states = { active_scene: "inner" };
+    expect(stateWithActiveScene(states, "outer")).toBe(states);
+  });
+
+  it("ignores missing, empty and non-string ids", () => {
+    const states = { brightness: 1 };
+    expect(stateWithActiveScene(states, undefined)).toBe(states);
+    expect(stateWithActiveScene(states, "")).toBe(states);
+    expect(stateWithActiveScene(states, 42)).toBe(states);
+  });
+
+  it("caps a runaway id at the stored scene-id ceiling", () => {
+    const folded = stateWithActiveScene({}, "x".repeat(maxSceneIdChars + 50));
+    expect((folded.active_scene as string).length).toBe(maxSceneIdChars);
   });
 });
 

--- a/cloud/apps/frame-hub/src/protocol.ts
+++ b/cloud/apps/frame-hub/src/protocol.ts
@@ -89,8 +89,30 @@ export function parseLogTimestamp(value: unknown, fallback = new Date()): Date {
 
 // Longest scene id the hub stores, matching the ceiling auth-web puts on a
 // set_current_scene payload. Applies to a log entry's `scene` and to the
-// active_scene a scene_ack merges into last_state.
+// active_scene merged into last_state.
 export const maxSceneIdChars = 256;
+
+// Devices report their active scene as a TOP-LEVEL sibling of `states`
+// (helloStatePayload on Linux, add_state_fields on the esp32), while the hub
+// stores the `states` object alone as last_state — so the id must be folded
+// in here or it is lost. scene_ack used to be the only writer of
+// last_state.active_scene, which left it empty after a reboot and stale
+// after any locally driven scene change (schedule, buttons), and the
+// workspace then showed "the active scene is not available" for a frame
+// that was happily rendering.
+export function stateWithActiveScene(
+  states: Record<string, unknown>,
+  activeScene: unknown,
+): Record<string, unknown> {
+  if (typeof activeScene !== "string" || activeScene.length === 0) {
+    return states;
+  }
+  // A scene id inside `states` is the device's own spelling — leave it be.
+  if (typeof states.active_scene === "string" && states.active_scene) {
+    return states;
+  }
+  return { ...states, active_scene: activeScene.slice(0, maxSceneIdChars) };
+}
 
 export function parseLogEntries(
   value: unknown,

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -26,6 +26,9 @@ export default tseslint.config(
       "**/src/test/shared-spa/cloud-deploy-dialog.test.tsx",
       // Same exclusion, same reason: mounts EmbeddedWebFlasher.
       "**/src/test/shared-spa/embedded-web-flasher.test.tsx",
+      // Same exclusion, same reason: frameStatusGroups's import graph
+      // reaches decorators/frame.tsx and the legacy components.
+      "**/src/test/shared-spa/frame-status-groups.test.ts",
     ],
   },
   js.configs.recommended,

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -1119,6 +1119,19 @@ static void ws_handle_get_metrics(const cJSON *id)
     for (size_t i = 0; i < count; i++) free(samples[i].json);
 }
 
+/* The scene the render task is currently on, "" until one is selected
+ * (selection happens on the first render pass, minutes after boot). */
+static void current_scene_id(char *out, size_t out_len)
+{
+    out[0] = '\0';
+    const char *info = frameos_nim_scene_info_json();
+    cJSON *info_json = info && info[0] ? cJSON_Parse(info) : NULL;
+    if (info_json) {
+        json_field_str(info_json, "currentSceneId", out, out_len);
+        cJSON_Delete(info_json);
+    }
+}
+
 /* Attach the hello-shaped state fields to msg. */
 static void add_state_fields(cJSON *msg)
 {
@@ -1129,6 +1142,14 @@ static void add_state_fields(cJSON *msg)
     if (state_json && state_json[0]) states = cJSON_Parse(state_json);
     if (!states) states = cJSON_CreateObject();
     cJSON_AddItemToObject(msg, "states", states);
+    /* Same top-level spot the Linux client puts it (helloStatePayload); the
+     * hub folds it into last_state, which is where the workspace reads the
+     * frame's active scene from. */
+    char scene_id[128] = "";
+    current_scene_id(scene_id, sizeof(scene_id));
+    if (scene_id[0]) {
+        cJSON_AddStringToObject(msg, "active_scene", scene_id);
+    }
     /* Cloud-installed scenes: report the checksum of the payload the render
      * task last applied, not the store's etag (which is the literal "local"
      * for every pushed payload). Anything else resident — backend-synced or
@@ -1141,6 +1162,30 @@ static void add_state_fields(cJSON *msg)
     }
 }
 
+/* Tell the provider when the render task moves to another scene. hello only
+ * covers connect time, and on a fresh boot the WS is usually up minutes
+ * before the first render pass selects a scene — without this push the
+ * cloud's last_state has no active scene until the next reconnect, and the
+ * workspace shows "the active scene is not available" for a frame that is
+ * happily rendering. Scene changes from set_scenes pushes also ride the
+ * scene_ack, so this mostly fires for boot, schedules and button presses. */
+static char s_active_scene_reported[128] = "";
+
+static void ws_poll_active_scene(void)
+{
+    if (!s_ws_client || !s_ws_ready) return;
+    char scene_id[128] = "";
+    current_scene_id(scene_id, sizeof(scene_id));
+    if (!scene_id[0] || strcmp(scene_id, s_active_scene_reported) == 0) return;
+    cJSON *msg = cJSON_CreateObject();
+    if (!msg) return;
+    cJSON_AddStringToObject(msg, "type", "state");
+    add_state_fields(msg);
+    ws_send_json(msg);
+    cJSON_Delete(msg);
+    strlcpy(s_active_scene_reported, scene_id, sizeof(s_active_scene_reported));
+}
+
 static void ws_send_hello(void)
 {
     cJSON *msg = cJSON_CreateObject();
@@ -1149,6 +1194,9 @@ static void ws_send_hello(void)
     add_state_fields(msg);
     ws_send_json(msg);
     cJSON_Delete(msg);
+    /* The hello just carried whatever scene is current (possibly none yet);
+     * the poll only needs to speak up when that changes. */
+    current_scene_id(s_active_scene_reported, sizeof(s_active_scene_reported));
 }
 
 /* challenge → auth: sign the base64-decoded nonce bytes with the enrolled
@@ -1273,12 +1321,7 @@ static void ws_poll_scene_ack(void)
         cJSON_AddStringToObject(msg, "checksum", s_scene_ack_checksum);
     }
     char scene_id[128] = "";
-    const char *info = frameos_nim_scene_info_json();
-    cJSON *info_json = info && info[0] ? cJSON_Parse(info) : NULL;
-    if (info_json) {
-        json_field_str(info_json, "currentSceneId", scene_id, sizeof(scene_id));
-        cJSON_Delete(info_json);
-    }
+    current_scene_id(scene_id, sizeof(scene_id));
     cJSON_AddStringToObject(msg, "active_scene", scene_id);
     ws_send_json(msg);
     cJSON_Delete(msg);
@@ -2589,6 +2632,7 @@ static void cloud_task(void *arg)
             ws_poll_scene_ack();
             ws_poll_logs();
             ws_poll_metrics();
+            ws_poll_active_scene();
             /* Streamed asset replies run here, off the WS task. A 1 s idle
              * tick keeps browse-the-SD latency humane; the polls are cheap
              * flag/queue checks. */

--- a/frontend/src/decorators/frame.tsx
+++ b/frontend/src/decorators/frame.tsx
@@ -67,16 +67,23 @@ export function formatFrameRelativeTime(timestamp?: string | null): string | nul
   return pluralize(days, 'day')
 }
 
+// Cloud frames carry no last_log_at, only the hub-maintained last_seen_at —
+// same substitution the sidebar status dots make.
+function frameActivityTimestamp(frame: FrameType): string | null | undefined {
+  return frame.last_log_at ?? frame.last_seen_at
+}
+
 export function frameIsStale(frame: FrameType): boolean {
-  if (!frame.last_log_at) {
+  const activityAt = frameActivityTimestamp(frame)
+  if (!activityAt) {
     return false
   }
-  const lastLogAt = parseFrameTimestamp(frame.last_log_at)
-  return Number.isFinite(lastLogAt) && Date.now() - lastLogAt > 1000 * 60 * 60
+  const lastActivityAt = parseFrameTimestamp(activityAt)
+  return Number.isFinite(lastActivityAt) && Date.now() - lastActivityAt > 1000 * 60 * 60
 }
 
 export function frameHasActivityLog(frame: FrameType): boolean {
-  return Number.isFinite(parseFrameTimestamp(frame.last_log_at))
+  return Number.isFinite(parseFrameTimestamp(frameActivityTimestamp(frame)))
 }
 
 export function frameIsHealthy(frame: FrameType): boolean {
@@ -85,6 +92,12 @@ export function frameIsHealthy(frame: FrameType): boolean {
 
 export function frameIsActive(frame: FrameType): boolean {
   if ((frame.active_connections ?? 0) > 0) {
+    return true
+  }
+  // The hub keeps `connected` live for cloud frames; an open device socket is
+  // as active as a frame gets. Everything below is heuristics for frames that
+  // carry no such flag (the backend) or are between reconnects.
+  if (frame.connected === true) {
     return true
   }
   if (frameIsStale(frame)) {

--- a/frontend/src/models/entityImagesModel.tsx
+++ b/frontend/src/models/entityImagesModel.tsx
@@ -6,6 +6,7 @@ import { getBasePath } from '../utils/getBasePath'
 import { projectApiPathFromCache } from '../utils/projectApi'
 import { apiFetch } from '../utils/apiFetch'
 import { isInFrameAdminMode } from '../utils/frameAdmin'
+import { isCloudMode } from '../utils/cloudMode'
 import type { FrameType } from '../types'
 
 const uploadedScenePrefix = 'uploaded/'
@@ -83,7 +84,7 @@ export const entityImagesModel = kea<entityImagesModelType>([
       },
     ],
   }),
-  listeners(({ actions, values }) => ({
+  listeners(({ actions, values, cache }) => ({
     updateEntityImage: async ({ entity, subentity, force }) => {
       if (!entity) {
         return
@@ -132,6 +133,29 @@ export const entityImagesModel = kea<entityImagesModelType>([
     },
     [socketLogic.actionTypes.newSceneImage]: ({ frameId, sceneId }) => {
       actions.updateEntityImage(`frames/${frameId}`, `scene_images/${sceneId}`)
+    },
+    [socketLogic.actionTypes.newMetrics]: ({ metrics }) => {
+      // Cloud only: the hub has no frame_rendered event, but the ESP32
+      // pushes a metrics sample after every render pass, so a rising
+      // `renders` counter is the "there is a new image" signal. Bumping the
+      // timestamp makes the image route wait for the device's fresh
+      // image_get instead of re-serving its cache. The first sample after
+      // connect only records the counter — refreshing on it would stampede
+      // the fleet page with one device round-trip per tile.
+      if (!isCloudMode()) {
+        return
+      }
+      const frameId = metrics?.frame_id
+      const renders = metrics?.metrics?.renders
+      if (!frameId || typeof renders !== 'number') {
+        return
+      }
+      const counts: Record<string, number> = cache.lastRenderCounts ?? (cache.lastRenderCounts = {})
+      const previous = counts[String(frameId)]
+      counts[String(frameId)] = renders
+      if (previous !== undefined && renders > previous) {
+        actions.updateEntityImage(`frames/${frameId}`, 'image')
+      }
     },
     [socketLogic.actionTypes.frameRendered]: ({ frameId }) => {
       actions.updateEntityImage(`frames/${frameId}`, 'image')


### PR DESCRIPTION
Three ways the cloud workspace misrepresented a live, happily-rendering esp32 frame (seen on a real 13.3" frame running an SD-card image scene), fixed across two commits.

## 1. The frame image lagged the panel, and Refresh re-served the old image

`GET /api/frames/{id}/image` served the cached row unconditionally and only *queued* an `image_get` behind it when stale — the click that asked for a fresh image got the stale bytes by design. The `?t=` param already encodes intent (`entityImagesModel`: `t=-1` = tile filling in passively, real timestamp = deliberate refresh):

- `t=-1` / absent — unchanged: serve stale instantly, refresh behind it.
- `t=<seconds>` with a stale cache — enqueue and long-poll up to 25 s for a row **newer** than the one being replaced; fall back to stale on device refusal (busy mid-render) or timeout.
- Fresh-enough cache (< 30 s) — serve immediately, no device round-trip.

And nothing told the SPA a render happened (the backend's `frame_rendered` socket event has no hub equivalent), so in cloud mode `entityImagesModel` now watches `new_metrics` — the ESP32 pushes a sample after every render pass — and bumps the frame image when a frame's `renders` counter rises. First sample after connect only records the counter, so the fleet page doesn't stampede one device round-trip per tile.

## 2. "The active scene is not available" for a frame with one deployed, active scene

Devices report `active_scene` as a **top-level sibling** of `states` (`helloStatePayload` on Linux), but the hub stored only the `states` object as `last_state`, dropping the id — the sole writer of `last_state.active_scene` was the `scene_ack`, so a reboot or locally driven scene change (boot-time selection, schedule, buttons) left it empty or stale, and the dashboard's live-preview drawer fell back to the `__live_preview__` sentinel it can't resolve.

- **Hub**: `stateWithActiveScene` (protocol.ts, unit-tested) folds a top-level `active_scene` into the stored state on both `hello` and `state` messages, capped at the scene-id ceiling.
- **ESP32**: never sent the field at all — and it selects its scene on the *first render pass*, minutes after `hello`. `fos_cloud.c` now includes `active_scene` in the hello-shaped state fields and pushes a `state` message whenever the current scene changes (1 s poll beside the metrics/log polls; `hello` records what it just reported so reconnects don't double-send). No new Nim symbols — C3 stub-safe; full `esp32-s3` image builds.

## 3. A connected frame "last seen just now" listed under Inactive

`frameIsActive` only knew backend fields (`active_connections`, `last_log_at`, `status: 'ready'`); a cloud frame carries `connected` / `last_seen_at` / `status: 'active'`, so every cloud frame landed in Inactive. The hub-maintained `connected` flag now counts as active outright, and the staleness/activity heuristics fall back from `last_log_at` to `last_seen_at` — the same substitution the sidebar status dots already made.

## Tests

- `frame-image.integration.test.ts` (real Postgres): passive load serves stale instantly + queues the fetch; explicit refresh waits for the newer image; fresh cache short-circuits; device refusal falls back to stale; pending frame keeps its 409.
- `protocol.test.ts`: the active_scene fold (sibling copied, inner id wins, junk ignored, runaway id capped) — 36/36.
- New `frame-status-groups.test.ts`: connected/recently-seen/stale/pending cloud shapes + backend shapes — 7/7.
- Full shared-spa suite 247/247; `tsc` clean in `frontend/`, `auth-web`, `frame-hub`; esp32-s3 firmware builds via `ci_build_image.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)