### PR TITLE
Cloud AI chat: store access, render-check loop, markdown, editor fixes

### DIFF
--- a/cloud/apps/auth-web/app/admin/scenes/page.tsx
+++ b/cloud/apps/auth-web/app/admin/scenes/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createDb } from "@frameos-cloud/db";
 import { AdminPublisherBanButton } from "../../../src/components/AdminPublisherBanButton";
+import { AdminPublisherVerifyButton } from "../../../src/components/AdminPublisherVerifyButton";
 import { AdminRecategorizeButton } from "../../../src/components/AdminRecategorizeButton";
 import { AdminSceneActions } from "../../../src/components/AdminSceneActions";
 import { AdminSceneCategorySelect } from "../../../src/components/AdminSceneCategorySelect";
@@ -112,6 +113,9 @@ export default async function AdminScenesPage({
                   <td>
                     <div>
                       {scene.ownerName ?? "—"}
+                      {scene.ownerVerifiedAt ? (
+                        <span className="pill pill-ok">verified</span>
+                      ) : null}
                       {scene.ownerBannedAt ? (
                         <span className="risk-badge">banned</span>
                       ) : null}
@@ -156,6 +160,13 @@ export default async function AdminScenesPage({
                         name={scene.name}
                         sceneId={scene.id}
                         status={scene.status}
+                      />
+                      <AdminPublisherVerifyButton
+                        accountId={scene.ownerId}
+                        ownerLabel={
+                          scene.ownerName ?? scene.ownerEmail ?? "this account"
+                        }
+                        verified={scene.ownerVerifiedAt !== null}
                       />
                       <AdminPublisherBanButton
                         accountId={scene.ownerId}

--- a/cloud/apps/auth-web/app/api/admin/publishers/[accountId]/route.ts
+++ b/cloud/apps/auth-web/app/api/admin/publishers/[accountId]/route.ts
@@ -20,7 +20,8 @@ type RouteContext = { params: Promise<{ accountId: string }> };
 // working — sign-in, backups, existing scenes — but every new store publish
 // is rejected until the ban is lifted; existing scenes are moderated
 // separately, pull them per scene if needed) and the verified-publisher
-// trust mark (consumed by the AI chat's store-catalog tool).
+// trust mark (surfaced as a trust signal in the AI chat's store search and
+// toggled from the admin store-scenes page).
 export async function PATCH(request: NextRequest, context: RouteContext) {
   const csrf = csrfResponse(request);
   if (csrf) {

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scenes/route.ts
@@ -1,10 +1,5 @@
-import { asc, eq, inArray } from "drizzle-orm";
-import {
-  frames,
-  frameSceneAssignments,
-  storeScenes,
-} from "@frameos-cloud/db";
-import { recordAuditEvent } from "../../../../../src/lib/audit";
+import { asc, eq } from "drizzle-orm";
+import { frameSceneAssignments, storeScenes } from "@frameos-cloud/db";
 import { NextRequest, NextResponse } from "next/server";
 import { csrfResponse } from "../../../../../src/lib/csrf";
 import {
@@ -13,27 +8,15 @@ import {
   requireDatabase,
 } from "../../../../../src/lib/device-flow";
 import {
-  buildScenesPayloadForFrame,
-  declaredServiceSettingGroups,
-  enqueueFrameCommand,
-  enqueueServiceSettingsRefreshIfScoped,
-  frameForAccount,
-  pinnedSceneVersion,
-  readServiceSettingGroups,
-  supersedePendingCommands,
-} from "../../../../../src/lib/frames";
+  assignScenesToFrame,
+  maxScenesPerFrame,
+  type RequestedScene,
+} from "../../../../../src/lib/frame-scenes";
+import { frameForAccount } from "../../../../../src/lib/frames";
 import { rateLimitResponse } from "../../../../../src/lib/rate-limit";
-import { copySceneCoversIntoFrameCache } from "../../../../../src/lib/scene-images";
 import { readSession } from "../../../../../src/lib/session";
 
 export const runtime = "nodejs";
-
-const maxScenesPerFrame = 20;
-
-// buildScenesPayloadForFrame reports failure by return value; inside the
-// assignment transaction that has to become a throw or the delete+insert
-// commits anyway.
-class PayloadBuildError extends Error {}
 
 export async function GET(
   request: NextRequest,
@@ -140,7 +123,7 @@ export async function POST(
     body.scene_id.length <= 256
       ? body.scene_id
       : undefined;
-  const requested: { sceneId: string; sceneVersion: number | null }[] = [];
+  const requested: RequestedScene[] = [];
   for (const entry of body.scenes) {
     if (!entry || typeof entry !== "object") {
       return jsonError("invalid_scenes", 400);
@@ -170,170 +153,30 @@ export async function POST(
     });
   }
 
-  if (requested.length > 0) {
-    const sceneRows = await db
-      .select({
-        accountId: storeScenes.accountId,
-        id: storeScenes.id,
-        status: storeScenes.status,
-        visibility: storeScenes.visibility,
-      })
-      .from(storeScenes)
-      .where(
-        inArray(
-          storeScenes.id,
-          requested.map((r) => r.sceneId),
-        ),
-      );
-    const byId = new Map(sceneRows.map((row) => [row.id, row]));
-    for (const { sceneId, sceneVersion } of requested) {
-      const scene = byId.get(sceneId);
-      if (!scene || scene.status !== "active") {
-        return jsonError("invalid_scene", 400, { scene_id: sceneId });
-      }
-      const accessible =
-        scene.accountId === session.accountId ||
-        scene.visibility === "public";
-      if (!accessible) {
-        return jsonError("invalid_scene", 400, { scene_id: sceneId });
-      }
-      // The version this push actually pins — not store_scenes.risk_flags,
-      // which is only the latest version's flags. Otherwise "publish shell
-      // v1, publish clean v2, pin v1" walks straight through this gate.
-      const version = await pinnedSceneVersion(db, sceneId, sceneVersion);
-      if (!version) {
-        return jsonError("scene_version_missing", 400, {
-          scene_id: sceneId,
-          scene_version: sceneVersion,
-        });
-      }
-      if (version.riskFlags?.includes("shell")) {
-        return jsonError("scene_not_allowed", 403, {
-          reason: "shell",
-          scene_id: sceneId,
-          scene_version: version.version,
-        });
-      }
-    }
-  }
-
-  // All-or-nothing: committing the new assignments while failing to enqueue
-  // the push would leave GET listing scenes the device was never sent, with
-  // assigned_checksum still describing the old set.
-  let payload: Exclude<
-    Awaited<ReturnType<typeof buildScenesPayloadForFrame>>,
-    { error: string }
-  >;
-  try {
-    payload = await db.transaction(async (tx) => {
-      await tx
-        .delete(frameSceneAssignments)
-        .where(eq(frameSceneAssignments.frameId, frame.id));
-      if (requested.length > 0) {
-        await tx.insert(frameSceneAssignments).values(
-          requested.map((entry, position) => ({
-            frameId: frame.id,
-            position,
-            sceneId: entry.sceneId,
-            sceneVersion: entry.sceneVersion,
-          })),
-        );
-      }
-      const built = await buildScenesPayloadForFrame(tx, frame.id);
-      if ("error" in built) {
-        throw new PayloadBuildError(built.error);
-      }
-      return built;
-    });
-  } catch (error) {
-    if (error instanceof PayloadBuildError) {
-      return jsonError(error.message, 400);
-    }
-    throw error;
-  }
-
-  // Which service-settings groups (unsplash, openAI, …) these scenes declare,
-  // denormalized onto the frame row while we still hold the assembled scenes.
-  // The device's service-settings pull needs this on every poll, and deriving
-  // it there would mean unzipping every assigned scene version (32 MiB apiece
-  // at the store's cap) per request. Group NAMES only — no credential ever
-  // lands in a frames row.
-  const serviceSettingGroups = declaredServiceSettingGroups(payload.scenes);
-  const previousGroups = readServiceSettingGroups(frame.serviceSettingGroups);
-  await db
-    .update(frames)
-    .set({
-      assignedChecksum: payload.checksum,
-      // Per-scene slices of the same payload. The hub promotes this map to
-      // deployed_scene_state when the device acks payload.checksum, so the
-      // workspace can name the scene that is not on the frame yet.
-      assignedSceneState: payload.sceneStates,
-      serviceSettingGroups,
-      updatedAt: new Date(),
-    })
-    .where(eq(frames.id, frame.id));
-
-  // A scene set that declares a DIFFERENT group set changes what the device's
-  // pull answers, so nudge it to re-pull. Both directions matter: a newly
-  // declared group means keys the frame does not have yet (without this it
-  // would render "please provide an API key" until its next `ready`), and a
-  // group that fell away means keys it should stop holding — the pull deletes
-  // every cloud-owned group absent from the answer. Order-insensitive compare:
-  // declaredServiceSettingGroups follows scene order, so reordering the same
-  // scenes must not cost a wake-up. The nudge carries no payload (the keys
-  // travel over the device-authed pull only) and supersedes its own pending
-  // rows, so N assignments while a frame is offline are one re-pull.
-  // A NULL column counts as "declares nothing": a frame that never had the
-  // column computed also never received a key, so going NULL → [] is not a
-  // change worth waking it for.
-  const previous = previousGroups ?? [];
-  const groupsChanged =
-    previous.length !== serviceSettingGroups.length ||
-    !serviceSettingGroups.every((group) => previous.includes(group));
-
-  await supersedePendingCommands(db, frame.id, "set_scenes");
-  const command = await enqueueFrameCommand(db, {
-    createdByAccountId: session.accountId,
-    frameId: frame.id,
-    payload: {
-      checksum: payload.checksum,
-      scenes: payload.scenes,
-      ...(activeSceneId ? { scene_id: activeSceneId } : {}),
-    },
-    type: "set_scenes",
-  });
-
-  if (groupsChanged) {
-    await enqueueServiceSettingsRefreshIfScoped(db, frame.id);
-  }
-
-  await recordAuditEvent(db, {
+  // Everything past validation of the wire shape — the accessibility and
+  // shell-risk gates, the assignment transaction, the set_scenes push, the
+  // audit event — is shared with the chat agent's add_scene_to_frame tool.
+  const outcome = await assignScenesToFrame(db, {
     accountId: session.accountId,
     actor: {
       accountId: session.accountId,
       providerSubject: session.providerSubject,
     },
-    eventType: "frame.scenes_assigned",
-    metadata: {
-      checksum: payload.checksum,
-      sceneCount: requested.length,
-      sceneNames: payload.sceneNames,
-    },
-    target: { commandId: command?.id, frameId: frame.id },
+    frame,
+    requested,
+    ...(activeSceneId ? { activeSceneId } : {}),
   });
-
-  // Install-time cover copy: without it a freshly assigned scene's tile
-  // stays blank until the device renders it and a snapshot fetch lands.
-  // Cosmetic, so a failure must not fail the push that just committed.
-  try {
-    await copySceneCoversIntoFrameCache(db, frame.id, requested);
-  } catch (error) {
-    console.error("install-time scene cover copy failed", error);
+  if (!outcome.ok) {
+    return jsonError(
+      outcome.failure.code,
+      outcome.failure.status,
+      outcome.failure.detail,
+    );
   }
 
   return NextResponse.json({
-    assigned_checksum: payload.checksum,
-    command_id: command?.id,
+    assigned_checksum: outcome.result.assignedChecksum,
+    command_id: outcome.result.commandId,
     status: "queued",
   });
 }

--- a/cloud/apps/auth-web/src/components/AdminPublisherVerifyButton.tsx
+++ b/cloud/apps/auth-web/src/components/AdminPublisherVerifyButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { BadgeCheck, BadgeMinus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+// Verified-publisher trust mark: surfaced as a badge in the store and as a
+// trust signal in the AI chat's store search.
+export function AdminPublisherVerifyButton({
+  accountId,
+  ownerLabel,
+  verified,
+}: {
+  accountId: string;
+  ownerLabel: string;
+  verified: boolean;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function toggle() {
+    if (
+      verified &&
+      !window.confirm(`Remove the verified-publisher mark from ${ownerLabel}?`)
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError(false);
+    const response = await fetch(`/api/admin/publishers/${accountId}`, {
+      body: JSON.stringify({ verified_publisher: !verified }),
+      headers: { "content-type": "application/json" },
+      method: "PATCH",
+    });
+    if (response.ok) {
+      router.refresh();
+    } else {
+      setError(true);
+    }
+    setBusy(false);
+  }
+
+  return (
+    <>
+      <button
+        className="button"
+        disabled={busy}
+        onClick={() => void toggle()}
+        type="button"
+      >
+        {verified ? (
+          <BadgeMinus aria-hidden size={16} />
+        ) : (
+          <BadgeCheck aria-hidden size={16} />
+        )}
+        {verified ? "Unverify publisher" : "Verify publisher"}
+      </button>
+      {error ? <span className="pill pill-warning">Failed</span> : null}
+    </>
+  );
+}

--- a/cloud/apps/auth-web/src/lib/admin.ts
+++ b/cloud/apps/auth-web/src/lib/admin.ts
@@ -81,6 +81,7 @@ export type AdminSceneRow = {
   ownerEmail: string | null;
   ownerId: string;
   ownerName: string | null;
+  ownerVerifiedAt: Date | null;
   pulledReason: string | null;
   riskFlags: string[];
   slug: string;
@@ -117,6 +118,7 @@ export async function listScenesForAdmin(
       ownerEmail: accounts.primaryEmail,
       ownerId: accounts.id,
       ownerName: accounts.displayName,
+      ownerVerifiedAt: accounts.verifiedPublisherAt,
       pulledReason: storeScenes.pulledReason,
       riskFlags: storeScenes.riskFlags,
       slug: storeScenes.slug,

--- a/cloud/apps/auth-web/src/lib/ai/context.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/context.test.ts
@@ -93,4 +93,13 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain('"interpreted"');
     expect(prompt).toContain("FrameOSContext");
   });
+
+  // The agent used to answer "I can't change the frame's assigned scene list
+  // from here" and recite the manual UI steps. It can, so the prompt has to
+  // say so — otherwise the tool exists and never gets called.
+  it("tells the agent it can install scenes on frames itself", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("add_scene_to_frame");
+    expect(prompt).toMatch(/never claim you cannot change a frame's scenes/i);
+  });
 });

--- a/cloud/apps/auth-web/src/lib/ai/prompts.ts
+++ b/cloud/apps/auth-web/src/lib/ai/prompts.ts
@@ -90,6 +90,13 @@ You can:
    starting points — the search covers every public scene AND the user's own scenes (private ones too),
    and get_store_scene can additionally read anything installed on their frames. Users can fork any of
    these and ask you to change them. Prefer verified publishers when suggesting third-party scenes.
+5. Install a store scene on a frame yourself with add_scene_to_frame: it adds the scene to that frame's
+   scenes and deploys the set to the device in one step. When the user asks to put a scene on a frame,
+   DO IT with that tool — never answer with the manual steps (open the frame, Scenes tab, add, Save,
+   Deploy) and never claim you cannot change a frame's scenes. Resolve the scene with the store tools and
+   the frame with list_frames first; if either is ambiguous, ask which one. It changes what a physical
+   frame displays, so call it when the user asked for that, not speculatively, and say afterwards what
+   you installed on which frame.
 
 Style:
 - Be concise and concrete. Short paragraphs, no filler. Reply in the user's language.
@@ -97,7 +104,9 @@ Style:
 - Before building a scene, check app details with get_app for every app you intend to use (fields matter),
   and look at a relevant example scene with get_example when one is close to the request.
 - When you finish building or changing a scene, summarize in one or two sentences what you made and how to
-  tweak it (which scene fields exist). The user still has to press Save/Deploy — mention that.
+  tweak it (which scene fields exist). A scene you built lands in the editor unsaved, so the user still
+  has to press Save/Deploy — mention that. This does NOT apply to add_scene_to_frame, which already
+  deployed: there tell them it is on the frame, not that they need to press anything.
 - If a tool errors or data is missing, say what you could not see rather than inventing an answer.
 - Never mention internal implementation languages of the frame runtime; scenes are JSON + JavaScript.
 

--- a/cloud/apps/auth-web/src/lib/ai/prompts.ts
+++ b/cloud/apps/auth-web/src/lib/ai/prompts.ts
@@ -61,6 +61,11 @@ Rules:
 - Scenes may bundle their own JS apps in a scene-level "apps" map: { [keyword]: { name, category,
   description, fields, output, sources: { "config.json": "...", "app.ts": "..." } } } — copy the pattern
   from the "Weather" example scene when a custom data app is warranted.
+- render/svg uses a strict, limited SVG renderer. Supported tags ONLY: svg, g, path, rect, circle,
+  ellipse, line, polyline, polygon, linearGradient/radialGradient (gradientUnits="userSpaceOnUse" only,
+  no gradientTransform), title, desc. ANY other tag — including <text>, <use>, <image>, <filter>,
+  <mask>, <style>, <foreignObject> — makes the WHOLE SVG fail to render. A viewBox attribute is
+  required. Draw text with render/text apps layered after the SVG, never with SVG <text>.
 `.trim();
 
 export function buildSystemPrompt(): string {
@@ -81,8 +86,10 @@ You can:
 3. Answer how-to and troubleshooting questions about FrameOS itself: search_docs / read_doc cover the
    architecture and cloud docs, list_repo_files / read_repo_file let you read the actual source code of the
    frontend, example scenes and JS apps on GitHub.
-4. Recommend published scenes from the store catalog (search_store_scenes / get_store_scene) and use them
-   as starting points — users can fork any public scene and ask you to change it.
+4. Recommend scenes from the store catalog (search_store_scenes / get_store_scene) and use them as
+   starting points — the search covers every public scene AND the user's own scenes (private ones too),
+   and get_store_scene can additionally read anything installed on their frames. Users can fork any of
+   these and ask you to change them. Prefer verified publishers when suggesting third-party scenes.
 
 Style:
 - Be concise and concrete. Short paragraphs, no filler. Reply in the user's language.

--- a/cloud/apps/auth-web/src/lib/ai/tools.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/tools.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { executeTool, toolDefinitions, toolLabels } from "./tools";
+import type { ToolContext } from "./tools";
+
+// Registering a tool takes three edits in this file — the definition, the
+// label the SPA shows while it runs, and the executor case. Missing the
+// second is silent (the raw name leaks into the UI) and missing the third
+// only shows up as "Unknown tool" mid-conversation, so assert all three line
+// up for every tool rather than only for the newest one.
+describe("tool registration", () => {
+  it("gives every tool a display label", () => {
+    const missing = toolDefinitions
+      .map((tool) => tool.name)
+      .filter((name) => !toolLabels[name]);
+    expect(missing).toEqual([]);
+  });
+
+  it("labels nothing that is not a tool", () => {
+    const names = new Set(toolDefinitions.map((tool) => tool.name));
+    expect(Object.keys(toolLabels).filter((name) => !names.has(name))).toEqual(
+      [],
+    );
+  });
+
+  it("declares every tool as a function with an object parameter schema", () => {
+    for (const tool of toolDefinitions) {
+      expect(tool.type).toBe("function");
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.parameters.type).toBe("object");
+      expect(tool.parameters.additionalProperties).toBe(false);
+    }
+  });
+
+  it("rejects an unknown tool name instead of throwing", async () => {
+    const output = await executeTool("no_such_tool", {}, {} as ToolContext);
+    expect(JSON.parse(output)).toEqual({ error: "Unknown tool: no_such_tool" });
+  });
+});
+
+describe("add_scene_to_frame", () => {
+  const tool = toolDefinitions.find(
+    (definition) => definition.name === "add_scene_to_frame",
+  );
+
+  it("is registered", () => {
+    expect(tool).toBeDefined();
+  });
+
+  it("takes a frame and a scene, with an optional pinned version", () => {
+    const parameters = tool?.parameters as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(parameters.required).toEqual(["frame_id", "scene_id"]);
+    expect(Object.keys(parameters.properties).sort()).toEqual([
+      "frame_id",
+      "scene_id",
+      "scene_version",
+    ]);
+  });
+
+  // The failure this tool exists to fix: the agent answering "I can't change
+  // the frame's assigned scene list from here" and listing the UI steps.
+  it("tells the model this replaces the manual Save/Deploy steps", () => {
+    expect(tool?.description).toMatch(/do NOT tell the user to do it by hand/i);
+    expect(tool?.description).toMatch(/deploy/i);
+  });
+});

--- a/cloud/apps/auth-web/src/lib/ai/tools.ts
+++ b/cloud/apps/auth-web/src/lib/ai/tools.ts
@@ -1,10 +1,11 @@
 // Tool definitions + executor for the AI chat agent loop. Tools fall into
 // five groups: knowledge (bundled catalog/docs), source code (GitHub raw,
 // Nim excluded), frames (Postgres telemetry + command queue), store catalog
-// (verified publishers), and scene delivery (create/update with local
-// validation — invalid JSON bounces back to the model as tool output instead
-// of reaching the editor).
-import { and, desc, eq, gt, isNotNull, isNull, or } from "drizzle-orm";
+// (public scenes plus everything the user owns or has installed on a
+// frame), and scene delivery (create/update with local validation — invalid
+// JSON bounces back to the model as tool output instead of reaching the
+// editor).
+import { and, desc, eq, exists, gt, isNull, or } from "drizzle-orm";
 import {
   accounts,
   createDb,
@@ -327,8 +328,9 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
   },
   {
     description:
-      "Search publicly published store scenes from verified publishers. Returns name, slug, description, " +
-      "category, tags and download counts.",
+      "Search store scenes: every public scene plus ALL of the user's own scenes (private ones included). " +
+      "Returns name, slug, description, category, tags, download counts, visibility and whether the " +
+      "publisher is verified. Check here before saying a scene does not exist.",
     name: "search_store_scenes",
     parameters: {
       additionalProperties: false,
@@ -341,8 +343,8 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
   },
   {
     description:
-      "Full scene JSON of a store scene (public scenes, or any scene the user owns). Use before " +
-      "recommending, forking or modifying a store scene.",
+      "Full scene JSON of a store scene (public scenes, any scene the user owns, or any scene installed " +
+      "on one of their frames). Use before recommending, forking or modifying a store scene.",
     name: "get_store_scene",
     parameters: {
       additionalProperties: false,
@@ -683,8 +685,12 @@ export async function executeTool(
     }
     case "search_store_scenes": {
       const query = asString(args.query)?.toLowerCase();
+      // Same visibility rules as the store front (no verified-publisher
+      // gate — verification is a trust signal in the results, not a filter),
+      // widened with the user's own scenes regardless of visibility.
       const rows = await ctx.db
         .select({
+          accountId: storeScenes.accountId,
           category: storeScenes.category,
           description: storeScenes.description,
           downloadCount: storeScenes.downloadCount,
@@ -693,27 +699,43 @@ export async function executeTool(
           publisher: accounts.displayName,
           slug: storeScenes.slug,
           tags: storeScenes.tags,
+          verifiedPublisherAt: accounts.verifiedPublisherAt,
+          visibility: storeScenes.visibility,
         })
         .from(storeScenes)
         .innerJoin(accounts, eq(accounts.id, storeScenes.accountId))
         .where(
           and(
-            eq(storeScenes.visibility, "public"),
             eq(storeScenes.status, "active"),
             gt(storeScenes.latestVersion, 0),
-            isNotNull(accounts.verifiedPublisherAt),
-            isNull(accounts.storeBannedAt),
+            or(
+              eq(storeScenes.accountId, ctx.accountId),
+              and(
+                eq(storeScenes.visibility, "public"),
+                isNull(accounts.storeBannedAt),
+              ),
+            ),
           ),
         )
-        .orderBy(desc(storeScenes.downloadCount), desc(storeScenes.updatedAt))
+        .orderBy(
+          desc(eq(storeScenes.accountId, ctx.accountId)),
+          desc(storeScenes.downloadCount),
+          desc(storeScenes.updatedAt),
+        )
         .limit(100);
-      const results = query
-        ? rows.filter((row) =>
-            `${row.name} ${row.description ?? ""} ${(row.tags ?? []).join(" ")} ${row.category ?? ""}`
-              .toLowerCase()
-              .includes(query),
-          )
-        : rows;
+      const results = (
+        query
+          ? rows.filter((row) =>
+              `${row.name} ${row.description ?? ""} ${(row.tags ?? []).join(" ")} ${row.category ?? ""} ${row.publisher ?? ""}`
+                .toLowerCase()
+                .includes(query),
+            )
+          : rows
+      ).map(({ accountId, verifiedPublisherAt, ...row }) => ({
+        ...row,
+        owned_by_user: accountId === ctx.accountId,
+        verified_publisher: verifiedPublisherAt !== null,
+      }));
       return truncateResult(JSON.stringify({ scenes: results.slice(0, 50) }));
     }
     case "get_store_scene": {
@@ -721,6 +743,22 @@ export async function executeTool(
       if (!sceneId || !/^[0-9a-f-]{36}$/i.test(sceneId)) {
         return JSON.stringify({ error: "scene_id must be a store scene uuid" });
       }
+      // Readable: public scenes, the user's own scenes, and anything
+      // installed on one of the user's frames (even if it has since gone
+      // private or was pulled — the frame already runs those bytes and the
+      // AI needs them to debug or modify what is on the wall).
+      const installedOnOwnFrame = exists(
+        ctx.db
+          .select({ id: frameSceneAssignments.id })
+          .from(frameSceneAssignments)
+          .innerJoin(frames, eq(frames.id, frameSceneAssignments.frameId))
+          .where(
+            and(
+              eq(frameSceneAssignments.sceneId, storeScenes.id),
+              eq(frames.accountId, ctx.accountId),
+            ),
+          ),
+      );
       const [scene] = await ctx.db
         .select()
         .from(storeScenes)
@@ -730,6 +768,7 @@ export async function executeTool(
             or(
               eq(storeScenes.accountId, ctx.accountId),
               and(eq(storeScenes.visibility, "public"), eq(storeScenes.status, "active")),
+              installedOnOwnFrame,
             ),
           ),
         )

--- a/cloud/apps/auth-web/src/lib/ai/tools.ts
+++ b/cloud/apps/auth-web/src/lib/ai/tools.ts
@@ -34,6 +34,11 @@ import {
 } from "./scene-utils";
 import type { ResponsesToolDefinition } from "./openai";
 import {
+  assignScenesToFrame,
+  currentSceneAssignments,
+  maxScenesPerFrame,
+} from "../frame-scenes";
+import {
   enqueueFrameCommand,
   frameForAccount,
   frameSummary,
@@ -328,6 +333,34 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
   },
   {
     description:
+      "Install a store scene on a frame and deploy it. Adds the scene to the frame's assigned scenes and " +
+      "immediately pushes the whole set to the device — this is exactly what the Scenes tab's Save/Deploy " +
+      "button does, so do NOT tell the user to do it by hand. The change is live on the physical frame, so " +
+      "only call this when the user asked for it. Use scene ids from search_store_scenes / get_store_scene " +
+      "and frame ids from list_frames. Already-assigned scenes are re-deployed rather than duplicated. An " +
+      "offline frame still accepts the call: the push is queued and lands when it reconnects.",
+    name: "add_scene_to_frame",
+    parameters: {
+      additionalProperties: false,
+      properties: {
+        frame_id: { description: "Frame id.", type: "string" },
+        scene_id: {
+          description: "Store scene id to install.",
+          type: "string",
+        },
+        scene_version: {
+          description:
+            "Pin this published version. Omit to track the latest version.",
+          type: "integer",
+        },
+      },
+      required: ["frame_id", "scene_id"],
+      type: "object",
+    },
+    type: "function",
+  },
+  {
+    description:
       "Search store scenes: every public scene plus ALL of the user's own scenes (private ones included). " +
       "Returns name, slug, description, category, tags, download counts, visibility and whether the " +
       "publisher is verified. Check here before saying a scene does not exist.",
@@ -395,6 +428,7 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
 
 // Short human labels the SPA shows in the activity log while a tool runs.
 export const toolLabels: Record<string, string> = {
+  add_scene_to_frame: "Installing scene on frame",
   create_scenes: "Building scene",
   get_app: "Reading app config",
   get_example: "Reading example scene",
@@ -681,6 +715,71 @@ export async function executeTool(
       return JSON.stringify({
         queued: true,
         note: "The frame reports metrics asynchronously; a fresh sample lands in get_frame_metrics within a few seconds.",
+      });
+    }
+    // The one tool that changes what a physical frame shows. Every gate the
+    // workspace's Save/Deploy runs is in assignScenesToFrame, shared with
+    // app/api/frames/[frameId]/scenes/route.ts — this case only turns "add
+    // one scene" into the full replacement list that helper expects.
+    case "add_scene_to_frame": {
+      const frame = await ownedFrame(ctx, args.frame_id);
+      const sceneId = asString(args.scene_id);
+      if (!sceneId) {
+        return JSON.stringify({ error: "scene_id is required" });
+      }
+      const sceneVersion =
+        typeof args.scene_version === "number" &&
+        Number.isInteger(args.scene_version) &&
+        args.scene_version >= 1
+          ? args.scene_version
+          : null;
+
+      const existing = await currentSceneAssignments(ctx.db, frame.id);
+      // Re-deploying an already-assigned scene is the useful reading of a
+      // duplicate add (the user asking again usually means "it is still not
+      // on there"), and the helper rejects duplicate ids outright.
+      const alreadyAssigned = existing.some(
+        (entry) => entry.sceneId === sceneId,
+      );
+      const requested = alreadyAssigned
+        ? existing.map((entry) =>
+            entry.sceneId === sceneId ? { sceneId, sceneVersion } : entry,
+          )
+        : [...existing, { sceneId, sceneVersion }];
+      if (requested.length > maxScenesPerFrame) {
+        return JSON.stringify({
+          error: `A frame can hold at most ${maxScenesPerFrame} scenes; this one already has ${existing.length}. Ask the user which scene to remove.`,
+        });
+      }
+
+      const outcome = await assignScenesToFrame(ctx.db, {
+        accountId: ctx.accountId,
+        actor: { accountId: ctx.accountId, via: "ai_chat" },
+        frame,
+        requested,
+        via: "ai_chat",
+      });
+      if (!outcome.ok) {
+        // The wire codes are meaningful to the model, but only just — spell
+        // out the two it can actually do something about.
+        const explanation =
+          outcome.failure.code === "scene_not_allowed"
+            ? "That scene version runs shell commands, which a cloud push may never carry. Tell the user it has to be installed from the frame itself."
+            : outcome.failure.code === "frame_not_active"
+              ? "The frame is not active yet — the owner has to confirm it before scenes can be pushed."
+              : outcome.failure.code;
+        return JSON.stringify({
+          error: explanation,
+          ...(outcome.failure.detail ?? {}),
+        });
+      }
+      return JSON.stringify({
+        assigned_scenes: outcome.result.sceneNames,
+        deployed: true,
+        note: frame.connected
+          ? "Installed and deployed. The frame applies it within seconds; no further action from the user."
+          : "Installed. The frame is offline, so the deploy is queued and lands when it reconnects.",
+        re_deployed: alreadyAssigned,
       });
     }
     case "search_store_scenes": {

--- a/cloud/apps/auth-web/src/lib/frame-scenes.ts
+++ b/cloud/apps/auth-web/src/lib/frame-scenes.ts
@@ -1,0 +1,315 @@
+// Assigning store scenes to a cloud-managed frame, and pushing the result to
+// the device. Extracted from app/api/frames/[frameId]/scenes/route.ts so the
+// AI chat agent's add_scene_to_frame tool runs the SAME gates as the
+// workspace's Save/Deploy button rather than a second, drifting copy of them:
+// the accessibility check and the shell-risk refusal are load-bearing, and a
+// tool that reimplemented them would be one refactor away from being the hole.
+//
+// The caller owns authentication (session, CSRF, rate limit) and ownership —
+// pass a frame row already resolved through frameForAccount. Everything after
+// that lives here.
+
+import { asc, eq, inArray } from "drizzle-orm";
+import {
+  createDb,
+  frames,
+  frameSceneAssignments,
+  storeScenes,
+} from "@frameos-cloud/db";
+import { recordAuditEvent } from "./audit";
+import {
+  buildScenesPayloadForFrame,
+  declaredServiceSettingGroups,
+  enqueueFrameCommand,
+  enqueueServiceSettingsRefreshIfScoped,
+  pinnedSceneVersion,
+  readServiceSettingGroups,
+  supersedePendingCommands,
+} from "./frames";
+import { copySceneCoversIntoFrameCache } from "./scene-images";
+
+export const maxScenesPerFrame = 20;
+
+type Database = ReturnType<typeof createDb>;
+type FrameRow = typeof frames.$inferSelect;
+
+export type RequestedScene = { sceneId: string; sceneVersion: number | null };
+
+// Failures carry the wire code and HTTP status the route already returned, so
+// delegating did not change a single response shape. Tools translate the same
+// values into their own JSON.
+export type AssignScenesFailure = {
+  code: string;
+  detail?: Record<string, unknown>;
+  status: number;
+};
+
+export type AssignScenesSuccess = {
+  assignedChecksum: string;
+  commandId: string | undefined;
+  sceneNames: string[];
+};
+
+export type AssignScenesOutcome =
+  | { ok: true; result: AssignScenesSuccess }
+  | { ok: false; failure: AssignScenesFailure };
+
+// buildScenesPayloadForFrame reports failure by return value; inside the
+// assignment transaction that has to become a throw or the delete+insert
+// commits anyway.
+class PayloadBuildError extends Error {}
+
+/** The frame's current assignments, in render order — the starting point for
+ *  any change that is a delta rather than a wholesale replacement. */
+export async function currentSceneAssignments(
+  db: Database,
+  frameId: string,
+): Promise<RequestedScene[]> {
+  const rows = await db
+    .select({
+      sceneId: frameSceneAssignments.sceneId,
+      sceneVersion: frameSceneAssignments.sceneVersion,
+    })
+    .from(frameSceneAssignments)
+    .where(eq(frameSceneAssignments.frameId, frameId))
+    .orderBy(asc(frameSceneAssignments.position));
+  return rows.map((row) => ({
+    sceneId: row.sceneId,
+    sceneVersion: row.sceneVersion,
+  }));
+}
+
+// Every scene must be accessible to this account (own scene or public), the
+// pinned version must exist, and a version carrying the store's "shell" risk
+// class is refused outright — a cloud push may never carry it (the device
+// refuses them independently). The risk flags checked are the PINNED
+// version's, not store_scenes.risk_flags, which only mirrors the latest.
+async function checkScenesAssignable(
+  db: Database,
+  accountId: string,
+  requested: RequestedScene[],
+): Promise<AssignScenesFailure | null> {
+  if (requested.length === 0) {
+    return null;
+  }
+  const sceneRows = await db
+    .select({
+      accountId: storeScenes.accountId,
+      id: storeScenes.id,
+      status: storeScenes.status,
+      visibility: storeScenes.visibility,
+    })
+    .from(storeScenes)
+    .where(
+      inArray(
+        storeScenes.id,
+        requested.map((r) => r.sceneId),
+      ),
+    );
+  const byId = new Map(sceneRows.map((row) => [row.id, row]));
+  for (const { sceneId, sceneVersion } of requested) {
+    const scene = byId.get(sceneId);
+    if (!scene || scene.status !== "active") {
+      return { code: "invalid_scene", detail: { scene_id: sceneId }, status: 400 };
+    }
+    const accessible =
+      scene.accountId === accountId || scene.visibility === "public";
+    if (!accessible) {
+      return { code: "invalid_scene", detail: { scene_id: sceneId }, status: 400 };
+    }
+    // The version this push actually pins — not store_scenes.risk_flags,
+    // which is only the latest version's flags. Otherwise "publish shell
+    // v1, publish clean v2, pin v1" walks straight through this gate.
+    const version = await pinnedSceneVersion(db, sceneId, sceneVersion);
+    if (!version) {
+      return {
+        code: "scene_version_missing",
+        detail: { scene_id: sceneId, scene_version: sceneVersion },
+        status: 400,
+      };
+    }
+    if (version.riskFlags?.includes("shell")) {
+      return {
+        code: "scene_not_allowed",
+        detail: {
+          reason: "shell",
+          scene_id: sceneId,
+          scene_version: version.version,
+        },
+        status: 403,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Replace the frame's scene assignments and enqueue the set_scenes push that
+ * deploys them. `requested` is the complete list in render order — this is a
+ * replacement, not a merge, so a caller adding one scene passes the existing
+ * assignments plus the new one (see currentSceneAssignments).
+ */
+export async function assignScenesToFrame(
+  db: Database,
+  {
+    accountId,
+    activeSceneId,
+    actor,
+    frame,
+    requested,
+    via,
+  }: {
+    accountId: string;
+    // Which RUNTIME scene the push should activate — the workspace's save
+    // passes the currently active scene so a deploy never yanks the display
+    // to another scene. The device ignores an id that is not in the payload
+    // (it then activates the first scene).
+    activeSceneId?: string | undefined;
+    actor: unknown;
+    frame: FrameRow;
+    requested: RequestedScene[];
+    // Recorded on the audit event so a scene set pushed by the chat agent is
+    // distinguishable from one a human deployed.
+    via?: string | undefined;
+  },
+): Promise<AssignScenesOutcome> {
+  if (frame.status !== "active") {
+    return { ok: false, failure: { code: "frame_not_active", status: 409 } };
+  }
+  if (requested.length > maxScenesPerFrame) {
+    return { ok: false, failure: { code: "invalid_scenes", status: 400 } };
+  }
+  const seen = new Set<string>();
+  for (const entry of requested) {
+    if (seen.has(entry.sceneId)) {
+      return { ok: false, failure: { code: "duplicate_scene", status: 400 } };
+    }
+    seen.add(entry.sceneId);
+  }
+
+  const notAssignable = await checkScenesAssignable(db, accountId, requested);
+  if (notAssignable) {
+    return { ok: false, failure: notAssignable };
+  }
+
+  // All-or-nothing: committing the new assignments while failing to enqueue
+  // the push would leave GET listing scenes the device was never sent, with
+  // assigned_checksum still describing the old set.
+  let payload: Exclude<
+    Awaited<ReturnType<typeof buildScenesPayloadForFrame>>,
+    { error: string }
+  >;
+  try {
+    payload = await db.transaction(async (tx) => {
+      await tx
+        .delete(frameSceneAssignments)
+        .where(eq(frameSceneAssignments.frameId, frame.id));
+      if (requested.length > 0) {
+        await tx.insert(frameSceneAssignments).values(
+          requested.map((entry, position) => ({
+            frameId: frame.id,
+            position,
+            sceneId: entry.sceneId,
+            sceneVersion: entry.sceneVersion,
+          })),
+        );
+      }
+      const built = await buildScenesPayloadForFrame(tx, frame.id);
+      if ("error" in built) {
+        throw new PayloadBuildError(built.error);
+      }
+      return built;
+    });
+  } catch (error) {
+    if (error instanceof PayloadBuildError) {
+      return { ok: false, failure: { code: error.message, status: 400 } };
+    }
+    throw error;
+  }
+
+  // Which service-settings groups (unsplash, openAI, …) these scenes declare,
+  // denormalized onto the frame row while we still hold the assembled scenes.
+  // The device's service-settings pull needs this on every poll, and deriving
+  // it there would mean unzipping every assigned scene version (32 MiB apiece
+  // at the store's cap) per request. Group NAMES only — no credential ever
+  // lands in a frames row.
+  const serviceSettingGroups = declaredServiceSettingGroups(payload.scenes);
+  const previousGroups = readServiceSettingGroups(frame.serviceSettingGroups);
+  await db
+    .update(frames)
+    .set({
+      assignedChecksum: payload.checksum,
+      // Per-scene slices of the same payload. The hub promotes this map to
+      // deployed_scene_state when the device acks payload.checksum, so the
+      // workspace can name the scene that is not on the frame yet.
+      assignedSceneState: payload.sceneStates,
+      serviceSettingGroups,
+      updatedAt: new Date(),
+    })
+    .where(eq(frames.id, frame.id));
+
+  // A scene set that declares a DIFFERENT group set changes what the device's
+  // pull answers, so nudge it to re-pull. Both directions matter: a newly
+  // declared group means keys the frame does not have yet (without this it
+  // would render "please provide an API key" until its next `ready`), and a
+  // group that fell away means keys it should stop holding — the pull deletes
+  // every cloud-owned group absent from the answer. Order-insensitive compare:
+  // declaredServiceSettingGroups follows scene order, so reordering the same
+  // scenes must not cost a wake-up. The nudge carries no payload (the keys
+  // travel over the device-authed pull only) and supersedes its own pending
+  // rows, so N assignments while a frame is offline are one re-pull.
+  // A NULL column counts as "declares nothing": a frame that never had the
+  // column computed also never received a key, so going NULL → [] is not a
+  // change worth waking it for.
+  const previous = previousGroups ?? [];
+  const groupsChanged =
+    previous.length !== serviceSettingGroups.length ||
+    !serviceSettingGroups.every((group) => previous.includes(group));
+
+  await supersedePendingCommands(db, frame.id, "set_scenes");
+  const command = await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId: frame.id,
+    payload: {
+      checksum: payload.checksum,
+      scenes: payload.scenes,
+      ...(activeSceneId ? { scene_id: activeSceneId } : {}),
+    },
+    type: "set_scenes",
+  });
+
+  if (groupsChanged) {
+    await enqueueServiceSettingsRefreshIfScoped(db, frame.id);
+  }
+
+  await recordAuditEvent(db, {
+    accountId,
+    actor,
+    eventType: "frame.scenes_assigned",
+    metadata: {
+      checksum: payload.checksum,
+      sceneCount: requested.length,
+      sceneNames: payload.sceneNames,
+      ...(via ? { via } : {}),
+    },
+    target: { commandId: command?.id, frameId: frame.id },
+  });
+
+  // Install-time cover copy: without it a freshly assigned scene's tile
+  // stays blank until the device renders it and a snapshot fetch lands.
+  // Cosmetic, so a failure must not fail the push that just committed.
+  try {
+    await copySceneCoversIntoFrameCache(db, frame.id, requested);
+  } catch (error) {
+    console.error("install-time scene cover copy failed", error);
+  }
+
+  return {
+    ok: true,
+    result: {
+      assignedChecksum: payload.checksum,
+      commandId: command?.id,
+      sceneNames: payload.sceneNames,
+    },
+  };
+}

--- a/cloud/apps/auth-web/src/test/integration/ai-frame-scenes.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/ai-frame-scenes.integration.test.ts
@@ -1,0 +1,298 @@
+// The chat agent's add_scene_to_frame tool, against a real database.
+//
+// This is the one tool that changes what a physical frame displays, so the
+// behaviour worth pinning is not "it writes a row" but the delta semantics
+// the tool adds on top of the shared assignment helper: adding a second
+// scene must KEEP the first (the underlying push is a wholesale replacement,
+// so an append that forgets to re-send the existing set silently wipes the
+// frame), and re-adding an assigned scene must re-deploy rather than
+// duplicate (the assignments table has a unique index on frame+scene).
+
+import { eq } from "drizzle-orm";
+import { zipSync } from "fflate";
+import {
+  createDb,
+  frameCommands,
+  frames,
+  frameSceneAssignments,
+  linkedClients,
+  storeScenes,
+  storeSceneVersions,
+  upsertAccountFromIdentity,
+} from "@frameos-cloud/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeTool, type ToolContext } from "../../lib/ai/tools";
+
+// recordAuditEvent reads request headers for the client IP; there is no
+// request scope here, and it already tolerates that.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
+  headers: async () => new Headers(),
+}));
+
+const db = createDb();
+const issuer = "https://accounts.google.com";
+let userCounter = 0;
+let frameCounter = 0;
+
+async function account() {
+  userCounter += 1;
+  const { accountId } = await upsertAccountFromIdentity(db, {
+    displayName: `AI Tools User ${userCounter}`,
+    email: `ai-tools-${userCounter}@example.com`,
+    emailVerified: true,
+    providerIssuer: issuer,
+    providerKey: "google",
+    providerSubject: `ai-tools-user-${userCounter}`,
+  });
+  return accountId;
+}
+
+// A cloud-managed frame in the given status. The enrollment handshake is
+// covered by frames.integration.test.ts; what matters here is a frame row
+// owned by the account, with the linked client every frame hangs off.
+async function frameRow(
+  accountId: string,
+  { name = "Kitchen frame", status = "active" as string } = {},
+) {
+  frameCounter += 1;
+  const [client] = await db
+    .insert(linkedClients)
+    .values({
+      accountId,
+      clientKind: "frame",
+      publicDisplayName: name,
+      tokenReference: `ai-tools-frame-${frameCounter}`,
+    })
+    .returning();
+  const [frame] = await db
+    .insert(frames)
+    .values({
+      accountId,
+      linkedClientId: client!.id,
+      name,
+      publicKey: `ai-tools-frame-key-${frameCounter}`,
+      status,
+    })
+    .returning();
+  if (!frame) {
+    throw new Error("frame insert failed");
+  }
+  return frame;
+}
+
+const activeFrame = (accountId: string, name?: string) =>
+  frameRow(accountId, name === undefined ? {} : { name });
+
+function sceneZip(sceneId: string) {
+  const scenes = [{ edges: [], id: sceneId, name: `Scene ${sceneId}`, nodes: [] }];
+  return Buffer.from(
+    zipSync({
+      "scene/scenes.json": new TextEncoder().encode(JSON.stringify(scenes)),
+      "scene/template.json": new TextEncoder().encode(
+        JSON.stringify({ name: `Scene ${sceneId}` }),
+      ),
+    }),
+  );
+}
+
+async function storeScene(
+  accountId: string,
+  options: {
+    name: string;
+    riskFlags?: string[];
+    visibility?: "private" | "public";
+  },
+) {
+  const [scene] = await db
+    .insert(storeScenes)
+    .values({
+      accountId,
+      latestVersion: 1,
+      name: options.name,
+      riskFlags: options.riskFlags ?? [],
+      slug: `${options.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${userCounter}`,
+      status: "active",
+      visibility: options.visibility ?? "private",
+    })
+    .returning();
+  if (!scene) {
+    throw new Error("scene insert failed");
+  }
+  await db.insert(storeSceneVersions).values({
+    content: sceneZip(scene.id),
+    contentType: "application/zip",
+    riskFlags: options.riskFlags ?? [],
+    sceneId: scene.id,
+    sha256: "test",
+    sizeBytes: 1000,
+    version: 1,
+  });
+  return scene;
+}
+
+function toolContext(accountId: string): ToolContext {
+  return {
+    accountId,
+    db,
+    emitScenes: () => undefined,
+    prompt: "put the bird journal on the kitchen frame",
+  };
+}
+
+async function addSceneToFrame(
+  accountId: string,
+  args: Record<string, unknown>,
+) {
+  const output = await executeTool(
+    "add_scene_to_frame",
+    args,
+    toolContext(accountId),
+  );
+  return JSON.parse(output) as Record<string, unknown>;
+}
+
+async function assignmentIds(frameId: string) {
+  const rows = await db
+    .select({ sceneId: frameSceneAssignments.sceneId })
+    .from(frameSceneAssignments)
+    .where(eq(frameSceneAssignments.frameId, frameId))
+    .orderBy(frameSceneAssignments.position);
+  return rows.map((row) => row.sceneId);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("add_scene_to_frame", () => {
+  it("installs the scene and queues the deploy", async () => {
+    const accountId = await account();
+    const frame = await activeFrame(accountId);
+    const scene = await storeScene(accountId, { name: "Bird field journal" });
+
+    const result = await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: scene.id,
+    });
+
+    expect(result.deployed).toBe(true);
+    expect(result.assigned_scenes).toEqual(["Bird field journal"]);
+    expect(await assignmentIds(frame.id)).toEqual([scene.id]);
+
+    // The deploy: a set_scenes command carrying the same checksum the frame
+    // row now advertises as assigned.
+    const commands = await db
+      .select()
+      .from(frameCommands)
+      .where(eq(frameCommands.frameId, frame.id));
+    expect(commands).toHaveLength(1);
+    expect(commands[0]?.type).toBe("set_scenes");
+    const [frameRow] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frame.id));
+    const payload = commands[0]?.payload as { checksum: string };
+    expect(payload.checksum).toBe(frameRow?.assignedChecksum);
+    expect(payload.checksum).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("keeps the scenes already on the frame", async () => {
+    const accountId = await account();
+    const frame = await activeFrame(accountId);
+    const first = await storeScene(accountId, { name: "Clock" });
+    const second = await storeScene(accountId, { name: "Weather" });
+
+    await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: first.id,
+    });
+    const result = await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: second.id,
+    });
+
+    expect(await assignmentIds(frame.id)).toEqual([first.id, second.id]);
+    expect(result.assigned_scenes).toEqual(["Clock", "Weather"]);
+  });
+
+  it("re-deploys an already assigned scene instead of duplicating it", async () => {
+    const accountId = await account();
+    const frame = await activeFrame(accountId);
+    const scene = await storeScene(accountId, { name: "Clock" });
+
+    await addSceneToFrame(accountId, { frame_id: frame.id, scene_id: scene.id });
+    const result = await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: scene.id,
+    });
+
+    expect(result.re_deployed).toBe(true);
+    expect(result.deployed).toBe(true);
+    expect(await assignmentIds(frame.id)).toEqual([scene.id]);
+  });
+
+  it("refuses a scene that runs shell commands", async () => {
+    const accountId = await account();
+    const frame = await activeFrame(accountId);
+    const scene = await storeScene(accountId, {
+      name: "Shell scene",
+      riskFlags: ["shell"],
+    });
+
+    const result = await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: scene.id,
+    });
+
+    expect(result.error).toMatch(/shell commands/i);
+    expect(await assignmentIds(frame.id)).toEqual([]);
+  });
+
+  it("refuses another account's private scene", async () => {
+    const accountId = await account();
+    const frame = await activeFrame(accountId);
+    const strangerId = await account();
+    const scene = await storeScene(strangerId, { name: "Someone elses" });
+
+    const result = await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: scene.id,
+    });
+
+    expect(result.error).toBe("invalid_scene");
+    expect(await assignmentIds(frame.id)).toEqual([]);
+  });
+
+  it("refuses a frame in another account", async () => {
+    const accountId = await account();
+    const strangerId = await account();
+    const frame = await activeFrame(strangerId);
+    const scene = await storeScene(accountId, { name: "Clock" });
+
+    await expect(
+      executeTool(
+        "add_scene_to_frame",
+        { frame_id: frame.id, scene_id: scene.id },
+        toolContext(accountId),
+      ),
+    ).rejects.toThrow(/No frame with id/);
+  });
+
+  it("refuses a frame the owner has not confirmed yet", async () => {
+    const accountId = await account();
+    const frame = await frameRow(accountId, {
+      name: "Unconfirmed",
+      status: "pending",
+    });
+    const scene = await storeScene(accountId, { name: "Clock" });
+
+    const result = await addSceneToFrame(accountId, {
+      frame_id: frame.id,
+      scene_id: scene.id,
+    });
+
+    expect(result.error).toMatch(/not active/i);
+    expect(await assignmentIds(frame.id)).toEqual([]);
+  });
+});

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,7 @@
 # FrameOS — consolidated remaining work
 
 One tracker for everything still open across the repo (last swept
-2026-08-14). Reference material — principles, permission scopes, store
+2026-08-14; launch-readiness audit added 2026-08-15). Reference material — principles, permission scopes, store
 decisions, threat models, wire protocols, measurements — stays in the
 linked docs; this file only lists what is left to do. When an item ships,
 delete it here.
@@ -94,6 +94,9 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
   UX still an open design question).
 - **Free-tier quotas** — pick numbers (frame count, backup size, private
   scene count) when provisioning starts, not before.
+- **Telemetry scope backfill** — frames enrolled before 2026-08-03 predate
+  the telemetry scope and ship no logs at all; known SQL fix on
+  `linked_clients` + a reconnect, no UI for it. Run the one-off in prod.
 
 ## ESP32
 
@@ -140,6 +143,40 @@ numbers and the measurement tooling live in `docs/esp32-memory.md`.
   password logins) or ticking an "enable passwordless root" checkbox that
   keeps the image default: console-only root with no password, SSH refusing
   password logins (`dropbear -s -g`, no authorized keys).
+
+## Cloud launch readiness — ops + legal (audit 2026-08-15)
+
+Gaps found auditing `cloud/` for "a lot of people can sign up" readiness.
+All are prerequisites for broad signups AND for charging; none touch the
+frame/release pipeline. Do these as one batch, then account hardening.
+
+- **Back up the cloud's own Postgres** — nothing exists: no dump script, no
+  offsite copy, no restore procedure anywhere in `cloud/scripts/` or
+  `docs/deployment.md`/`docs/operational-runbooks.md` (every "backup"
+  mention there is the user-facing feature). We must not charge for backups
+  while the database holding accounts, scenes, and link tokens has none.
+  Nightly dump + offsite storage + a documented, *tested* restore drill.
+- **Error tracking, health, and uptime alerting** — no Sentry/aggregation,
+  no structured logging (bare `console.error` ×19 in auth-web), no health
+  endpoint on auth-web (only frame-hub has `/healthz`), no uptime
+  monitoring or alerting. Runbooks exist but nothing announces an incident.
+  Minimum: error aggregation, an auth-web health endpoint, external uptime
+  checks that page someone.
+- **Email is a silent single point of failure gating all logins** — login
+  enforces verified email, but Postmark send failures are caught and only
+  `console.error`'d (`lib/email-verification.ts`, `api/auth/reset/request`),
+  so a bad token or Postmark outage blocks every new signup invisibly.
+  Surface send failures into the error tracking above, and add Postmark
+  delivery to the `/admin` system-checks panel.
+- **Legal pages + self-serve deletion/export** — no terms, no privacy
+  policy, no imprint anywhere under `apps/auth-web/app/`; PostHog loads in
+  the browser with no consent notice; account deletion is superadmin-only
+  and there is no data export. EU-facing hard requirement before broad
+  signup, non-negotiable before charging.
+- **Signup abuse gates** — the only gate is the Postgres rate limiter
+  (10/h/IP); no captcha, no disposable-email blocking. Add Cloudflare
+  Turnstile (or similar) on signup + reset. (Store publishing abuse is
+  already well covered: moderation, caps, bans, reports.)
 
 ## Cloud services (scope table in CLOUD-TODO.md)
 
@@ -195,6 +232,9 @@ numbers and the measurement tooling live in `docs/esp32-memory.md`.
 
 - Billing mechanics (Stripe? bundled tiers vs per-service metering) —
   decide before anything paid ships.
+- What the privacy policy can promise about frame data and telemetry
+  retention — decide early, it shapes the legal pages in the launch-
+  readiness batch above.
 - `store:publish` human review: always, only for the public store, or
   pre-review for risky (shell-app) scenes? Currently automated moderation
   + badges + post-moderation only.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,7 +1,8 @@
 # FrameOS — consolidated remaining work
 
 One tracker for everything still open across the repo (last swept
-2026-08-14; launch-readiness audit added 2026-08-15). Reference material — principles, permission scopes, store
+2026-08-15; launch-readiness audit added 2026-08-15, backups + uptime
+monitoring shipped the same day). Reference material — principles, permission scopes, store
 decisions, threat models, wire protocols, measurements — stays in the
 linked docs; this file only lists what is left to do. When an item ships,
 delete it here.
@@ -150,18 +151,24 @@ Gaps found auditing `cloud/` for "a lot of people can sign up" readiness.
 All are prerequisites for broad signups AND for charging; none touch the
 frame/release pipeline. Do these as one batch, then account hardening.
 
-- **Back up the cloud's own Postgres** — nothing exists: no dump script, no
-  offsite copy, no restore procedure anywhere in `cloud/scripts/` or
-  `docs/deployment.md`/`docs/operational-runbooks.md` (every "backup"
-  mention there is the user-facing feature). We must not charge for backups
-  while the database holding accounts, scenes, and link tokens has none.
-  Nightly dump + offsite storage + a documented, *tested* restore drill.
-- **Error tracking, health, and uptime alerting** — no Sentry/aggregation,
-  no structured logging (bare `console.error` ×19 in auth-web), no health
-  endpoint on auth-web (only frame-hub has `/healthz`), no uptime
-  monitoring or alerting. Runbooks exist but nothing announces an incident.
-  Minimum: error aggregation, an auth-web health endpoint, external uptime
-  checks that page someone.
+- **Rehearse a cloud Postgres restore** — backups themselves shipped
+  2026-08-15 (`cloud/docs/backups.md`): pgBackRest continuous WAL
+  archiving to the Hetzner Storage Box (point-in-time recovery, ≤5 min
+  RPO, weekly full + daily diff) plus a nightly `pg_dump` + host-config
+  tarball, both healthchecks-monitored, Storage Box capacity reported in
+  every run. What is still missing is the *drill*: restore last night's
+  dump into a scratch database, and once, rebuild a throwaway Hetzner box
+  from the Storage Box alone (procedure in the doc). Until that has been
+  done once, the backups are a hypothesis.
+- **Error tracking + auth-web health endpoint** — uptime alerting is
+  covered (2026-08-15: `frameos-cloud-uptime.timer` curls the three
+  public URLs every 5 min and pings a healthchecks.io dead-man check —
+  `cloud/ops/monitoring/`, runbook in `docs/operational-runbooks.md`).
+  Still open: no Sentry/aggregation, no structured logging (bare
+  `console.error` ×19 in auth-web), no health endpoint on auth-web (only
+  frame-hub has `/healthz`; the uptime check hits `/login` as a proxy).
+  Minimum: error aggregation + a real auth-web `/healthz` that checks the
+  DB, then point the uptime check at it.
 - **Email is a silent single point of failure gating all logins** — login
   enforces verified email, but Postmark send failures are caught and only
   `console.error`'d (`lib/email-verification.ts`, `api/auth/reset/request`),

--- a/e2e/frontend-visual/tests/visual-cases.ts
+++ b/e2e/frontend-visual/tests/visual-cases.ts
@@ -152,11 +152,15 @@ async function scrollLogsToLatest(page: Page): Promise<void> {
 }
 
 async function closeSecondaryPanel(page: Page): Promise<void> {
-  const activeNavigationButton = page.locator('.frameos-nav-button[title^="Hide "]').first()
-  if (await activeNavigationButton.isVisible().catch(() => false)) {
-    await activeNavigationButton.click()
+  const collapsedSidebar = page.locator('.workspace-sidebar-collapsed').first()
+  if (await collapsedSidebar.isVisible().catch(() => false)) {
+    return
   }
-  await page.locator('.workspace-sidebar-collapsed').first().waitFor()
+  // Let click() do the waiting instead of a point-in-time isVisible() check:
+  // skipping the click when the button has not rendered yet turns into a
+  // guaranteed timeout on the collapsed sidebar below.
+  await page.locator('.frameos-nav-button[title^="Hide "]').first().click()
+  await collapsedSidebar.waitFor()
 }
 
 async function openAddFrameDrawer(page: Page): Promise<void> {

--- a/e2e/frontend-visual/tests/visual-helpers.ts
+++ b/e2e/frontend-visual/tests/visual-helpers.ts
@@ -505,8 +505,22 @@ export async function settleForScreenshot(page: Page): Promise<void> {
     return Boolean(body.querySelector('button, canvas, img, input, select, textarea, video, [role="button"]'))
   })
   await page.waitForLoadState('domcontentloaded')
+  await waitForWorkspaceShell(page)
   await page.waitForTimeout(500)
   await stabilizeActiveLogsSearchScroll(page)
+}
+
+/**
+ * The workspace route placeholder (`WorkspaceRouteLoading`) renders the same
+ * `.workspace-sidebar` / `.frameos-nav-button` markup — with the same titles —
+ * as the real shell, but its buttons only navigate instead of toggling the
+ * secondary panel. Clicking one before the route chunk mounts therefore looks
+ * like "the toggle did nothing", so wait it out before any interaction.
+ * Screens without a workspace shell (login, signup, the cloud app) never render
+ * the marker, so this resolves immediately for them.
+ */
+export async function waitForWorkspaceShell(page: Page): Promise<void> {
+  await page.locator('[data-workspace-shell="loading"]').waitFor({ state: 'detached' })
 }
 
 async function stabilizeActiveLogsSearchScroll(page: Page): Promise<void> {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -980,6 +980,62 @@ html[data-frameos-theme='dark'] .apps-source-mode-toggle-button:not(.frameos-pri
   color: #334155;
 }
 
+/* Markdown inside assistant chat bubbles: restore the list/heading styling
+   the Tailwind preflight strips, at chat-bubble scale. */
+.chat-markdown > div > * + * {
+  /* Tighter rhythm than the Markdown component's default space-y-4. */
+  margin-top: 0.5rem;
+}
+.chat-markdown ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+  margin: 0.25rem 0;
+}
+.chat-markdown ol {
+  list-style: decimal;
+  padding-left: 1.25rem;
+  margin: 0.25rem 0;
+}
+.chat-markdown li {
+  margin: 0.125rem 0;
+}
+.chat-markdown h1,
+.chat-markdown h2,
+.chat-markdown h3,
+.chat-markdown h4 {
+  font-weight: 600;
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+.chat-markdown h1 {
+  font-size: 1.1em;
+}
+.chat-markdown h2 {
+  font-size: 1.05em;
+}
+.chat-markdown h3,
+.chat-markdown h4 {
+  font-size: 1em;
+}
+.chat-markdown pre {
+  overflow-x: auto;
+  max-width: 100%;
+}
+.chat-markdown table {
+  border-collapse: collapse;
+  margin: 0.25rem 0;
+}
+.chat-markdown th,
+.chat-markdown td {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 0.2rem 0.5rem;
+}
+.chat-markdown blockquote {
+  border-left: 3px solid rgba(148, 163, 184, 0.55);
+  padding-left: 0.75rem;
+  opacity: 0.9;
+}
+
 .frameos-skeleton-line {
   background: rgba(203, 213, 225, 0.72);
 }

--- a/frontend/src/models/wasmPreviewModel.tsx
+++ b/frontend/src/models/wasmPreviewModel.tsx
@@ -47,7 +47,7 @@ interface CapturedFrame {
 // backend. Cached per key for the session; a failed fetch degrades to no
 // secrets for that render only.
 const settingsJsonPromises = new Map<string, Promise<string>>()
-function fetchSettingsJson(frameId: FrameId): Promise<string> {
+export function fetchSettingsJson(frameId: FrameId): Promise<string> {
   const cacheKey = isCloudMode() ? 'cloud' : `frame:${frameId}`
   let promise = settingsJsonPromises.get(cacheKey)
   if (!promise) {
@@ -74,7 +74,7 @@ function fetchSettingsJson(frameId: FrameId): Promise<string> {
   return promise
 }
 
-async function previewProxyUrl(frameId: FrameId): Promise<string> {
+export async function previewProxyUrl(frameId: FrameId): Promise<string> {
   // Same-origin proxy for the runtime's CORS-blocked HTTP fetches — the same
   // per-mode endpoints livePreviewLogic resolves.
   const configuredProxyUrl = (window as any).FRAMEOS_APP_CONFIG?.preview_proxy_url

--- a/frontend/src/scenes/frame/panels/Chat/Chat.tsx
+++ b/frontend/src/scenes/frame/panels/Chat/Chat.tsx
@@ -6,6 +6,7 @@ import { frameEditorsLogic } from '../../frameEditorsLogic'
 import { scenesLogic } from '../Scenes/scenesLogic'
 import { settingsLogic } from '../../../settings/settingsLogic'
 import { Button } from '../../../../components/Button'
+import { Markdown } from '../../../../components/Markdown'
 import { TextArea } from '../../../../components/TextArea'
 import { Spinner } from '../../../../components/Spinner'
 import { useEffect, useRef, useState } from 'react'
@@ -351,12 +352,24 @@ export function Chat() {
     )
   }
 
+  // Assistant replies are markdown (the cloud agent answers in it); user
+  // messages stay plain text so typed characters are never re-interpreted.
+  const renderMessageContent = (messageContent: string, isUser: boolean) =>
+    isUser ? (
+      <div className="whitespace-pre-wrap break-words">{messageContent}</div>
+    ) : (
+      <div className="chat-markdown break-words">
+        <Markdown value={messageContent} />
+      </div>
+    )
+
   const renderMessageBody = (
     messageContent: string,
     isLog: boolean,
     messageId: string,
     isStreaming?: boolean,
-    logContent?: string
+    logContent?: string,
+    isUser?: boolean
   ) => {
     if (isLog) {
       return renderLogMessage(messageContent, messageId, isStreaming)
@@ -366,7 +379,7 @@ export function Chat() {
       return (
         <div className="space-y-3">
           <div>{renderLogMessage(logContent, messageId, isStreaming)}</div>
-          {messageContent ? <div className="whitespace-pre-wrap break-words">{messageContent}</div> : null}
+          {messageContent ? renderMessageContent(messageContent, Boolean(isUser)) : null}
         </div>
       )
     }
@@ -388,7 +401,7 @@ export function Chat() {
       return <div className="whitespace-pre-wrap break-words">{renderGeneratedSceneMessage(generatedSceneName)}</div>
     }
 
-    return <div className="whitespace-pre-wrap break-words">{messageContent}</div>
+    return renderMessageContent(messageContent, Boolean(isUser))
   }
 
   return (
@@ -530,7 +543,8 @@ export function Chat() {
                             isLog,
                             message.id,
                             message.isStreaming,
-                            message.logContent
+                            message.logContent,
+                            isUser
                           )}
                         </div>
                       </div>

--- a/frontend/src/scenes/frame/panels/Chat/chatLogic.ts
+++ b/frontend/src/scenes/frame/panels/Chat/chatLogic.ts
@@ -22,6 +22,7 @@ import { editAppLogic } from '../EditApp/editAppLogic'
 import { isFrameControlMode } from '../../../../utils/frameControlMode'
 import { isCloudMode } from '../../../../utils/cloudMode'
 import { streamCloudAiChat, type CloudAiChatEvent } from '../../../../utils/cloudAiChat'
+import { renderSceneCheck } from '../../../../utils/wasmSceneRenderCheck'
 import { projectApiPathForProject } from '../../../../utils/projectApi'
 
 import type { chatLogicType } from './chatLogicType'
@@ -29,6 +30,11 @@ import type { chatLogicType } from './chatLogicType'
 const MAX_HISTORY = 8
 const CHAT_PAGE_SIZE = 20
 const APP_CONTEXT_SEPARATOR = '::'
+// After the cloud agent delivers a scene, it is rendered once in the wasm
+// preview runtime; runtime errors go back to the agent as an automatic
+// follow-up message, at most this many rounds per user message.
+const MAX_RENDER_CHECK_ROUNDS = 2
+const RENDER_CHECK_PREFIX = '[Automatic render check]'
 
 function frameProjectId(frameForm: Partial<FrameType>, frame: FrameType | null | undefined): number | null {
   return frameForm.project_id ?? frame?.project_id ?? null
@@ -133,7 +139,11 @@ export const chatLogic = kea<chatLogicType>([
   })),
   actions({
     setInput: (input: string) => ({ input }),
-    submitMessage: (content: string, chatId?: string | null) => ({ content, chatId }),
+    submitMessage: (content: string, chatId?: string | null, renderCheckRound?: number) => ({
+      content,
+      chatId,
+      renderCheckRound,
+    }),
     setSubmitting: (isSubmitting: boolean) => ({ isSubmitting }),
     setError: (error: string | null) => ({ error }),
     appendMessage: (chatId: string, message: ChatMessage) => ({ chatId, message }),
@@ -176,7 +186,9 @@ export const chatLogic = kea<chatLogicType>([
       '',
       {
         setInput: (_, { input }) => input,
-        submitMessage: () => '',
+        // Automatic render-check follow-ups must not clear a draft the user
+        // may be typing while the check runs.
+        submitMessage: (state, { renderCheckRound }) => (renderCheckRound ? state : ''),
       },
     ],
     isSubmitting: [
@@ -788,7 +800,7 @@ export const chatLogic = kea<chatLogicType>([
         actions.loadChatMessagesFailure(chatId, error instanceof Error ? error.message : 'Failed to load chat history')
       }
     },
-    submitMessage: async ({ content, chatId: chatIdOverride }) => {
+    submitMessage: async ({ content, chatId: chatIdOverride, renderCheckRound }) => {
       const prompt = content.trim()
       if (!prompt) {
         actions.setSubmitting(false)
@@ -956,9 +968,10 @@ export const chatLogic = kea<chatLogicType>([
           let logContent = ''
           let finalTool: string | undefined
           let streamError: string | null = null
-          const applyBuildScenes = async (scenes: Record<string, any>[], title?: string): Promise<void> => {
+          let deliveredSceneId: string | null = null
+          const applyBuildScenes = async (scenes: Record<string, any>[], title?: string): Promise<string | null> => {
             if (!scenes.length) {
-              return
+              return null
             }
             const frameStore = frameLogic({ frameId: props.frameId })
             const existingSceneIds = new Set(frameStore.values.scenes.map((scene) => scene.id))
@@ -982,6 +995,7 @@ export const chatLogic = kea<chatLogicType>([
             if (newlyAddedScene) {
               scenesLogic({ frameId: props.frameId }).actions.focusScene(newlyAddedScene.id)
             }
+            return newlyAddedScene?.id ?? null
           }
           await streamCloudAiChat(
             {
@@ -1019,12 +1033,13 @@ export const chatLogic = kea<chatLogicType>([
                   break
                 case 'scenes':
                   if (event.tool === 'build_scene') {
-                    await applyBuildScenes(event.scenes ?? [], event.title)
+                    deliveredSceneId = (await applyBuildScenes(event.scenes ?? [], event.title)) ?? deliveredSceneId
                   } else {
                     const updatedScene = event.scenes?.[0]
                     const targetSceneId = updatedScene?.id || selectedScene?.id
                     if (updatedScene && targetSceneId) {
                       actions.updateScene(targetSceneId, updatedScene)
+                      deliveredSceneId = targetSceneId
                     }
                   }
                   break
@@ -1046,6 +1061,57 @@ export const chatLogic = kea<chatLogicType>([
             isStreaming: false,
             isPlaceholder: false,
           })
+          if (deliveredSceneId) {
+            // Render the delivered scene once in the wasm preview runtime and
+            // hand runtime errors straight back to the agent — a scene that
+            // validated as JSON can still fail at render time.
+            logContent = `${logContent ? `${logContent}\n` : ''}Checking that the scene renders…`
+            actions.updateMessage(chatId, assistantMessageId, { logContent })
+            try {
+              const frameValues = frameLogic({ frameId: props.frameId }).values
+              const check = await renderSceneCheck(
+                {
+                  id: props.frameId,
+                  width: frameValues.frameForm?.width ?? frameValues.frame?.width,
+                  height: frameValues.frameForm?.height ?? frameValues.frame?.height,
+                  rotate: frameValues.frameForm?.rotate ?? frameValues.frame?.rotate,
+                  name: frameValues.frameForm?.name ?? frameValues.frame?.name,
+                  timezone: frameValues.frameForm?.timezone ?? frameValues.frame?.timezone,
+                },
+                frameValues.frameForm?.scenes ?? frameValues.scenes,
+                deliveredSceneId
+              )
+              const uniqueErrors = Array.from(new Set(check.errors))
+              if (uniqueErrors.length === 0 && check.rendered) {
+                logContent = `${logContent}\nRender check passed${
+                  check.renderMs !== null ? ` (${(check.renderMs / 1000).toFixed(1)}s)` : ''
+                }`
+                actions.updateMessage(chatId, assistantMessageId, { logContent })
+              } else {
+                const round = renderCheckRound ?? 0
+                logContent = `${logContent}\nRender check found ${uniqueErrors.length || 'render'} problem${
+                  uniqueErrors.length === 1 ? '' : 's'
+                }`
+                actions.updateMessage(chatId, assistantMessageId, { logContent })
+                if (round < MAX_RENDER_CHECK_ROUNDS) {
+                  const reported = uniqueErrors.slice(0, 8)
+                  const feedback =
+                    `${RENDER_CHECK_PREFIX} I rendered the delivered scene with the in-browser preview runtime` +
+                    `${check.rendered ? '' : ' and it produced no image'}. It reported these errors:\n` +
+                    reported.map((error) => `- ${error}`).join('\n') +
+                    (uniqueErrors.length > reported.length
+                      ? `\n(and ${uniqueErrors.length - reported.length} more)`
+                      : '') +
+                    '\nPlease fix the scene so it renders without errors and deliver the corrected version.'
+                  actions.submitMessage(feedback, chatId, round + 1)
+                  return
+                }
+              }
+            } catch (checkError) {
+              // The check is best-effort; never fail the chat over it.
+              console.error('Render check failed', checkError)
+            }
+          }
           actions.setSubmitting(false)
           return
         }

--- a/frontend/src/scenes/workspace/FrameosShell.tsx
+++ b/frontend/src/scenes/workspace/FrameosShell.tsx
@@ -479,7 +479,14 @@ export function FrameosShell({
   }, [resolvedBrowserTitle])
 
   return (
-    <div className={clsx('frameos-app-shell min-h-screen overflow-x-hidden text-slate-900', `frameos-theme-${theme}`)}>
+    <div
+      // The route-loading placeholder renders a pixel-identical rail with the
+      // same classes and titles, but its nav buttons only navigate — they can
+      // not toggle the secondary panel. Tests (and anything else scripting the
+      // UI) need to tell the two apart before clicking.
+      data-workspace-shell="ready"
+      className={clsx('frameos-app-shell min-h-screen overflow-x-hidden text-slate-900', `frameos-theme-${theme}`)}
+    >
       <aside
         className={clsx(
           'workspace-sidebar frameos-panel fixed bottom-5 left-5 top-5 z-30 flex max-w-[calc(100vw-40px)] overflow-hidden rounded-[24px] border border-white/80 bg-white/90 shadow-2xl shadow-slate-400/30 backdrop-blur-xl',

--- a/frontend/src/scenes/workspace/SceneWorkspace.tsx
+++ b/frontend/src/scenes/workspace/SceneWorkspace.tsx
@@ -999,7 +999,7 @@ function SceneWorkspaceFrame({ frameId }: SceneWorkspaceFrameProps): JSX.Element
   const frameLogicProps = { frameId }
   const { frame, scenes, unsavedChanges, undeployedChanges } = useValues(frameLogic(frameLogicProps))
   const { framesList } = useValues(framesModel)
-  const { selectedSceneId, templateDrawerFrameId, utilityPanel } = useValues(workspaceLogic)
+  const { selectedSceneId, selectedSceneIdsByFrame, templateDrawerFrameId, utilityPanel } = useValues(workspaceLogic)
 
   if (!frame) {
     return (
@@ -1016,8 +1016,18 @@ function SceneWorkspaceFrame({ frameId }: SceneWorkspaceFrameProps): JSX.Element
     )
   }
 
+  // Resolve against the RAW per-frame selection first: workspaceLogic's
+  // selectedSceneId validates against framesModel, which only knows SAVED
+  // scenes — an unsaved scene (e.g. one the AI chat just delivered into the
+  // frame form) would bounce to the default scene on every click. frameLogic's
+  // `scenes` includes the frame form, so it can vouch for unsaved scenes too.
+  const requestedSceneId = selectedSceneIdsByFrame[frameId] ?? selectedSceneId
   const resolvedSceneId =
-    selectedSceneId && scenes.some((scene) => scene.id === selectedSceneId) ? selectedSceneId : scenes[0]?.id ?? null
+    requestedSceneId && scenes.some((scene) => scene.id === requestedSceneId)
+      ? requestedSceneId
+      : selectedSceneId && scenes.some((scene) => scene.id === selectedSceneId)
+      ? selectedSceneId
+      : scenes[0]?.id ?? null
   const selectedScene = scenes.find((scene) => scene.id === resolvedSceneId) ?? null
   const activeUtilityDefinition = sceneUtilityDefinition(utilityPanel, selectedScene, frame.mode)
 

--- a/frontend/src/scenes/workspace/WorkspaceRouteLoading.tsx
+++ b/frontend/src/scenes/workspace/WorkspaceRouteLoading.tsx
@@ -209,7 +209,12 @@ export function WorkspaceRouteLoading({ scene }: { scene: string | null }): JSX.
   const preloadHome = () => preloadSceneComponent('frames')
 
   return (
-    <div className={clsx('frameos-app-shell min-h-screen overflow-x-hidden text-slate-900', `frameos-theme-${theme}`)}>
+    <div
+      // See FrameosShell: this placeholder mimics the real rail, so it marks
+      // itself as the loading one.
+      data-workspace-shell="loading"
+      className={clsx('frameos-app-shell min-h-screen overflow-x-hidden text-slate-900', `frameos-theme-${theme}`)}
+    >
       <aside
         className={clsx(
           'workspace-sidebar frameos-panel fixed bottom-5 left-5 top-5 z-30 flex max-w-[calc(100vw-40px)] overflow-hidden rounded-[24px] border border-white/80 bg-white/90 shadow-2xl shadow-slate-400/30 backdrop-blur-xl',

--- a/frontend/src/utils/wasmSceneRenderCheck.ts
+++ b/frontend/src/utils/wasmSceneRenderCheck.ts
@@ -1,0 +1,147 @@
+import { collectScenePreviewPayloadScenes } from '../scenes/frame/panels/Scenes/scenesLogic'
+import { fetchSettingsJson, previewProxyUrl } from '../models/wasmPreviewModel'
+import { assetUrl } from './assetUrl'
+import { wasmPreviewDimensions } from './wasmScenePreview'
+import type { FrameId, FrameScene } from '../types'
+
+// Headless render check for AI-delivered scenes: run the scene once in the
+// frameos-wasm worker (the same runtime the device runs) and collect what it
+// logs instead of what it draws. The chat uses the result to feed runtime
+// errors back to the AI agent for another pass — a scene that validates as
+// JSON can still fail at render time (unsupported SVG, missing fields, app
+// errors), and the device is too far away to tell us quickly.
+
+const RENDER_CHECK_SETTLE_MS = 2000
+const RENDER_CHECK_TIMEOUT_MS = 30_000
+const MAX_COLLECTED_LOGS = 100
+const MAX_COLLECTED_ERRORS = 20
+
+export interface SceneRenderCheckFrame {
+  id: FrameId
+  width?: number
+  height?: number
+  rotate?: number
+  name?: string
+  timezone?: string
+}
+
+export interface SceneRenderCheckResult {
+  /** At least one frame was produced (errors may still have been logged). */
+  rendered: boolean
+  renderMs: number | null
+  /** Log lines the runtime flagged as errors (logError, render failures). */
+  errors: string[]
+  /** All collected log lines, errors included, oldest first. */
+  logs: string[]
+}
+
+function pushCapped(list: string[], entry: string, cap: number): void {
+  list.push(entry)
+  if (list.length > cap) {
+    list.splice(0, list.length - cap)
+  }
+}
+
+function formatLogPayload(message: string): { line: string; isError: boolean } {
+  try {
+    const payload = JSON.parse(message)
+    if (payload && typeof payload === 'object') {
+      const event = typeof payload.event === 'string' ? payload.event : ''
+      const isError = event.startsWith('error') || typeof payload.error === 'string'
+      return { line: message, isError }
+    }
+  } catch {
+    // plain-text log line (http hook failures etc.)
+  }
+  return { line: message, isError: /\berror\b/i.test(message) }
+}
+
+/**
+ * Renders `sceneId` from `scenes` once in a dedicated worker and resolves
+ * with the collected logs. Never rejects: a crashed or hung worker resolves
+ * as `rendered: false` with the failure in `errors`.
+ */
+export async function renderSceneCheck(
+  frame: SceneRenderCheckFrame,
+  scenes: FrameScene[],
+  sceneId: string
+): Promise<SceneRenderCheckResult> {
+  const scene = scenes.find((item) => item.id === sceneId)
+  if (!scene) {
+    return { rendered: false, renderMs: null, errors: [`Scene ${sceneId} not found`], logs: [] }
+  }
+  const payloadScenes = collectScenePreviewPayloadScenes(scene, scenes, null)
+  const { width, height } = wasmPreviewDimensions({
+    width: frame.width,
+    height: frame.height,
+    rotate: frame.rotate,
+  })
+  const settingsJson = await fetchSettingsJson(frame.id)
+  const proxyUrl = await previewProxyUrl(frame.id)
+
+  const errors: string[] = []
+  const logs: string[] = []
+  let rendered = false
+  let renderMs: number | null = null
+
+  const worker = new Worker(assetUrl('/frameos-wasm/preview-worker.js'), { type: 'module' })
+  await new Promise<void>((resolve) => {
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
+    const finish = (): void => {
+      if (settleTimer !== null) {
+        clearTimeout(settleTimer)
+      }
+      clearTimeout(timeoutTimer)
+      worker.terminate()
+      resolve()
+    }
+    const timeoutTimer = setTimeout(() => {
+      if (!rendered) {
+        pushCapped(errors, 'Render check timed out: the scene produced no frame within 30s', MAX_COLLECTED_ERRORS)
+      }
+      finish()
+    }, RENDER_CHECK_TIMEOUT_MS)
+    worker.onerror = (event) => {
+      pushCapped(errors, event.message || 'Preview worker failed to load', MAX_COLLECTED_ERRORS)
+      if (!rendered) {
+        finish()
+      }
+    }
+    worker.onmessage = (event: MessageEvent) => {
+      const msg = event.data || {}
+      if (msg.type === 'frame') {
+        const firstFrame = !rendered
+        rendered = true
+        renderMs = typeof msg.renderMs === 'number' ? msg.renderMs : renderMs
+        if (firstFrame) {
+          // Let immediate re-renders and async data apps settle so their
+          // errors are collected too.
+          settleTimer = setTimeout(finish, RENDER_CHECK_SETTLE_MS)
+        }
+      } else if (msg.type === 'log' && typeof msg.message === 'string') {
+        const { line, isError } = formatLogPayload(msg.message)
+        pushCapped(logs, line, MAX_COLLECTED_LOGS)
+        if (isError) {
+          pushCapped(errors, line, MAX_COLLECTED_ERRORS)
+        }
+      } else if (msg.type === 'error') {
+        pushCapped(errors, String(msg.message ?? 'Render failed'), MAX_COLLECTED_ERRORS)
+        if (!rendered) {
+          finish()
+        }
+      }
+    }
+    worker.postMessage({
+      type: 'init',
+      width,
+      height,
+      name: frame.name || 'render check',
+      timeZone: frame.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+      scenesJson: JSON.stringify(payloadScenes),
+      settingsJson,
+      proxyUrl,
+      sceneId: scene.id,
+    })
+  })
+  return { rendered, renderMs, errors, logs }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,10 @@ overrides:
   postcss@8: '>=8.5.23'
   qs@6: '>=6.15.2'
   svgo@4: '>=4.0.2'
+  nanoid@3: '>=3.3.18 <4'
+  dompurify@3: '>=3.4.13'
+  '@babel/core@7': '>=7.29.6 <8'
+  '@babel/plugin-transform-modules-systemjs@7': '>=7.29.4 <8'
 
 packageExtensionsChecksum: sha256-vsSjLdIOYVSo9NEFqxgkMNt3v3VTzjXkaTYuz7XdnIM=
 
@@ -872,16 +876,28 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -892,25 +908,33 @@ packages:
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-create-class-features-plugin@7.28.6':
     resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-create-regexp-features-plugin@7.28.5':
     resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-define-polyfill-provider@0.6.7':
     resolution: {integrity: sha512-6Fqi8MtQ/PweQ9xvux65emkLQ83uB+qAVtfHkC9UodyHMIZdxNI01HjLCLUtybElp2KY2XNE0nOgyP1E1vXw9w==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
@@ -921,11 +945,21 @@ packages:
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
@@ -935,17 +969,21 @@ packages:
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-remap-async-to-generator@7.27.1':
     resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-replace-supers@7.28.6':
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
@@ -955,20 +993,32 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-wrap-function@7.28.6':
     resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.6':
-    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.0':
@@ -976,412 +1026,417 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
     resolution: {integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1':
     resolution: {integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1':
     resolution: {integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.13.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6':
     resolution: {integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-syntax-import-assertions@7.28.6':
     resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-syntax-import-attributes@7.28.6':
     resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-syntax-jsx@7.28.6':
     resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-syntax-typescript@7.28.6':
     resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-arrow-functions@7.27.1':
     resolution: {integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-async-generator-functions@7.29.0':
     resolution: {integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-async-to-generator@7.28.6':
     resolution: {integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1':
     resolution: {integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-block-scoping@7.28.6':
     resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-class-properties@7.28.6':
     resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-class-static-block@7.28.6':
     resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.12.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-classes@7.28.6':
     resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-computed-properties@7.28.6':
     resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-destructuring@7.28.5':
     resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-dotall-regex@7.28.6':
     resolution: {integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-duplicate-keys@7.27.1':
     resolution: {integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0':
     resolution: {integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-dynamic-import@7.27.1':
     resolution: {integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-explicit-resource-management@7.28.6':
     resolution: {integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-exponentiation-operator@7.28.6':
     resolution: {integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-export-namespace-from@7.27.1':
     resolution: {integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-for-of@7.27.1':
     resolution: {integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-function-name@7.27.1':
     resolution: {integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-json-strings@7.28.6':
     resolution: {integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-literals@7.27.1':
     resolution: {integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.6':
     resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-member-expression-literals@7.27.1':
     resolution: {integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-modules-amd@7.27.1':
     resolution: {integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-modules-commonjs@7.28.6':
     resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.8':
+    resolution: {integrity: sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-modules-umd@7.27.1':
     resolution: {integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.0':
     resolution: {integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-new-target@7.27.1':
     resolution: {integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
     resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-numeric-separator@7.28.6':
     resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-object-rest-spread@7.28.6':
     resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-object-super@7.27.1':
     resolution: {integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-optional-catch-binding@7.28.6':
     resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-optional-chaining@7.28.6':
     resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-parameters@7.27.7':
     resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-private-methods@7.28.6':
     resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-private-property-in-object@7.28.6':
     resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-property-literals@7.27.1':
     resolution: {integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-regenerator@7.29.0':
     resolution: {integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-regexp-modifiers@7.28.6':
     resolution: {integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-reserved-words@7.27.1':
     resolution: {integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-shorthand-properties@7.27.1':
     resolution: {integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-spread@7.28.6':
     resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-sticky-regex@7.27.1':
     resolution: {integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-template-literals@7.27.1':
     resolution: {integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-typeof-symbol@7.27.1':
     resolution: {integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-typescript@7.28.6':
     resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-unicode-escapes@7.27.1':
     resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-unicode-property-regex@7.28.6':
     resolution: {integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-unicode-regex@7.27.1':
     resolution: {integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-unicode-sets-regex@7.28.6':
     resolution: {integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/preset-env@7.29.0':
     resolution: {integrity: sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/preset-modules@0.1.6-no-external-plugins':
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/preset-typescript@7.28.5':
     resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -1391,12 +1446,24 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
@@ -3017,17 +3084,17 @@ packages:
   babel-plugin-polyfill-corejs2@0.4.16:
     resolution: {integrity: sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   babel-plugin-polyfill-corejs3@0.14.1:
     resolution: {integrity: sha512-ENp89vM9Pw4kv/koBb5N2f9bDZsR0hpf3BdPMOg/pkS3pwO4dzNnQZVXtBbeyAadgm865DmQG2jMMLqmZXvuCw==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   babel-plugin-polyfill-regenerator@0.6.7:
     resolution: {integrity: sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -3475,8 +3542,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4377,8 +4444,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5923,19 +5990,27 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -5953,6 +6028,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -5965,29 +6048,37 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.7(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
@@ -5997,6 +6088,8 @@ snapshots:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -6012,12 +6105,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -6027,18 +6136,20 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.29.0
@@ -6054,9 +6165,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
 
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
@@ -6066,525 +6183,529 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.28.6':
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/parser@7.29.8':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/types': 7.29.8
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.0(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.16(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.14.1(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.7(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-systemjs': 7.29.8(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.16(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.14.1(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.7(@babel/core@7.29.7)
       core-js-compat: 3.48.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -6595,6 +6716,12 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -6608,10 +6735,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -8062,9 +8206,9 @@ snapshots:
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.6(@types/node@26.0.1)(jiti@1.21.7)(less@4.8.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.23.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -8173,27 +8317,27 @@ snapshots:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  babel-plugin-polyfill-corejs2@0.4.16(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.16(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.1(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs3@0.14.1(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.7)
       core-js-compat: 3.48.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.7(@babel/core@7.29.0):
+  babel-plugin-polyfill-regenerator@0.6.7(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -8654,7 +8798,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9237,9 +9381,9 @@ snapshots:
 
   kea-typegen@3.7.1(typescript@5.9.3):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
       prettier: 3.8.5
       recast: 0.23.11
       ts-clone-node: 3.0.0(typescript@5.9.3)
@@ -9736,7 +9880,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -10280,7 +10424,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10292,7 +10436,7 @@ snapshots:
       '@posthog/core': 1.46.1
       '@posthog/types': 1.399.0
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       fflate: 0.4.9
       preact: 10.29.8
       query-selector-shadow-dom: 1.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,10 @@ overrides:
   postcss@8: '>=8.5.23'
   qs@6: '>=6.15.2'
   svgo@4: '>=4.0.2'
+  nanoid@3: '>=3.3.18 <4'
+  dompurify@3: '>=3.4.13'
+  '@babel/core@7': '>=7.29.6 <8'
+  '@babel/plugin-transform-modules-systemjs@7': '>=7.29.4 <8'
 
 packageExtensions:
   kea-forms@*:


### PR DESCRIPTION
## Why

Three cloud AI chat problems from real use:
1. Asking the AI to install a published scene ("bird field journal") failed — `search_store_scenes` required `accounts.verified_publisher_at`, which was never seeded in prod, so the AI's store search returned zero scenes for everyone.
2. AI-generated scenes could validate as JSON but fail at render time (e.g. SVG with `<text>`, which pixie's strict parser rejects wholesale) — the user only found out from a blank frame.
3. Chat replies arrived as markdown but rendered as plain text, and freshly generated (unsaved) scenes couldn't be selected in the scene editor.

## What

**AI scene access**
- `search_store_scenes`: no verified-publisher gate; returns every public scene from non-banned accounts **plus all of the user's own scenes** (private included, own-first), with `owned_by_user` / `visibility` / `verified_publisher` in results. Query also matches publisher names.
- `get_store_scene`: additionally readable — any scene installed on one of the user's frames, even if since gone private/pulled (the frame already runs those bytes; debugging them is the point).
- Admin: verified-publisher toggle + badge on `/admin/scenes`, wired to the existing `PATCH /api/admin/publishers/[accountId]` route (audited server-side).

**Render-check feedback loop**
- After the cloud chat delivers a scene, it is rendered headlessly in the existing frameos-wasm preview worker (`frontend/src/utils/wasmSceneRenderCheck.ts`). Runtime error logs (`event: "error:*"` / `error` payloads) are fed back to the agent as a visible `[Automatic render check]` follow-up message — max 2 automatic rounds per user message. App settings/keys reuse the wasm preview's existing `/api/settings` fetch.
- `SCENE_RULES` now spell out pixie's supported SVG tag list ("draw text with render/text, never SVG `<text>`") so broken SVG is mostly avoided up front.

**Frontend fixes**
- Assistant chat bubbles render markdown via the existing `Markdown` component (new `.chat-markdown` styles); user bubbles stay plain text.
- Scene editor: unsaved AI-delivered scenes were unclickable — `workspaceLogic.selectedSceneId` validates against framesModel's *saved* scenes and bounced them to the default scene. `SceneWorkspaceFrame` now resolves the raw per-frame selection against `frameLogic`'s scene list (which includes the frame form).

## Testing

- `cloud/apps/auth-web`: `pnpm typecheck`, `pnpm lint`, `pnpm test` (68 files, 559 tests) all pass
- `frontend`: `npm run build` (kea-typegen + tsc + esbuild) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)