### PR TITLE
Flash a blank ESP32 from the release, and stop timing out slow builds

### DIFF
--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -144,6 +144,7 @@ from app.tasks.embedded_firmware import (
     embedded_toolchain_available,
     latest_embedded_firmware,
     embedded_platform_spec_for_frame,
+    embedded_provisioning_plan,
     is_virtual_frame,
     normalize_embedded_platform,
     refresh_embedded_firmware_status,
@@ -3253,6 +3254,26 @@ async def api_frame_embedded_firmware_status(
             "otaSupported": ota_supported,
         })
     }
+
+
+@api_project.get("/frames/{id:int}/embedded/provisioning")
+async def api_frame_embedded_provisioning(
+    id: int,
+    db: Session = Depends(get_db),
+):
+    """The console command list that turns a stock release image into this
+    frame — the alternative to compiling a per-frame image for a first flash.
+    Carries the frame's API key and Wi-Fi password, which the frame payload
+    this same session already fetches carries too."""
+    frame = _project_frame(db, id)
+    if not frame:
+        _not_found()
+    if (frame.mode or "rpios") != "embedded":
+        _bad_request("Firmware provisioning is only available for embedded frames")
+    try:
+        return {"provisioning": embedded_provisioning_plan(frame)}
+    except ValueError as exc:
+        _bad_request(str(exc))
 
 
 @api_project.post("/frames/{id:int}/embedded/firmware")

--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -34,6 +34,7 @@ from app.tasks.embedded_firmware import (
     embedded_pins_for_frame,
     embedded_pixel_format_for_panel,
     embedded_pixie_path,
+    embedded_provisioning_plan,
     embedded_required_sdkconfig_for_frame,
     embedded_render_psram_bytes,
     embedded_render_mode_for_frame,
@@ -1118,6 +1119,166 @@ def test_generated_config_bakes_gpio_buttons():
 
 def test_embedded_hostname_falls_back_for_ip_hosts():
     assert embedded_hostname_for_frame(Frame(id=12, frame_host="192.168.1.50")) == "frame12"
+
+
+def _provisioned(plan) -> dict:
+    """The plan's `set` commands as a key -> value dict, for assertions that do
+    not care about ordering."""
+    return {setting["key"]: setting["value"] for setting in plan["settings"]}
+
+
+def test_provisioning_plan_carries_every_setting_the_image_would_bake_in():
+    """A stock generic image plus these commands is the same frame as a
+    per-frame build — that equivalence is the whole reason the flow exists."""
+    frame = Frame(
+        id=9,
+        embedded={"hardwarePreset": "xteink_x4"},
+        network={"wifiSSID": "Home WiFi", "wifiPassword": "hunter2"},
+        server_host="10.0.0.5",
+        server_port=8989,
+        server_api_key="key-9",
+        interval=600,
+        rotate=90,
+        scaling_mode="contain",
+    )
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame)
+
+    assert plan["supported"] is True
+    assert plan["blockers"] == []
+    assert plan["platform"] == "esp32-c3"
+    assert plan["releasePlatform"] == "esp32-c3-generic"
+    settings = _provisioned(plan)
+    # `set hardware` applies a whole board bundle, so it has to land before
+    # anything this frame overrides on top of it.
+    assert plan["settings"][0]["key"] == "hardware"
+    assert settings["hardware"] == "xteink_x4"
+    assert settings["panel"] == "EPD_4in26"
+    assert settings["pins"] == "rst=5,dc=4,cs=21,cs2=-1,busy=6,sck=8,mosi=10,pwr=-1"
+    assert settings["gpio_buttons"] == "3:POWER"
+    assert settings["backend"] == "http://10.0.0.5:8989"
+    assert settings["api_key"] == "key-9"
+    assert settings["frame_id"] == "9"
+    # No PSRAM on the C3, so it can only ever be a thin client.
+    assert settings["render_mode"] == "remote"
+    assert settings["interval"] == "600"
+    assert settings["rotate"] == "90"
+    assert settings["scaling_mode"] == "contain"
+    assert settings["server_send_logs"] == "1"
+    assert settings["assets_sd"] == "0"
+    assert plan["wifi"] == {"ssid": "Home WiFi", "password": "hunter2"}
+    # The API key must be flagged so the flasher's log redacts it.
+    secrets = {setting["key"] for setting in plan["settings"] if setting["secret"]}
+    assert secrets == {"api_key"}
+
+
+def test_provisioning_plan_warns_about_the_published_images_flash_layout():
+    """The XTEINK X4 has 16MB, but the published C3 asset is the 4MB no-OTA
+    build — it works, it just leaves the rest of the chip and OTA on the table."""
+    frame = Frame(id=9, embedded={"hardwarePreset": "xteink_x4"}, server_host="host",
+                  server_api_key="key", network={"wifiSSID": "net"})
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame)
+
+    assert plan["supported"] is True
+    assert plan["releaseFlashSize"] == "4MB"
+    assert any("4MB partition layout" in warning for warning in plan["warnings"])
+    assert any("no OTA slot" in warning for warning in plan["warnings"])
+
+
+def test_provisioning_plan_sends_sd_card_pins_before_enabling_the_socket():
+    frame = Frame(
+        id=9,
+        embedded={"hardwarePreset": "waveshare_esp32_s3_photopainter"},
+        server_host="host",
+        server_api_key="key",
+        network={"wifiSSID": "net"},
+        device_config={
+            "hardwarePreset": "waveshare_esp32_s3_photopainter",
+            "sdCardAssets": {"enabled": True, "pins": {"cs": 38, "sck": 39, "miso": 40, "mosi": 41}},
+        },
+    )
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame)
+    keys = [setting["key"] for setting in plan["settings"]]
+    settings = _provisioned(plan)
+
+    assert settings["assets_sd_pins"] == "cs=38,sck=39,miso=40,mosi=41"
+    assert settings["assets_sd"] == "1"
+    # Enabling the socket before its pins are known would mount the wrong bus.
+    assert keys.index("assets_sd_pins") < keys.index("assets_sd")
+
+
+def test_provisioning_plan_blocks_a_frame_that_terminates_tls_itself():
+    """A TLS certificate has no console key, and a backend expecting https
+    cannot fetch from a device serving plain http — that frame needs a build."""
+    frame = Frame(
+        id=9,
+        device="waveshare.EPD_7in5_V2",
+        server_host="host",
+        server_api_key="key",
+        network={"wifiSSID": "net"},
+        https_proxy={"enable": True, "certs": {"server": "cert", "server_key": "key"}},
+    )
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame)
+
+    assert plan["supported"] is False
+    assert any("TLS" in blocker for blocker in plan["blockers"])
+
+
+def test_provisioning_plan_warns_that_the_device_admin_login_is_not_provisioned():
+    """Every embedded frame gets a generated device login, so refusing on one
+    would refuse every frame. The board simply answers without it — say so."""
+    frame = Frame(id=9, device="waveshare.EPD_7in5_V2", server_host="host",
+                  server_api_key="key", network={"wifiSSID": "net"})
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame)
+
+    assert plan["supported"] is True
+    assert any("admin login" in warning for warning in plan["warnings"])
+
+
+def test_provisioning_plan_blocks_a_frame_with_nowhere_to_call_home():
+    """No defaults applied here on purpose: a saved frame always has a server
+    API key, but the plan must not hand the device a half-built identity if
+    one of these is ever missing."""
+    frame = Frame(id=9, device="waveshare.EPD_7in5_V2", server_host="", server_api_key="")
+
+    plan = embedded_provisioning_plan(frame)
+
+    assert plan["supported"] is False
+    assert any("no server host" in blocker for blocker in plan["blockers"])
+    assert any("no API key" in blocker for blocker in plan["blockers"])
+    assert plan["wifi"] is None
+
+
+def test_provisioning_plan_warns_when_the_hostname_cannot_be_provisioned():
+    frame = Frame(id=9, frame_host="kitchen.local", device="waveshare.EPD_7in5_V2",
+                  server_host="host", server_api_key="key", network={"wifiSSID": "net"})
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame)
+
+    assert plan["supported"] is True
+    assert any("kitchen" in warning for warning in plan["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_provisioning_endpoint_returns_the_plan(async_client):
+    frame = await create_embedded_frame(async_client)
+
+    response = await async_client.get(f"/api/frames/{frame['id']}/embedded/provisioning")
+
+    assert response.status_code == 200, response.text
+    plan = response.json()["provisioning"]
+    assert plan["releasePlatform"] == "esp32-s3-generic"
+    assert {setting["key"] for setting in plan["settings"]} >= {"backend", "api_key", "frame_id", "panel"}
 
 
 def test_generated_config_omits_absent_power_settings():

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -535,6 +535,16 @@ EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
         "otaSupported": True,
     },
 }
+# The published GENERIC images (release assets), and the layout each is built
+# with — the esp32 job in .github/workflows/docker-publish-multi.yml, via
+# embedded/esp32/ci_build_image.sh. They carry no per-frame configuration at
+# all: a board flashed with one is told what it is over the USB console
+# afterwards (embedded_provisioning_plan). Keep in sync with
+# PROVISIONING_ASSETS in app/api/firmware_release.py.
+EMBEDDED_RELEASE_FIRMWARE: dict[str, dict[str, str]] = {
+    "esp32-s3": {"asset": "esp32-s3-generic", "flashSize": "8MB"},
+    "esp32-c3": {"asset": "esp32-c3-generic", "flashSize": "4MB"},
+}
 # Memory guardrail (M4): the on-device renderer composites into an RGBA pixie
 # buffer (4 B/px), packs it to the selected panel format, and needs headroom
 # for the Nim heap + QuickJS. Keep the reserve in sync with
@@ -1425,6 +1435,29 @@ def embedded_firmware_config_hash(frame: Frame) -> str:
     return hashlib.sha256(generated.encode("utf-8")).hexdigest()
 
 
+def embedded_backend_url_for_frame(frame: Frame) -> str:
+    """Where the device reaches this backend: what the built image bakes in as
+    FRAMEOS_DEFAULT_BACKEND_URL, and what console provisioning sends as
+    `set backend`. Empty when the frame has no server host yet."""
+    server_host = str(frame.server_host or "")
+    if not server_host:
+        return ""
+    server_port = int(frame.server_port or 8989)
+    scheme = "https" if server_port == 443 else "http"
+    if server_port in (80, 443):
+        return f"{scheme}://{server_host}"
+    return f"{scheme}://{server_host}:{server_port}"
+
+
+def _embedded_device_config_value(frame: Frame, *keys: str) -> object:
+    """First present of ``keys`` in the frame's device_config (camel or snake)."""
+    device_config = embedded_device_config(frame)
+    for key in keys:
+        if key in device_config:
+            return device_config[key]
+    return None
+
+
 def _generated_config_header(frame: Frame, wifi_ssid: str = "", wifi_password: str = "") -> str:
     """Per-frame compile-time defaults baked into the image (NVS overrides win).
 
@@ -1444,12 +1477,7 @@ def _generated_config_header(frame: Frame, wifi_ssid: str = "", wifi_password: s
             + '"'
         )
 
-    server_host = str(frame.server_host or "")
-    server_port = int(frame.server_port or 8989)
-    scheme = "https" if server_port == 443 else "http"
-    backend_url = f"{scheme}://{server_host}:{server_port}" if server_host else ""
-    if server_host and server_port in (80, 443):
-        backend_url = f"{scheme}://{server_host}"
+    backend_url = embedded_backend_url_for_frame(frame)
     https_proxy = normalize_https_proxy(frame.https_proxy)
     tls_certs = https_proxy.get("certs", {})
     tls_port = https_proxy.get("port") or 8443
@@ -1502,13 +1530,8 @@ def _generated_config_header(frame: Frame, wifi_ssid: str = "", wifi_password: s
 
     # Optional power-management settings (M4). Absent → firmware defaults
     # (no deep sleep, no battery pin); all still overridable from the device.
-    device_config = embedded_device_config(frame)
-
     def _config_value(*keys: str) -> object:
-        for key in keys:
-            if key in device_config:
-                return device_config[key]
-        return None
+        return _embedded_device_config_value(frame, *keys)
 
     deep_sleep = _config_value("deepSleep", "deep_sleep")
     if isinstance(deep_sleep, bool):
@@ -1531,6 +1554,183 @@ def _generated_config_header(frame: Frame, wifi_ssid: str = "", wifi_password: s
     if isinstance(battery_divider, (int, float)) and not isinstance(battery_divider, bool):
         lines.append(f"#define FRAMEOS_DEFAULT_BATTERY_DIVIDER {float(battery_divider)}f")
     return "\n".join(lines) + "\n"
+
+
+def _provisioning_setting(key: str, value: object, secret: bool = False) -> dict[str, Any]:
+    return {"key": key, "value": str(value), "secret": secret}
+
+
+def embedded_provisioning_plan(frame: Frame) -> dict[str, Any]:
+    """What the published GENERIC firmware has to be told to become this frame.
+
+    The browser flasher's other path builds a per-frame image, which bakes
+    every setting below into generated_config.h — a full ESP-IDF compile, tens
+    of minutes on a small self-hosted box for the first build of a chip target.
+    Nothing about that is required: all panel drivers are compiled into every
+    image (embedded/esp32/main/fos_defaults.h) and every baked value here has a
+    `set` key on the device's USB console (cmd_set in fos_console.c). So the
+    stock release image plus this command list is the same frame, minutes
+    sooner — the shape the cloud's enrollment flasher has always used
+    (cloud-frontend/src/components/Esp32CloudFlasher.tsx).
+
+    ``settings`` are `usb_api set <key> <value>` pairs IN ORDER: `hardware`
+    first because a preset applies a whole board bundle (panel, EPD wiring,
+    buttons, TF socket, battery sensing) that this frame's own values must be
+    able to override.
+
+    ``blockers`` are settings that exist only as compile-time defaults, so a
+    frame that needs one cannot be provisioned this way at all and has to build
+    an image. ``warnings`` are differences the user should know about but that
+    still leave a working frame.
+    """
+    platform = embedded_platform_for_frame(frame)
+    release = EMBEDDED_RELEASE_FIRMWARE.get(platform)
+    blockers: list[str] = []
+    warnings: list[str] = []
+    settings: list[dict[str, Any]] = []
+
+    if release is None:
+        label = embedded_platform_spec_for_frame(frame)["label"]
+        blockers.append(f"FrameOS publishes no generic {label} firmware image, so there is nothing to provision.")
+
+    preset = embedded_hardware_preset_for_frame(frame)
+    if preset:
+        settings.append(_provisioning_setting("hardware", preset))
+
+    panel = embedded_panel_for_frame(frame)
+    if panel == "none":
+        warnings.append(
+            "This frame has no e-paper panel selected, so the board will come up without a display driver."
+        )
+    else:
+        settings.append(_provisioning_setting("panel", panel))
+
+    pins = embedded_pins_for_frame(frame)
+    settings.append(_provisioning_setting("pins", ",".join(f"{key}={pins[key]}" for key in EMBEDDED_PIN_KEYS)))
+
+    # The console takes the newline-separated button spec with commas instead.
+    buttons = embedded_gpio_buttons_config(frame).replace("\n", ",")
+    if buttons:
+        settings.append(_provisioning_setting("gpio_buttons", buttons))
+    elif preset and EMBEDDED_HARDWARE_PRESETS[preset].get("gpioButtons"):
+        # `set gpio_buttons ""` is not a thing — the console's argument parser
+        # rejects an empty value — so the preset's buttons stay wired.
+        warnings.append(
+            f"This frame defines no buttons, but the {preset} preset does; the device keeps the preset's buttons. "
+            "Build an image instead if the board must come up with none."
+        )
+
+    backend_url = embedded_backend_url_for_frame(frame)
+    if backend_url:
+        settings.append(_provisioning_setting("backend", backend_url))
+    else:
+        blockers.append("This frame has no server host set, so the device would have no backend to talk to.")
+
+    api_key = str(frame.server_api_key or "")
+    if api_key:
+        settings.append(_provisioning_setting("api_key", api_key, secret=True))
+    else:
+        blockers.append("This frame has no API key, so the device could not authenticate against this backend.")
+
+    settings.append(_provisioning_setting("frame_id", int(frame.id)))
+    settings.append(_provisioning_setting(
+        "render_mode",
+        "remote" if embedded_render_mode_for_frame(frame) == EMBEDDED_RENDER_REMOTE else "local",
+    ))
+    settings.append(_provisioning_setting("interval", max(5, int(frame.interval or 300))))
+    settings.append(_provisioning_setting("rotate", int(frame.rotate or 0) % 360))
+    settings.append(_provisioning_setting("scaling_mode", embedded_scaling_mode_for_frame(frame)))
+    settings.append(_provisioning_setting("server_send_logs", 1 if frame.server_send_logs is not False else 0))
+
+    sd_card_assets = embedded_sd_card_assets_for_frame(frame)
+    if sd_card_assets["enabled"]:
+        sd_pins = sd_card_assets["pins"]
+        settings.append(_provisioning_setting(
+            "assets_sd_pins",
+            ",".join(f"{key}={sd_pins[key]}" for key in EMBEDDED_SD_CARD_ASSETS_PIN_KEYS),
+        ))
+        settings.append(_provisioning_setting("assets_sd_freq", sd_card_assets["maxFrequencyKHz"]))
+    # Sent either way: a hardware preset enables the socket it knows about, and
+    # a frame that turned SD assets off must be able to turn it back off.
+    settings.append(_provisioning_setting("assets_sd", 1 if sd_card_assets["enabled"] else 0))
+
+    deep_sleep = _embedded_device_config_value(frame, "deepSleep", "deep_sleep")
+    if isinstance(deep_sleep, bool):
+        settings.append(_provisioning_setting("deep_sleep", 1 if deep_sleep else 0))
+    deep_sleep_on_battery = _embedded_device_config_value(frame, "deepSleepOnBattery", "deep_sleep_on_battery")
+    if isinstance(deep_sleep_on_battery, bool):
+        settings.append(_provisioning_setting("deep_sleep_on_battery", 1 if deep_sleep_on_battery else 0))
+    wake_schedule = _embedded_device_config_value(frame, "wakeSchedule", "wake_schedule")
+    if isinstance(wake_schedule, bool):
+        settings.append(_provisioning_setting("wake_schedule", 1 if wake_schedule else 0))
+    wake_check_seconds = _embedded_device_config_value(frame, "wakeCheckSeconds", "wake_check_seconds")
+    if isinstance(wake_check_seconds, int) and not isinstance(wake_check_seconds, bool):
+        settings.append(_provisioning_setting("wake_check", max(0, wake_check_seconds)))
+    battery_pin = _embedded_device_config_value(frame, "batteryPin", "battery_pin")
+    if isinstance(battery_pin, int) and not isinstance(battery_pin, bool):
+        settings.append(_provisioning_setting("battery_pin", battery_pin))
+    battery_divider = _embedded_device_config_value(frame, "batteryDivider", "battery_divider")
+    if isinstance(battery_divider, (int, float)) and not isinstance(battery_divider, bool):
+        settings.append(_provisioning_setting("battery_divider", float(battery_divider)))
+
+    # Compile-time only: the console has no key for any of these, so a frame
+    # that needs them would come up quietly missing them.
+    https_proxy = normalize_https_proxy(frame.https_proxy)
+    if https_proxy.get("enable"):
+        blockers.append(
+            "This frame terminates TLS with its own certificate, which only exists as a compile-time default."
+        )
+    # Not a blocker: every embedded frame gets a generated device login
+    # (ensure_embedded_frame_defaults), and the cloud's enrollment flasher has
+    # always shipped generic images without one. But the frame row would then
+    # show a password the board does not actually ask for, so say it plainly.
+    admin_auth = normalize_frame_admin_auth(frame.frame_admin_auth)
+    if admin_auth["enabled"] and admin_auth["user"] and admin_auth["pass"]:
+        warnings.append(
+            "The console cannot set the device admin login, so the board's own web UI answers without the "
+            "password shown for this frame. Build an image if that page must be protected."
+        )
+
+    if frame.frame_host:
+        hostname = embedded_hostname_for_frame(frame)
+        warnings.append(
+            f"The board keeps the firmware's default DHCP hostname instead of \"{hostname}\" — "
+            "the console cannot set a hostname."
+        )
+    if embedded_max_http_response_bytes_for_frame(frame) != EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES:
+        warnings.append(
+            "This frame's HTTP response limit is a compile-time default; the board uses the firmware's."
+        )
+
+    if release is not None:
+        frame_flash_size = embedded_flash_size_for_frame(frame)
+        release_profile = EMBEDDED_FLASH_PROFILES[release["flashSize"]]
+        if frame_flash_size != release["flashSize"]:
+            warnings.append(
+                f"The published image uses the {release['flashSize']} partition layout; this frame is configured "
+                f"for {frame_flash_size} flash, so the rest of the chip stays unused."
+            )
+        if embedded_ota_supported_for_frame(frame) and not release_profile["otaSupported"]:
+            warnings.append(
+                "The published image has no OTA slot, so future firmware updates need the USB cable again."
+            )
+
+    wifi_ssid, wifi_password = embedded_wifi_credentials(frame)
+    if not wifi_ssid:
+        warnings.append(
+            "This frame has no Wi-Fi network configured, so the board starts its setup portal instead of connecting."
+        )
+
+    return {
+        "supported": not blockers,
+        "platform": platform,
+        "releasePlatform": release["asset"] if release else None,
+        "releaseFlashSize": release["flashSize"] if release else None,
+        "blockers": blockers,
+        "warnings": warnings,
+        "settings": settings,
+        "wifi": {"ssid": wifi_ssid, "password": wifi_password} if wifi_ssid else None,
+    }
 
 
 def ensure_embedded_frame_defaults(frame: Frame, platform: str | None = None) -> None:
@@ -2231,6 +2431,11 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
             last_heartbeat = datetime.now(timezone.utc)
             last_progress_at = build_started
             last_progress_percent = -EMBEDDED_BUILD_PROGRESS_PERCENT_STEP
+            # Latest ninja edge count, published on the heartbeat below rather
+            # than written on its own: the browser flasher waits on this to
+            # tell a slow build from a dead one, and a full first build is
+            # ~1100 edges — one status write each would be absurd.
+            build_progress: dict[str, Any] | None = None
             try:
                 async for line in _iter_process_lines(process.stdout):
                     text = line.decode("utf-8", errors="replace").rstrip()
@@ -2244,6 +2449,7 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
                     if progress:
                         done, total = int(progress.group(1)), int(progress.group(2))
                         percent = (100.0 * done / total) if total else 0.0
+                        build_progress = {"done": done, "total": total, "percent": round(percent, 1)}
                         if percent >= last_progress_percent + EMBEDDED_BUILD_PROGRESS_PERCENT_STEP or \
                                 now_monotonic - last_progress_at >= EMBEDDED_BUILD_PROGRESS_MAX_SILENCE_SECONDS:
                             last_progress_at = now_monotonic
@@ -2257,7 +2463,10 @@ async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: s
                         frame = get_fresh_frame(db, int(frame.id)) or frame
                         current = latest_embedded_firmware(frame) or {}
                         if current.get("status") == "building":
-                            await _set_firmware_status(db, redis, frame, {**current, "lastHeartbeatAt": _utc_now()})
+                            heartbeat = {**current, "lastHeartbeatAt": _utc_now()}
+                            if build_progress:
+                                heartbeat["buildProgress"] = build_progress
+                            await _set_firmware_status(db, redis, frame, heartbeat)
                 returncode = await process.wait()
             except BaseException:
                 # Includes CancelledError: an abandoned build must not keep a

--- a/cloud/apps/auth-web/src/test/shared-spa/embedded-release-flasher.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/embedded-release-flasher.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+//
+// The self-hosted backend's "Flash latest release" flow: write the published
+// generic image to a blank board and then tell the board what frame it is over
+// the USB console, instead of compiling a per-frame image first.
+//
+// What these cover is the part that can silently produce a wrong frame — that
+// the bytes written are the RELEASE asset (not the frame's build), that the
+// provisioning commands go out in the backend's order (a hardware preset
+// applies a whole board bundle, so anything overriding it must come after),
+// and that a frame whose settings only exist as compile-time defaults is
+// refused rather than half-provisioned.
+//
+// Lives here (auth-web's vitest) because frontend/ has no test runner; same
+// cross-package arrangement as the other shared-spa suites.
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initKea } from "../../../../../../frontend/src/initKea";
+import { framesModel } from "../../../../../../frontend/src/models/framesModel";
+import {
+  EmbeddedReleaseFlasher,
+  provisionOverUsb,
+  type EmbeddedProvisioningPlan,
+} from "../../../../../../frontend/src/scenes/workspace/EmbeddedReleaseFlasher";
+import type { FrameType } from "../../../../../../frontend/src/types";
+import { mergedImage } from "./esp32ImageFixtures";
+
+interface WriteFlashOptions {
+  eraseAll: boolean;
+  fileArray: { address: number; data: Uint8Array }[];
+}
+
+// A fake esptool-js: writeFlash records its options and then throws, which
+// ends the flow on the component's error path — deliberately, so the test
+// never enters the post-flash boot wait, which needs a live device.
+const esptool = vi.hoisted(() => {
+  const state = { writeFlashCalls: [] as unknown[] };
+  class FakeESPLoader {
+    chip = { CHIP_NAME: "ESP32-C3" };
+    constructor(_options: unknown) {}
+    main() {
+      return Promise.resolve("ESP32-C3");
+    }
+    writeFlash(options: unknown): Promise<void> {
+      state.writeFlashCalls.push(options);
+      return Promise.reject(new Error("test stop: write captured"));
+    }
+    writeReg() {
+      return Promise.resolve();
+    }
+  }
+  class FakeTransport {
+    constructor(_port: unknown, _tracing: boolean) {}
+    trace(_message: string) {}
+    disconnect() {
+      return Promise.resolve();
+    }
+    setDTR(_value: boolean) {
+      return Promise.resolve();
+    }
+    setRTS(_value: boolean) {
+      return Promise.resolve();
+    }
+  }
+  return { state, module: { ESPLoader: FakeESPLoader, Transport: FakeTransport } };
+});
+
+vi.mock("../../../../../../frontend/src/scenes/workspace/esptoolLoader", () => ({
+  loadEsptool: () => Promise.resolve(esptool.module),
+}));
+
+// The USB console, as the flasher reaches it. Mocked at the model so the tests
+// see the command list without a serial device behind it.
+const usbSetMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+vi.mock("../../../../../../frontend/src/models/embeddedUsbLogsModel", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, usbSet: usbSetMock };
+});
+
+const apiFetchMock = vi.hoisted(() => vi.fn<(input: string) => Promise<Response>>());
+vi.mock("../../../../../../frontend/src/utils/apiFetch", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, apiFetch: (input: string) => apiFetchMock(input) };
+});
+
+const releaseImage = mergedImage();
+
+function plan(overrides: Partial<EmbeddedProvisioningPlan> = {}): EmbeddedProvisioningPlan {
+  return {
+    supported: true,
+    platform: "esp32-c3",
+    releasePlatform: "esp32-c3-generic",
+    releaseFlashSize: "4MB",
+    blockers: [],
+    warnings: [],
+    settings: [
+      { key: "hardware", value: "xteink_x4", secret: false },
+      { key: "panel", value: "EPD_4in26", secret: false },
+      { key: "backend", value: "http://10.0.0.5:8989", secret: false },
+      { key: "api_key", value: "key-9", secret: true },
+      { key: "frame_id", value: "1", secret: false },
+    ],
+    wifi: { ssid: "Home WiFi", password: "hunter2" },
+    ...overrides,
+  };
+}
+
+function embeddedC3Frame(): FrameType {
+  return {
+    id: 1 as unknown as FrameType["id"],
+    project_id: 1,
+    name: "Bench frame",
+    mode: "embedded",
+    frame_host: "",
+    frame_port: 8787,
+    frame_access_key: "",
+    frame_access: "private",
+    ssh_port: 22,
+    server_port: 8989,
+    status: "active",
+    interval: 300,
+    metrics_interval: 60,
+    scaling_mode: "contain",
+    background_color: "#000000",
+    scenes: [],
+    embedded: { platform: "esp32-c3" },
+  } as FrameType;
+}
+
+function mockBackendApi(provisioning: EmbeddedProvisioningPlan) {
+  apiFetchMock.mockImplementation((input: string) => {
+    const url = String(input);
+    if (url === "/api/frames/1/embedded/provisioning") {
+      return Promise.resolve(Response.json({ provisioning }));
+    }
+    if (url === "/api/frames/firmware") {
+      return Promise.resolve(
+        Response.json({
+          release: "v2026.8.26",
+          assets: [{ name: "frameos-2026.8.26-esp32-c3-generic.bin", platform: "esp32-c3-generic", size: 1024 }],
+        }),
+      );
+    }
+    if (url.startsWith("/api/frames/firmware?platform=")) {
+      return Promise.resolve(new Response(releaseImage.slice()));
+    }
+    return Promise.resolve(new Response("null", { status: 404 }));
+  });
+}
+
+function stubSerial() {
+  const port = {
+    getInfo: () => ({ usbProductId: 0x1001, usbVendorId: 0x303a }),
+    close: () => Promise.resolve(),
+    open: () => Promise.resolve(),
+    readable: null,
+    writable: null,
+  };
+  Object.defineProperty(navigator, "serial", {
+    configurable: true,
+    value: {
+      getPorts: () => Promise.resolve([port]),
+      requestPort: () => Promise.resolve(port),
+    },
+  });
+  return port;
+}
+
+type CloudTestWindow = Window & {
+  FRAMEOS_APP_CONFIG?: { cloudMode: boolean };
+  FRAMEOS_EMBEDDED_NO_BACKEND?: boolean;
+};
+const testWindow = window as CloudTestWindow;
+
+beforeEach(() => {
+  testWindow.FRAMEOS_APP_CONFIG = { cloudMode: true };
+  testWindow.FRAMEOS_EMBEDDED_NO_BACKEND = true;
+  apiFetchMock.mockReset();
+  usbSetMock.mockClear();
+  esptool.state.writeFlashCalls = [];
+  stubSerial();
+  initKea();
+  framesModel.mount();
+});
+
+afterEach(() => {
+  cleanup();
+  delete (navigator as { serial?: unknown }).serial;
+  delete testWindow.FRAMEOS_APP_CONFIG;
+  delete testWindow.FRAMEOS_EMBEDDED_NO_BACKEND;
+});
+
+describe("EmbeddedReleaseFlasher", () => {
+  it("writes the published image as one image from 0x0", async () => {
+    mockBackendApi(plan());
+    render(<EmbeddedReleaseFlasher frame={embeddedC3Frame()} />);
+    await screen.findByText(/esp32-c3-generic image/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /flash latest release/i }));
+    await waitFor(() => expect(esptool.state.writeFlashCalls.length).toBe(1), { timeout: 5000 });
+
+    const options = esptool.state.writeFlashCalls[0] as WriteFlashOptions;
+    // A blank board has no settings to spare, so this is the monolithic write
+    // — and the bytes are the release asset, not a per-frame build.
+    expect(options.fileArray.length).toBe(1);
+    expect(options.fileArray[0].address).toBe(0);
+    expect(options.fileArray[0].data.byteLength).toBe(releaseImage.byteLength);
+  });
+
+  it("shows what the published image cannot carry, before anyone chooses it", async () => {
+    mockBackendApi(
+      plan({
+        warnings: ["The published image uses the 4MB partition layout; this frame is configured for 16MB flash."],
+      }),
+    );
+    render(<EmbeddedReleaseFlasher frame={embeddedC3Frame()} />);
+
+    expect(await screen.findByText(/4MB partition layout/i)).toBeTruthy();
+    expect((screen.getByRole("button", { name: /flash latest release/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("refuses a frame whose settings only exist as compile-time defaults", async () => {
+    mockBackendApi(
+      plan({
+        supported: false,
+        blockers: ["This frame terminates TLS with its own certificate."],
+      }),
+    );
+    render(<EmbeddedReleaseFlasher frame={embeddedC3Frame()} />);
+
+    expect(await screen.findByText(/has to build its own image/i)).toBeTruthy();
+    expect((screen.getByRole("button", { name: /flash latest release/i }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders nothing for a platform with no published image", async () => {
+    mockBackendApi(plan({ releasePlatform: null, releaseFlashSize: null }));
+    const { container } = render(<EmbeddedReleaseFlasher frame={embeddedC3Frame()} />);
+
+    await waitFor(() => expect(container.textContent).toBe(""));
+  });
+});
+
+describe("provisionOverUsb", () => {
+  it("sends the backend's commands in the backend's order", async () => {
+    const port = stubSerial() as unknown as SerialPort;
+
+    await provisionOverUsb(1 as unknown as FrameType["id"], plan(), port, () => {});
+
+    // `set hardware` applies the board bundle (panel, wiring, buttons), so a
+    // frame's own panel has to be sent after it, never before.
+    expect(usbSetMock.mock.calls.map((call) => call[1])).toEqual([
+      "hardware",
+      "panel",
+      "backend",
+      "api_key",
+      "frame_id",
+    ]);
+    // The port is handed to every command and kept open: the open/close churn
+    // of per-command reconnects can strap a USB-Serial/JTAG board into reset.
+    expect(usbSetMock.mock.calls[0][3]).toMatchObject({ port, keepOpen: true });
+  });
+
+  it("keeps a secret's value out of the status messages", async () => {
+    const port = stubSerial() as unknown as SerialPort;
+    const messages: string[] = [];
+
+    await provisionOverUsb(1 as unknown as FrameType["id"], plan(), port, (message) => messages.push(message));
+
+    expect(messages.some((message) => message.includes("key-9"))).toBe(false);
+    expect(messages.some((message) => message.includes("EPD_4in26"))).toBe(true);
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/embedded-web-flasher.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/embedded-web-flasher.test.tsx
@@ -20,6 +20,7 @@ import { initKea } from "../../../../../../frontend/src/initKea";
 import { framesModel } from "../../../../../../frontend/src/models/framesModel";
 import {
   EmbeddedWebFlasher,
+  firmwareBuildProgressMessage,
   planServerFirmwareWrite,
 } from "../../../../../../frontend/src/scenes/workspace/EmbeddedWebFlasher";
 import type { FrameType } from "../../../../../../frontend/src/types";
@@ -306,6 +307,110 @@ describe("EmbeddedWebFlasher keep-settings flashing", () => {
     expect(screen.getByText(/frameos has been updated/i)).toBeTruthy();
     // The board is never touched: the failure happens before any write.
     expect(esptool.state.writeFlashCalls).toHaveLength(0);
+  });
+});
+
+describe("EmbeddedWebFlasher waiting for the firmware build", () => {
+  // The flasher used to give up after a fixed ten minutes. A first ESP-IDF
+  // build of a chip target is ~1100 objects, so on a Home Assistant box that
+  // deadline hit while the build was perfectly healthy — and the user was told
+  // the flash had timed out. What it waits on now is the build's heartbeat.
+  function mockBuildingBackend(buildingPolls: number) {
+    let polls = 0;
+    apiFetchMock.mockImplementation((input: string) => {
+      const url = String(input);
+      if (url.startsWith("/api/frames/1/embedded/firmware/download")) {
+        return Promise.resolve(new Response(image.slice()));
+      }
+      if (url.startsWith("/api/frames/1/embedded/firmware")) {
+        polls += 1;
+        if (polls > buildingPolls) {
+          return Promise.resolve(
+            Response.json({
+              firmware: {
+                status: "ready",
+                flashOffset: "0x0",
+                flashSize: "8MB",
+                downloadUrl: "/api/frames/1/embedded/firmware/download",
+              },
+            }),
+          );
+        }
+        return Promise.resolve(
+          Response.json({
+            firmware: {
+              status: "building",
+              startedAt: new Date(Date.now() - 60_000).toISOString(),
+              // Both of these move on every poll — the proof of life the wait
+              // is looking for.
+              lastHeartbeatAt: new Date().toISOString(),
+              buildProgress: { done: polls, total: 1114, percent: (100 * polls) / 1114 },
+            },
+          }),
+        );
+      }
+      return Promise.resolve(new Response("null", { status: 404 }));
+    });
+    return () => polls;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps waiting while the build reports progress, well past the old ten-minute deadline", async () => {
+    // 250 polls at 3s is 12.5 minutes of build — the old fixed deadline would
+    // have thrown a quarter of the way through.
+    const polls = mockBuildingBackend(250);
+    render(<EmbeddedWebFlasher frame={backendEsp32Frame({ status: "idle" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /flash from browser/i }));
+    for (let minute = 0; minute < 15; minute += 1) {
+      await vi.advanceTimersByTimeAsync(60_000);
+    }
+
+    expect(polls()).toBeGreaterThan(250);
+    expect(esptool.state.writeFlashCalls.length).toBe(1);
+  });
+
+  it("gives up on a build whose status stops moving at all", async () => {
+    apiFetchMock.mockImplementation((input: string) => {
+      const url = String(input);
+      if (url.startsWith("/api/frames/1/embedded/firmware")) {
+        // Same payload forever: no heartbeat, no edge count, no progress.
+        return Promise.resolve(Response.json({ firmware: { status: "building" } }));
+      }
+      return Promise.resolve(new Response("null", { status: 404 }));
+    });
+    render(<EmbeddedWebFlasher frame={backendEsp32Frame({ status: "idle" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /flash from browser/i }));
+    for (let minute = 0; minute < 18; minute += 1) {
+      await vi.advanceTimersByTimeAsync(60_000);
+    }
+
+    expect(screen.getByText(/stopped reporting progress/i)).toBeTruthy();
+    expect(esptool.state.writeFlashCalls.length).toBe(0);
+  });
+});
+
+describe("firmwareBuildProgressMessage", () => {
+  it("names the edge count, so a slow build is visibly a moving one", () => {
+    expect(
+      firmwareBuildProgressMessage({
+        status: "building",
+        startedAt: new Date(Date.now() - 9 * 60_000).toISOString(),
+        buildProgress: { done: 198, total: 1114, percent: 17.8 },
+      }),
+    ).toBe("Building firmware image: 18% (198/1114), 9m elapsed");
+  });
+
+  it("says what a queued build is waiting for", () => {
+    expect(firmwareBuildProgressMessage({ status: "queued" })).toBe("Waiting for a build worker");
   });
 });
 

--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -33,6 +33,10 @@
     // legacy workspace components (bare JSX namespace, pre-strict typing).
     // Vitest still runs it; only tsc leaves it out.
     "src/test/shared-spa/embedded-web-flasher.test.tsx",
+    // Same story: mounts EmbeddedReleaseFlasher, whose import graph reaches
+    // the legacy workspace components through framesModel.
+    // Vitest still runs it; only tsc leaves it out.
+    "src/test/shared-spa/embedded-release-flasher.test.tsx",
     // Same story: frameStatusGroups imports decorators/frame.tsx, which
     // renders the legacy connection dot/spinner components (bare JSX
     // namespace). Vitest still runs it; only tsc leaves it out.

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -26,6 +26,8 @@ export default tseslint.config(
       "**/src/test/shared-spa/cloud-deploy-dialog.test.tsx",
       // Same exclusion, same reason: mounts EmbeddedWebFlasher.
       "**/src/test/shared-spa/embedded-web-flasher.test.tsx",
+      // Same exclusion, same reason: mounts EmbeddedReleaseFlasher.
+      "**/src/test/shared-spa/embedded-release-flasher.test.tsx",
       // Same exclusion, same reason: frameStatusGroups's import graph
       // reaches decorators/frame.tsx and the legacy components.
       "**/src/test/shared-spa/frame-status-groups.test.ts",

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -300,6 +300,10 @@ Everything else parked:
   key, cached) so users do not need per-service API keys.
 - ESP32 spill follow-ups: a proactive Content-Length trigger; a URL+ETag decode
   cache.
+- Publish a 16MB ESP32-C3 release asset. "Flash latest release" provisions a
+  XTEINK X4 from the 4MB no-OTA generic image today, which works but leaves
+  three quarters of the chip and OTA unused — the flasher warns about exactly
+  this. A `esp32-c3-16mb` asset in the release job removes the warning.
 - ESP32 board nice-to-haves: parallel firmware builds (shared
   `generated_config.h` and nimcache serialise under the build lock), a portal
   Wi-Fi scan list and AP password, mDNS advertisement, log persistence across

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -201,6 +201,41 @@ frameos> ota                             # check for an OTA update now
 frameos> factory-reset
 ```
 
+## Self-hosted provisioning (no per-frame build)
+
+A self-hosted backend can flash a blank board two ways, and the deploy
+drawer's firmware card offers both:
+
+* **Flash latest release** writes the published *generic* image
+  (`frameos-<version>-esp32-{s3,c3}-generic.bin`) and then sends this frame's
+  settings over the USB console. Nothing has to be compiled.
+* **Flash from browser** compiles a per-frame image with those settings baked
+  into `main/generated_config.h`. The first build of a chip target is ~1100
+  ESP-IDF objects — tens of minutes on a NUC, over an hour on a Home
+  Assistant box.
+
+The two produce the same frame because every panel driver is compiled into
+every image and each baked value has a `set` key here. The command list the
+first path replays comes from the backend (`embedded_provisioning_plan` in
+`backend/app/tasks/embedded_firmware.py`), built from the same helpers that
+generate the header, so the two cannot drift. By hand it is:
+
+```
+frameos> set hardware xteink_x4          # board bundle FIRST: panel, wiring, buttons, TF socket
+frameos> set panel EPD_4in26             # then anything the frame overrides
+frameos> set pins rst=5,dc=4,cs=21,cs2=-1,busy=6,sck=8,mosi=10,pwr=-1
+frameos> set backend http://10.0.0.5:8989
+frameos> set api_key <the frame's server_api_key>
+frameos> set frame_id 9
+frameos> wifi MySSID MyPassword          # saves and reboots
+```
+
+Four things exist only as compile-time defaults, because the console has no
+key for them: the DHCP hostname, the HTTP response limit, the device's own
+TLS certificate, and the device admin login. A frame that terminates TLS is
+refused by the release path (its backend could not fetch from it); the rest
+are reported as warnings on the button.
+
 ## Cloud enrollment (cloud-managed frames)
 
 Generic firmware can enroll directly with a cloud provider (enrollment flow A

--- a/frontend/src/models/embeddedUsbLogsModel.ts
+++ b/frontend/src/models/embeddedUsbLogsModel.ts
@@ -55,7 +55,7 @@ const lastPorts = new Map<FrameId, SerialPort>()
 const usbApiCommandLocks = new Map<FrameId, Promise<void>>()
 const serialPortReconnectEligible = new WeakMap<SerialPort, boolean>()
 
-interface EmbeddedUsbApiCommandOptions {
+export interface EmbeddedUsbApiCommandOptions {
   payload?: string | Uint8Array
   timeoutMs?: number
   promptIfNeeded?: boolean
@@ -76,6 +76,10 @@ interface EmbeddedUsbApiCommandOptions {
   // its failures are the expected case, so keep them out of the log — the
   // caller reports the progress and the final error itself.
   probe?: boolean
+  // What the log view calls this command, when the command line itself must
+  // not appear there: `set api_key <key>` and `set wifi_pass <password>` are
+  // sent verbatim to the device but logged as "set api_key (redacted)".
+  logLabel?: string
 }
 
 function sleep(ms: number): Promise<void> {
@@ -764,8 +768,12 @@ async function runEmbeddedUsbApiCommandLocked(
   command: string,
   options?: EmbeddedUsbApiCommandOptions
 ): Promise<EmbeddedUsbApiCommandResult> {
+  // What the log calls this command. Commands that carry a secret (the API
+  // key, a Wi-Fi password) pass a redacted label — the value goes down the
+  // wire, never into the log view.
+  const label = options?.logLabel ?? command
   if (!webSerialSupported()) {
-    appendUsbLine(frameId, `[USB API] ${command} failed: ${webSerialUnavailableReason('Talking to the board')}`)
+    appendUsbLine(frameId, `[USB API] ${label} failed: ${webSerialUnavailableReason('Talking to the board')}`)
     throw new Error(webSerialUnavailableReason('Talking to the board'))
   }
   const hadLogStream = sessions.has(frameId)
@@ -779,7 +787,7 @@ async function runEmbeddedUsbApiCommandLocked(
     port = await navigator.serial.requestPort()
   }
   if (!port) {
-    appendUsbLine(frameId, `[USB API] ${command} failed: No USB serial port selected for this frame`)
+    appendUsbLine(frameId, `[USB API] ${label} failed: No USB serial port selected for this frame`)
     throw new Error('No USB serial port selected for this frame')
   }
   appendSelectedUsbPort(frameId, port)
@@ -788,9 +796,9 @@ async function runEmbeddedUsbApiCommandLocked(
   }
   const payload = typeof options?.payload === 'string' ? new TextEncoder().encode(options.payload) : options?.payload
   if (!options?.probe) {
-    appendUsbLine(frameId, `[USB API] ${command}${payload ? ` (${payload.byteLength} bytes)` : ''}`)
+    appendUsbLine(frameId, `[USB API] ${label}${payload ? ` (${payload.byteLength} bytes)` : ''}`)
     if (payload) {
-      appendUsbLine(frameId, `[USB API] waiting for ${command} ready marker`)
+      appendUsbLine(frameId, `[USB API] waiting for ${label} ready marker`)
     }
   }
   const mirrorSerialText = options?.mirrorOutput !== false && usbApiResponseCommand(command) !== 'image'
@@ -841,7 +849,7 @@ async function runEmbeddedUsbApiCommandLocked(
         }
         throw error
       }
-      appendUsbLine(frameId, `[USB API] USB device re-enumerated; retrying ${command} on the new port`)
+      appendUsbLine(frameId, `[USB API] USB device re-enumerated; retrying ${label} on the new port`)
       port = replacement
       appendSelectedUsbPort(frameId, port)
       result = await runUsbApiCommandOnPort(
@@ -855,14 +863,14 @@ async function runEmbeddedUsbApiCommandLocked(
     }
     flushCommandLogText()
     if (!options?.probe) {
-      appendUsbLine(frameId, `[USB API] ${command} complete`)
+      appendUsbLine(frameId, `[USB API] ${label} complete`)
     }
     rebootAcknowledged = options?.expectReboot === true
     return result
   } catch (error) {
     flushCommandLogText()
     if (!options?.probe) {
-      appendUsbLine(frameId, `[USB API] ${command} failed: ${serialErrorMessage(error)}`)
+      appendUsbLine(frameId, `[USB API] ${label} failed: ${serialErrorMessage(error)}`)
     }
     throw error
   } finally {
@@ -1127,12 +1135,20 @@ export type EmbeddedUsbConfigKey =
   | 'hardware'
   | 'panel'
   | 'render_mode'
+  | 'rotate'
+  | 'scaling_mode'
   | 'interval'
   | 'server_send_logs'
   | 'assets_path'
   | 'assets_sd'
+  | 'assets_sd_pins'
+  | 'assets_sd_freq'
   | 'deep_sleep'
+  | 'deep_sleep_on_battery'
   | 'wake_schedule'
+  | 'wake_check'
+  | 'battery_pin'
+  | 'battery_divider'
   | 'pins'
   | 'gpio_buttons'
 
@@ -1195,16 +1211,43 @@ export async function usbStatus(frameId: FrameId): Promise<EmbeddedUsbStatus> {
 }
 
 /**
- * `usb_api set <key> <value...>` — persist one config value. Values may
- * contain spaces (the console re-joins the arguments), but runs of
- * whitespace collapse to single spaces and empty values are rejected by
- * the console's argument parser.
+ * Quote one value for the device console.
+ *
+ * esp_console_split_argv (ESP-IDF components/console/split_argv.c, reached
+ * through esp_console_run in fos_console.c) understands double quotes and
+ * backslash escapes: inside "…" a space is a literal space, and the only
+ * recognized escapes are \\, \" and backslash-space. Quoting the whole value
+ * and escaping backslashes and quotes is therefore exactly expressible, and
+ * it is what keeps a Wi-Fi password of "a  b" from arriving as "a b" — the
+ * argument re-join in cmd_set collapses runs of whitespace.
  */
-export async function usbSet(frameId: FrameId, key: EmbeddedUsbConfigKey, value: string): Promise<void> {
+export function quoteEmbeddedUsbConsoleValue(value: string): string {
+  return `"${value.replace(/[\\"]/g, '\\$&')}"`
+}
+
+/** Config keys whose value must never reach the log view. */
+const USB_SECRET_CONFIG_KEYS = new Set<EmbeddedUsbConfigKey>(['api_key', 'wifi_pass', 'claim_token'])
+
+/**
+ * `usb_api set <key> <value>` — persist one config value. The value is quoted,
+ * so spaces and punctuation survive intact; an empty value is rejected by the
+ * console's argument parser and so refused here, with a message that says
+ * which key it was. Secrets go down the wire but reach the log redacted.
+ */
+export async function usbSet(
+  frameId: FrameId,
+  key: EmbeddedUsbConfigKey,
+  value: string,
+  options?: EmbeddedUsbApiCommandOptions
+): Promise<void> {
   if (!value.trim()) {
     throw new Error(`The USB console cannot store an empty value for ${key}`)
   }
-  await runEmbeddedUsbApiCommand(frameId, `set ${key} ${value}`, { timeoutMs: USB_SET_TIMEOUT_MS })
+  await runEmbeddedUsbApiCommand(frameId, `set ${key} ${quoteEmbeddedUsbConsoleValue(value)}`, {
+    timeoutMs: USB_SET_TIMEOUT_MS,
+    ...(USB_SECRET_CONFIG_KEYS.has(key) ? { logLabel: `set ${key} (redacted)` } : {}),
+    ...options,
+  })
 }
 
 /** `usb_api wifi-scan` — list visible networks (strongest first). */
@@ -1231,10 +1274,11 @@ export async function usbWifiScan(frameId: FrameId): Promise<EmbeddedUsbWifiScan
 }
 
 /** `usb_api restart` — acks OK, reboots, then reconnects the serial session. */
-export async function usbRestart(frameId: FrameId): Promise<void> {
+export async function usbRestart(frameId: FrameId, options?: EmbeddedUsbApiCommandOptions): Promise<void> {
   await runEmbeddedUsbApiCommand(frameId, 'restart', {
     timeoutMs: USB_REBOOT_COMMAND_TIMEOUT_MS,
     expectReboot: true,
+    ...options,
   })
 }
 
@@ -1317,27 +1361,29 @@ export async function loadEmbeddedUsbLogHistory(frameId: FrameId): Promise<numbe
 /**
  * Provision Wi-Fi credentials and reboot into them. Uses `set wifi_ssid` +
  * `set wifi_pass` + `restart` (NOT the positional `wifi <ssid> <pass>`),
- * so SSIDs and passwords containing spaces survive the console's argument
- * splitting. Open networks fall back to `wifi <ssid>` because `set` cannot
- * store an empty wifi_pass — that path only works for SSIDs without spaces.
+ * because `set` is the path that can store an empty value's counterpart —
+ * an open network has no password, and `set wifi_pass ""` is refused by the
+ * console's argument parser, so that case takes the positional command.
+ * Both quote their arguments, so spaces survive either way.
  */
-export async function usbProvisionWifi(frameId: FrameId, ssid: string, password: string): Promise<void> {
+export async function usbProvisionWifi(
+  frameId: FrameId,
+  ssid: string,
+  password: string,
+  options?: EmbeddedUsbApiCommandOptions
+): Promise<void> {
   if (!ssid.trim()) {
     throw new Error('Wi-Fi network name is required')
   }
   if (!password) {
-    if (/\s/.test(ssid)) {
-      throw new Error(
-        'The device console cannot join an open network whose name contains spaces. Set a password, or rename the network.'
-      )
-    }
-    await runEmbeddedUsbApiCommand(frameId, `wifi ${ssid}`, {
+    await runEmbeddedUsbApiCommand(frameId, `wifi ${quoteEmbeddedUsbConsoleValue(ssid)}`, {
       timeoutMs: USB_REBOOT_COMMAND_TIMEOUT_MS,
       expectReboot: true,
+      ...options,
     })
     return
   }
-  await usbSet(frameId, 'wifi_ssid', ssid)
-  await usbSet(frameId, 'wifi_pass', password)
-  await usbRestart(frameId)
+  await usbSet(frameId, 'wifi_ssid', ssid, options)
+  await usbSet(frameId, 'wifi_pass', password, options)
+  await usbRestart(frameId, options)
 }

--- a/frontend/src/scenes/workspace/EmbeddedReleaseFlasher.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedReleaseFlasher.tsx
@@ -1,0 +1,398 @@
+import { useEffect, useState } from 'react'
+import { CloudArrowDownIcon } from '@heroicons/react/24/outline'
+import { useActions } from 'kea'
+import type { Transport as EspTransport } from 'esptool-js'
+
+import { Spinner } from '../../components/Spinner'
+import {
+  embeddedUsbLogStreamSessionPort,
+  prepareSerialPortReconnect,
+  resolveLiveSerialPort,
+  startEmbeddedUsbLogStream,
+  stopEmbeddedUsbLogStream,
+  usbProvisionWifi,
+  usbRestart,
+  usbSet,
+  type EmbeddedUsbConfigKey,
+} from '../../models/embeddedUsbLogsModel'
+import { framesModel, scheduleEmbeddedUsbFrameImageRefresh } from '../../models/framesModel'
+import type { FrameId, FrameType } from '../../types'
+import { apiFetch } from '../../utils/apiFetch'
+import { webSerialSupported as isWebSerialSupported, webSerialUnavailableReason } from '../../utils/webSerial'
+import { downloadReleaseFirmware, releaseFirmwarePlatform } from './EmbeddedUsbFirmwareUpdate'
+import {
+  POST_FLASH_BOOT_WAIT_MS,
+  appendBrowserFlashLog,
+  createUsbLogTerminal,
+  loadEsptoolForFlash,
+  recordTransportTrace,
+  sleep,
+  uploadScenesOverUsbAfterFlash,
+  waitForUsbApiReadyAfterFlash,
+  watchdogResetAfterFlash,
+  type FlashLogTerminal,
+  type FlashPhase,
+  type FlashTraceRecorder,
+} from './EmbeddedWebFlasher'
+import { workspaceLogic } from './workspaceLogic'
+
+// Flash a BLANK board from the published release instead of compiling an
+// image for it.
+//
+// The other browser-flash path (EmbeddedWebFlasher) builds a per-frame image,
+// which bakes this frame's Wi-Fi, backend URL, API key, panel and wiring into
+// generated_config.h. Nothing about that is required: every panel driver is
+// compiled into every image, and each of those values has a `set` key on the
+// device's USB console. So this path writes the stock generic image and then
+// tells the board what it is over the same cable — the shape the cloud's
+// enrollment flasher has always used (Esp32CloudFlasher.tsx). What that buys
+// is the first build of a chip target, which is ~1100 ESP-IDF objects: tens of
+// minutes on a NUC, well over an hour on a Home Assistant box.
+//
+// The command list is the backend's (embedded_provisioning_plan), not this
+// component's: it comes from the same helpers that generate the header, so the
+// two paths cannot drift into producing different frames. It also reports what
+// this path CANNOT do — a frame terminating TLS with its own certificate has
+// no console key for it — and the button is refused for those frames.
+//
+// The counterpart for a board that is already enrolled is
+// EmbeddedUsbFirmwareUpdate: same release bytes, but written around the NVS
+// partition so the device keeps the settings this flow is here to establish.
+
+const PROVISION_COMMAND_TIMEOUT_MS = 15000
+
+export interface EmbeddedProvisioningSetting {
+  key: EmbeddedUsbConfigKey
+  value: string
+  secret: boolean
+}
+
+export interface EmbeddedProvisioningPlan {
+  supported: boolean
+  platform: string
+  releasePlatform: string | null
+  releaseFlashSize: string | null
+  blockers: string[]
+  warnings: string[]
+  settings: EmbeddedProvisioningSetting[]
+  wifi: { ssid: string; password: string } | null
+}
+
+export async function fetchProvisioningPlan(frameId: FrameId): Promise<EmbeddedProvisioningPlan> {
+  const response = await apiFetch(`/api/frames/${frameId}/embedded/provisioning`)
+  if (!response.ok) {
+    throw new Error('Could not work out what to provision this board with.')
+  }
+  return ((await response.json())?.provisioning ?? {}) as EmbeddedProvisioningPlan
+}
+
+/**
+ * Replay the plan over the board's USB API, in the order the backend gave it:
+ * `set hardware` applies a whole board bundle (panel, EPD wiring, buttons, TF
+ * socket), so everything this frame overrides on top of it has to come after.
+ *
+ * Wi-Fi goes last and reboots the board, because that is the point at which it
+ * is finished — a board that reconnects half-provisioned would call home as
+ * something that is not quite this frame.
+ */
+export async function provisionOverUsb(
+  frameId: FrameId,
+  plan: EmbeddedProvisioningPlan,
+  port: SerialPort,
+  onStatus: (message: string) => void
+): Promise<void> {
+  const total = plan.settings.length
+  for (const [index, setting] of plan.settings.entries()) {
+    onStatus(
+      `Provisioning the board (${index + 1}/${total}): ${setting.key}${setting.secret ? '' : ` = ${setting.value}`}`
+    )
+    await usbSet(frameId, setting.key, setting.value, {
+      port,
+      keepOpen: true,
+      timeoutMs: PROVISION_COMMAND_TIMEOUT_MS,
+    })
+  }
+}
+
+export function EmbeddedReleaseFlasher({
+  frame,
+  disabled = false,
+  onBusyChange,
+}: {
+  frame: FrameType
+  disabled?: boolean
+  onBusyChange?: (busy: boolean) => void
+}): JSX.Element | null {
+  const [phase, setPhase] = useState<FlashPhase>('idle')
+  const [message, setMessage] = useState<string | null>(null)
+  const [progress, setProgress] = useState<number | null>(null)
+  const [plan, setPlan] = useState<EmbeddedProvisioningPlan | null>(null)
+  const [planError, setPlanError] = useState<string | null>(null)
+  const { openFrameToolBehindDrawer } = useActions(workspaceLogic)
+
+  const webSerialSupported = isWebSerialSupported()
+  const busy = phase === 'connecting' || phase === 'preparing' || phase === 'flashing'
+
+  useEffect(() => {
+    onBusyChange?.(busy)
+  }, [busy, onBusyChange])
+
+  useEffect(() => {
+    return () => onBusyChange?.(false)
+  }, [onBusyChange])
+
+  // Fetched up front, not on click: whether this frame can be provisioned at
+  // all decides whether the button appears, and its warnings are what the user
+  // needs BEFORE choosing this over a build.
+  useEffect(() => {
+    let cancelled = false
+    setPhase('idle')
+    setMessage(null)
+    setProgress(null)
+    setPlan(null)
+    setPlanError(null)
+    fetchProvisioningPlan(frame.id)
+      .then((fetched) => {
+        if (!cancelled) {
+          setPlan(fetched)
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setPlanError(error instanceof Error ? error.message : String(error))
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [frame.id])
+
+  const flash = async (): Promise<void> => {
+    if (!plan) {
+      return
+    }
+    let port: SerialPort | null = null
+    let transport: EspTransport | null = null
+    let flashTerminal: FlashLogTerminal | null = null
+    let traceRecorder: FlashTraceRecorder | null = null
+    let flashed = false
+    const setFlashMessage = (nextMessage: string | null): void => {
+      setMessage(nextMessage)
+      if (nextMessage) {
+        appendBrowserFlashLog(frame.id, nextMessage)
+      }
+    }
+
+    setPhase('connecting')
+    setProgress(null)
+    setFlashMessage('Selecting USB port')
+    try {
+      // Must run inside the click gesture, before any other await, or the
+      // browser refuses the port prompt.
+      const activeLogPort = embeddedUsbLogStreamSessionPort(frame.id)
+      port = activeLogPort ? await stopEmbeddedUsbLogStream(frame.id) : await navigator.serial.requestPort()
+      if (!port) {
+        setPhase('idle')
+        setMessage(null)
+        return
+      }
+      await prepareSerialPortReconnect(port)
+      openFrameToolBehindDrawer(frame.id, 'logs')
+
+      setPhase('preparing')
+      const releasePlatform = plan.releasePlatform || releaseFirmwarePlatform(frame)
+      const firmware = await downloadReleaseFirmware(releasePlatform, setFlashMessage)
+
+      // Loaded on demand: esptool-js adds ~380KB we only need when flashing.
+      const { ESPLoader, Transport } = await loadEsptoolForFlash()
+      transport = new Transport(port, false)
+      traceRecorder = recordTransportTrace(frame.id, transport)
+      flashTerminal = createUsbLogTerminal(frame.id)
+
+      setPhase('connecting')
+      setFlashMessage('Connecting to the board')
+      const loader = new ESPLoader({ transport, baudrate: 460800, enableTracing: true, terminal: flashTerminal })
+      const chip = await loader.main()
+
+      setPhase('flashing')
+      setFlashMessage(`Flashing ${firmware.name} to ${chip}`)
+      await loader.writeFlash({
+        // The merged provisioning image is the whole flash from 0x0
+        // (bootloader, partition table, blank otadata, app), so it goes down
+        // as one write. Nothing is spared: this board is not yet a frame, and
+        // its settings are about to be provisioned from scratch anyway.
+        fileArray: [{ address: 0x0, data: firmware.bytes }],
+        flashSize: 'keep',
+        flashMode: 'keep',
+        flashFreq: 'keep',
+        eraseAll: false,
+        compress: true,
+        reportProgress: (_fileIndex, written, total) => {
+          setProgress(total > 0 ? Math.min(100, Math.round((written / total) * 100)) : null)
+        },
+      })
+      flashed = true
+      traceRecorder.expectReboot()
+
+      if (!(await watchdogResetAfterFlash(loader))) {
+        try {
+          await transport.setDTR(false)
+          await transport.setRTS(true)
+          await sleep(100)
+          await transport.setRTS(false)
+          await transport.setDTR(false)
+        } catch (error) {
+          // The port drops if the chip already reset mid-command; the
+          // post-flash wait re-acquires it.
+        }
+      }
+      setPhase('preparing')
+      setProgress(null)
+      setFlashMessage('Firmware written. Waiting for the board to reboot.')
+    } catch (error) {
+      setPhase('error')
+      setProgress(null)
+      const detail = error instanceof Error ? error.message : String(error)
+      if (/No port selected/i.test(detail)) {
+        setPhase('idle')
+        setMessage(null)
+      } else {
+        const displayMessage = /Failed to open serial port/i.test(detail)
+          ? 'Could not open the serial port. Close other serial monitors and try again.'
+          : detail
+        setMessage(displayMessage)
+        appendBrowserFlashLog(frame.id, `Flash failed: ${displayMessage}`)
+        traceRecorder?.dumpAfterFailure()
+      }
+    } finally {
+      flashTerminal?.flush()
+      if (transport) {
+        try {
+          await transport.disconnect()
+        } catch (error) {}
+      }
+      if (flashed && port) {
+        try {
+          await sleep(POST_FLASH_BOOT_WAIT_MS)
+          port = await waitForUsbApiReadyAfterFlash(frame, port, setFlashMessage)
+          await provisionOverUsb(frame.id, plan, port, setMessage)
+          appendBrowserFlashLog(frame.id, `Provisioned ${plan.settings.length} setting(s) over USB.`)
+
+          // Scenes before the Wi-Fi reboot: the board is up and answering, and
+          // pushing them now saves a second boot wait. A frame with none gets
+          // them from the backend once it connects.
+          if (await uploadScenesOverUsbAfterFlash(frame, port, setFlashMessage)) {
+            const completeResponse = await apiFetch(`/api/frames/${frame.id}/embedded/usb_deploy_complete`, {
+              method: 'POST',
+            })
+            if (!completeResponse.ok) {
+              throw new Error('Scene upload completed, but backend deploy state update failed')
+            }
+          }
+
+          if (plan.wifi) {
+            setFlashMessage(`Joining ${plan.wifi.ssid} and restarting`)
+            await usbProvisionWifi(frame.id, plan.wifi.ssid, plan.wifi.password, { port, keepOpen: true })
+          } else {
+            setFlashMessage('Restarting the board')
+            await usbRestart(frame.id, { port, keepOpen: true })
+          }
+          // That reboot re-enumerates the USB device, so the port object the
+          // log stream below is handed has to be the replacement, not the one
+          // that went away with the reset.
+          port = (await resolveLiveSerialPort(port)) ?? port
+
+          framesModel.actions.loadFrame(frame.id)
+          scheduleEmbeddedUsbFrameImageRefresh(frame.id)
+          setPhase('done')
+          setFlashMessage(
+            plan.wifi
+              ? `Flashed the published firmware and provisioned this frame. The board is joining ${plan.wifi.ssid}.`
+              : 'Flashed the published firmware and provisioned this frame. Add a Wi-Fi network, or join one from the board’s setup portal.'
+          )
+        } catch (error) {
+          setPhase('error')
+          const detail = error instanceof Error ? error.message : String(error)
+          setFlashMessage(
+            `Firmware written, but provisioning did not finish: ${detail} The board is running FrameOS — ` +
+              'flash again to retry, or set the remaining values from "Set up over USB".'
+          )
+        }
+        const logStreamStarted = await startEmbeddedUsbLogStream(frame.id, port)
+        openFrameToolBehindDrawer(frame.id, 'logs')
+        if (!logStreamStarted) {
+          appendBrowserFlashLog(frame.id, 'USB serial log stream could not be reopened after flashing.')
+        }
+      }
+    }
+  }
+
+  // Nothing published for this chip (pico, virtual): the card's build path is
+  // the only one, and an explanation nobody asked for is just noise.
+  if (plan && !plan.releasePlatform) {
+    return null
+  }
+  if (!webSerialSupported) {
+    return null
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={flash}
+        disabled={disabled || busy || !plan?.supported}
+        title={
+          plan && !plan.supported
+            ? plan.blockers.join(' ')
+            : 'Write the latest published firmware and provision this frame over the same cable — no build needed.'
+        }
+        className="frameos-secondary-button inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40"
+      >
+        {busy ? <Spinner /> : <CloudArrowDownIcon className="h-4 w-4" />}
+        {phase === 'flashing' && progress !== null
+          ? `Flashing ${progress}%`
+          : busy
+          ? 'Flashing'
+          : 'Flash latest release'}
+      </button>
+      {planError ? (
+        <div className="frame-tool-muted text-xs leading-5">{planError}</div>
+      ) : plan && !plan.supported ? (
+        <div className="frame-tool-muted text-xs leading-5">
+          This frame has to build its own image: {plan.blockers.join(' ')}
+        </div>
+      ) : plan ? (
+        <div className="frame-tool-muted text-xs leading-5">
+          Writes the published {plan.releasePlatform} image and provisions this frame over USB — seconds instead of a
+          firmware build. Everything the board needs is sent over the cable afterwards.
+          {plan.warnings.length > 0 ? (
+            <ul className="mt-1 list-disc space-y-0.5 pl-4">
+              {plan.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+      {phase === 'flashing' && progress !== null ? (
+        <div className="frameos-inset h-2 w-full overflow-hidden rounded-full border">
+          <div className="h-full rounded-full bg-blue-500 transition-all" style={{ width: `${progress}%` }} />
+        </div>
+      ) : null}
+      {message ? (
+        <div
+          className={
+            phase === 'error'
+              ? 'text-xs font-semibold text-red-500'
+              : phase === 'done'
+              ? 'text-xs font-semibold text-green-600'
+              : 'frame-tool-muted text-xs leading-5'
+          }
+        >
+          {message}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
@@ -102,7 +102,7 @@ export async function fetchReleaseFirmwareListing(): Promise<ReleaseFirmwareList
   return (await listingResponse.json()) as ReleaseFirmwareListing
 }
 
-async function downloadReleaseFirmware(
+export async function downloadReleaseFirmware(
   platform: string,
   log: (message: string) => void
 ): Promise<{ bytes: Uint8Array; name: string; release: string }> {

--- a/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedWebFlasher.tsx
@@ -41,7 +41,19 @@ export type FlashLogTerminal = IEspLoaderTerminal & { flush: () => void }
 type TraceableTransportInternals = { trace: (message: string) => void; lastTraceTime?: number }
 
 const FIRMWARE_POLL_INTERVAL_MS = 3000
-const FIRMWARE_POLL_TIMEOUT_MS = 10 * 60 * 1000
+// How long the build may go without the status payload moving at all before
+// it counts as hung. NOT a budget for the build: a first ESP-IDF build of a
+// chip target compiles ~1100 objects, which is half an hour on a NUC and well
+// over an hour on a Home Assistant box — a fixed deadline (this was 10
+// minutes) reported "Timed out waiting for the firmware build" on builds that
+// were running perfectly well, and the next flash then had to start over.
+// The worker republishes lastHeartbeatAt (and its ninja edge count) every 15
+// seconds while it compiles, and the backend itself marks a build failed once
+// that stops for EMBEDDED_FIRMWARE_INACTIVE_AFTER_SECONDS (15 minutes), so a
+// slightly longer stall window here only ever catches a backend that has
+// stopped answering at all.
+const FIRMWARE_STALL_TIMEOUT_MS = 16 * 60 * 1000
+const FIRMWARE_PROGRESS_REPORT_INTERVAL_MS = 60 * 1000
 export const POST_FLASH_BOOT_WAIT_MS = 7000
 // First boot after an erase-all flash formats the 24MB SPIFFS state
 // partition before the console starts — measured ~180s on a XIAO ESP32-S3
@@ -269,43 +281,83 @@ function firmwareFlashSize(frame: FrameType, firmware?: FirmwareStatus | null): 
   return normalizeFlashSize(firmware?.flashSize ?? frame.embedded?.flashSize ?? frame.embedded?.firmware?.flashSize)
 }
 
+function buildStartMessage(status: FirmwareStatus['status']): string {
+  return status === 'stale'
+    ? 'Rebuilding firmware from current settings'
+    : status === 'missing'
+    ? 'Rebuilding missing firmware image'
+    : 'Building firmware image'
+}
+
+/**
+ * What the build looks like from outside: its ninja edge count when the worker
+ * has published one, so the user can tell a build that is 4% done from one
+ * that is stuck. `startedAt` gives the elapsed time, which is the number that
+ * says whether it is worth waiting for.
+ */
+export function firmwareBuildProgressMessage(firmware: FirmwareStatus): string {
+  if (firmware.status === 'queued') {
+    return 'Waiting for a build worker'
+  }
+  const progress = firmware.buildProgress
+  const startedAt = firmware.startedAt ? Date.parse(firmware.startedAt) : NaN
+  const elapsedMinutes = Number.isNaN(startedAt) ? null : Math.floor((Date.now() - startedAt) / 60000)
+  const elapsed = elapsedMinutes && elapsedMinutes > 0 ? `, ${elapsedMinutes}m elapsed` : ''
+  if (!progress || !progress.total) {
+    return `Building firmware image${elapsed}`
+  }
+  return `Building firmware image: ${Math.round(progress.percent)}% (${progress.done}/${progress.total})${elapsed}`
+}
+
+/** Whatever in the status proves the build is still moving. */
+function firmwareActivityKey(firmware: FirmwareStatus): string {
+  return [firmware.status, firmware.lastHeartbeatAt ?? '', firmware.buildProgress?.done ?? ''].join('|')
+}
+
 /** Make sure a fresh firmware image exists, building one if needed. */
 async function ensureFirmwareReady(frameId: FrameId, onStatus: (message: string) => void): Promise<FirmwareStatus> {
   let firmware = await fetchFirmwareStatus(frameId)
   if (firmware.status !== 'ready') {
-    onStatus(
-      firmware.status === 'stale'
-        ? 'Rebuilding firmware from current settings'
-        : firmware.status === 'missing'
-        ? 'Rebuilding missing firmware image'
-        : 'Building firmware image'
-    )
+    onStatus(buildStartMessage(firmware.status))
     firmware = await startFirmwareBuild(frameId, firmware.status === 'stale' || firmware.status === 'missing')
 
-    const deadline = Date.now() + FIRMWARE_POLL_TIMEOUT_MS
     let recoveryAttempts = 0
+    let activityKey = firmwareActivityKey(firmware)
+    let stallDeadline = Date.now() + FIRMWARE_STALL_TIMEOUT_MS
+    let lastReportAt = Date.now()
     while (firmware.status !== 'ready') {
       if (firmware.status === 'missing' || firmware.status === 'stale') {
         if (recoveryAttempts >= 2) {
           throw new Error(firmware.error || 'Firmware image needs to be rebuilt')
         }
         recoveryAttempts += 1
-        onStatus(
-          firmware.status === 'stale'
-            ? 'Rebuilding firmware from current settings'
-            : 'Rebuilding missing firmware image'
-        )
+        onStatus(buildStartMessage(firmware.status))
         firmware = await startFirmwareBuild(frameId, true)
         continue
       }
       if (firmware.status === 'error') {
         throw new Error(firmware.error || 'Firmware build failed')
       }
-      if (Date.now() > deadline) {
-        throw new Error('Timed out waiting for the firmware build')
+      if (Date.now() > stallDeadline) {
+        throw new Error(
+          'The firmware build stopped reporting progress. Check the frame log, then start the flash again — ' +
+            'a build that is still running is picked up where it left off.'
+        )
       }
       await sleep(FIRMWARE_POLL_INTERVAL_MS)
       firmware = await fetchFirmwareStatus(frameId)
+      const nextActivityKey = firmwareActivityKey(firmware)
+      if (nextActivityKey !== activityKey) {
+        activityKey = nextActivityKey
+        stallDeadline = Date.now() + FIRMWARE_STALL_TIMEOUT_MS
+        // Every status message is also a frame-log line, and the build
+        // heartbeats every 15 seconds for anything up to an hour. Report on
+        // the minute instead of writing 240 lines about the same build.
+        if (Date.now() - lastReportAt >= FIRMWARE_PROGRESS_REPORT_INTERVAL_MS) {
+          lastReportAt = Date.now()
+          onStatus(firmwareBuildProgressMessage(firmware))
+        }
+      }
     }
   }
   return firmware
@@ -424,7 +476,11 @@ function scenesArriveFromCloud(frame: FrameType): boolean {
   return isEsp32CloudFrame(frame)
 }
 
-async function uploadScenesOverUsbAfterFlash(
+/** Send the workspace's scenes to a board that has just come back on USB.
+ * Retries: the board answers `status` before its scene store is settled often
+ * enough that one attempt loses a first deploy. Returns false when the frame
+ * has no scenes to send. */
+export async function uploadScenesOverUsbAfterFlash(
   frame: FrameType,
   port: SerialPort,
   onStatus: (message: string) => void
@@ -596,9 +652,11 @@ export function EmbeddedUsbConnectionButton({
 
 export function EmbeddedWebFlasher({
   frame,
+  disabled = false,
   onBusyChange,
 }: {
   frame: FrameType
+  disabled?: boolean
   onBusyChange?: (busy: boolean) => void
 }): JSX.Element {
   const [phase, setPhase] = useState<FlashPhase>('idle')
@@ -658,17 +716,11 @@ export function EmbeddedWebFlasher({
       openFrameToolBehindDrawer(frame.id, 'logs')
       appendBrowserFlashLog(frame.id, 'USB port selected')
 
-      // Loaded on demand: esptool-js adds ~380KB we only need when actually flashing
-      const { ESPLoader, Transport } = await loadEsptoolForFlash()
-      transport = new Transport(port, false)
-      traceRecorder = recordTransportTrace(frame.id, transport)
-      flashTerminal = createUsbLogTerminal(frame.id)
-
-      setFlashMessage('Connecting to the board')
-      const loader = new ESPLoader({ transport, baudrate: 460800, enableTracing: true, terminal: flashTerminal })
-      const chip = await loader.main()
-      setFlashMessage(`Connected to ${chip}`)
-
+      // The image comes first, and the board is only put into download mode
+      // once there are bytes to write. A first build of a chip target takes
+      // tens of minutes; connecting first would hold the chip in the ROM
+      // bootloader for all of it, with the serial port claimed and the frame
+      // showing nothing.
       setPhase('preparing')
       const firmwareStatus = await ensureFirmwareReady(frame.id, setFlashMessage)
       const downloadUrl = firmwareStatus.downloadUrl || `/api/frames/${frame.id}/embedded/firmware/download`
@@ -677,6 +729,18 @@ export function EmbeddedWebFlasher({
       const flashSize = firmwareFlashSize(frame, firmwareStatus)
       setFlashMessage('Downloading firmware image')
       const firmware = await downloadFirmware(downloadUrl)
+
+      // Loaded on demand: esptool-js adds ~380KB we only need when actually flashing
+      const { ESPLoader, Transport } = await loadEsptoolForFlash()
+      transport = new Transport(port, false)
+      traceRecorder = recordTransportTrace(frame.id, transport)
+      flashTerminal = createUsbLogTerminal(frame.id)
+
+      setPhase('connecting')
+      setFlashMessage('Connecting to the board')
+      const loader = new ESPLoader({ transport, baudrate: 460800, enableTracing: true, terminal: flashTerminal })
+      const chip = await loader.main()
+      setFlashMessage(`Connected to ${chip}`)
 
       // Keep-settings: write the image in segments around its NVS partition so
       // whatever the board saved at runtime (Wi-Fi joined over the console,
@@ -829,7 +893,7 @@ export function EmbeddedWebFlasher({
         <button
           type="button"
           onClick={flash}
-          disabled={busy}
+          disabled={disabled || busy}
           className="frameos-primary-action inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40"
         >
           {busy ? <Spinner color="white" /> : <BoltIcon className="h-4 w-4" />}
@@ -839,7 +903,7 @@ export function EmbeddedWebFlasher({
             ? 'Flashing'
             : 'Flash from browser'}
         </button>
-        <EmbeddedUsbConnectionButton frame={frame} disabled={busy} />
+        <EmbeddedUsbConnectionButton frame={frame} disabled={disabled || busy} />
       </div>
       {canKeepSettings ? (
         <label className="frame-tool-muted flex items-center gap-2 text-xs leading-5">

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -80,6 +80,7 @@ import { registeredFramePanel } from './addFramePanelRegistry'
 import { pushScenesOverUsb, pushedScenesMessage } from './embeddedUsbScenePush'
 import { EmbeddedUsbSetup } from './EmbeddedUsbSetup'
 import { EmbeddedUsbConnectionButton, EmbeddedWebFlasher } from './EmbeddedWebFlasher'
+import { EmbeddedReleaseFlasher } from './EmbeddedReleaseFlasher'
 import { frameBootstrapLogic } from './frameBootstrapLogic'
 import { framePendingCommandsLogic, pendingCommandLabel, type FramePendingCommand } from './framePendingCommandsLogic'
 import { workspaceLogic } from './workspaceLogic'
@@ -1937,7 +1938,11 @@ function EmbeddedFirmwareSection({
   onOtaUpdate: () => void
 }): JSX.Element {
   const [copied, setCopied] = useState(false)
-  const [browserFlashBusy, setBrowserFlashBusy] = useState(false)
+  const [buildFlashBusy, setBuildFlashBusy] = useState(false)
+  const [releaseFlashBusy, setReleaseFlashBusy] = useState(false)
+  // Two flashers share one cable and one board; either one running is "busy"
+  // for everything else on this card.
+  const browserFlashBusy = buildFlashBusy || releaseFlashBusy
   const firmware = frame.embedded?.firmware
   const platformLabel = frame.embedded?.platform || 'esp32-s3'
   // Pico-family boards flash a generic UF2 release asset over BOOTSEL and are
@@ -2052,8 +2057,10 @@ function EmbeddedFirmwareSection({
         <>
           <div className="frame-tool-card space-y-4 rounded-[22px] p-4">
             <div className="frame-tool-muted text-sm leading-5">
-              Plug the board into this computer over USB, then flash it straight from the browser. The firmware is built
-              on demand, so the first flash can take a few minutes.
+              Plug the board into this computer over USB, then flash it straight from the browser. “Flash latest
+              release” writes the published image and sends this frame’s settings over the cable — the quick way to a
+              working board. “Flash from browser” compiles an image with those settings baked in instead; the first
+              build of a chip target can take an hour on a small machine.
               {showUsbJtagPortGuidance ? (
                 <span className="mt-2 block">
                   The 13.3&quot; ESP32 board can appear as two serial ports. Choose
@@ -2064,7 +2071,13 @@ function EmbeddedFirmwareSection({
                 </span>
               ) : null}
             </div>
-            <EmbeddedWebFlasher frame={frame} onBusyChange={setBrowserFlashBusy} />
+            {/* Backend mode only, like the release updater below: a device's
+                own frame-admin bundle serves neither /api/frames/firmware nor
+                the provisioning plan. */}
+            {workspaceMode() === 'backend' && hasReleaseFirmwarePlatform(frame) ? (
+              <EmbeddedReleaseFlasher frame={frame} disabled={buildFlashBusy} onBusyChange={setReleaseFlashBusy} />
+            ) : null}
+            <EmbeddedWebFlasher frame={frame} disabled={releaseFlashBusy} onBusyChange={setBuildFlashBusy} />
           </div>
           {/* Backend mode only: the frame-admin bundle renders this section
               too, but a device serves no /api/frames/firmware release pipe —

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -1323,5 +1323,13 @@ export interface FrameEmbeddedConfig {
     lastHeartbeatAt?: string
     completedAt?: string
     error?: string
+    /** Ninja's edge count while `status` is "building", republished on the
+     * build's 15-second heartbeat. A first build of a chip target is ~1100
+     * edges, so this is the difference between "slow" and "hung". */
+    buildProgress?: {
+      done: number
+      total: number
+      percent: number
+    }
   }
 }


### PR DESCRIPTION
Two problems surfaced by a self-hosted ESP32-C3 first flash on a Home Assistant box: the browser flasher compiled a per-frame image nobody needed, and then gave up on that build while it was still running fine.

```
21:45:04  [browser flash] Building firmware image
21:48:26  Compiling firmware: 1/1114 (0%), 3m17s elapsed
...
21:55:08  [browser flash] Flash failed: Timed out waiting for the firmware build
```

## Flash latest release

The firmware card now offers writing the **published generic image** and telling the board what frame it is over the USB console, instead of compiling one with those values baked in.

Nothing required the build. Every panel driver is compiled into every image (`embedded/esp32/main/fos_defaults.h:46` — `FRAMEOS_SELECTED_PANEL` only picks the boot default), and each baked value has a `set` key on the device console (`cmd_set` in `fos_console.c`). It is the shape the cloud's enrollment flasher has always used; its own comment says C3 was excluded there only because the cloud can't render for thin clients, which is exactly what a self-hosted backend *can* do.

The command list comes from the backend (`embedded_provisioning_plan`), built from the same helpers that generate `generated_config.h`, so the two paths cannot drift into producing different frames. `set hardware` leads, because a preset applies a whole board bundle (panel, EPD wiring, buttons, TF socket) that the frame's own values then override.

Four settings exist only as compile-time defaults, and the plan says so rather than shipping a board quietly missing them:

| | |
|---|---|
| TLS certificate | **blocker** — a backend expecting https could not fetch from a device serving plain http |
| Device admin login | warning — every embedded frame gets a generated one, so blocking would block every frame; the board simply answers without it |
| DHCP hostname, HTTP response limit | warning |

## Waiting for a build

The wait was a fixed `10 * 60 * 1000`. A first build of a chip target is ~1100 ESP-IDF objects — half an hour on a NUC, over an hour on a HA box — so a healthy build was reported as a timeout at 18%.

It now waits on the build's heartbeat. The worker already republished `lastHeartbeatAt` every 15 seconds; this adds its ninja edge count alongside it (on the same write, no extra status churn), so the flasher can tell a slow build from a dead one and shows `Building firmware image: 18% (198/1114), 9m elapsed` while it waits. Only a payload that stops moving for 16 minutes counts as a hang — past the point where the backend marks the build failed itself.

The build also happens **before** the board is connected now. Connecting first held the chip in the ROM bootloader, port claimed and frame blank, for the entire build.

## Along the way

- Console values are quoted, which fixes a Wi-Fi password of `a  b` arriving as `a b` and lets an open network's SSID contain spaces (that case used to be refused outright).
- Secrets — `api_key`, `wifi_pass`, `claim_token` — go down the wire but reach the log view redacted instead of in full.

## Left for later

A 16MB ESP32-C3 release asset (noted in `docs/todo.md`). An XTEINK X4 provisions from the 4MB no-OTA generic image today: it works, but three quarters of the chip and OTA go unused — which is what the flasher warns about.

## Testing

- 6 backend tests for the provisioning plan and its endpoint
- 6 frontend tests for the release flasher: the bytes written are the release asset, command ordering, secret redaction, blocked/warned frames
- 4 for the build wait, including one that polls 12.5 simulated minutes — past the old deadline — and still flashes, and one that gives up on a frozen status
- Full suites: 486 backend API tests, 656 cloud vitest, `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)