### PR TITLE
Keep credentials and private content out of cloud analytics

### DIFF
--- a/cloud/apps/auth-web/app/account/layout.tsx
+++ b/cloud/apps/auth-web/app/account/layout.tsx
@@ -102,7 +102,10 @@ export default async function AccountLayout({
   }
 
   return (
-    <AppShell isSuperadmin={isSuperadmin} title="FrameOS Account">
+    // noCapture: every /account page is the signed-in user's own data — their
+    // name and email in the header here, and frame names, scene names and
+    // images, install hostnames, backup names and activity in the subpages.
+    <AppShell isSuperadmin={isSuperadmin} noCapture title="FrameOS Account">
       {session.accountId ? (
         <UserIdentifier
           email={session.email}

--- a/cloud/apps/auth-web/app/admin/page.tsx
+++ b/cloud/apps/auth-web/app/admin/page.tsx
@@ -38,7 +38,8 @@ export default async function AdminPage({ searchParams }: AdminPageProps) {
   }));
 
   return (
-    <AppShell isSuperadmin title="Users">
+    // noCapture: this table lists every account's email address.
+    <AppShell isSuperadmin noCapture title="Users">
       <div className="content-header">
         <div>
           <p className="copy">

--- a/cloud/apps/auth-web/app/admin/reports/page.tsx
+++ b/cloud/apps/auth-web/app/admin/reports/page.tsx
@@ -24,7 +24,9 @@ export default async function AdminReportsPage() {
   const reports = await listOpenReportsForAdmin(createDb());
 
   return (
-    <AppShell isSuperadmin title="Scene reports">
+    // noCapture: reports carry the reporter's email and the reported
+    // scene's name.
+    <AppShell isSuperadmin noCapture title="Scene reports">
       <div className="content-header">
         <div>
           <p className="copy">

--- a/cloud/apps/auth-web/app/admin/scenes/page.tsx
+++ b/cloud/apps/auth-web/app/admin/scenes/page.tsx
@@ -37,7 +37,8 @@ export default async function AdminScenesPage({
   const scenes = await listScenesForAdmin(createDb(), query);
 
   return (
-    <AppShell isSuperadmin title="Store scenes">
+    // noCapture: the moderation table joins every scene to its owner's email.
+    <AppShell isSuperadmin noCapture title="Store scenes">
       <div className="content-header">
         <div>
           <p className="copy">

--- a/cloud/apps/auth-web/app/device/page.tsx
+++ b/cloud/apps/auth-web/app/device/page.tsx
@@ -32,7 +32,9 @@ export default async function DevicePage({ searchParams }: DevicePageProps) {
   }
 
   return (
-    <AppShell title="Connect this FrameOS backend">
+    // noCapture: the approval panel shows the connecting install's own
+    // details, and the pairing code is in this page's URL.
+    <AppShell noCapture title="Connect this FrameOS backend">
       <div className="content-header">
         <div>
           <p className="copy">

--- a/cloud/apps/auth-web/app/s/[slug]/page.tsx
+++ b/cloud/apps/auth-web/app/s/[slug]/page.tsx
@@ -287,6 +287,11 @@ export default async function ScenePage({
       isSuperadmin={
         isOwner ? await accountIsSuperadmin(session?.accountId) : isAdmin
       }
+      // A public store page is public, and its browse traffic is worth
+      // measuring. A private scene reached through its share link is not:
+      // its name, description and images are the owner's, shown to whoever
+      // holds the link, and none of that should reach analytics.
+      noCapture={isPrivate}
       signedIn={Boolean(session)}
       title="FrameOS Scenes"
     >
@@ -407,7 +412,11 @@ export default async function ScenePage({
         </p>
       ) : null}
 
-      <div className="scene-detail section-block">
+      {/* ph-no-capture: the scene itself — gallery images, live preview,
+          description, editor. Autocapture would otherwise ship image URLs as
+          element attributes and the scene's own text as click labels. The
+          deliberate scene_viewed / scene_forked events are unaffected. */}
+      <div className="scene-detail section-block ph-no-capture">
         <SceneImageGallery
           canEdit={isOwner}
           hasPreview={scene.hasPreview}

--- a/cloud/apps/auth-web/src/components/AppShell.test.tsx
+++ b/cloud/apps/auth-web/src/components/AppShell.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppShell } from "./AppShell";
+import { PublicShell } from "./PublicShell";
+
+// The shells build absolute nav URLs from the deployment's origins.
+vi.mock("../lib/env", () => ({
+  getAccountBaseUrl: () => "https://cloud.example.net",
+  getAccountUrl: (path?: string) => `https://cloud.example.net${path ?? "/account"}`,
+  getCloudBaseUrl: () => "https://cloud.example.net",
+  getScenesBaseUrl: () => "https://scenes.example.net",
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+// `ph-no-capture` on <main> is what keeps frame names, other people's email
+// addresses and private scene content out of PostHog autocapture. It is one
+// word in a className, so it is exactly the kind of thing a later refactor
+// drops without noticing.
+describe("AppShell", () => {
+  it("marks the page body as no-capture when asked", () => {
+    const { container } = render(<AppShell noCapture>body</AppShell>);
+    expect(container.querySelector("main")?.className).toContain(
+      "ph-no-capture",
+    );
+  });
+
+  it("leaves autocapture alone by default", () => {
+    const { container } = render(<AppShell>body</AppShell>);
+    expect(container.querySelector("main")?.className).not.toContain(
+      "ph-no-capture",
+    );
+  });
+});
+
+describe("PublicShell", () => {
+  it("marks the page body as no-capture when asked", () => {
+    const { container } = render(
+      <PublicShell noCapture signedIn={false}>
+        body
+      </PublicShell>,
+    );
+    expect(container.querySelector("main")?.className).toContain(
+      "ph-no-capture",
+    );
+  });
+
+  it("keeps the public store capturable by default", () => {
+    const { container } = render(
+      <PublicShell signedIn={false}>body</PublicShell>,
+    );
+    expect(container.querySelector("main")?.className).not.toContain(
+      "ph-no-capture",
+    );
+  });
+});

--- a/cloud/apps/auth-web/src/components/AppShell.tsx
+++ b/cloud/apps/auth-web/src/components/AppShell.tsx
@@ -14,10 +14,18 @@ import {
 export function AppShell({
   children,
   isSuperadmin = false,
+  noCapture = false,
   title,
 }: Readonly<{
   children: React.ReactNode;
   isSuperadmin?: boolean;
+  // Marks the page body as off-limits to PostHog autocapture (see
+  // lib/analytics-redaction.ts). Set it on any surface whose content is the
+  // user's own data — frame names, scene names, install hostnames, other
+  // people's email addresses — which is nearly everything behind a login.
+  // Pageviews still fire, so traffic to the page is still measured; only the
+  // click events that would carry the content are dropped.
+  noCapture?: boolean;
   title?: React.ReactNode;
 }>) {
   const cloudBaseUrl = getCloudBaseUrl();
@@ -54,7 +62,9 @@ export function AppShell({
           </form>
         </nav>
       </header>
-      <main className="content">{children}</main>
+      <main className={noCapture ? "content ph-no-capture" : "content"}>
+        {children}
+      </main>
       <BackForwardRefresh />
     </div>
   );

--- a/cloud/apps/auth-web/src/components/AuthCard.tsx
+++ b/cloud/apps/auth-web/src/components/AuthCard.tsx
@@ -13,7 +13,12 @@ export function AuthCard({
 }>) {
   return (
     <main className="page center-page">
-      <section className="auth-card" aria-labelledby="auth-title">
+      {/* ph-no-capture: every card that uses this shell is an email/password
+          form or a token-bearing link landing (/verify-email, /recovery), so
+          nothing here should reach autocapture. The deliberate
+          user_logged_in / user_signed_up / google_sign_in_started events are
+          explicit captures and still fire. */}
+      <section className="auth-card ph-no-capture" aria-labelledby="auth-title">
         <div className="auth-card__body">
           <BrandMark />
           <p className="eyebrow">{eyebrow}</p>

--- a/cloud/apps/auth-web/src/components/PostHogProvider.test.tsx
+++ b/cloud/apps/auth-web/src/components/PostHogProvider.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { REDACTED } from "../lib/analytics-redaction";
+
+const init = vi.fn();
+vi.mock("posthog-js", () => ({ default: { init } }));
+
+// Imported after the mock is registered.
+const { PostHogProvider } = await import("./PostHogProvider");
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+});
+
+afterEach(() => {
+  cleanup();
+  init.mockReset();
+  window.history.pushState({}, "", "/");
+  delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+});
+
+function initConfig() {
+  render(<PostHogProvider>{null}</PostHogProvider>);
+  expect(init).toHaveBeenCalledTimes(1);
+  return init.mock.calls[0]![1] as Record<string, unknown>;
+}
+
+describe("PostHogProvider", () => {
+  it("masks element attributes, so image and link URLs never leave", () => {
+    // `ph-sensitive` does not cover attributes — only element text and an
+    // anchor's href — so this config flag is the only thing keeping scene
+    // preview images (attr__src) out of autocapture.
+    expect(initConfig().mask_all_element_attributes).toBe(true);
+  });
+
+  it("hands the sensitive query parameters to posthog's own masking", () => {
+    const config = initConfig();
+    expect(config.mask_personal_data_properties).toBe(true);
+    expect(config.custom_personal_data_properties).toContain("share");
+    expect(config.custom_personal_data_properties).toContain("token");
+    expect(config.custom_personal_data_properties).toContain("user_code");
+  });
+
+  // The node-environment tests in lib/analytics-redaction.test.ts cover the
+  // URL-carrying events. This is the other branch: an event with no URL of
+  // its own, dropped because of where the browser actually is.
+  it("drops an event with no url while the browser is on /admin", () => {
+    const beforeSend = initConfig().before_send as (
+      data: { event: string; properties?: Record<string, unknown> } | null,
+    ) => unknown;
+
+    window.history.pushState({}, "", "/admin/scenes");
+    expect(beforeSend({ event: "$identify" })).toBeNull();
+    expect(beforeSend({ event: "$autocapture", properties: { x: 1 } })).toBeNull();
+
+    window.history.pushState({}, "", "/account");
+    expect(beforeSend({ event: "$identify" })).not.toBeNull();
+  });
+
+  it("redacts capability tokens through the before_send hook", () => {
+    const beforeSend = initConfig().before_send as (
+      data: { event: string; properties: Record<string, unknown> } | null,
+    ) => { properties: Record<string, unknown> } | null;
+
+    expect(
+      beforeSend({
+        event: "$pageview",
+        properties: { $current_url: "https://cloud.frameos.net/recovery?token=abc" },
+      })?.properties.$current_url,
+    ).toBe(`https://cloud.frameos.net/recovery?token=${REDACTED}`);
+  });
+});

--- a/cloud/apps/auth-web/src/components/PostHogProvider.tsx
+++ b/cloud/apps/auth-web/src/components/PostHogProvider.tsx
@@ -2,6 +2,10 @@
 
 import posthog from "posthog-js";
 import { useEffect } from "react";
+import {
+  SENSITIVE_QUERY_PARAMS,
+  sanitizeAnalyticsEvent,
+} from "../lib/analytics-redaction";
 
 export function PostHogProvider({
   children,
@@ -10,6 +14,20 @@ export function PostHogProvider({
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY ?? "", {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
       defaults: "2026-05-30",
+      // Analytics runs on every route of this app, including pages whose URL
+      // is itself a credential (/recovery?token=…, /s/<slug>?share=…). These
+      // settings keep those out of PostHog; the reasoning, and why both the
+      // native masking and the hook are here, is in analytics-redaction.ts.
+      mask_personal_data_properties: true,
+      custom_personal_data_properties: SENSITIVE_QUERY_PARAMS,
+      before_send: sanitizeAnalyticsEvent,
+      // Autocapture records every attribute of every element in the clicked
+      // chain, which is how scene preview images (attr__src) and share links
+      // (attr__href) would end up in analytics. The `ph-sensitive` class does
+      // NOT cover attributes — only an element's own text and an anchor's
+      // href — so the only reliable answer is to drop attributes wholesale.
+      // Clicks are still captured, with the element's text and position.
+      mask_all_element_attributes: true,
     });
   }, []);
   return <>{children}</>;

--- a/cloud/apps/auth-web/src/components/PublicShell.tsx
+++ b/cloud/apps/auth-web/src/components/PublicShell.tsx
@@ -15,11 +15,16 @@ import {
 export function PublicShell({
   children,
   isSuperadmin = false,
+  noCapture = false,
   signedIn,
   title,
 }: Readonly<{
   children: React.ReactNode;
   isSuperadmin?: boolean;
+  // As AppShell's: suppresses autocapture for the page body. The store is
+  // public by definition, so this is off by default and set only for the
+  // views that are not — a private scene reached through its share link.
+  noCapture?: boolean;
   signedIn: boolean;
   title?: React.ReactNode;
 }>) {
@@ -74,7 +79,9 @@ export function PublicShell({
           )}
         </nav>
       </header>
-      <main className="content">{children}</main>
+      <main className={noCapture ? "content ph-no-capture" : "content"}>
+        {children}
+      </main>
       <BackForwardRefresh />
     </div>
   );

--- a/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
+++ b/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
@@ -300,7 +300,8 @@ export function SceneEditorModal({ sceneId, width, height, description, canSave 
   }
 
   return (
-    <div aria-modal className="editor-modal" role="dialog">
+    // ph-no-capture: the scene's own diagram, node labels and settings.
+    <div aria-modal className="editor-modal ph-no-capture" role="dialog">
       <div className="editor-modal__bar">
         <div className="editor-modal__title">
           Scene editor

--- a/cloud/apps/auth-web/src/components/SceneImageGallery.tsx
+++ b/cloud/apps/auth-web/src/components/SceneImageGallery.tsx
@@ -96,7 +96,10 @@ export function SceneImageGallery({
   }
 
   return (
-    <div className="scene-gallery">
+    // ph-no-capture travels with the gallery rather than being left to each
+    // page that mounts it: the scene's own images and name are never
+    // analytics material, wherever it is rendered.
+    <div className="scene-gallery ph-no-capture">
       {current ? (
         <div className="scene-gallery__main">
           <img

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
@@ -352,7 +352,9 @@ export function SceneLivePreview({
   return (
     // The open preview takes over the whole viewport, like the scene editor
     // modal — the page underneath stays put for when it closes.
-    <div aria-modal className="editor-modal" role="dialog">
+    // ph-no-capture: what it renders is the scene's own imagery and its
+    // settings values, some of them user-supplied.
+    <div aria-modal className="editor-modal ph-no-capture" role="dialog">
       <div className="editor-modal__bar">
         <div className="editor-modal__title">
           Live preview

--- a/cloud/apps/auth-web/src/lib/analytics-redaction.test.ts
+++ b/cloud/apps/auth-web/src/lib/analytics-redaction.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSuppressedUrl,
+  REDACTED,
+  redactAnalyticsProperties,
+  redactEmails,
+  redactSensitiveParams,
+  sanitizeAnalyticsEvent,
+} from "./analytics-redaction";
+
+describe("redactSensitiveParams", () => {
+  it("redacts the capability tokens our own routes put in URLs", () => {
+    expect(
+      redactSensitiveParams("https://cloud.frameos.net/recovery?token=abc123"),
+    ).toBe(`https://cloud.frameos.net/recovery?token=${REDACTED}`);
+    expect(
+      redactSensitiveParams("https://scenes.frameos.net/s/my-scene?share=uuid-1"),
+    ).toBe(`https://scenes.frameos.net/s/my-scene?share=${REDACTED}`);
+    expect(
+      redactSensitiveParams("https://cloud.frameos.net/device?user_code=WDJB-MJHT"),
+    ).toBe(`https://cloud.frameos.net/device?user_code=${REDACTED}`);
+  });
+
+  it("keeps the parts of the URL that carry no secret", () => {
+    expect(
+      redactSensitiveParams("/s/my-scene?share=uuid-1&version=3"),
+    ).toBe(`/s/my-scene?share=${REDACTED}&version=3`);
+  });
+
+  it("catches compound spellings the exact list does not enumerate", () => {
+    expect(redactSensitiveParams("?client_secret=x&frameToken=y&nope=z")).toBe(
+      `?client_secret=${REDACTED}&frameToken=${REDACTED}&nope=z`,
+    );
+  });
+
+  it("redacts inside an elements chain, not just bare URLs", () => {
+    const chain =
+      'a:attr__href="/recovery?token=abc"nth-child="1";div:nth-child="2"';
+    expect(redactSensitiveParams(chain)).toBe(
+      `a:attr__href="/recovery?token=${REDACTED}"nth-child="1";div:nth-child="2"`,
+    );
+  });
+
+  it("redacts a token in the fragment as well as the query", () => {
+    expect(redactSensitiveParams("/callback#access_token=abc&state=1")).toBe(
+      `/callback#access_token=${REDACTED}&state=1`,
+    );
+  });
+
+  it("leaves ordinary text alone", () => {
+    expect(redactSensitiveParams("Scene deployed to the kitchen frame")).toBe(
+      "Scene deployed to the kitchen frame",
+    );
+  });
+});
+
+describe("redactEmails", () => {
+  it("replaces addresses anywhere in the string", () => {
+    expect(redactEmails("Signed in as ada@example.com")).toBe(
+      `Signed in as ${REDACTED}`,
+    );
+  });
+});
+
+describe("redactAnalyticsProperties", () => {
+  it("redacts nested autocapture properties", () => {
+    const properties = {
+      $current_url: "https://cloud.frameos.net/verify-email?token=secret-1",
+      $elements: [
+        { attr__href: "/s/private-scene?share=uuid-9", tag_name: "a" },
+        { $el_text: "ada@example.com", tag_name: "span" },
+      ],
+      $event_type: "click",
+    };
+
+    expect(redactAnalyticsProperties(properties)).toEqual({
+      $current_url: `https://cloud.frameos.net/verify-email?token=${REDACTED}`,
+      $elements: [
+        { attr__href: `/s/private-scene?share=${REDACTED}`, tag_name: "a" },
+        { $el_text: REDACTED, tag_name: "span" },
+      ],
+      $event_type: "click",
+    });
+  });
+
+  it("does not mutate the caller's object", () => {
+    const properties = { $current_url: "/recovery?token=abc" };
+    redactAnalyticsProperties(properties);
+    expect(properties.$current_url).toBe("/recovery?token=abc");
+  });
+
+  it("keeps the account's own email on its person profile", () => {
+    // UserIdentifier sets these on purpose; redacting them would defeat
+    // identify rather than protect anyone.
+    const properties = {
+      $set: { email: "ada@example.com", name: "Ada Lovelace" },
+      $current_url: "/account",
+    };
+    expect(redactAnalyticsProperties(properties)).toEqual(properties);
+  });
+
+  it("still redacts URLs inside person properties", () => {
+    expect(
+      redactAnalyticsProperties({
+        $set: { $initial_current_url: "/recovery?token=abc" },
+      }),
+    ).toEqual({ $set: { $initial_current_url: `/recovery?token=${REDACTED}` } });
+  });
+
+  it("passes non-string values through untouched", () => {
+    const properties = { count: 3, nested: { ok: true }, missing: null };
+    expect(redactAnalyticsProperties(properties)).toEqual(properties);
+  });
+});
+
+describe("isSuppressedUrl", () => {
+  it("matches the admin surface and everything under it", () => {
+    expect(isSuppressedUrl("/admin")).toBe(true);
+    expect(isSuppressedUrl("/admin/scenes")).toBe(true);
+    expect(isSuppressedUrl("https://cloud.frameos.net/admin/reports?q=ada")).toBe(
+      true,
+    );
+  });
+
+  it("does not match paths that merely start with the same letters", () => {
+    expect(isSuppressedUrl("/administrators")).toBe(false);
+    expect(isSuppressedUrl("/account")).toBe(false);
+    expect(isSuppressedUrl("/s/admin-dashboard-scene")).toBe(false);
+  });
+
+  it("ignores non-strings and empty values", () => {
+    expect(isSuppressedUrl(undefined)).toBe(false);
+    expect(isSuppressedUrl("")).toBe(false);
+    expect(isSuppressedUrl(42)).toBe(false);
+  });
+});
+
+describe("sanitizeAnalyticsEvent", () => {
+  it("drops every event from the admin surface", () => {
+    for (const event of ["$pageview", "$autocapture", "$web_vitals", "$exception"]) {
+      expect(
+        sanitizeAnalyticsEvent({
+          event,
+          properties: { $current_url: "https://cloud.frameos.net/admin/scenes" },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("drops an admin event identified only by $pathname", () => {
+    expect(
+      sanitizeAnalyticsEvent({ event: "$pageleave", properties: { $pathname: "/admin" } }),
+    ).toBeNull();
+  });
+
+  it("keeps events from everywhere else", () => {
+    expect(
+      sanitizeAnalyticsEvent({
+        event: "$pageview",
+        properties: { $current_url: "https://cloud.frameos.net/account/frames" },
+      }),
+    ).not.toBeNull();
+  });
+
+  it("redacts the properties of a capture", () => {
+    expect(
+      sanitizeAnalyticsEvent({
+        event: "$pageview",
+        properties: { $current_url: "/s/x?share=uuid-1" },
+      }),
+    ).toEqual({
+      event: "$pageview",
+      properties: { $current_url: `/s/x?share=${REDACTED}` },
+    });
+  });
+
+  it("passes through a capture with no properties", () => {
+    const data = { event: "$pageview" };
+    expect(sanitizeAnalyticsEvent(data)).toBe(data);
+  });
+
+  it("drops the event rather than send it unredacted", () => {
+    const exploding = {
+      event: "$pageview",
+      get properties(): Record<string, unknown> {
+        throw new Error("boom");
+      },
+    };
+    expect(sanitizeAnalyticsEvent(exploding)).toBeNull();
+  });
+});

--- a/cloud/apps/auth-web/src/lib/analytics-redaction.ts
+++ b/cloud/apps/auth-web/src/lib/analytics-redaction.ts
@@ -1,0 +1,245 @@
+// Last line of defence before anything leaves the browser for PostHog.
+//
+// Analytics runs on every auth-web route (PostHogProvider is mounted in the
+// root layout), and several of those routes carry a capability in the query
+// string: /verify-email?token=…, /recovery?token=…, /s/<slug>?share=… and
+// /device?user_code=…. Pageview capture sends $current_url verbatim, so
+// without this those one-time links and the long-lived scene share token
+// would be stored in a third-party analytics product, readable by anyone
+// with access to the project.
+//
+// Two mechanisms cover that, and they overlap on purpose:
+//
+//   1. `custom_personal_data_properties` (see PostHogProvider) hands
+//      SENSITIVE_QUERY_PARAMS to posthog-js itself, which masks them in the
+//      URL properties it builds natively ($current_url, $referrer, campaign
+//      and person info).
+//   2. `redactAnalyticsProperties` re-walks the finished property bag from a
+//      `before_send` hook. posthog-js only masks the properties it knows are
+//      URLs; autocapture also ships `$elements_chain` (one string containing
+//      every ancestor's attr__href), per-element attr__src/attr__href, and
+//      network-timing entries. Those are plain strings as far as the SDK is
+//      concerned, so they need a scan of their own.
+//
+// The scan is deliberately blunt: it redacts any `key=value` pair whose key
+// looks sensitive, anywhere in any string, whether or not the surrounding
+// text parses as a URL. Over-redacting an analytics property costs nothing;
+// under-redacting leaks a credential.
+
+// Query parameters whose value is itself a capability or an identifier we do
+// not want in analytics. Exported so PostHogProvider can hand the same list
+// to posthog-js as `custom_personal_data_properties` — one list, both layers.
+export const SENSITIVE_QUERY_PARAMS = [
+  "access_token",
+  "api_key",
+  "apikey",
+  "auth",
+  "authorization",
+  "code",
+  "credential",
+  "credentials",
+  "email",
+  "id_token",
+  "invite",
+  "key",
+  "otp",
+  "password",
+  "passwd",
+  "pin",
+  "recovery",
+  "refresh_token",
+  "secret",
+  "session",
+  "share",
+  "share_token",
+  "sig",
+  "signature",
+  "token",
+  "user_code",
+];
+
+const sensitiveParamSet = new Set(SENSITIVE_QUERY_PARAMS);
+
+// Catches the compound spellings the exact list cannot enumerate —
+// `frame_token`, `backupKey`, `x-signature`, `client_secret`, and whatever
+// the next feature invents.
+const SENSITIVE_KEY_PATTERN =
+  /(token|secret|password|passwd|api[_-]?key|apikey|auth|signature|credential|session|share)/i;
+
+export const REDACTED = "[redacted]";
+
+// Bounded on both sides: a key long enough to be a real parameter name, and a
+// value short enough that we are not rewriting a base64 image blob. Values
+// stop at the delimiters that end a query parameter, so `?token=abc&next=/x`
+// redacts only `abc`.
+const PARAM_PAIR_PATTERN = /([A-Za-z0-9_.%-]{1,64})=([^&#\s"'<>]{1,4096})/g;
+
+const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+// Person properties set by UserIdentifier: the account's own email and name,
+// attached to its own profile on purpose so a user is identifiable in
+// PostHog at all. Redacting those would defeat `identify` rather than
+// protect anyone, so the email scrub skips these subtrees. URL redaction
+// still applies inside them.
+const PERSON_PROPERTY_KEYS = new Set(["$set", "$set_once"]);
+
+// Property bags are JSON-shaped, so this bound is about pathological input
+// (or a cycle someone introduces later), not about real events.
+const MAX_DEPTH = 8;
+
+function isSensitiveKey(rawKey: string) {
+  let key = rawKey;
+  try {
+    key = decodeURIComponent(rawKey);
+  } catch {
+    // A malformed escape is not a reason to skip the check — fall through
+    // with the raw key.
+  }
+  const normalized = key.toLowerCase();
+  return (
+    sensitiveParamSet.has(normalized) || SENSITIVE_KEY_PATTERN.test(normalized)
+  );
+}
+
+/**
+ * Redact `key=value` pairs with a sensitive-looking key, anywhere in a
+ * string: a bare URL, a `$elements_chain` blob, a referrer, a fetch URL in a
+ * network-timing entry.
+ */
+export function redactSensitiveParams(value: string) {
+  return value.replace(PARAM_PAIR_PATTERN, (match, key: string) =>
+    isSensitiveKey(key) ? `${key}=${REDACTED}` : match,
+  );
+}
+
+/** Replace anything email-shaped. Autocapture reads element text, and plenty
+ * of our pages render an address in a button or link (the admin users table
+ * most of all). The `ph-no-capture` markers on those regions are the primary
+ * defence; this catches the page someone adds next year without one. */
+export function redactEmails(value: string) {
+  return value.replace(EMAIL_PATTERN, REDACTED);
+}
+
+function redactString(value: string, allowEmails: boolean) {
+  const withoutParams = redactSensitiveParams(value);
+  return allowEmails ? withoutParams : redactEmails(withoutParams);
+}
+
+function redactValue(value: unknown, allowEmails: boolean, depth: number): unknown {
+  if (typeof value === "string") {
+    return redactString(value, allowEmails);
+  }
+  if (depth >= MAX_DEPTH || value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry, allowEmails, depth + 1));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = redactValue(
+      entry,
+      allowEmails || PERSON_PROPERTY_KEYS.has(key),
+      depth + 1,
+    );
+  }
+  return out;
+}
+
+/**
+ * Redact a finished PostHog property bag. Returns a new object; the input is
+ * never mutated, because posthog-js reuses parts of it (person properties,
+ * campaign params) across events.
+ */
+export function redactAnalyticsProperties<T extends Record<string, unknown>>(
+  properties: T,
+): T {
+  return redactValue(properties, false, 0) as T;
+}
+
+// Paths that produce no analytics at all — not a pageview, not a click, not
+// a web vital, not an exception. Redaction is the rule everywhere else, but
+// superadmin tooling reads every account's email, every scene's owner and
+// every open report, and the fact that it was looked at is not worth
+// measuring. Dropping whole events here rather than relying on the
+// `ph-no-capture` markers means it holds for events that have nothing to do
+// with the DOM.
+export const SUPPRESSED_PATH_PREFIXES = ["/admin"];
+
+function pathnameOf(value: string) {
+  try {
+    // The base only matters for relative values ($pathname); an absolute URL
+    // ignores it.
+    return new URL(value, "http://frameos.invalid").pathname;
+  } catch {
+    return value;
+  }
+}
+
+/** True when a URL or path sits under a suppressed prefix. */
+export function isSuppressedUrl(value: unknown) {
+  if (typeof value !== "string" || value === "") {
+    return false;
+  }
+  const pathname = pathnameOf(value);
+  return SUPPRESSED_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+// Both the event's own URL and where the browser actually is. An event
+// usually carries $current_url, but not every one does ($identify, feature
+// flag calls), and a $pageleave fired while navigating away from /admin
+// still belongs to /admin. Either being under the prefix is enough to drop.
+function isSuppressedEvent(properties: Record<string, unknown>) {
+  if (
+    isSuppressedUrl(properties.$current_url) ||
+    isSuppressedUrl(properties.$pathname)
+  ) {
+    return true;
+  }
+  return (
+    typeof window !== "undefined" &&
+    isSuppressedUrl(window.location?.pathname)
+  );
+}
+
+// Structurally posthog-js's CaptureResult, kept local so the hook stays a
+// plain function the tests can call with a two-field object. `before_send`
+// is also handed nulls (an earlier hook in the chain may have dropped the
+// event), which pass straight through.
+type CaptureLike = {
+  event: string;
+  properties?: Record<string, unknown> | undefined;
+};
+
+/**
+ * `before_send` hook: drops events from suppressed paths outright, and
+ * redacts the properties of everything else. posthog-js also has a
+ * `sanitize_properties` option with the same reach, but it is deprecated in
+ * posthog-js 1.x and logs an error line on every single capture; `before_send`
+ * is the supported spelling of the same idea, and unlike the deprecated hook
+ * it can drop an event rather than only rewrite it.
+ *
+ * Never throws: a failure here must drop the redaction, not the page. If the
+ * walk somehow fails we drop the event rather than send an unredacted one.
+ */
+export function sanitizeAnalyticsEvent<T extends CaptureLike>(
+  data: T | null,
+): T | null {
+  try {
+    if (!data?.properties) {
+      // No properties to check against, so fall back to where the browser is.
+      return typeof window !== "undefined" &&
+        isSuppressedUrl(window.location?.pathname)
+        ? null
+        : data;
+    }
+    if (isSuppressedEvent(data.properties)) {
+      return null;
+    }
+    return { ...data, properties: redactAnalyticsProperties(data.properties) };
+  } catch {
+    return null;
+  }
+}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -68,6 +68,65 @@ because the cloud protocol has no shell verbs — structural, nothing to close.
 
 ## Cloud-managed frames
 
+- **Cloud frame settings parity + an honest Settings panel** — cloud-managed
+  Linux/Pi frames currently render nearly the full self-hosted per-frame form,
+  even though cloud save/diff/readback only support the declarative base keys
+  (`name`, `debug`, `interval`, `rotate`, `scaling_mode`, `timezone`; schedule
+  and service secrets use their own paths). Most of those visible controls are
+  therefore unsaveable and may appear to save while being dropped from the
+  cloud payload. First make the surface honest: hide unsupported sections or
+  disable them with a useful explanation, and never render an editable field
+  that the active device profile cannot round-trip.
+
+  Then widen `set_settings` in deliberately small, validated batches, keeping
+  the shared SPA payload list, auth-web validator/readback, Pi/Nim allowlist,
+  ESP32 handler (where applicable), docs, and drift tests in lockstep:
+
+  - Straightforward Pi/Linux candidates: `flip`, `error_behavior` (mode and
+    retry timings), and `control_code` (enable, placement, size/padding,
+    offsets, and colors).
+  - Useful with explicit bounds/policy: `metrics_interval` (including a clear,
+    actually-working disabled value), platform-capped
+    `max_http_response_bytes`, and `save_assets` (boolean/per-app, respecting
+    disk quotas). For `timezone_updater`, expose only enabled/hour and keep the
+    download endpoint fixed and trusted — never accept an arbitrary update
+    URL from the provider.
+  - Hardware-aware settings are especially worthwhile: custom display
+    `palette` colors, the strict partial-refresh subset of `device_config`
+    (`partial`, `partialMaxAreaPercent`,
+    `partialMaxRefreshesBeforeFull`), and `gpio_buttons` (pin + label). Validate
+    them against the reported panel/platform, advertise capability/version
+    requirements, and restart the runtime/device when the driver only reads
+    them at initialization. Never allow the whole `device_config` object just
+    to carry the partial-refresh fields.
+  - ESP32 follow-ups: `max_http_response_bytes`, noisy/debug logging, and GPIO
+    buttons are plausible because the NVS fields already exist; add only the
+    settings the firmware really consumes and preserve the whole-payload
+    rejection contract. The existing cloud power controls remain their own
+    ESP32-only subset.
+  - Automatic reboot is useful, but the self-hosted `reboot` object is mostly
+    deploy-time configuration rather than a live FrameConfig field. Implement
+    it as a real cloud-safe scheduler capability (possibly through the
+    existing schedule verb) instead of merely persisting an inert object.
+    Brightness is also desirable once the runtime and relevant drivers gain a
+    real brightness setting.
+
+  Do **not** add `image_engine` to the cloud allowlist. We want to remove
+  ImageMagick, not make it a cloud-facing compatibility promise: converge on
+  Pixie, migrate/ignore old `imagemagick` config values, remove the Settings
+  selector and ImageMagick-specific runtime/build/dependency paths, and test
+  that existing frames degrade to Pixie cleanly.
+
+  Keep provisioning, credentials, and host authority local: deployment mode,
+  panel/driver/VCOM/dimensions, flash and GPIO wiring, SD-card wiring, Wi-Fi
+  and hotspot credentials, private-network elevation, frame HTTP/admin/TLS
+  access and keys, SSH/backend/agent configuration, mountpoints, HTTP-upload
+  URLs/headers, arbitrary update URLs, and service API secrets must not ride
+  `set_settings`. Likewise, do not expose raw `assets_path` or `log_to_file`
+  paths; if those features are wanted remotely, redesign them as bounded
+  toggles using fixed FrameOS-owned directories. Hardware identity reported by
+  the frame should stay authoritative rather than becoming provider-editable.
+
 - **Cloud AI chat follow-ups** — the 2026-08-14 chat v2 rebuild (branch
   `cloud-ai-chat-v2`) replaced the ported pipeline with a streaming agentic
   loop (`/api/ai/chat`, NDJSON) with tools for the app catalog, docs,
@@ -210,6 +269,36 @@ numbers and the measurement tooling live in `docs/esp32-memory.md`.
   acceptable?
 
 ## Ideas parking lot (unscheduled)
+
+- **SVG `<text>` support in render/svg** (investigated 2026-08-15; verdict:
+  1–2 days, ~150–250 lines). Today any `<text>` tag makes the whole SVG fail,
+  and the AI scene prompt tells models to layer render/text instead. Pixie
+  already has all the hard parts: the fork's SVG parser
+  (`pixie/src/pixie/fileformats/svg.nim`) turns every tag into
+  `(Path, SvgProperties)` pairs, and `fonts.nim` already does text→path
+  (`typeset`, `getGlyphPath`, private `computePaths` — exposing it is a
+  one-word change). A `"text"` case in `parseSvgElement` would typeset the
+  inner text and append glyph paths translated by `(x, y − ascent·scale)`
+  (SVG `y` is the baseline; pixie's origin is top-left) — then fill, stroke,
+  gradients, transforms (rotated text), and FrameOS's banded rendering all
+  work for free. The one design question is font resolution: pixie's parser
+  has no font access, so `parseSvg` needs a `resolveTypeface(family)` hook;
+  FrameOS plugs in `getTypeface()` from `frameos/utils/font.nim` (embedded
+  Ubuntu-Regular default + `assets/fonts` + emoji fallback) — unknown
+  families must degrade to the default, never fail. v1 scope cuts: no
+  `<tspan>`, no `textLength`/`letter-spacing`, minimal `dominant-baseline`,
+  no complex shaping (pixie has none), and **no emoji** (color glyphs are
+  bitmaps the path-only element model can't carry — keep the "emoji via
+  render/text" prompt note). `text-anchor` middle/end is cheap via
+  `layoutBounds`. Preferred home: the pixie fork (single parse, sits next to
+  the banding/`renderInto` contract; nimble lock bump via the known
+  manual-checksum recipe). Alternative considered: a FrameOS-side pre-pass
+  replacing `<text>` nodes with computed `<path d>` before `parseSvg` — no
+  fork change, but double XML parse and hand-rolled attribute inheritance.
+  Follow-ons if built: update BOTH cloud AI prompt copies
+  (`cloud/apps/auth-web/src/lib/ai/prompts.ts` + the ai-scene prompt); WASM
+  preview works automatically (default font ships via nimassets); ESP32
+  flash cost near zero (fonts already embedded).
 
 - **Thin-client frames on the cloud (ESP32-C3, embedded Pi/Pico).** Parked
   2026-08-13 pending a product decision: serving these boards means the


### PR DESCRIPTION
PostHog runs on every auth-web route, and several of those routes carry a capability in the query string: `/verify-email?token=`, `/recovery?token=`, `/s/<slug>?share=` and `/device?user_code=`. Pageview capture sent `$current_url` verbatim, so those one-time links — and the long-lived scene share token, which grants anonymous read of a private scene — were being stored in a third-party analytics product, readable by anyone with access to the project.

Found while auditing what we actually collect. For the record, the rest of that audit came back clean: session recording is off project-side, and there is no LLM analytics wired anywhere, so nothing from the AI chat reaches PostHog.

## Redaction

`src/lib/analytics-redaction.ts`, unit-tested. Two overlapping layers because they cover different things:

- `custom_personal_data_properties` hands the sensitive parameter names to posthog-js, which masks them in the URL properties it builds natively (`$current_url`, `$referrer`, campaign and person info).
- A `before_send` hook re-walks the finished property bag and redacts any `key=value` pair with a sensitive-looking key, at any depth. This covers what the SDK does not know are URLs: the `$elements_chain` blob (the project has `elementsChainAsString` on), per-element `attr__href`, and network-timing entries. Emails are redacted too, except under `$set`/`$set_once` so `identify` still names the account.

`before_send` rather than `sanitize_properties`: the latter is deprecated in posthog-js 1.x and logs an error line on *every* capture, and unlike it, `before_send` can drop an event outright.

## No analytics at all under /admin

The hook returns `null` for any event whose URL — or the browser's current location, for events that carry no URL of their own — sits under `/admin`. Superadmin tooling reads every account's email and every scene's owner; that it was looked at is not worth measuring. Dropping whole events rather than relying on DOM markers means it also holds for `$exception`, web vitals and `$identify`.

## mask_all_element_attributes

Autocapture records every attribute of every element in the clicked chain, which is how scene preview images (`attr__src`) and share links (`attr__href`) reached analytics. Worth knowing: the `ph-sensitive` class does **not** cover attributes — only an element's own text and an anchor's `href` — so dropping attributes wholesale is the only reliable answer. Clicks are still captured, with element text and position; `href` is lost from click analytics.

## ph-no-capture regions

A `noCapture` prop on `AppShell`/`PublicShell` marks `<main>`. Autocapture events are dropped there while pageviews still fire, so traffic is still measured and only content-bearing clicks are lost:

- all of `/account/*`, via the layout, so future subpages inherit it
- the three admin pages, the device page
- private scene pages reached by share link (`noCapture={isPrivate}`); the public store stays capturable
- the scene detail block, and the gallery / live preview / editor components, so the marker travels with them
- `AuthCard`, which backs login, signup, reset, recovery and verify-email

The deliberate captures (`scene_viewed`, `user_logged_in`, `scene_forked`, …) are unaffected everywhere except `/admin`.

## Testing

588 unit tests pass (7 new files' worth of cases), `tsc --noEmit` and eslint clean, `next build` succeeds. Tests lock in the shell markers and the provider config, since `ph-no-capture` is one word in a `className` and exactly the kind of thing a refactor drops silently.

This exact tree is already running in production (deployed from a branch), and I verified against the live site that the config, the `auth-card ph-no-capture` marker and the `scene-detail … ph-no-capture` marker are all in effect.

Note: this stops new leakage only. Tokens captured before the deploy are still in existing PostHog events and would need deleting there; rotating the affected `share_token` values on `store_scenes` is the belt-and-braces follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)