### PR TITLE
Call the driver back without re-rendering the scene

### DIFF
--- a/frameos/src/frameos/driver_render_hint.nim
+++ b/frameos/src/frameos/driver_render_hint.nim
@@ -20,9 +20,17 @@
 ## Statically linked drivers share the host's copy and skip the round trip.
 ## Only a float ever crosses the boundary.
 ##
-## The request is *advisory*: the runner takes the earliest one asked for since
-## the last pass, clamps it to a floor so a driver cannot spin the loop, and
-## ignores it when the scene already renders sooner.
+## The request is *advisory*, and it asks for a DRIVER callback — not a render.
+## The runner takes the earliest one asked for since the last pass, clamps it to
+## a floor so a driver cannot spin the loop, and then, during its sleep, calls
+## the driver again with the frame it already has. The scene's own schedule is
+## untouched.
+##
+## That distinction is the whole design. Re-rendering the scene to satisfy a
+## driver runs its apps — HTTP fetches, image generation — to produce a frame
+## the driver was already handed, and a panel that never appears would pay that
+## every backoff step forever. Ask for a callback; the pixels are already
+## drawn.
 
 import std/options
 

--- a/frameos/src/frameos/runner.nim
+++ b/frameos/src/frameos/runner.nim
@@ -302,6 +302,12 @@ proc startRenderLoop*(self: RunnerThread, maxCycles = -1): Future[void] {.async.
       driverTimer = getMonoTime()
       markRuntimeCheckpoint("driver:start", currentSceneId = currentScene.id.string, device = self.frameConfig.device,
         clearNode = true)
+      # Set when a driver asks to be called back before the next scheduled
+      # pass. Holding the canvas is the point: the driver wants THIS frame
+      # again, and re-rendering the scene to get another copy of it would run
+      # the scene's apps — HTTP fetches, image generation — once per retry.
+      var driverRetryImage: Image = nil
+      var driverRetrySeconds = 0.0
       try:
         let nextRenderSeconds = if nextSleep >= 0:
             nextSleep
@@ -321,17 +327,22 @@ proc startRenderLoop*(self: RunnerThread, maxCycles = -1): Future[void] {.async.
       except Exception as e:
         self.logger.log(%*{"event": "render:driver:error", "error": $e.msg, "stacktrace": e.getStackTrace()})
       finally:
+        # Read the drivers' answer while the image is still in hand. A driver
+        # that raised is exactly the one most likely to want another try, so
+        # this belongs in the `finally` rather than after it.
+        let earlierRenderRequest = takeEarlierRenderRequest()
+        if earlierRenderRequest.isSome:
+          driverRetrySeconds = max(earlierRenderRequest.get(), DRIVER_RETRY_MIN_SECONDS)
+          driverRetryImage = lastRotatedImage
         lastRotatedImage = nil
         renderResult[0] = nil
         # Return decode/render spikes to the OS on every device; e-ink frames
-        # otherwise hold tens of MB of dead heap between refreshes.
-        reclaimRenderMemory()
+        # otherwise hold tens of MB of dead heap between refreshes. Skipped
+        # while a retry holds the canvas — one canvas for the length of a
+        # retry window is far cheaper than the render that would rebuild it.
+        if driverRetryImage.isNil:
+          reclaimRenderMemory()
         clearNextRenderSeconds()
-      # Read (and clear) whatever the drivers asked for during that render.
-      # Outside the `finally` on purpose: the request has to survive a driver
-      # that raised, which is exactly the driver most likely to want another
-      # try. Applied to the sleep below.
-      let earlierRenderRequest = takeEarlierRenderRequest()
       markRuntimeDone()
 
       if interval < 1 or (nextSleep > 0 and nextSleep < interval):
@@ -377,20 +388,6 @@ proc startRenderLoop*(self: RunnerThread, maxCycles = -1): Future[void] {.async.
       # If no sleep duration provided by the scene, calculate based on the interval
       sleepDuration = if nextSleep >= 0: nextSleep * 1000
                       else: max((interval - durationToSeconds(getMonoTime() - timer)) * 1000, 0.1)
-      # A driver that could not draw — the framebuffer waiting for a KMS
-      # modeset is the live example — asks to be called back sooner than the
-      # scene's own schedule (frameos/driver_render_hint). Advisory: it can
-      # only ever shorten the wait, never lengthen it, and never below the
-      # floor, so a driver stuck in a "not ready" loop costs one cheap probe
-      # every DRIVER_RETRY_MIN_SECONDS rather than a spinning render thread.
-      if earlierRenderRequest.isSome:
-        let requestedMs = max(earlierRenderRequest.get(), DRIVER_RETRY_MIN_SECONDS) * 1000
-        if requestedMs < sleepDuration:
-          self.logger.log(%*{"event": "render:driver:retry",
-            "device": self.frameConfig.device,
-            "inSeconds": round(requestedMs / 1000, 3),
-            "insteadOfSeconds": round(sleepDuration / 1000, 3)})
-          sleepDuration = requestedMs
       self.logger.log(%*{"event": "render:sleep", "ms": round(sleepDuration, 3)})
 
       var nextDriverIdleTurnOffAt =
@@ -398,6 +395,16 @@ proc startRenderLoop*(self: RunnerThread, maxCycles = -1): Future[void] {.async.
           some(getMonoTime() + initDuration(seconds = DRIVER_IDLE_TURN_OFF_HEARTBEAT_SECONDS))
         else:
           none(MonoTime)
+      # "Call me back sooner" from a driver that could not draw — the
+      # framebuffer waiting for a KMS modeset is the live example. It re-runs
+      # the DRIVER against the frame already rendered; it does not re-run the
+      # scene. A panel that never appears therefore costs one cheap ioctl per
+      # backoff step, not a scene render: the first version shortened this
+      # sleep instead, and a headless frame on an hourly interval re-rendered
+      # every 60 seconds forever, apps and all.
+      var nextDriverRetryAt =
+        if driverRetryImage.isNil: none(MonoTime)
+        else: some(getMonoTime() + initDuration(milliseconds = int(driverRetrySeconds * 1000)))
       var remainingSleepMs = sleepDuration
       while remainingSleepMs > 0:
         if self.triggerRenderNext:
@@ -406,9 +413,35 @@ proc startRenderLoop*(self: RunnerThread, maxCycles = -1): Future[void] {.async.
         if nextDriverIdleTurnOffAt.isSome and now >= nextDriverIdleTurnOffAt.get():
           drivers.turnOff()
           nextDriverIdleTurnOffAt = some(now + initDuration(seconds = DRIVER_IDLE_TURN_OFF_HEARTBEAT_SECONDS))
+        if nextDriverRetryAt.isSome and now >= nextDriverRetryAt.get():
+          try:
+            setNextRenderSeconds(remainingSleepMs / 1000)
+            drivers.render(driverRetryImage)
+          except Exception as e:
+            self.logger.log(%*{"event": "render:driver:error", "error": $e.msg})
+          finally:
+            clearNextRenderSeconds()
+          let againRequest = takeEarlierRenderRequest()
+          if againRequest.isSome:
+            let againSeconds = max(againRequest.get(), DRIVER_RETRY_MIN_SECONDS)
+            nextDriverRetryAt = some(getMonoTime() + initDuration(milliseconds = int(againSeconds * 1000)))
+            self.logger.log(%*{"event": "render:driver:retry",
+              "device": self.frameConfig.device,
+              "inSeconds": round(againSeconds, 3)})
+          else:
+            # It drew. Stop holding the canvas and give the memory back.
+            nextDriverRetryAt = none(MonoTime)
+            driverRetryImage = nil
+            reclaimRenderMemory()
+            self.logger.log(%*{"event": "render:driver:drew",
+              "device": self.frameConfig.device})
         let nextSleepMs = min(remainingSleepMs, RENDER_SLEEP_SLICE_MS)
         await sleepAsync(nextSleepMs)
         remainingSleepMs -= nextSleepMs
+      if not driverRetryImage.isNil:
+        # The next pass renders its own frame; do not carry this one into it.
+        driverRetryImage = nil
+        reclaimRenderMemory()
     except Exception as e:
       # Never let one escaped exception kill the render thread (and with it
       # the whole process under systemd). Log, reset state, and back off.

--- a/frameos/src/frameos/tests/test_runner_loop.nim
+++ b/frameos/src/frameos/tests/test_runner_loop.nim
@@ -82,13 +82,13 @@ proc fastInit(sceneId: SceneId, frameConfig: FrameConfig, logger: Logger, persis
     backgroundColor: parseHtmlColor("#ffffff")
   )
 
-proc hourlyInit(sceneId: SceneId, frameConfig: FrameConfig, logger: Logger, persistedState: JsonNode): FrameScene =
+proc oneSecondInit(sceneId: SceneId, frameConfig: FrameConfig, logger: Logger, persistedState: JsonNode): FrameScene =
   FrameScene(
     id: sceneId,
     frameConfig: frameConfig,
     logger: logger,
     state: %*{},
-    refreshInterval: 3600.0,
+    refreshInterval: 1.0,
     backgroundColor: parseHtmlColor("#ffffff")
   )
 
@@ -145,21 +145,26 @@ suite "runner loop safety":
     check runnerThread.lastRenderAt > 0.0
     check sawRenderEvent
 
-  test "a driver asking for an earlier retry shortens the sleep":
+  test "a driver asking for an earlier retry is called back without re-rendering":
     # The framebuffer waiting for a KMS modeset is the live example: without
     # the return channel it is re-probed only on the next scheduled pass, so a
     # frame on a long interval stays blank for an interval after a boot that
     # was seconds from working (frameos/driver_render_hint).
+    #
+    # What it must NOT do is shorten the scene's own schedule. The first
+    # version did, and a headless frame on an hourly interval re-rendered
+    # every 60 seconds forever — running the scene's apps, HTTP fetches and
+    # image generation included — to produce a frame the driver already had.
     clearEventChannel()
     clearEarlierRenderRequest()
 
     let sceneId = "tests/runner/driver-retry".SceneId
     var uploaded = initTable[SceneId, ExportedInterpretedScene]()
     uploaded[sceneId] = ExportedInterpretedScene(
-      name: "Hourly scene",
+      name: "One second scene",
       publicStateFields: @[],
       persistedStateKeys: @[],
-      init: hourlyInit,
+      init: oneSecondInit,
       render: fastRender,
       runEvent: proc (self: FrameScene, context: ExecutionContext): void = discard
     )
@@ -192,22 +197,24 @@ suite "runner loop safety":
     # Stands in for the driver: the runner reads the request off the same
     # thread-local slot whether a statically linked driver wrote it or the host
     # folded it back out of a `.so`.
-    requestEarlierRender(0.3)
-    # Two cycles: the first sleeps (and is the one that must be shortened),
-    # the second breaks out before sleeping again.
+    requestEarlierRender(0.25)
+    # Two cycles: the first sleeps (and is where the callback happens), the
+    # second breaks out before sleeping again.
     waitFor runnerThread.startRenderLoop(maxCycles = 2)
 
-    check hasEvent(store, "render:driver:retry")
+    # The scene keeps its own schedule — the whole point of the fix. (The
+    # sleep is the interval minus the render that just happened, so it lands
+    # just under a second; what matters is that it is nowhere near the 250 ms
+    # the driver asked for.)
     for entry in store.entries:
-      if entry{"event"}.getStr() == "render:driver:retry":
-        check entry{"inSeconds"}.getFloat() == 0.3
-        check entry{"insteadOfSeconds"}.getFloat() > 3000.0
       if entry{"event"}.getStr() == "render:sleep":
-        check entry{"ms"}.getFloat() == 300.0
+        check entry{"ms"}.getFloat() > 900.0
+    # Exactly one scene render per cycle, not one per driver callback.
+    check countEvent(store, "render:done") == 2
     # Consumed, not left standing for the next pass.
     check takeEarlierRenderRequest().isNone
 
-  test "a driver request never lengthens a sleep the scene already wants sooner":
+  test "a driver request leaves a fast scene's schedule alone":
     clearEventChannel()
     clearEarlierRenderRequest()
 
@@ -250,7 +257,12 @@ suite "runner loop safety":
     requestEarlierRender(30.0)
     waitFor runnerThread.startRenderLoop(maxCycles = 2)
 
+    # A request far beyond the scene's own interval never fires inside the
+    # sleep, and never delays the next render either.
     check not hasEvent(store, "render:driver:retry")
+    for entry in store.entries:
+      if entry{"event"}.getStr() == "render:sleep":
+        check entry{"ms"}.getFloat() <= 50.0
 
   test "scene init errors render as scene errors and clear boot guard count":
     let savedBootGuardState = saveBootGuardState()


### PR DESCRIPTION
Found by upgrading a real frame to 2026.8.27 and reading its log.

### What went wrong

The driver retry channel that shipped in 2026.8.27 works by **shortening the
render sleep** — which re-runs the whole render loop. So a driver asking "call
me back in 2 seconds" got a fresh *scene render*, rather than another go at the
frame it had already been handed.

On a Pi with no display attached, on an hourly interval, the loop settled into
this:

```
09:54:26  driver:frameBuffer  "Framebuffer not ready…"  probeError="Unable to open /dev/fb0"
09:54:26  render:driver:retry inSeconds=2  insteadOfSeconds=3600 → render:sleep 2000
09:54:28  render:scene → render:done 32ms  → retry 4  → sleep 4000
09:54:32  render:scene → render:done 32ms  → render:pause "Rendering fast…"
09:54:56  render:scene → render:done 33ms  → retry 32 → sleep 32000
09:55:28  render:scene → log:5 category="building-art-styles"
          render:done 1921ms → retry 60 → sleep 60000
```

A scene render every 60 seconds, forever, on a frame that should render once an
hour — apps, HTTP fetches and image generation included, one of them measured at
1.9 s, to produce pixels the driver already had. It also tripped the fast-render
log suppression, which is the same symptom wearing a different hat.

### The fix

The request asks for a **driver callback**, not a render, and the runner now
treats it that way: it holds the rendered canvas — only while a retry is
outstanding — and re-invokes `drivers.render` from inside its sleep. The
scene's own schedule is untouched.

When the driver finally draws, the canvas is dropped and the memory returned
(`render:driver:drew`). When the sleep ends, it is dropped regardless, because
the next pass renders its own. One canvas held for the length of a retry window
is far cheaper than the render that would rebuild it, which is why
`reclaimRenderMemory` is skipped in exactly that case and nowhere else.

The behaviour that motivated the feature is unchanged: a panel that appears
seconds after boot still gets drawn on within seconds instead of waiting out
the interval — it just costs an ioctl and a blit now instead of a scene.

### Tests

The runner test that asserted "shortens the sleep" now asserts the opposite,
which is the actual contract: with a driver asking for 0.25 s and a scene on a
1 s interval, the sleep stays ~1 s and there is **exactly one `render:done` per
cycle** — not one per driver callback. The module doc in
`driver_render_hint.nim` leads with the distinction, since getting it wrong is
what produced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)