### PR TITLE
Give the Pi 5 a framebuffer, and stop dying over one that is not ready yet

### DIFF
--- a/backend/app/tasks/buildroot_image.py
+++ b/backend/app/tasks/buildroot_image.py
@@ -102,7 +102,10 @@ BUILDROOT_HOST_CXXFLAGS = "-O2 -pipe -std=gnu++17"
 BUILDROOT_HOST_CFLAGS = "-O2 -pipe"
 BUILDROOT_JLEVEL = int(os.environ.get("FRAMEOS_BUILDROOT_JLEVEL", "0"))
 BUILDROOT_BOOTSTRAP_SCRIPT_VERSION = "6"
-BUILDROOT_SD_IMAGE_CUSTOMIZATION_VERSION = 19
+# 20: the Pi 5 gained dtoverlay=vc4-kms-v3d, which _frame_boot_config_lines
+# merges into /boot/config.txt during customization — cards cached from before
+# it carry no framebuffer and must be regenerated, not reused.
+BUILDROOT_SD_IMAGE_CUSTOMIZATION_VERSION = 20
 BUILDROOT_FRAMEOS_PARTITION_SIZE = os.environ.get("FRAMEOS_BUILDROOT_FRAMEOS_PARTITION_SIZE", "30M")
 BUILDROOT_ASSETS_PARTITION_SIZE = os.environ.get("FRAMEOS_BUILDROOT_ASSETS_PARTITION_SIZE", "30M")
 BUILDROOT_DATA_PARTITION_HEADROOM_BYTES = 8 * 1024 * 1024
@@ -3409,9 +3412,10 @@ def render_post_image_script(platform: BuildrootPlatform) -> str:
             f"Post-image script generation is not implemented for the {platform.family} family"
         )
     # The rpi-firmware sample config.txt is inherited, not authored: apply the
-    # platform's default lines (replacing same-key lines; a gpu_mem line also
-    # replaces the gpu_mem_256/512/1024 variants) and strip pinned keys that
-    # break multi-model images (start_file/fixup_file).
+    # platform's default lines (replacing same-key lines, except the additive
+    # dtoverlay/dtparam lists; a gpu_mem line also replaces the
+    # gpu_mem_256/512/1024 variants) and strip pinned keys that break
+    # multi-model images (start_file/fixup_file).
     boot_config_spec = json.dumps(
         {
             "set": list(platform.default_boot_config_lines),
@@ -3433,9 +3437,16 @@ spec = json.loads(sys.argv[2])
 with open(path, encoding="utf-8") as handle:
     lines = handle.read().splitlines()
 
+# dtoverlay/dtparam are lists, not settings: config.txt may legitimately carry
+# several, and each one loads a different overlay. Adding ours must not delete
+# the sample's (miniuart-bt, say) the way a same-key replacement would.
+ADDITIVE_KEYS = {{"dtoverlay", "dtparam", "device_tree_overlay"}}
+
 drop_keys = set(spec["remove"])
 for line in spec["set"]:
     key = line.split("=", 1)[0]
+    if key in ADDITIVE_KEYS:
+        continue
     drop_keys.add(key)
     if key == "gpu_mem":
         drop_keys.update({{"gpu_mem_256", "gpu_mem_512", "gpu_mem_1024"}})

--- a/backend/app/tasks/buildroot_platforms.py
+++ b/backend/app/tasks/buildroot_platforms.py
@@ -306,8 +306,14 @@ RASPBERRY_PI_5 = BuildrootPlatform(
     kernel_fragment_lines=("CONFIG_ARM64_4K_PAGES=y",),
     # bcm2712 kernel Image + DTBs + overlays outgrow the 32M boot partition.
     boot_partition_size="64M",
-    # No gpu_mem on the Pi 5 (firmware ignores it; memory split is fixed).
-    default_boot_config_lines=(),
+    # No gpu_mem on the Pi 5 (firmware ignores it; memory split is fixed), but
+    # the KMS overlay is not optional here the way it is on older boards: the
+    # BCM2712 firmware sets up no framebuffer of its own (bcm2708_fb is Pi 1-4
+    # only), so without vc4 there is no /dev/fb0 at all and the `framebuffer`
+    # device has nothing to write to. The firmware remaps the generic name per
+    # SoC via overlays/overlay_map.dtb (bcm2712 -> vc4-kms-v3d-pi5), so the
+    # unsuffixed line is the correct one to ship.
+    default_boot_config_lines=("dtoverlay=vc4-kms-v3d",),
     # Pi 5 Wi-Fi is a BCM43455; generic + board-specific NVRAM files ship in
     # BR2_PACKAGE_BRCMFMAC_SDIO_FIRMWARE_RPI already.
     wifi_firmware_models=(),

--- a/backend/app/tasks/tests/test_buildroot_image.py
+++ b/backend/app/tasks/tests/test_buildroot_image.py
@@ -5,9 +5,11 @@ import gzip
 import importlib.util
 import json
 import re
+import shlex
 import stat
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
@@ -2379,18 +2381,71 @@ def test_post_image_script_unified_image_strips_start_file_pins():
     assert "size = 64M" in post_image
 
 
-def test_post_image_script_pi_5_leaves_boot_config_alone():
+def test_post_image_script_pi_5_enables_kms_and_sets_no_gpu_mem():
     from app.tasks.buildroot_platforms import BUILDROOT_PLATFORMS
 
     post_image = render_post_image_script(BUILDROOT_PLATFORMS["raspberry-pi-5"])
 
-    # No default lines and no keys to strip: the config.txt patcher is
-    # omitted entirely (no gpu_mem on the Pi 5).
-    assert "rpi-firmware/config.txt" not in post_image.split("rootfs_image=")[0]
-    assert "gpu_mem" not in post_image
+    boot_config_block = post_image.split("rootfs_image=")[0]
+    # BCM2712 ships no firmware framebuffer, so the KMS overlay is what makes
+    # /dev/fb0 exist at all. The unsuffixed name is deliberate: the firmware
+    # remaps it to vc4-kms-v3d-pi5 through overlays/overlay_map.dtb.
+    assert '\'{"remove": [], "set": ["dtoverlay=vc4-kms-v3d"]}\'' in boot_config_block
+    # Still no memory-split key of its own — the Pi 5 firmware ignores gpu_mem.
+    # (The patcher's generic body names the key; the platform's spec must not.)
+    assert not any("gpu_mem" in line for line in BUILDROOT_PLATFORMS["raspberry-pi-5"].default_boot_config_lines)
     assert "size = 64M" in post_image
     # The kernel still lands on the FAT partition even without a kernel= pin.
     assert 'kernel="Image"' in post_image
+
+
+def _extract_boot_config_python(post_image: str) -> str:
+    """The config.txt patcher's heredoc body, as the build host would run it."""
+    body = post_image.split("<<'PY'\n", 1)[1]
+    return body.split("\nPY\n", 1)[0]
+
+
+def _run_boot_config_patcher(script: str, post_image: str, existing: str) -> str:
+    """Run that patcher over `existing` with the platform's own JSON spec."""
+    invocation = next(
+        line for line in post_image.splitlines()
+        if line.strip().startswith('python3 - "$boot_config"')
+    )
+    spec = shlex.split(invocation)[3]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        config_path = Path(tmp) / "config.txt"
+        config_path.write_text(existing, encoding="utf-8")
+        script_path = Path(tmp) / "patch.py"
+        script_path.write_text(script, encoding="utf-8")
+        subprocess.run(
+            [sys.executable, str(script_path), str(config_path), spec],
+            check=True,
+        )
+        return config_path.read_text(encoding="utf-8")
+
+
+def test_post_image_config_patcher_keeps_other_dtoverlay_lines():
+    """dtoverlay is a list, not a setting.
+
+    Replacing by key would have the Pi 5's vc4 line delete a sample config's
+    miniuart-bt line (and, on a board that ever sets both, delete the first
+    one it set). Only same-key *settings* are replaced.
+    """
+    from app.tasks.buildroot_platforms import BUILDROOT_PLATFORMS
+
+    post_image = render_post_image_script(BUILDROOT_PLATFORMS["raspberry-pi-5"])
+    script = _extract_boot_config_python(post_image)
+
+    merged = _run_boot_config_patcher(
+        script,
+        post_image,
+        "dtoverlay=miniuart-bt\ndtparam=spi=on\ndisable_overscan=1\n",
+    )
+
+    assert "dtoverlay=miniuart-bt" in merged
+    assert "dtoverlay=vc4-kms-v3d" in merged
+    assert "dtparam=spi=on" in merged
 
 
 def test_zero_w_frame_uses_armv6_cross_target(tmp_path, monkeypatch):

--- a/backend/app/tasks/tests/test_buildroot_platforms.py
+++ b/backend/app/tasks/tests/test_buildroot_platforms.py
@@ -169,8 +169,11 @@ def test_raspberry_pi_5_has_its_own_kernel_and_no_gpu_mem():
     assert "CONFIG_ARM64_4K_PAGES=y" in platform.kernel_fragment_lines
     # raspberrypi5_defconfig disables overlays; e-ink displays need them.
     assert "BR2_PACKAGE_RPI_FIRMWARE_INSTALL_DTB_OVERLAYS=y" in platform.extra_config_lines
-    # No start*.elf firmware on the Pi 5 and no gpu_mem key either.
-    assert platform.default_boot_config_lines == ()
+    # No start*.elf firmware on the Pi 5 and no gpu_mem key either — but the
+    # KMS overlay is mandatory: BCM2712 has no firmware framebuffer, so
+    # without vc4 there is no /dev/fb0 and the `framebuffer` device is dead.
+    assert platform.default_boot_config_lines == ("dtoverlay=vc4-kms-v3d",)
+    assert not any("gpu_mem" in line for line in platform.default_boot_config_lines)
     for alias in ("pi-5", "pi5", "raspberrypi5"):
         assert normalize_buildroot_platform(alias) == "raspberry-pi-5"
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -110,6 +110,17 @@ Three Raspberry Pi platforms ship with published base images:
 (every ARMv6 board: Zero, Zero W, Pi 1, CM1) and `raspberry-pi-5` (Pi 5 /
 CM5).
 
+- **Drivers own pixie refs they did not allocate** — the shared driver
+  libraries each carry their own ARC/ORC runtime, and
+  `frameos_driver_render` hands them the host's `Image` via
+  `cast[Image](image)`. Anything in a driver that copies that ref (a plain
+  `var renderImage = image` will do it) has a second cycle collector
+  bookkeeping one object; the host then dies releasing the image at the end
+  of its render loop, with a stack that names only `runner.nim`. Cost one
+  crash-looping Pi 5 already (see the framebuffer note in
+  `drivers/frameBuffer/frameBuffer.nim`). The real fix is a borrowed,
+  non-owning view across the ABI rather than a cast — until then, drivers
+  must not take owning copies of the rendered image.
 - **Next base-image rebuild drops ImageMagick** — the defconfig no longer
   selects `BR2_PACKAGE_IMAGEMAGICK` (the runtime is Pixie-only), but the
   published base images still carry it. Nothing to do beyond dispatching

--- a/frameos/src/drivers/frameBuffer/frameBuffer.nim
+++ b/frameos/src/drivers/frameBuffer/frameBuffer.nim
@@ -42,6 +42,12 @@ type Driver* = ref object of FrameOSDriver
   screenInfo*: ScreenInfo
   logger*: DriverLogger
   sizeMismatchLogged*: bool
+  # False when /dev/fb0 could not be interrogated at init. The screenInfo we
+  # carry is then a fabrication (configuredScreenInfo), there is nothing to
+  # write to, and render must bail before it so much as touches the image —
+  # see the note on `render`.
+  available*: bool
+  unavailableLogged*: bool
   renderBuffer: seq[uint8]
 
 proc logFrameBuffer(logger: DriverLogger, payload: JsonNode) =
@@ -207,16 +213,19 @@ proc configuredScreenInfo(frameOS: DriverContext): ScreenInfo =
 proc init*(frameOS: DriverContext): Driver =
   let logger = if frameOS.isNil: nil else: frameOS.logger
   var screenInfo: ScreenInfo
+  var available = true
   try:
     tryToDisableCursorBlinking()
     screenInfo = getScreenInfo(logger)
   except DivByZeroDefect as e:
+    available = false
     screenInfo = configuredScreenInfo(frameOS)
     logFrameBuffer(logger, %*{"event": "driver:frameBuffer",
         "error": "Invalid framebuffer metadata caused division by zero",
         "exception": e.msg,
         "fallbackScreenInfo": screenInfo})
   except Exception as e:
+    available = false
     screenInfo = configuredScreenInfo(frameOS)
     logFrameBuffer(logger, %*{"event": "driver:frameBuffer",
         "error": "Failed to initialize driver", "exception": e.msg,
@@ -231,6 +240,7 @@ proc init*(frameOS: DriverContext): Driver =
     name: "frameBuffer",
     screenInfo: screenInfo,
     logger: logger,
+    available: available,
   )
 
 proc setup*(frameOS: DriverContext = nil): SetupResult =
@@ -255,6 +265,24 @@ proc setup*(frameOS: DriverContext = nil): SetupResult =
 
 proc render*(self: Driver, image: Image) =
   if self.isNil:
+    return
+  # Bail before touching `image`, not after. This driver is a shared library
+  # with its OWN ARC runtime: the moment it takes an owning copy of a pixie
+  # ref the host allocated (`var renderImage = image` below), two independent
+  # cycle collectors are bookkeeping one object. On the /dev/fb0 failure path
+  # that goes wrong and the HOST dies later, releasing the image at the end of
+  # its render loop — SIGSEGV in unregisterCycle, from a stack that names only
+  # runner.nim, on a frame whose real fault is a missing framebuffer. A Pi 5
+  # (no bcm2708_fb, so no fb0 unless vc4 KMS is on) crash-looped on exactly
+  # that. So: no framebuffer, no reference, no crash.
+  if not self.available:
+    if not self.unavailableLogged:
+      self.unavailableLogged = true
+      logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
+          "error": "Framebuffer unavailable, skipping every render",
+          "device": DEVICE,
+          "hint": "No " & DEVICE & " to write to. On a Pi 5 the firmware " &
+            "provides no framebuffer; config.txt needs dtoverlay=vc4-kms-v3d."})
     return
   let bitsPerPixel = self.screenInfo.bitsPerPixel
   if self.screenInfo.width == 0 or self.screenInfo.height == 0 or bitsPerPixel == 0:
@@ -321,7 +349,16 @@ proc render*(self: Driver, image: Image) =
             self.renderBuffer[j + alphaByte] = color.a
           j += bytesPerPixel
 
-    var fb = open(DEVICE, fmWrite, self.renderBuffer.len)
+    # The non-raising overload on purpose. A framebuffer that disappears after
+    # init (device unbound, permissions revoked) is a condition to log, not to
+    # throw through a scope that holds `renderImage` — an owning copy of a
+    # host-allocated pixie ref, destroyed by this library's ARC runtime rather
+    # than the host's. Fewer paths through that hazard is strictly better.
+    var fb: File
+    if not open(fb, DEVICE, fmWrite, self.renderBuffer.len):
+      logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
+          "error": "Failed to open " & DEVICE & " for writing"})
+      return
     try:
       discard fb.writeBuffer(addr self.renderBuffer[0], self.renderBuffer.len)
     finally:

--- a/frameos/src/drivers/frameBuffer/frameBuffer.nim
+++ b/frameos/src/drivers/frameBuffer/frameBuffer.nim
@@ -266,24 +266,22 @@ proc setup*(frameOS: DriverContext = nil): SetupResult =
 proc render*(self: Driver, image: Image) =
   if self.isNil:
     return
-  # Bail before touching `image`, not after. This driver is a shared library
-  # with its OWN ARC runtime: the moment it takes an owning copy of a pixie
-  # ref the host allocated (`var renderImage = image` below), two independent
-  # cycle collectors are bookkeeping one object. On the /dev/fb0 failure path
-  # that goes wrong and the HOST dies later, releasing the image at the end of
-  # its render loop — SIGSEGV in unregisterCycle, from a stack that names only
-  # runner.nim, on a frame whose real fault is a missing framebuffer. A Pi 5
-  # (no bcm2708_fb, so no fb0 unless vc4 KMS is on) crash-looped on exactly
-  # that. So: no framebuffer, no reference, no crash.
+
+  # A failed probe at init is not a permanent verdict. On a Pi 5 the KMS
+  # driver registers its fbdev after frameos has already started, so a driver
+  # that latched "no framebuffer" at init would sit dark forever on a board
+  # whose display works perfectly a second later. Retry the cheap probe until
+  # it lands; it also upgrades the fabricated screenInfo to the panel's real
+  # geometry.
   if not self.available:
-    if not self.unavailableLogged:
-      self.unavailableLogged = true
-      logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
-          "error": "Framebuffer unavailable, skipping every render",
-          "device": DEVICE,
-          "hint": "No " & DEVICE & " to write to. On a Pi 5 the firmware " &
-            "provides no framebuffer; config.txt needs dtoverlay=vc4-kms-v3d."})
-    return
+    try:
+      self.screenInfo = getScreenInfo(self.logger)
+      self.available = true
+    except DivByZeroDefect:
+      discard
+    except Exception:
+      discard
+
   let bitsPerPixel = self.screenInfo.bitsPerPixel
   if self.screenInfo.width == 0 or self.screenInfo.height == 0 or bitsPerPixel == 0:
     logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
@@ -298,24 +296,52 @@ proc render*(self: Driver, image: Image) =
 
   let width = self.screenInfo.width.int
   let height = self.screenInfo.height.int
-  var renderImage = image
-  if image.width != width or image.height != height:
-    if not self.sizeMismatchLogged:
-      self.sizeMismatchLogged = true
-      logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
-          "warning": "Rendered image does not match framebuffer resolution, scaling to fit",
-          "imageWidth": image.width, "imageHeight": image.height,
-          "screenInfo": self.screenInfo})
-    renderImage = image.resize(width, height)
-  let imageData = renderImage.data
-
   let bytesPerPixel = int(bitsPerPixel) div 8
   let rowBytes = width * bytesPerPixel
   # The framebuffer can pad each row; skip the padding bytes when writing
   let lineLength = if self.screenInfo.lineLength.int >= rowBytes: self.screenInfo.lineLength.int
     else: rowBytes
+  let bufferLen = lineLength * height
+
+  # Open the device BEFORE touching `image`, and bail here if it will not
+  # open. This driver is a shared library carrying its own ARC runtime: the
+  # moment it takes an owning reference to a pixie object the host allocated,
+  # two cycle collectors are bookkeeping one object, and the HOST dies later
+  # releasing the image at the end of its render loop — SIGSEGV in
+  # unregisterCycle, from a stack that names only runner.nim. A Pi 5 with no
+  # writable framebuffer crash-looped on exactly that, fourteen restarts in
+  # two minutes. No device, no reference, no crash.
+  var fb: File
+  if not open(fb, DEVICE, fmWrite, bufferLen):
+    if not self.unavailableLogged:
+      self.unavailableLogged = true
+      logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
+          "error": "Cannot open " & DEVICE & " for writing, skipping renders",
+          "device": DEVICE,
+          "hint": "On a Pi 5 the firmware provides no framebuffer of its own " &
+            "(bcm2708_fb is Pi 1-4 only); config.txt needs dtoverlay=vc4-kms-v3d."})
+    return
+  self.unavailableLogged = false
+
   try:
-    let bufferLen = lineLength * height
+    # Deliberately NOT `var renderImage = image`: that is an owning copy of
+    # the host's ref, and the hazard described above. Read the host's pixels
+    # through a raw view instead, and only allocate here when the panel
+    # geometry forces a resize (that image is ours, so owning it is fine).
+    var scaled: Image = nil
+    if image.width != width or image.height != height:
+      if not self.sizeMismatchLogged:
+        self.sizeMismatchLogged = true
+        logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
+            "warning": "Rendered image does not match framebuffer resolution, scaling to fit",
+            "imageWidth": image.width, "imageHeight": image.height,
+            "screenInfo": self.screenInfo})
+      scaled = image.resize(width, height)
+    let source = if scaled.isNil: image else: scaled
+    if source.width * source.height == 0:
+      return
+    let pixels = cast[ptr UncheckedArray[ColorRGBX]](unsafeAddr source.data[0])
+
     if self.renderBuffer.len != bufferLen:
       self.renderBuffer = newSeq[uint8](bufferLen)
     else:
@@ -324,7 +350,7 @@ proc render*(self: Driver, image: Image) =
       for y in 0 ..< height:
         var j = y * lineLength
         for x in 0 ..< width:
-          let color = imageData[y * width + x]
+          let color = pixels[y * width + x]
           let pixel = ((uint16(color.r) shr 3) shl 11) or ((uint16(
               color.g) shr 2) shl 5) or (uint16(color.b) shr 3)
           self.renderBuffer[j] = uint8(pixel and 0xff)
@@ -338,7 +364,7 @@ proc render*(self: Driver, image: Image) =
       for y in 0 ..< height:
         var j = y * lineLength
         for x in 0 ..< width:
-          let color = imageData[y * width + x]
+          let color = pixels[y * width + x]
           self.renderBuffer[j + redByte] = color.r
           self.renderBuffer[j + greenByte] = color.g
           self.renderBuffer[j + blueByte] = color.b
@@ -349,24 +375,14 @@ proc render*(self: Driver, image: Image) =
             self.renderBuffer[j + alphaByte] = color.a
           j += bytesPerPixel
 
-    # The non-raising overload on purpose. A framebuffer that disappears after
-    # init (device unbound, permissions revoked) is a condition to log, not to
-    # throw through a scope that holds `renderImage` — an owning copy of a
-    # host-allocated pixie ref, destroyed by this library's ARC runtime rather
-    # than the host's. Fewer paths through that hazard is strictly better.
-    var fb: File
-    if not open(fb, DEVICE, fmWrite, self.renderBuffer.len):
-      logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
-          "error": "Failed to open " & DEVICE & " for writing"})
-      return
-    try:
-      discard fb.writeBuffer(addr self.renderBuffer[0], self.renderBuffer.len)
-    finally:
-      fb.close()
+    discard fb.writeBuffer(addr self.renderBuffer[0], self.renderBuffer.len)
+    fb.flushFile()
     claimConsoleAfterSuccessfulRender(self.logger)
   except:
     logFrameBuffer(self.logger, %*{"event": "driver:frameBuffer",
-        "error": "Failed to write image to /dev/fb0"})
+        "error": "Failed to write image to " & DEVICE})
+  finally:
+    fb.close()
 
 proc turnOn*(self: Driver) =
   try:

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -1705,6 +1705,18 @@ proc cloudHubThreadMain(frameConfig: FrameConfig) {.thread.} =
         if attempted:
           log(%*{"event": "cloud:enroll:boot", "ok": outcome.ok,
                  "resolved": resolved, "error": outcome.error})
+        else:
+          # No request went out, and until now nothing said so. An expired
+          # claim token deletes the pending file and gives up on enrollment
+          # for the life of the card, and an unreadable one retries into a
+          # growing backoff — both in total silence, which reads from the
+          # logs exactly like a frame that never tried to enroll at all.
+          # (Cost: a Pi 5 that came up healthy and simply never appeared in
+          # the cloud, with no line anywhere to say why.)
+          log(%*{"event": "cloud:enroll:boot:skipped",
+                 "resolved": resolved,
+                 "error": if outcome.error.len > 0: outcome.error
+                          else: "no_pending_enrollment_readable"})
         if resolved:
           enrollBackoff = HubEnrollBackoffMinSeconds
           nextEnrollAttemptAt = 0.0

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -1701,6 +1701,14 @@ proc cloudHubThreadMain(frameConfig: FrameConfig) {.thread.} =
         nextEnrollAttemptAt = 0.0
         enrollBackoff = HubEnrollBackoffMinSeconds
       if epochTime() >= nextEnrollAttemptAt and fileExists(pendingEnrollmentPath()):
+        # Announced BEFORE the attempt, because the attempt is what changes
+        # state: a successful or permanently-rejected enrollment deletes the
+        # pending file, and if the process dies between that and the outcome
+        # log, the card is left unable to retry with nothing on record saying
+        # it ever tried. A Pi 5 crash-looping on its display driver lost its
+        # enrollment exactly that way — token redeemed, pending file gone,
+        # not one line about it in a 300 KB log.
+        log(%*{"event": "cloud:enroll:boot:attempt"})
         let (resolved, attempted, outcome) = processPendingCloudEnrollment(frameConfig)
         if attempted:
           log(%*{"event": "cloud:enroll:boot", "ok": outcome.ok,


### PR DESCRIPTION
The Pi 5 image booted, joined WiFi, rendered its first scene — then
crash-looped: fourteen restarts in two minutes, `SIGSEGV` every time. Fixing
that turned out to also explain why the frame never appeared in the cloud.

**Confirmed on hardware.** The Pi 5 now renders
(`render:driver ms=12.985 device="framebuffer"`), is enrolled, and is taking
scene pushes. Together with the Zero W regression boot, all three Pi
platforms are hardware-tested.

Two diagnoses in this PR were wrong on the first pass and are corrected
below rather than tidied away.

## 1. The framebuffer

BCM2712 ships no firmware framebuffer — `bcm2708_fb` is Pi 1–4 only — so the
vc4 KMS driver is the only thing that can provide a working one. And
`raspberry-pi-5` had `default_boot_config_lines=()`, so the generated
`config.txt` was `kernel=Image` + `disable_overscan=1`, with no `dtoverlay=`
line and the post-image config patcher skipped for the platform entirely.

Ships `dtoverlay=vc4-kms-v3d` now. Unsuffixed on purpose: the card's own
`overlays/overlay_map.dtb` remaps `bcm2712 → vc4-kms-v3d-pi5`, and that
`.dtbo` is already on the boot partition. `_frame_boot_config_lines` merges
platform defaults at customization time, so it reaches cards without a
base-image rebuild — hence the customization-version bump.

> **Correction.** I first wrote this up as "there is no `/dev/fb0`". Wrong.
> The init failure is `frameBuffer.nim(154)`, the `FBIOGET_VSCREENINFO`
> raise, not the `open()` raise at `:150` — the node opened fine, the ioctl
> on it did not. What the overlay changed is that *writes* land: before it,
> `render:driver` never once appeared in the log.

**Adjacent bug, fixed here:** the config.txt patcher replaced lines by key, so
a `dtoverlay=` default would have silently deleted a sample config's
`dtoverlay=miniuart-bt`. `dtoverlay`/`dtparam` are lists, not settings, and
are additive now. The new test executes the generated patcher rather than
asserting on its source.

## 2. The crash

Reproduced off-hardware — arm64 container, release tarball,
`device: framebuffer`, no `/dev/fb0` — then put under gdb:

```
Thread 20 "frameos" hit Breakpoint 1, frameos_driver_render () from .../frameBuffer.so
=== returned from render ===
Thread 20 "frameos" received signal SIGSEGV, Segmentation fault.
#0  unregisterCycle__system_u3122 ()
#1  eqsink___pkgZpixieZcommon_u805 ()
#2  startRenderLoopX20X28AsyncX29___frameosZrunner_u284 ()
```

`frameos_driver_render` is entered and **returns normally**; the host dies
immediately after, releasing the pixie image at `lastRotatedImage = nil` in
the render loop's `finally`.

Each driver `.so` carries its own ARC/ORC runtime, and the generated wrapper
hands it the host's `Image` as `cast[Image](image)`. `var renderImage = image`
then takes an **owning** copy — two cycle collectors, one object.

Which half does the damage is testable, and was tested. `httpUpload.render`
returns before touching `image` when it has no URL; running with
`device: http.upload` logs `render:driver ms=0.001` and survives
indefinitely. So the wrapper's cast is harmless and the driver body's owning
copy is the fault. `var renderImage = image` is gone — pixels are read
through a raw view, and the only `Image` this library owns is one it
allocated itself for a resize. The device is opened for writing *before*
`image` is touched, and failure there logs once and returns.

> **Correction.** My first attempt latched `available = false` at init and
> skipped every render. That would have bricked this exact frame: the probe
> still fails at init on every boot, and the render that works does so
> through the fabricated 800×480 screenInfo. The probe retries on render
> instead, upgrading to the panel's real geometry if it ever lands.

## 3. Why it never reached the cloud — resolved

Not expiry. The deleted `cloud_enroll_pending.json` was still sitting in free
blocks on the FRAMEOS partition, and carries
`"expires_epoch":1786905489` — 2026-08-16 18:38 UTC, exactly 24 h after first
boot, i.e. stamped *by the frame itself*. So it was read, validated, saved
back and posted; and the file is gone, which only happens on success or
permanent rejection. `/state/cloud_device_key` was written at 18:38 too.

Meanwhile a 299 KB log covering 69 startups over five hours contains the
substring `cloud` **zero times**.

That is the bug: the outcome is logged *after* the state change, so a process
dying in between — this one, every five seconds — leaves a card that has
redeemed its single-use token, deleted its only record of what to retry, and
said nothing. The attempt is now announced before it changes anything
(`cloud:enroll:boot:attempt`), and the two silent non-attempt paths log
`cloud:enroll:boot:skipped` with a reason.

Recovery needed no reflash: the first-boot unit re-fires whenever
`/boot/frameos-cloud.txt` exists, so writing the recovered token back to that
file re-armed enrollment.

Still unexplained, flagged not guessed: `/state/cloud_link.json` is 0 bytes.
`saveCloudLinkState` writes to `.tmp` and renames, and no stray `.tmp` was
left, so an empty file should not be reachable that way.

## Verification

- `nim check` clean on both Nim files; 325 passed / 3 skipped in
  `backend/app/tasks/tests`.
- Crash mechanism: gdb plus three controls (`web_only`, no `.so`,
  `http.upload`).
- Hardware: the frame that crash-looped fourteen times now renders, enrols
  and takes scene pushes.
- Not verified on hardware: the rewritten `render` itself — building an arm64
  `frameBuffer.so` was out of scope, and the booted card still runs the
  shipped 2026.8.22 driver. Its no-touch-the-image shape is the one proven
  safe by the `http.upload` control.

Incidental: the Pi 5 kernel calls itself `6.6.28-v8-16k`, but the arm64 Image
header reads 4K pages — `kernel_fragment_lines` applied; only
`CONFIG_LOCALVERSION` disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
