### PR TITLE
Fix Buildroot OTA: setup could not write the read-only rootfs

### DIFF
--- a/backend/app/tasks/buildroot_image.py
+++ b/backend/app/tasks/buildroot_image.py
@@ -1668,16 +1668,18 @@ class BuildrootImageBuilder:
                 mtime=0,
             )
         )
+        # Byte-identical to the unit staged into /etc/systemd/system (see
+        # stage_buildroot_frameos_service). It must be: `frameos setup` copies
+        # the release directory's unit over the installed one on every upgrade,
+        # so any difference — this used to miss render_buildroot_frameos_service's
+        # NetworkManager Wants=/After= lines — turns each upgrade into a write
+        # to the read-only rootfs that has no business happening at all.
+        #
         # No console_output: frameos draws to the framebuffer on the same VT,
         # so mirroring its logs to tty1 would scribble over the rendered image.
-        self._write_service(
-            REPO_ROOT / "frameos" / "frameos.service",
-            release_dir / "frameos.service",
-            user="root",
-            environment={
-                "FRAMEOS_HOME": "/srv/frameos/current",
-                "LD_LIBRARY_PATH": "/srv/frameos/current/drivers:/srv/frameos/current/scenes:/usr/lib:/usr/local/lib",
-            },
+        (release_dir / "frameos.service").write_text(
+            render_buildroot_frameos_service(self.platform.uses_network_manager),
+            encoding="utf-8",
         )
 
         shutil.copy2(remote_binary, remote_release_dir / "frameos_remote")

--- a/backend/app/tasks/tests/test_buildroot_image.py
+++ b/backend/app/tasks/tests/test_buildroot_image.py
@@ -2155,6 +2155,16 @@ def test_buildroot_stage_overlay_leaves_service_install_to_firstboot(tmp_path, m
     )
     assert "StandardOutput=journal+console" not in frameos_service
     assert "StandardError=journal+console" not in frameos_service
+    # `frameos setup` copies the release directory's unit over the installed
+    # one on every upgrade, so the two renderers must agree byte for byte. When
+    # they did not, the release copy was missing the NetworkManager Wants=/
+    # After= lines and each Buildroot upgrade tried to rewrite a file on the
+    # read-only rootfs — which is what made cloud OTA fail outright.
+    installed_root = tmp_path / "installed-unit"
+    stage_buildroot_frameos_service(installed_root, builder.platform.uses_network_manager)
+    assert frameos_service == (
+        installed_root / "etc" / "systemd" / "system" / "frameos.service"
+    ).read_text(encoding="utf-8")
     assert (remote_release_dir / "frameos-remote.service").exists()
     assert not (overlay_dir / "etc" / "systemd" / "system" / "frameos.service").exists()
     assert not (overlay_dir / "etc" / "systemd" / "system" / "frameos-remote.service").exists()

--- a/frameos/src/frameos/device_setup.nim
+++ b/frameos/src/frameos/device_setup.nim
@@ -72,6 +72,114 @@ proc privilegedCommand*(command: string): string =
 proc privilegedAptCommand(command: string): string =
   sudoPrefix() & "env DEBIAN_FRONTEND=noninteractive " & command
 
+# --- writing to a read-only root filesystem --------------------------------
+#
+# Buildroot frames run with `/` mounted read-only: the kernel command line asks
+# for neither `ro` nor `rw` (so the kernel default, read-only, wins) and the
+# generated /etc/fstab has no `/` entry for systemd-remount-fs to act on — only
+# the first-boot scripts remount it, briefly. Every setup step that writes to
+# the root filesystem therefore failed with EROFS on those frames, which is
+# what aborted every Buildroot OTA upgrade in `frameos setup` after the release
+# had been downloaded and its signature verified:
+#
+#   install: cannot remove '/etc/systemd/system/frameos.service': Read-only file system
+#
+# Leaving the rootfs writable is not the fix: a frame loses power at arbitrary
+# moments and only /srv is expected to be dirty when it does. So setup remounts
+# read-write around the writes and puts the mount back afterwards.
+
+proc unescapeMountField(value: string): string =
+  ## /proc/mounts octal-escapes the characters that would otherwise split a
+  ## field. Only these four are escaped by the kernel.
+  value.multiReplace(("\\040", " "), ("\\011", "\t"), ("\\012", "\n"), ("\\134", "\\"))
+
+proc mountPointForPath*(mounts, path: string): tuple[mountPoint: string, readOnly: bool] =
+  ## The /proc/mounts entry `path` lives on: the longest mount point that is a
+  ## prefix of it, last entry winning among equals (that is what an overmount
+  ## means). Pure, and `path` need not exist yet — the file we are about to
+  ## write usually does not.
+  result = ("", false)
+  if not path.startsWith("/"):
+    return
+  for line in mounts.splitLines():
+    let fields = line.splitWhitespace()
+    if fields.len < 4:
+      continue
+    let mountPoint = unescapeMountField(fields[1])
+    if not mountPoint.startsWith("/"):
+      continue
+    if not (mountPoint == "/" or path == mountPoint or path.startsWith(mountPoint & "/")):
+      continue
+    if mountPoint.len < result.mountPoint.len:
+      continue
+    result.mountPoint = mountPoint
+    result.readOnly = "ro" in unescapeMountField(fields[3]).split(',')
+
+proc procMountsPath(): string =
+  ## FRAMEOS_PROC_MOUNTS is a test seam, mirroring FRAMEOS_BOOT_CONFIG.
+  getEnv("FRAMEOS_PROC_MOUNTS", "/proc/mounts")
+
+proc readOnlyMountPointFor*(path: string): string =
+  ## The mount point `path` sits on, but only while that mount is read-only.
+  ## "" when it is writable, or when /proc/mounts cannot be read at all (macOS,
+  ## a container, a test) — there setup simply writes and reports whatever
+  ## error it gets, exactly as it did before.
+  try:
+    let mountsPath = procMountsPath()
+    if not fileExists(mountsPath):
+      return ""
+    let entry = mountPointForPath(readFile(mountsPath), path)
+    if entry.readOnly:
+      return entry.mountPoint
+  except CatchableError:
+    discard
+  ""
+
+proc beginWritableMount*(path: string): string =
+  ## Remounts the filesystem `path` lives on read-write and returns the mount
+  ## point to hand back to endWritableMount. Returns "" when nothing was
+  ## remounted: already writable (including by an enclosing scope — /proc/mounts
+  ## is the nesting counter), or the remount failed, in which case the write
+  ## below fails with its own, more informative, error.
+  let mountPoint = readOnlyMountPointFor(path)
+  if mountPoint.len == 0:
+    return ""
+  setupLog("FrameOS setup: remounting " & mountPoint & " read-write")
+  let remounted = runSetupCommand(
+    privilegedCommand("mount -o remount,rw " & shellQuote(mountPoint)),
+    raiseOnError = false,
+  )
+  if remounted.exitCode != 0:
+    setupLog("FrameOS setup: could not remount " & mountPoint & " read-write")
+    return ""
+  mountPoint
+
+proc endWritableMount*(mountPoint: string) =
+  if mountPoint.len == 0:
+    return
+  setupLog("FrameOS setup: restoring " & mountPoint & " to read-only")
+  # Flush first, exactly as the backend deploy path does before its own
+  # remount: a remount,ro that races unwritten data is how a frame comes back
+  # from an upgrade with a truncated unit file.
+  discard runSetupCommand(privilegedCommand("sync"), raiseOnError = false)
+  let restored = runSetupCommand(
+    privilegedCommand("mount -o remount,ro " & shellQuote(mountPoint)),
+    raiseOnError = false,
+  )
+  if restored.exitCode != 0:
+    setupLog("FrameOS setup: could not restore " & mountPoint &
+      " to read-only; it stays writable until the next boot")
+
+template withWritableMount*(path: string, body: untyped) =
+  ## Runs `body` with the filesystem behind `path` writable. Restores the mount
+  ## even when `body` raises — a half-finished setup must not leave the rootfs
+  ## writable for the rest of the device's uptime.
+  let frameosWritableMountPoint = beginWritableMount(path)
+  try:
+    body
+  finally:
+    endWritableMount(frameosWritableMountPoint)
+
 proc isValidAptPackageName*(name: string): bool =
   let normalized = name.strip()
   if normalized.len == 0:
@@ -193,22 +301,23 @@ proc writePrivilegedFile*(path: string, content: string) =
     except CatchableError:
       discard
 
-  try:
-    writeFile(path, content)
-  except CatchableError as writeError:
-    let writeErrorMessage = writeError.msg
-    let tmpPath = getTempDir() / ("frameos-setup-" & $epochTime().int64 & "-" & lastPathPart(path))
-    writeFile(tmpPath, content)
+  withWritableMount(path):
     try:
-      discard runSetupCommand(privilegedShell("install -m 644 " & shellQuote(tmpPath) & " " & shellQuote(path)))
-    except CatchableError as installError:
-      raise newException(
-        OSError,
-        "Cannot write " & path & ": " & writeErrorMessage & "; privileged install failed: " & installError.msg,
-      )
-    finally:
-      if fileExists(tmpPath):
-        removeFile(tmpPath)
+      writeFile(path, content)
+    except CatchableError as writeError:
+      let writeErrorMessage = writeError.msg
+      let tmpPath = getTempDir() / ("frameos-setup-" & $epochTime().int64 & "-" & lastPathPart(path))
+      writeFile(tmpPath, content)
+      try:
+        discard runSetupCommand(privilegedShell("install -m 644 " & shellQuote(tmpPath) & " " & shellQuote(path)))
+      except CatchableError as installError:
+        raise newException(
+          OSError,
+          "Cannot write " & path & ": " & writeErrorMessage & "; privileged install failed: " & installError.msg,
+        )
+      finally:
+        if fileExists(tmpPath):
+          removeFile(tmpPath)
 
 proc setupBootConfig*(requestedLines: seq[string], bootConfigPath = ""): SetupResult =
   if requestedLines.len == 0:

--- a/frameos/src/frameos/setup.nim
+++ b/frameos/src/frameos/setup.nim
@@ -292,21 +292,25 @@ proc setupSystemdServices*(frameOS: FrameOS): SetupResult =
     setupLog("FrameOS setup: systemd services: systemctl not found, skipping")
     return setupOk()
 
-  setupLog("FrameOS setup: systemd services: ensuring service directories")
-  ensureSystemdServiceDirectories()
+  # Every step below writes to /etc/systemd/system, unit files and `systemctl
+  # enable`'s wants/ symlinks alike, so the whole block runs inside one
+  # writable scope instead of remounting per file (see withWritableMount).
+  withWritableMount("/etc/systemd/system"):
+    setupLog("FrameOS setup: systemd services: ensuring service directories")
+    ensureSystemdServiceDirectories()
 
-  setupLog("FrameOS setup: systemd services: installing frameos.service")
-  installFrameOSServiceFile(frameOS)
+    setupLog("FrameOS setup: systemd services: installing frameos.service")
+    installFrameOSServiceFile(frameOS)
 
-  if frameOS.frameConfig.agent != nil and frameOS.frameConfig.agent.agentEnabled:
-    setupLog("FrameOS setup: systemd services: installing frameos-remote.service")
-    installServiceFile("/srv/frameos/remote/current/frameos-remote.service", "/etc/systemd/system/frameos-remote.service")
-  else:
-    discard runSetupCommand(privilegedCommand("systemctl disable frameos-remote.service"), raiseOnError = false)
+    if frameOS.frameConfig.agent != nil and frameOS.frameConfig.agent.agentEnabled:
+      setupLog("FrameOS setup: systemd services: installing frameos-remote.service")
+      installServiceFile("/srv/frameos/remote/current/frameos-remote.service", "/etc/systemd/system/frameos-remote.service")
+    else:
+      discard runSetupCommand(privilegedCommand("systemctl disable frameos-remote.service"), raiseOnError = false)
 
-  discard runSetupCommand(privilegedCommand("systemctl daemon-reload"))
-  discard runSetupCommand(privilegedCommand("systemctl enable " & systemdServiceNames(frameOS).join(" ")))
-  discard runSetupCommand(scheduleLegacyRemoteCleanupCommand(), raiseOnError = false)
+    discard runSetupCommand(privilegedCommand("systemctl daemon-reload"))
+    discard runSetupCommand(privilegedCommand("systemctl enable " & systemdServiceNames(frameOS).join(" ")))
+    discard runSetupCommand(scheduleLegacyRemoteCleanupCommand(), raiseOnError = false)
 
   result = setupOk()
 
@@ -366,9 +370,10 @@ proc setupSystemHardening*(liveApply = true): SetupResult =
     const watchdogConf = "[Manager]\nRuntimeWatchdogSec=15s\nRebootWatchdogSec=2min\n"
     if privilegedFileNeedsUpdate(watchdogConfPath, watchdogConf):
       setupLog("FrameOS setup: system hardening: enabling hardware watchdog")
-      discard runSetupCommand(privilegedCommand("install -d -m 755 /etc/systemd/system.conf.d"),
-        raiseOnError = false)
-      writePrivilegedFile(watchdogConfPath, watchdogConf)
+      withWritableMount(watchdogConfPath):
+        discard runSetupCommand(privilegedCommand("install -d -m 755 /etc/systemd/system.conf.d"),
+          raiseOnError = false)
+        writePrivilegedFile(watchdogConfPath, watchdogConf)
       if liveApply:
         # Apply without a reboot; PID 1 re-executes in place.
         discard runSetupCommand(privilegedCommand("systemctl daemon-reexec"), raiseOnError = false)
@@ -396,9 +401,10 @@ proc setupSystemHardening*(liveApply = true): SetupResult =
       const powersaveConf = "[connection]\n# 2 = disable wifi power saving\nwifi.powersave = 2\n"
       if privilegedFileNeedsUpdate(powersaveConfPath, powersaveConf):
         setupLog("FrameOS setup: system hardening: disabling wifi power save")
-        discard runSetupCommand(privilegedCommand("install -d -m 755 /etc/NetworkManager/conf.d"),
-          raiseOnError = false)
-        writePrivilegedFile(powersaveConfPath, powersaveConf)
+        withWritableMount(powersaveConfPath):
+          discard runSetupCommand(privilegedCommand("install -d -m 755 /etc/NetworkManager/conf.d"),
+            raiseOnError = false)
+          writePrivilegedFile(powersaveConfPath, powersaveConf)
         if liveApply:
           # reload (unlike restart) re-reads config without dropping connections
           discard runSetupCommand(privilegedCommand("systemctl reload NetworkManager"), raiseOnError = false)
@@ -484,8 +490,9 @@ proc setupTimezone*(timeZone: string): SetupResult =
       return setupOk()
 
   setupLog("FrameOS setup: timezone: setting " & normalized)
-  writePrivilegedFile("/etc/timezone", normalized & "\n")
-  discard runSetupCommand(privilegedCommand("ln -sfn " & shellQuote(zoneinfoPath) & " /etc/localtime"))
+  withWritableMount("/etc/localtime"):
+    writePrivilegedFile("/etc/timezone", normalized & "\n")
+    discard runSetupCommand(privilegedCommand("ln -sfn " & shellQuote(zoneinfoPath) & " /etc/localtime"))
   result = setupOk()
 
 proc startFrameOSSystemdServices*(configPath = "") =

--- a/frameos/src/frameos/tests/test_setup.nim
+++ b/frameos/src/frameos/tests/test_setup.nim
@@ -447,3 +447,121 @@ block test_samba_mount_failures_do_not_raise:
     doAssert commands.anyIt(it.contains("mount -a -t cifs"))
   finally:
     resetSetupCommandRunnerForTest()
+
+block test_mount_point_for_path_finds_the_longest_matching_mount:
+  # A Buildroot frame: read-only rootfs, the writable data partition on top.
+  const mounts = """/dev/root / ext4 ro,relatime 0 0
+devtmpfs /dev devtmpfs rw,nosuid 0 0
+/dev/mmcblk0p3 /srv/frameos ext4 rw,noatime 0 0
+/dev/mmcblk0p1 /boot vfat rw,noatime,umask=077 0 0
+"""
+
+  doAssert mountPointForPath(mounts, "/etc/systemd/system/frameos.service") == ("/", true)
+  doAssert mountPointForPath(mounts, "/srv/frameos/logs/upgrade.log") == ("/srv/frameos", false)
+  doAssert mountPointForPath(mounts, "/boot/config.txt") == ("/boot", false)
+  # /srv is on the rootfs; only /srv/frameos is not. Prefix matching must be
+  # per path component, or "/srv/frameos-backup" would resolve to /srv/frameos.
+  doAssert mountPointForPath(mounts, "/srv/frameos-backup/x") == ("/", true)
+  doAssert mountPointForPath(mounts, "relative/path") == ("", false)
+
+block test_mount_point_for_path_handles_escapes_and_overmounts:
+  const mounts = """/dev/root / ext4 rw,relatime 0 0
+/dev/sda1 /mnt/my\040share ext4 ro,relatime 0 0
+/dev/sdb1 /mnt/over ext4 rw 0 0
+/dev/sdc1 /mnt/over ext4 ro 0 0
+"""
+
+  doAssert mountPointForPath(mounts, "/mnt/my share/file") == ("/mnt/my share", true)
+  # Last mount of the same point wins: that is what an overmount does.
+  doAssert mountPointForPath(mounts, "/mnt/over/file") == ("/mnt/over", true)
+  # "rw" must not match a mount whose options merely contain the letters.
+  doAssert mountPointForPath("/dev/root / ext4 rw,errors=remount-ro 0 0\n", "/etc/x") == ("/", false)
+
+block test_writable_mount_remounts_a_read_only_root_and_restores_it:
+  let mountsPath = getTempDir() / ("frameos-mounts-" & $epochTime().int64)
+  writeFile(mountsPath, "/dev/root / ext4 ro,relatime 0 0\n")
+  putEnv("FRAMEOS_PROC_MOUNTS", mountsPath)
+  var commands: seq[string] = @[]
+  setSetupCommandRunnerForTest(proc(command: string): SetupCommandResult =
+    commands.add(command)
+    ("", 0)
+  )
+  try:
+    withWritableMount("/etc/systemd/system/frameos.service"):
+      commands.add("<body>")
+
+    doAssert commands.len == 4
+    doAssert commands[0].endsWith("mount -o remount,rw '/'")
+    doAssert commands[1] == "<body>"
+    doAssert commands[2].endsWith("sync")
+    doAssert commands[3].endsWith("mount -o remount,ro '/'")
+  finally:
+    resetSetupCommandRunnerForTest()
+    delEnv("FRAMEOS_PROC_MOUNTS")
+    removeFile(mountsPath)
+
+block test_writable_mount_restores_the_mount_when_the_body_raises:
+  let mountsPath = getTempDir() / ("frameos-mounts-raise-" & $epochTime().int64)
+  writeFile(mountsPath, "/dev/root / ext4 ro,relatime 0 0\n")
+  putEnv("FRAMEOS_PROC_MOUNTS", mountsPath)
+  var commands: seq[string] = @[]
+  setSetupCommandRunnerForTest(proc(command: string): SetupCommandResult =
+    commands.add(command)
+    ("", 0)
+  )
+  try:
+    var raised = false
+    try:
+      withWritableMount("/etc/timezone"):
+        raise newException(OSError, "boom")
+    except OSError:
+      raised = true
+    doAssert raised
+    doAssert commands.len == 3
+    doAssert commands[2].endsWith("mount -o remount,ro '/'")
+  finally:
+    resetSetupCommandRunnerForTest()
+    delEnv("FRAMEOS_PROC_MOUNTS")
+    removeFile(mountsPath)
+
+block test_writable_mount_is_a_no_op_on_a_writable_filesystem:
+  let mountsPath = getTempDir() / ("frameos-mounts-rw-" & $epochTime().int64)
+  writeFile(mountsPath, "/dev/root / ext4 rw,relatime 0 0\n")
+  putEnv("FRAMEOS_PROC_MOUNTS", mountsPath)
+  var commands: seq[string] = @[]
+  setSetupCommandRunnerForTest(proc(command: string): SetupCommandResult =
+    commands.add(command)
+    ("", 0)
+  )
+  try:
+    withWritableMount("/etc/systemd/system/frameos.service"):
+      discard
+    doAssert commands.len == 0
+  finally:
+    resetSetupCommandRunnerForTest()
+    delEnv("FRAMEOS_PROC_MOUNTS")
+    removeFile(mountsPath)
+
+block test_writable_mount_leaves_the_mount_alone_when_the_remount_fails:
+  # A frame where the remount is refused must still attempt the write, so the
+  # caller reports the real EROFS error instead of a remount failure.
+  let mountsPath = getTempDir() / ("frameos-mounts-fail-" & $epochTime().int64)
+  writeFile(mountsPath, "/dev/root / ext4 ro,relatime 0 0\n")
+  putEnv("FRAMEOS_PROC_MOUNTS", mountsPath)
+  var commands: seq[string] = @[]
+  setSetupCommandRunnerForTest(proc(command: string): SetupCommandResult =
+    commands.add(command)
+    if command.contains("remount,rw"):
+      return ("mount: permission denied", 1)
+    ("", 0)
+  )
+  try:
+    withWritableMount("/etc/systemd/system/frameos.service"):
+      commands.add("<body>")
+    doAssert commands.len == 2
+    doAssert commands[1] == "<body>"
+    doAssert not commands.anyIt(it.contains("remount,ro"))
+  finally:
+    resetSetupCommandRunnerForTest()
+    delEnv("FRAMEOS_PROC_MOUNTS")
+    removeFile(mountsPath)

--- a/frameos/src/frameos/upgrade.nim
+++ b/frameos/src/frameos/upgrade.nim
@@ -668,12 +668,20 @@ proc stageFrameOSRelease*(release: FrameOSReleaseInfo): StagedFrameOSRelease =
       # Buildroot service files carry image-specific settings (User=root,
       # FRAMEOS_HOME and LD_LIBRARY_PATH pointing into the release); carry them
       # over instead of generating the Raspberry Pi OS variants.
+      #
+      # The INSTALLED unit is the source of truth, not the release directory's
+      # copy: images built before this was fixed staged the two from different
+      # renderers, and the release copy is missing the NetworkManager
+      # Wants=/After= lines that the installed one has. Preferring the release
+      # copy made the upgrade rewrite /etc/systemd/system/frameos.service on
+      # every single run — a write the read-only Buildroot rootfs refuses, and
+      # a needless downgrade of the unit even where it succeeds.
       copyFirstExistingFile(
-        [oldReleaseDir / "frameos.service", "/etc/systemd/system/frameos.service"],
+        ["/etc/systemd/system/frameos.service", oldReleaseDir / "frameos.service"],
         result.frameosReleaseDir / "frameos.service",
       )
       copyFirstExistingFile(
-        [oldRemoteReleaseDir / "frameos-remote.service", "/etc/systemd/system/frameos-remote.service"],
+        ["/etc/systemd/system/frameos-remote.service", oldRemoteReleaseDir / "frameos-remote.service"],
         result.remoteReleaseDir / "frameos-remote.service",
       )
     if not fileExists(result.frameosReleaseDir / "frameos.service"):


### PR DESCRIPTION
## What happened

A cloud "Update FrameOS" on a Buildroot frame (2026.8.22 → 2026.8.23) reached the last step and died. From `/srv/frameos/logs/upgrade.log` on the frame's SD card:

```
FrameOS upgrade: downloading frameos-2026.8.23-debian-bookworm-arm64.tar.gz
FrameOS upgrade: verifying the release signature
FrameOS upgrade: signature OK (key 27c4c7f5df300370)
...
> cd '/srv/frameos/releases/release_upgrade_20260816011635_2026_8_23' && FRAMEOS_SERVICE_USER='root' ./frameos setup
FrameOS setup: systemd services: installing frameos.service
install: cannot remove '/etc/systemd/system/frameos.service': Read-only file system
FrameOS fatal: Cannot write /etc/systemd/system/frameos.service ...
device_setup.nim(205)    writePrivilegedFile
FrameOS upgrade: activation failed; rolling back current symlinks
```

Download, signature verification, extraction, install and driver setup were all fine. Rollback worked correctly and the frame kept rendering — but no Buildroot frame could ever complete a cloud OTA.

## Two stacked faults

**1. The rootfs is read-only and nothing remounts it.** `cmdline.txt` is `root=/dev/mmcblk0p2 rootwait console=tty1 …` — neither `ro` nor `rw`, so the kernel default (read-only) wins — and `BUILDROOT_FSTAB_CONTENT` has no `/` entry, so `systemd-remount-fs` is a no-op. Only the first-boot scripts remount it. `grep -rn remount frameos/src` returned nothing.

So *every* rootfs write in setup failed on Buildroot, not just this one: unit files, `/etc/timezone`, the watchdog drop-in, the wifi power-save conf, and `systemctl enable`'s `wants/` symlinks (that call is not `raiseOnError = false`, so it would have raised next).

Setup now remounts read-write around those writes and restores the mount afterwards, `sync` first — the same thing `frame_deploy_workflow._remount_root_rw_if_needed` already does over SSH for the deploy path. A failed remount changes nothing, so the write still surfaces the real error rather than a remount failure.

**2. The unit file could never match the installed one**, so the write was mandatory on every run. The release directory's copy came from `_write_service`; `/etc/systemd/system/frameos.service` came from `render_buildroot_frameos_service`, which adds the NetworkManager lines. Diffed straight off the card:

```
< Wants=NetworkManager.service
< After=network.target NetworkManager.service
---
> After=network.target
```

`writePrivilegedFile`'s "identical, skip" fast path therefore never fired. Fixed at both ends: the image builder renders the release copy through the same function, and `stageFrameOSRelease` now treats the *installed* unit as the source of truth rather than the old release directory's copy (an OTA tarball carries no unit file, so "keep what is installed" is the correct semantic).

## Changes

- `device_setup.nim`: `mountPointForPath` / `readOnlyMountPointFor` / `withWritableMount`. `/proc/mounts` is the nesting counter, so nested scopes cost nothing and the outer one restores. `writePrivilegedFile` uses it.
- `setup.nim`: one writable scope around the whole systemd-services block, plus the timezone, watchdog and power-save writes.
- `upgrade.nim`: prefer `/etc/systemd/system/frameos.service` over the old release directory's copy (same for the remote unit).
- `buildroot_image.py`: render the release directory's unit with `render_buildroot_frameos_service`, so it is byte-identical to the installed one.

## Tests

- 6 new blocks in `test_setup.nim` covering longest-prefix mount matching, `\040` escapes and overmounts, `ro` not matching `errors=remount-ro`, the remount/restore command sequence, restore-on-raise, no-op on a writable fs, and the failed-remount path. New `FRAMEOS_PROC_MOUNTS` test seam (mirrors `FRAMEOS_BOOT_CONFIG`).
- `test_buildroot_image.py` now asserts the release-directory unit is byte-identical to the staged `/etc` one — the invariant whose violation caused fault 2.
- `test_setup.nim`, `test_upgrade.nim` pass; 139 backend tests across `test_buildroot_image` / `test_frame_deploy_workflow` / `test_buildroot_release_image` pass.

## Note

Frames built from older images take one upgrade where the staged unit loses those two ordering lines — harmless, since NetworkManager is enabled independently and `After=` only affects ordering, and it is corrected by the next image build. Hardware verification of the OTA on a real Buildroot frame is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)