### PR TITLE
The SD builder stops guessing which board you have

### DIFF
--- a/cloud-frontend/src/components/CloudFrameSdImageCard.tsx
+++ b/cloud-frontend/src/components/CloudFrameSdImageCard.tsx
@@ -2,6 +2,7 @@ import { DevicePhoneMobileIcon } from '@heroicons/react/24/outline'
 import { useState } from 'react'
 import type { ReactElement } from 'react'
 
+import { normalizeBuildrootPlatform } from '../../../frontend/src/devices'
 import type { FrameType } from '../../../frontend/src/types'
 import { cloudOrigin } from '../cloudConfig'
 import { SdImageBuilder } from './SdImageBuilder'
@@ -30,6 +31,12 @@ import { SdImageBuilder } from './SdImageBuilder'
  */
 export function CloudFrameSdImageCard({ frame }: { frame: FrameType }): ReactElement {
   const [open, setOpen] = useState(false)
+
+  // Only seed the board when the frame actually records one — normalize on a
+  // missing value would hand back the raspberry-pi-64 default, which is a
+  // guess, and a guessed board is exactly what does not survive being wrong.
+  const storedPlatform = frame.buildroot?.platform
+  const buildrootPlatform = storedPlatform ? normalizeBuildrootPlatform(storedPlatform) : undefined
 
   // Bound (re-enrollment) codes only: single-use, one-hour, no frame quota.
   // Minted per build rather than cached, because one code can only ever key
@@ -79,6 +86,7 @@ export function CloudFrameSdImageCard({ frame }: { frame: FrameType }): ReactEle
               width: frame.width,
               height: frame.height,
               rotate: frame.rotate,
+              buildrootPlatform,
             }}
           />
         ) : (

--- a/cloud-frontend/src/components/CloudFrameSdImageCard.tsx
+++ b/cloud-frontend/src/components/CloudFrameSdImageCard.tsx
@@ -38,6 +38,18 @@ export function CloudFrameSdImageCard({ frame }: { frame: FrameType }): ReactEle
   const storedPlatform = frame.buildroot?.platform
   const buildrootPlatform = storedPlatform ? normalizeBuildrootPlatform(storedPlatform) : undefined
 
+  // The display comes from the device's own `hardware` report, not from the
+  // frame's settings: `device`, `width` and `height` are not in the cloud's
+  // settings allowlist (src/lib/frames.ts — only `rotate` of the four is), so
+  // frameSummary never carries them and seeding from frame.device alone left
+  // every re-download on "pick the display later" for a frame whose panel the
+  // cloud already knew. `hardware` is what the device sent at enrollment and
+  // re-sends on every hub hello.
+  const hardware = frame.hardware
+  const seededDevice = frame.device || hardware?.device || undefined
+  const seededWidth = frame.width ?? hardware?.width ?? undefined
+  const seededHeight = frame.height ?? hardware?.height ?? undefined
+
   // Bound (re-enrollment) codes only: single-use, one-hour, no frame quota.
   // Minted per build rather than cached, because one code can only ever key
   // one card.
@@ -82,9 +94,9 @@ export function CloudFrameSdImageCard({ frame }: { frame: FrameType }): ReactEle
               // Seed the display picker from what the frame already runs —
               // "pick the display later" is the wrong default for hardware
               // that is already configured. All still editable in the form.
-              device: frame.device,
-              width: frame.width,
-              height: frame.height,
+              device: seededDevice,
+              width: seededWidth,
+              height: seededHeight,
               rotate: frame.rotate,
               buildrootPlatform,
             }}

--- a/cloud-frontend/src/components/SdImageBuilder.tsx
+++ b/cloud-frontend/src/components/SdImageBuilder.tsx
@@ -170,6 +170,13 @@ export function SdImageBuilder({
         width?: number | undefined
         height?: number | undefined
         rotate?: number | undefined
+        // Canonical buildroot platform key of the board this frame runs on,
+        // when the frame records one (the caller maps legacy keys first).
+        // The board is the one field a wrong value cannot be recovered from
+        // in the setup portal: a 64-bit card in an ARMv6 Pi does not boot far
+        // enough to say so. Unknown board = no seed, and the select holds its
+        // "Pick a board…" placeholder.
+        buildrootPlatform?: string | undefined
       }
     | undefined
 }): ReactElement {
@@ -223,6 +230,7 @@ export function SdImageBuilder({
   )
   const [canStreamToDisk] = useState(() => typeof window !== 'undefined' && 'showSaveFilePicker' in window)
 
+  const seedPlatform = reenrollFrame?.buildrootPlatform
   useEffect(() => {
     let cancelled = false
     async function loadRelease(): Promise<void> {
@@ -251,9 +259,17 @@ export function SdImageBuilder({
           // The route sends "" when the release carries no tag.
           version: data.release || 'latest',
         })
-        const firstAvailable = boards.find((board) => board.asset)
-        if (firstAvailable) {
-          setPlatform((current) => current || firstAvailable.platform)
+        // Seed the board only from the frame being re-enrolled — never from
+        // the first entry in the list. Auto-selecting a board is how an
+        // ARMv6 Pi Zero W ends up holding the 64-bit image: every other
+        // field is pre-filled from the frame, the two topmost labels both
+        // open with "Raspberry Pi Zero", and the card fails with nothing but
+        // a dark ACT LED to say why. With no seed the select keeps its
+        // disabled "Pick a board…" placeholder and the download button stays
+        // disabled until someone chooses.
+        const seeded = boards.find((board) => board.asset && board.platform === seedPlatform)
+        if (seeded) {
+          setPlatform((current) => current || seeded.platform)
         }
       } catch (loadError) {
         if (!cancelled) {
@@ -268,7 +284,7 @@ export function SdImageBuilder({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [seedPlatform])
 
   function failWith(message: string): void {
     setError(message)

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-sd-image-builder.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-sd-image-builder.test.tsx
@@ -164,10 +164,22 @@ function savedBytes(saved: SavedFile): Uint8Array {
   return joined;
 }
 
-// The frame name and a root-login choice are both required now — every build
-// path fills the name and (unless it sets a password itself) opts into
-// passwordless root first.
+// The board is never auto-selected: picking it is the one choice the builder
+// refuses to guess, because a wrong board produces a card that cannot say so
+// (a 64-bit image in an ARMv6 Pi Zero W just leaves the ACT LED dark). Every
+// build path therefore chooses one first.
+function pickBoard(platform = "raspberry-pi-64") {
+  const board = screen.getByLabelText("Board") as HTMLSelectElement;
+  if (!board.value) {
+    fireEvent.change(board, { target: { value: platform } });
+  }
+}
+
+// The board, the frame name and a root-login choice are all required now —
+// every build path fills them and (unless it sets a password itself) opts
+// into passwordless root first.
 function nameFrame(value = "Kitchen Frame") {
+  pickBoard();
   fireEvent.change(screen.getByPlaceholderText("Frame name"), {
     target: { value },
   });
@@ -207,6 +219,87 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero / Zero W / 1 (32-bit) — image not published yet",
     });
     expect((missing as HTMLOptionElement).disabled).toBe(true);
+  });
+
+  // Regression: the builder used to select the first board with a published
+  // asset. In a form where every other field is pre-filled that reads as a
+  // decision already made, and the first entry is the 64-bit image — which an
+  // ARMv6 Pi Zero W cannot boot, and cannot report: it flashes the ACT LED
+  // twice and goes dark. The board is the one field nothing can recover from,
+  // so it is the one field the builder never guesses.
+  it("selects no board on its own, leaving the download disabled", async () => {
+    mockReleaseAndImage();
+    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_x")} />);
+    await screen.findByRole("option", {
+      name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
+    });
+
+    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe("");
+    expect(
+      (screen.getByRole("button", {
+        name: /download sd image/i,
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("seeds the board from the frame being re-enrolled", async () => {
+    fetchMock.mockImplementation((input) =>
+      String(input).startsWith("/api/frames/firmware")
+        ? Promise.resolve(
+            Response.json({
+              ...firmwarePayload,
+              assets: [
+                ...firmwarePayload.assets,
+                {
+                  name: "frameos-1.2.3-raspberry-pi-32-buildroot.img.gz",
+                  platform: "raspberry-pi-32",
+                  size: gzippedImage.length,
+                },
+              ],
+            }),
+          )
+        : Promise.reject(new Error(`unexpected fetch: ${String(input)}`)),
+    );
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_x")}
+        reenrollFrame={{
+          id: "f-1",
+          name: "Kitchen Frame",
+          buildrootPlatform: "raspberry-pi-32",
+        }}
+      />,
+    );
+    await screen.findByRole("option", {
+      name: "Raspberry Pi Zero / Zero W / 1 (32-bit) (v1.2.3)",
+    });
+
+    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe(
+      "raspberry-pi-32",
+    );
+  });
+
+  // A frame whose board has no published image must not fall back to a
+  // different board's — a silent substitution is the bug, not the fix.
+  it("does not seed a board whose image is missing from the release", async () => {
+    mockReleaseAndImage();
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_x")}
+        reenrollFrame={{
+          id: "f-1",
+          name: "Kitchen Frame",
+          buildrootPlatform: "raspberry-pi-32",
+        }}
+      />,
+    );
+    await screen.findByRole("option", {
+      name: "Raspberry Pi Zero / Zero W / 1 (32-bit) — image not published yet",
+    });
+
+    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe("");
   });
 
   it("reports a failed release lookup instead of silently offering nothing", async () => {
@@ -308,7 +401,9 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
-    // Name only — neither a root password nor the passwordless checkbox.
+    // Board and name only — neither a root password nor the passwordless
+    // checkbox.
+    pickBoard();
     fireEvent.change(screen.getByPlaceholderText("Frame name"), {
       target: { value: "Kitchen Frame" },
     });
@@ -338,6 +433,7 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
+    pickBoard();
     fireEvent.change(screen.getByPlaceholderText("Frame name"), {
       target: { value: "Kitchen Frame" },
     });
@@ -687,6 +783,8 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
+    // A board but no name: the name check is the one that must speak up.
+    pickBoard();
     fireEvent.click(
       screen.getByRole("button", { name: /download sd image/i }),
     );
@@ -740,6 +838,8 @@ describe("SdImageBuilder", () => {
       // The cover copy has to be honest about what does and does not travel.
       expect(screen.getByText(/Assets do not travel/)).toBeTruthy();
 
+      // This frame records no board, so the select stays on its placeholder.
+      pickBoard();
       const passwordless = screen.getByLabelText(
         /Enable passwordless root login/,
       ) as HTMLInputElement;
@@ -774,6 +874,7 @@ describe("SdImageBuilder", () => {
         name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
       });
 
+      pickBoard();
       fireEvent.click(
         screen.getByLabelText(/Enable passwordless root login/),
       );
@@ -863,6 +964,7 @@ describe("SdImageBuilder", () => {
         name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
       });
 
+      pickBoard();
       fireEvent.click(
         screen.getByLabelText(/Enable passwordless root login/),
       );

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -36,6 +36,7 @@ import {
   EMBEDDED_VIRTUAL,
   isThinClientEmbeddedPlatform,
   modes,
+  normalizeBuildrootPlatform,
   virtualColorModes,
 } from '../../../../devices'
 import { secureToken } from '../../../../utils/secureToken'
@@ -1960,7 +1961,20 @@ export function FrameSettings({
           {isBuildrootMode ? (
             <Group name="buildroot">
               <Field name="platform" label="Platform">
-                <Select name="buildroot.platform" options={buildrootPlatforms} />
+                {({ value, onChange }) => (
+                  // Frames saved before the platform consolidation still store
+                  // 'raspberry-pi-zero-w' / 'raspberry-pi-zero-2-w', which match
+                  // no option and render the select blank. Show the platform
+                  // whose image actually boots that board (the backend resolves
+                  // the legacy keys the same way), so the field reads as the
+                  // truth instead of as "unset".
+                  <Select
+                    name="buildroot.platform"
+                    options={buildrootPlatforms}
+                    value={normalizeBuildrootPlatform(value)}
+                    onChange={(v) => onChange(v)}
+                  />
+                )}
               </Field>
               <Field
                 name="compilationMode"


### PR DESCRIPTION
A Pi Zero W was handed the 64-bit image and answered with two flashes of the
ACT LED and then nothing. This is why, and the two adjacent places the same
kind of guess was being made.

## The board

"Write another SD card" pre-fills every field from the frame — name, display,
size, rotation — except the one that decides whether the card boots at all.
The board select seeded itself from the first entry with a published asset,
which is `raspberry-pi-64`, labelled "Raspberry Pi Zero 2 W / 3 / 4 (64-bit)",
directly above "Raspberry Pi Zero / Zero W / 1 (32-bit)". In a form where
everything else is already correct, a filled-in select reads as a decision
already made.

On an ARMv6 board the resulting card carries `arm_64bit=1`, `kernel=Image`,
and no `bcm2708-*.dtb` at all, so the failure cannot report itself: nothing
gets far enough to report anything.

So the builder no longer picks. It seeds the board from the frame being
re-enrolled — `CloudFrameSdImageCard` now passes it, mapped through
`normalizeBuildrootPlatform` so pre-consolidation frames still resolve — and
only when that board has a published image in the release. With nothing to
seed from, the select keeps its `Pick a board…` placeholder and the download
button stays disabled until someone chooses.

## The display

The same card seeded the display picker from `frame.device`, which the cloud
never has: `device`, `width` and `height` are not in the frame-settings
allowlist (`cloud/apps/auth-web/src/lib/frames.ts` — of the four the builder
wants, only `rotate` is), so `frameSummary` never carries them and every
re-download opened on "pick the display later", including for frames whose
panel the cloud has known since enrollment.

The device does report them — `hardwarePayload` sends `device`/`width`/
`height`, the cloud stores it as `frames.hardware`, `frameSummary` passes it
through — so seed from that.

## The self-hosted Platform field

`FrameSettings` ran the stored platform straight into an options list that no
longer contains the legacy keys, so a frame saved as `raspberry-pi-zero-w`
rendered blank. Normalize it the way the backend resolves it.

## Not a bug: the raspberry-pi-32 image

Checked before changing anything. Its boot partition is byte-identical to the
last known-good `raspberry-pi-zero-w` image for every boot-critical file —
`config.txt`, `cmdline.txt`, `bootcode.bin`, `start.elf`, `fixup.dat` and
`bcm2708-rpi-zero-w.dtb` all match by hash; the only differences are the five
added DTBs and ~8 bytes of kernel rebuild noise. v2026.8.22 boots a Pi Zero W,
which closes the pi-32 hardware boot-test in `docs/todo.md`.

## Tests

`cloud-sd-image-builder.test.tsx` gains a `pickBoard()` helper on the build
paths and three cases: no board auto-selected (download disabled), board
seeded from the re-enrolled frame, and no seeding when that board's image is
missing from the release. 25/25 in that file, 275/275 across `shared-spa`.
`tsc --noEmit` clean in `frontend` and `cloud/apps/auth-web`; `cloud-frontend`
reports only its three pre-existing errors, none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
