### PR TITLE
Reserve the thin-client framebuffer at boot; report the real chip in /status

### DIFF
--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -111,7 +111,7 @@ EMBEDDED_PLATFORMS: dict[str, dict[str, Any]] = {
 EMBEDDED_PLATFORM_ALIASES = EMBEDDED_PLATFORMS[SUPPORTED_EMBEDDED_PLATFORM]["aliases"]
 EMBEDDED_PROJECT_DIR = REPO_ROOT / "embedded" / "esp32"
 # Bump when the firmware project changes so existing "ready" images rebuild on next request
-EMBEDDED_FIRMWARE_VERSION = 46  # ESP32-C3 platform, TRMNL/XTEINK/Sticky boards, EPD_7in5yr + EPD_3in97 panels
+EMBEDDED_FIRMWARE_VERSION = 47  # boot-time framebuffer reservation (C3 thin-client OOM), honest board.target
 EMBEDDED_DEFAULT_PANEL = "EPD_7in5_V2"
 EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES = 4 * 1024 * 1024
 EMBEDDED_PIN_KEYS = ("rst", "dc", "cs", "cs2", "busy", "sck", "mosi", "pwr")

--- a/backend/app/tasks/frame_deploy_workflow.py
+++ b/backend/app/tasks/frame_deploy_workflow.py
@@ -117,9 +117,16 @@ def _embedded_status_failure_context(body: bytes) -> str | None:
     memory = status.get("memory")
     if isinstance(memory, dict):
         internal_free = memory.get("internalFree")
+        # Free bytes alone read as "plenty of room" on a board that just failed
+        # to allocate: a PSRAM-less C3 can report 120 KB free and still have no
+        # single block big enough for a 96 KB framebuffer. Carry the largest
+        # block whenever the firmware reports it.
+        internal_largest = memory.get("internalLargestBlock")
         psram_free = memory.get("psramFree")
         if isinstance(internal_free, int):
             parts.append(f"internalFree={internal_free}")
+        if isinstance(internal_largest, int):
+            parts.append(f"internalLargestBlock={internal_largest}")
         if isinstance(psram_free, int):
             parts.append(f"psramFree={psram_free}")
 

--- a/backend/app/tasks/tests/test_esp32_board.py
+++ b/backend/app/tasks/tests/test_esp32_board.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Runs embedded/esp32/main/tests/test_fos_board.c.
+#
+# Same arrangement as test_esp32_netguard.py next door, and for the same
+# reason: host tests that nothing invokes are host tests that do not exist.
+#
+# What it covers came out of one XTEINK X4 log. The frame reported
+# `"board":{"target":"esp32-s3","module":"Seeed XIAO ESP32-S3 class"}` — both
+# hardcoded literals — and then failed with "out of memory for 96000 byte
+# framebuffer". It is an ESP32-C3, so the first half sent its reader hunting a
+# broken S3, and the second half is what a C3 does when a 96000-byte
+# contiguous request meets an internal heap that Wi-Fi has already carved up.
+#
+# fos_board.c is pure string mapping, and fos_framebuffer.c keeps its
+# reservation policy above the ESP_PLATFORM guard, so a laptop compiler is all
+# this needs.
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ESP32_DIR = REPO_ROOT / "embedded" / "esp32"
+MAIN_DIR = ESP32_DIR / "main"
+BOARD_SOURCE = MAIN_DIR / "fos_board.c"
+FRAMEBUFFER_SOURCE = MAIN_DIR / "fos_framebuffer.c"
+BOARD_TEST_SOURCE = MAIN_DIR / "tests" / "test_fos_board.c"
+
+
+def test_sources_exist():
+    assert BOARD_SOURCE.is_file(), f"missing {BOARD_SOURCE}"
+    assert FRAMEBUFFER_SOURCE.is_file(), f"missing {FRAMEBUFFER_SOURCE}"
+    assert BOARD_TEST_SOURCE.is_file(), f"missing {BOARD_TEST_SOURCE}"
+
+
+def test_status_json_does_not_hardcode_a_board():
+    """The regression itself: a literal chip name in the status JSON.
+
+    Every board FrameOS supports shares this one builder, so a hardcoded
+    target is wrong for all but one of them — and wrong in the place people
+    look first when a frame misbehaves.
+    """
+    status_json = (MAIN_DIR / "fos_http.c").read_text()
+    assert '"target":\\"esp32-s3\\"' not in status_json
+    assert "Seeed XIAO ESP32-S3 class" not in status_json
+    assert "fos_board_target()" in status_json
+
+
+@pytest.mark.skipif(shutil.which("cc") is None, reason="no C compiler on PATH")
+def test_fos_board_host_tests_pass(tmp_path: Path):
+    binary = tmp_path / "test_fos_board"
+    compile_result = subprocess.run(
+        [
+            "cc",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-O2",
+            "-I",
+            str(MAIN_DIR),
+            str(BOARD_SOURCE),
+            str(FRAMEBUFFER_SOURCE),
+            str(BOARD_TEST_SOURCE),
+            "-o",
+            str(binary),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "board host tests do not compile:\n" + compile_result.stderr
+    )
+
+    run_result = subprocess.run(
+        [str(binary)], capture_output=True, text=True, timeout=180
+    )
+    assert run_result.returncode == 0, (
+        "board host tests failed:\n" + run_result.stdout[-4000:]
+    )
+
+    # Assert the count too: a binary that asserted nothing would also exit 0.
+    summary = re.search(r"(\d+) checks, (\d+) failures", run_result.stdout)
+    assert summary is not None, (
+        "could not find the check summary in the output:\n" + run_result.stdout[-4000:]
+    )
+    checks, failures = int(summary.group(1)), int(summary.group(2))
+    assert failures == 0
+    assert checks >= 20, f"expected the full board suite to run, saw {checks} checks"

--- a/backend/app/tasks/tests/test_frame_deploy_workflow.py
+++ b/backend/app/tasks/tests/test_frame_deploy_workflow.py
@@ -1986,7 +1986,9 @@ async def test_execute_embedded_fast_failure_includes_status_context(monkeypatch
             return 200, json.dumps({
                 "version": "v2026.6.29-14-gd17bbe05",
                 "storage": {"stateBytes": 25165824, "flashBytes": 33554432},
-                "memory": {"internalFree": 123456, "psramFree": 4567890},
+                # A PSRAM-less C3 reports exactly this shape when a render
+                # fails: six figures free, no block big enough to use.
+                "memory": {"internalFree": 123456, "internalLargestBlock": 15872, "psramFree": 0},
                 "scenes": {"loaded": 0, "available": 0},
             }).encode("utf-8"), {}
         return 500, b"UNKNOWN ERROR", {}
@@ -2016,6 +2018,8 @@ async def test_execute_embedded_fast_failure_includes_status_context(monkeypatch
     assert "UNKNOWN ERROR" in str(exc.value)
     assert "version=v2026.6.29-14-gd17bbe05" in str(exc.value)
     assert "stateBytes=25165824" in str(exc.value)
+    assert "internalFree=123456" in str(exc.value)
+    assert "internalLargestBlock=15872" in str(exc.value)
     assert "scenes.loaded=0" in str(exc.value)
     assert frame.status == "uninitialized"
 

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -415,6 +415,20 @@ thin-client mode. Backend local-render builds run the same check
 default 8MB) and fail early with an actionable error; backend-rendered
 thin-client builds are allowed for panels that exceed local PSRAM.
 
+**Thin clients reserve their framebuffer at boot.** A PSRAM-less board (every
+supported ESP32-C3) has no second heap to put the packed panel buffer in, so
+`fos_big_malloc` lands it on internal RAM — and an XTEINK X4 asking a
+Wi-Fi-fragmented C3 heap for 96000 contiguous bytes fails with six figures
+still free. `fos_framebuffer_reserve()` therefore takes that buffer once in
+`app_main`, right after the panel is known and before the network stack
+starts, and `fos_framebuffer_acquire()/release()` lend the same pointer to
+every full-frame call site (render, portal status screen, `display_test`).
+Peak usage is unchanged; what changes is that the allocation can no longer
+fail later. PSRAM boards skip the reservation and keep allocating per render.
+The reservation is skipped, with a log line saying so, if it would leave less
+than `FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE` (96 KB) for Wi-Fi and TLS — a
+frame that renders but cannot fetch is no better than one that retries.
+
 **No image proxies, ever:** when a remote image source serves files too large
 to decode on-device (e.g. multi-MB PNGs), the fix is a streaming decoder —
 incremental inflate with row-by-row unfilter/scale into the render target, so
@@ -431,6 +445,12 @@ Default pins target the XIAO ESP32-S3: CS=GPIO3 (D2), DC=GPIO4 (D3), RST=GPIO5 (
 BUSY=GPIO6 (D5), SCK=GPIO7 (D8), MOSI=GPIO9 (D10). Remap at runtime with `set pins`,
 in the portal, or per-frame via `deviceConfig.pins` in the backend. The 13.3-inch
 Spectra 6 panel (`EPD_13in3e`) has two controllers and requires `cs2`.
+
+`GET /status` reports the chip it is actually running on (`board.target` from
+`CONFIG_IDF_TARGET`, `board.module` and `config.hardwarePreset` from the preset
+the backend baked in). It also reports `memory.internalLargestBlock` next to
+`internalFree`, because on a fragmented heap only the first of those explains
+a failed allocation.
 
 When connected, the device serves `GET /status` (heap/PSRAM/Wi-Fi/render stats JSON)
 and `POST /api/action/render` / `POST /api/action/ota` on port 80. If

--- a/embedded/esp32/main/CMakeLists.txt
+++ b/embedded/esp32/main/CMakeLists.txt
@@ -1,8 +1,10 @@
 idf_component_register(
     SRCS
         "main.c"
+        "fos_board.c"
         "fos_buttons.c"
         "fos_config.c"
+        "fos_framebuffer.c"
         "fos_wifi.c"
         "fos_http.c"
         "fos_client.c"

--- a/embedded/esp32/main/fos_board.c
+++ b/embedded/esp32/main/fos_board.c
@@ -1,0 +1,58 @@
+#include "fos_board.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#ifdef ESP_PLATFORM
+#include "sdkconfig.h"
+#endif
+
+/* Every target ESP-IDF can build for today. A chip missing from this table
+ * reports its raw IDF spelling ("esp32c5") rather than a wrong dashed guess,
+ * which is still readable and still honest — but add the row when FrameOS
+ * starts building for it, because the rest of the stack (the backend's
+ * `platform` keys, the hardware presets) uses the dashed form. */
+static const struct {
+    const char *idf;
+    const char *frameos;
+} k_targets[] = {
+    {"esp32", "esp32"},
+    {"esp32s2", "esp32-s2"},
+    {"esp32s3", "esp32-s3"},
+    {"esp32c2", "esp32-c2"},
+    {"esp32c3", "esp32-c3"},
+    {"esp32c5", "esp32-c5"},
+    {"esp32c6", "esp32-c6"},
+    {"esp32c61", "esp32-c61"},
+    {"esp32h2", "esp32-h2"},
+    {"esp32p4", "esp32-p4"},
+};
+
+const char *fos_board_target_name(const char *idf_target)
+{
+    if (!idf_target || !idf_target[0]) return "unknown";
+    for (size_t i = 0; i < sizeof(k_targets) / sizeof(k_targets[0]); i++) {
+        if (strcmp(idf_target, k_targets[i].idf) == 0) return k_targets[i].frameos;
+    }
+    return idf_target;
+}
+
+const char *fos_board_target(void)
+{
+#ifdef CONFIG_IDF_TARGET
+    return fos_board_target_name(CONFIG_IDF_TARGET);
+#else
+    return "unknown";
+#endif
+}
+
+const char *fos_board_module(const char *hardware_preset)
+{
+    /* The backend bakes the preset key into main/generated_config.h when it
+     * builds an image for a specific frame (and the setup portal can override
+     * it in NVS), so on any board provisioned through FrameOS this is the
+     * exact answer: "xteink_x4", "trmnl_og", "waveshare_esp32_s3_photopainter".
+     * The generic published binary has no preset, so fall back to the chip. */
+    if (hardware_preset && hardware_preset[0]) return hardware_preset;
+    return fos_board_target();
+}

--- a/embedded/esp32/main/fos_board.h
+++ b/embedded/esp32/main/fos_board.h
@@ -1,0 +1,26 @@
+#ifndef FOS_BOARD_H
+#define FOS_BOARD_H
+
+/* What chip and board this firmware is actually running on.
+ *
+ * The status JSON used to hardcode `"target":"esp32-s3"` and
+ * `"module":"Seeed XIAO ESP32-S3 class"`, which was true of the first board
+ * FrameOS supported and of nothing since. A C3 thin client reporting itself
+ * as an S3 sends anyone reading its log down the wrong path: "S3 with 120 KB
+ * free" looks like a broken S3, "C3 with 120 KB free" is a C3 doing exactly
+ * what a C3 does. Report the truth instead. */
+
+/* Maps an ESP-IDF CONFIG_IDF_TARGET value ("esp32c3") to the platform
+ * spelling FrameOS uses everywhere else ("esp32-c3"). Unknown targets come
+ * back verbatim rather than guessed at. Pure string work, no IDF. */
+const char *fos_board_target_name(const char *idf_target);
+
+/* The chip this image was built for, in FrameOS platform spelling. */
+const char *fos_board_target(void);
+
+/* Human-facing board label: the hardware preset the backend baked into the
+ * image (or an NVS override) when there is one, else a chip-derived
+ * fallback. Never NULL. */
+const char *fos_board_module(const char *hardware_preset);
+
+#endif /* FOS_BOARD_H */

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -26,6 +26,7 @@
 #include "fos_buttons.h"
 #include "fos_cloud.h"
 #include "fos_config.h"
+#include "fos_framebuffer.h"
 #include "fos_mem.h"
 #include "fos_ota.h"
 #include "fos_scenes.h"
@@ -679,10 +680,18 @@ static esp_err_t render_once(void)
         err = frameos_nim_render_alloc(&buf, &buf_len, fos_display_format()) == 0 ? ESP_OK : ESP_FAIL;
         if (err != ESP_OK) ESP_LOGE(TAG, "nim render failed");
     } else {
-        buf = fos_big_malloc(buf_len);
-        if (!buf) buf = malloc(buf_len);
+        buf = fos_framebuffer_acquire(buf_len);
         if (!buf) {
-            ESP_LOGE(TAG, "out of memory for %u byte framebuffer", (unsigned)buf_len);
+            /* Free bytes alone never explained this failure — a C3 with 120 KB
+             * free and a largest block of 16 KB cannot hold 96000 contiguous
+             * bytes. Print what actually decides it. */
+            ESP_LOGE(TAG, "out of memory for %u byte framebuffer "
+                          "(internal free=%u largest=%u, psram total=%u, reserved=%u)",
+                     (unsigned)buf_len,
+                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+                     (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),
+                     (unsigned)heap_caps_get_total_size(MALLOC_CAP_SPIRAM),
+                     (unsigned)fos_framebuffer_reserved_bytes());
             log_render_event("render:error", scene_id, scene_name, "error", "allocate",
                              mode, "none", "out-of-memory", render_attempt,
                              (esp_timer_get_time() - start) / 1000, width, height,
@@ -768,7 +777,9 @@ static esp_err_t render_once(void)
                      err == ESP_OK ? s_render_count : render_attempt, total_ms,
                      width, height, format, buf_len, err);
     frameos_nim_flush_logs();
-    free(buf);
+    /* Returns the reservation to the pool, or frees a one-off allocation —
+     * including the Nim renderer's buffer on the local-render path. */
+    fos_framebuffer_release(buf);
     if (err != ESP_OK) {
         render_failure_recover(scene_name);
     }

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -29,6 +29,7 @@
 #include "fos_client.h"
 #include "fos_cloud.h"
 #include "fos_config.h"
+#include "fos_framebuffer.h"
 #include "fos_http.h"
 #include "fos_mem.h"
 #include "fos_ota.h"
@@ -713,8 +714,7 @@ static int cmd_display_test(int argc, char **argv)
         return 1;
     }
 
-    uint8_t *buf = fos_big_malloc(len);
-    if (!buf) buf = malloc(len);
+    uint8_t *buf = fos_framebuffer_acquire(len);
     if (!buf) {
         printf("display_test: allocation failed (%u bytes)\n", (unsigned)len);
         return 1;
@@ -746,7 +746,7 @@ static int cmd_display_test(int argc, char **argv)
     printf("display_test: mode=%s panel=%s %dx%d format=%d bytes=%u\n",
            mode, fos_display_selected_panel(), width, height, (int)format, (unsigned)len);
     esp_err_t err = fos_display_blit(buf, len);
-    free(buf);
+    fos_framebuffer_release(buf);
     printf("display_test: %s (%d)\n", err == ESP_OK ? "ESP_OK" : esp_err_to_name(err), (int)err);
     return err == ESP_OK ? 0 : 1;
 }

--- a/embedded/esp32/main/fos_framebuffer.c
+++ b/embedded/esp32/main/fos_framebuffer.c
@@ -1,0 +1,105 @@
+#include "fos_framebuffer.h"
+
+#ifdef ESP_PLATFORM
+#include <stdlib.h>
+
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+#include "fos_mem.h"
+
+static const char *TAG = "fos_fb";
+#endif
+
+bool fos_framebuffer_should_reserve(size_t len, size_t psram_total, size_t internal_free)
+{
+    if (len == 0) return false;
+    /* PSRAM boards allocate these buffers from PSRAM, where a per-render
+     * malloc has never been the failing step. Leave that path alone. */
+    if (psram_total > 0) return false;
+    if (internal_free < len) return false;
+    return internal_free - len >= FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE;
+}
+
+#ifdef ESP_PLATFORM
+
+static uint8_t *s_reserved;
+static size_t s_reserved_len;
+static SemaphoreHandle_t s_lock;
+
+void fos_framebuffer_reserve(size_t len)
+{
+    if (s_reserved) return;
+
+    size_t psram_total = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
+    size_t internal_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (!fos_framebuffer_should_reserve(len, psram_total, internal_free)) {
+        if (psram_total == 0 && len > 0) {
+            ESP_LOGW(TAG, "framebuffer not reserved: the panel needs %u bytes, %u internal "
+                          "bytes are free and %u must stay for Wi-Fi/TLS. Renders will "
+                          "allocate per cycle and can fail once the heap fragments.",
+                     (unsigned)len, (unsigned)internal_free,
+                     (unsigned)FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE);
+        }
+        return;
+    }
+
+    if (!s_lock) s_lock = xSemaphoreCreateMutex();
+    if (!s_lock) {
+        ESP_LOGW(TAG, "framebuffer not reserved: no memory for the lock");
+        return;
+    }
+
+    uint8_t *buf = heap_caps_malloc(len, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (!buf) {
+        /* should_reserve() said it fits, so this means the largest free block
+         * is already smaller than the total — i.e. we are being called later
+         * than intended. Say so; the fix is the call site, not the size. */
+        ESP_LOGW(TAG, "framebuffer not reserved: %u bytes free but no block that big "
+                      "(largest=%u) — reserve earlier in boot",
+                 (unsigned)internal_free,
+                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+        return;
+    }
+
+    s_reserved = buf;
+    s_reserved_len = len;
+    ESP_LOGI(TAG, "framebuffer reserved: %u bytes held for the panel (no PSRAM on this "
+                  "module), %u internal bytes left for the rest of the system",
+             (unsigned)len,
+             (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+}
+
+uint8_t *fos_framebuffer_acquire(size_t len)
+{
+    if (len == 0) return NULL;
+    /* Non-blocking on purpose: a console `display_test` asking for the buffer
+     * mid-render should fail immediately and say so, not stall the console for
+     * the twenty seconds an e-paper refresh takes. */
+    if (s_reserved && len == s_reserved_len && s_lock &&
+        xSemaphoreTake(s_lock, 0) == pdTRUE) {
+        return s_reserved;
+    }
+    uint8_t *buf = fos_big_malloc(len);
+    if (!buf) buf = malloc(len);
+    return buf;
+}
+
+void fos_framebuffer_release(uint8_t *buf)
+{
+    if (!buf) return;
+    if (buf == s_reserved) {
+        xSemaphoreGive(s_lock);
+        return;
+    }
+    free(buf);
+}
+
+size_t fos_framebuffer_reserved_bytes(void)
+{
+    return s_reserved ? s_reserved_len : 0;
+}
+
+#endif /* ESP_PLATFORM */

--- a/embedded/esp32/main/fos_framebuffer.h
+++ b/embedded/esp32/main/fos_framebuffer.h
@@ -1,0 +1,56 @@
+#ifndef FOS_FRAMEBUFFER_H
+#define FOS_FRAMEBUFFER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* The one panel-sized buffer a thin client reuses for every full-frame
+ * operation.
+ *
+ * On a PSRAM board these buffers come out of PSRAM (see fos_mem.h) where
+ * there are megabytes to spare and a per-render malloc/free is free of
+ * consequence. On a PSRAM-less ESP32-C3 the same call lands on the internal
+ * heap, and there it is a different thing entirely: an XTEINK X4 (4.26"
+ * 800x480, four-grey) needs 96000 contiguous bytes out of the ~380 KB the
+ * chip has, on a heap that Wi-Fi, lwIP and httpd have already carved up. It
+ * works on the first boot and stops working the moment anything fragments —
+ * "render #1 failed at allocate: out-of-memory" with 120 KB free, because no
+ * single free block was big enough.
+ *
+ * So take the buffer once, at boot, while the heap is still whole, and hand
+ * the same pointer to every caller for the life of the process. Peak usage is
+ * unchanged (these call sites were always mutually exclusive in practice);
+ * what changes is that the allocation can no longer fail later. */
+
+/* Reserve the buffer. Call once at boot, after the panel is known and before
+ * the network stack starts. No-op on boards with PSRAM, and a no-op (with a
+ * log line saying so) when the reservation would not leave enough internal
+ * heap for Wi-Fi and TLS. */
+void fos_framebuffer_reserve(size_t len);
+
+/* Borrow a panel-sized buffer: the reservation when it fits and is not
+ * already lent out, otherwise a fresh allocation, otherwise NULL. Pair every
+ * non-NULL return with fos_framebuffer_release(). */
+uint8_t *fos_framebuffer_acquire(size_t len);
+
+/* Hand a buffer back. Anything that is not the reservation is freed. NULL is
+ * accepted and ignored. */
+void fos_framebuffer_release(uint8_t *buf);
+
+/* Bytes held by the boot-time reservation, 0 when there is none. Reported in
+ * the status JSON so "why did this render fail" is answerable from a log. */
+size_t fos_framebuffer_reserved_bytes(void);
+
+/* Reservation policy, split out so the host tests can pin it: reserve only on
+ * PSRAM-less boards, only when the buffer fits, and only when enough internal
+ * heap survives it for the network stack. */
+bool fos_framebuffer_should_reserve(size_t len, size_t psram_total, size_t internal_free);
+
+/* Internal heap that must remain after the reservation. Wi-Fi plus lwIP plus
+ * an httpd instance sit around 60-80 KB on the C3; this leaves room for that
+ * and a TLS handshake on top. A panel that cannot clear this bar keeps the
+ * old per-render allocation — worse, but not "the frame never joins Wi-Fi". */
+#define FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE (96u * 1024u)
+
+#endif /* FOS_FRAMEBUFFER_H */

--- a/embedded/esp32/main/fos_http.c
+++ b/embedded/esp32/main/fos_http.c
@@ -27,9 +27,11 @@
 #include "fos_assets.h"
 #include "fos_assets_sd.h"
 #include "fos_battery.h"
+#include "fos_board.h"
 #include "fos_client.h"
 #include "fos_cloud.h"
 #include "fos_config.h"
+#include "fos_framebuffer.h"
 #include "fos_mem.h"
 #include "fos_scenes.h"
 #include "fos_wifi.h"
@@ -695,6 +697,11 @@ char *fos_http_status_json(void)
     const char *snapshot_mode = fos_client_snapshot_mode();
     bool display_state_ready = fos_client_display_state_ready();
     size_t internal_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    /* Free bytes on their own mislead: the render that fails at 96000 bytes
+     * often does so with six figures free, because none of it is contiguous.
+     * Report the largest block next to the total so a log can tell the two
+     * apart. */
+    size_t internal_largest = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     size_t psram_free = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
     size_t psram_total = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
     const char *scene_json = frameos_nim_scene_info_json();
@@ -711,6 +718,11 @@ char *fos_http_status_json(void)
     char *partition = json_escape_dup(running ? running->label : "?");
     char *ip = json_escape_dup(fos_wifi_ip());
     char *panel = json_escape_dup(config->panel);
+    /* The preset key ("xteink_x4") is the one field that says which physical
+     * board this is; without it a log cannot distinguish a C3 thin client
+     * from an S3 with the same panel. NVS-settable, so it gets escaped. */
+    char *hardware_preset = json_escape_dup(config->hardware_preset);
+    char *board_module = json_escape_dup(fos_board_module(config->hardware_preset));
     char *pins_json = json_escape_dup(pins);
     char *sd_pins_json = json_escape_dup(sd_pins);
     char *assets_path = json_escape_dup(config->assets_path);
@@ -721,10 +733,12 @@ char *fos_http_status_json(void)
      * what makes SD problems unanswerable from the panel. */
     char *sd_error = json_escape_dup(fos_assets_sd_last_error());
     if (!app_name || !app_version || !idf_version || !partition || !ip ||
-        !panel || !pins_json || !sd_pins_json || !assets_path || !backend || !ssid || !nim_info ||
+        !panel || !hardware_preset || !board_module ||
+        !pins_json || !sd_pins_json || !assets_path || !backend || !ssid || !nim_info ||
         !sd_error || !cloud_url || !cloud_frame_id || !cloud_error) {
         free(app_name); free(app_version); free(idf_version); free(partition); free(ip);
-        free(panel); free(pins_json); free(sd_pins_json); free(assets_path); free(backend); free(ssid); free(nim_info);
+        free(panel); free(hardware_preset); free(board_module);
+        free(pins_json); free(sd_pins_json); free(assets_path); free(backend); free(ssid); free(nim_info);
         free(sd_error);
         free(cloud_url); free(cloud_frame_id); free(cloud_error);
         return NULL;
@@ -734,8 +748,9 @@ char *fos_http_status_json(void)
     int len = asprintf(&json,
         "{\"app\":\"%s\",\"version\":\"%s\",\"elfSha256\":\"%s\",\"idf\":\"%s\",\"partition\":\"%s\","
         "\"uptimeSec\":%lld,"
-        "\"board\":{\"target\":\"esp32-s3\",\"module\":\"Seeed XIAO ESP32-S3 class\",\"display\":\"%s\"},"
-        "\"memory\":{\"internalFree\":%u,\"psramFree\":%u,\"psramTotal\":%u},"
+        "\"board\":{\"target\":\"%s\",\"module\":\"%s\",\"display\":\"%s\"},"
+        "\"memory\":{\"internalFree\":%u,\"psramFree\":%u,\"psramTotal\":%u,"
+        "\"internalLargestBlock\":%u,\"framebufferReserved\":%u},"
         "\"storage\":{\"flashBytes\":%u,\"nvsBytes\":%u,\"otadataBytes\":%u,\"phyBytes\":%u,"
         "\"factorySlotBytes\":%u,\"otaSlots\":%u,\"otaSlotBytes\":%u,\"otaBytes\":%u,"
         "\"stateBytes\":%u},"
@@ -755,15 +770,17 @@ char *fos_http_status_json(void)
         /* enrollment state only — no claim token, access token, or key */
         "\"cloud\":{\"state\":\"%s\",\"url\":\"%s\",\"frameId\":\"%s\","
         "\"wsConnected\":%s,\"error\":\"%s\"},"
-        "\"config\":{\"frameId\":%lu,\"panel\":\"%s\",\"renderMode\":\"%s\","
+        "\"config\":{\"frameId\":%lu,\"panel\":\"%s\","
+        "\"hardwarePreset\":\"%s\",\"renderMode\":\"%s\","
         "\"intervalSec\":%lu,\"maxHttpResponseBytes\":%lu,"
         "\"serverSendLogs\":%s,\"tlsEnabled\":%s,\"tlsActive\":%s,\"tlsPort\":%u,"
         "\"deepSleep\":%s,\"wakeSchedule\":%s,\"pins\":\"%s\","
         "\"backendUrl\":\"%s\",\"wifiSsid\":\"%s\"}}",
         app_name, app_version, elf_sha, idf_version, partition,
         esp_timer_get_time() / 1000000,
-        panel,
+        fos_board_target(), board_module, panel,
         (unsigned)internal_free, (unsigned)psram_free, (unsigned)psram_total,
+        (unsigned)internal_largest, (unsigned)fos_framebuffer_reserved_bytes(),
         (unsigned)storage.flash_bytes, (unsigned)storage.nvs_bytes,
         (unsigned)storage.otadata_bytes, (unsigned)storage.phy_bytes,
         (unsigned)storage.factory_slot_bytes, (unsigned)storage.ota_slots,
@@ -790,7 +807,7 @@ char *fos_http_status_json(void)
         nim_info, scene_json,
         fos_cloud_state_name(), cloud_url, cloud_frame_id,
         fos_cloud_ws_connected() ? "true" : "false", cloud_error,
-        (unsigned long)config->frame_id, panel,
+        (unsigned long)config->frame_id, panel, hardware_preset,
         config->render_mode == FOS_RENDER_LOCAL ? "local" : "remote",
         (unsigned long)config->interval_sec,
         (unsigned long)config->max_http_response_bytes,
@@ -800,7 +817,8 @@ char *fos_http_status_json(void)
         config->wake_schedule ? "true" : "false",
         pins_json, backend, ssid);
     free(app_name); free(app_version); free(idf_version); free(partition); free(ip);
-    free(panel); free(pins_json); free(sd_pins_json); free(assets_path); free(backend); free(ssid); free(nim_info);
+    free(panel); free(hardware_preset); free(board_module);
+    free(pins_json); free(sd_pins_json); free(assets_path); free(backend); free(ssid); free(nim_info);
     free(sd_error);
     free(cloud_url); free(cloud_frame_id); free(cloud_error);
     if (len < 0 || !json) {

--- a/embedded/esp32/main/fos_status_screen.c
+++ b/embedded/esp32/main/fos_status_screen.c
@@ -1,5 +1,5 @@
 #include "fos_status_screen.h"
-#include "fos_mem.h"
+#include "fos_framebuffer.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -208,9 +208,9 @@ esp_err_t fos_status_screen_show_portal(const char *ssid, const char *ip)
     int height = fos_display_height();
     fos_pixel_format_t format = fos_display_format();
     size_t len = fos_display_buffer_size();
-    uint8_t *buf = fos_big_malloc(len);
+    uint8_t *buf = fos_framebuffer_acquire(len);
     if (!buf) {
-        ESP_LOGE(TAG, "out of PSRAM for %u byte status screen", (unsigned)len);
+        ESP_LOGE(TAG, "out of memory for %u byte status screen", (unsigned)len);
         return ESP_ERR_NO_MEM;
     }
     memset(buf, white_fill(format), len);
@@ -240,7 +240,7 @@ esp_err_t fos_status_screen_show_portal(const char *ssid, const char *ip)
     draw_centered(buf, width, height, format, ip_line, y, scale);
 
     esp_err_t err = fos_display_blit(buf, len);
-    free(buf);
+    fos_framebuffer_release(buf);
     if (err == ESP_OK) {
         ESP_LOGI(TAG, "portal status screen rendered: ssid=%s ip=%s",
                  ssid_line, ip && ip[0] ? ip : "192.168.4.1");

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -32,6 +32,7 @@
 #include "fos_cloud.h"
 #include "fos_config.h"
 #include "fos_console.h"
+#include "fos_framebuffer.h"
 #include "fos_http.h"
 #include "fos_ota.h"
 #include "fos_scenes.h"
@@ -151,6 +152,15 @@ void app_main(void)
     BOOTMEM("after-config");
     if (fos_display_init(&display_config) != ESP_OK) {
         ESP_LOGW(TAG, "display init failed, continuing headless");
+    }
+
+    /* Claim the panel buffer here — the panel size is known and Wi-Fi, lwIP,
+     * httpd and SPIFFS have not yet carved up the internal heap. On a
+     * PSRAM-less C3 this is the difference between a frame that renders and
+     * one that reports "out of memory for 96000 byte framebuffer" with 120 KB
+     * free but no block that size. No-op on PSRAM boards. */
+    if (fos_display_present()) {
+        fos_framebuffer_reserve(fos_display_buffer_size());
     }
 
     /* fos_assets_sd_mount emits its own structured "assets:sd" line into the

--- a/embedded/esp32/main/tests/test_fos_board.c
+++ b/embedded/esp32/main/tests/test_fos_board.c
@@ -1,0 +1,125 @@
+/*
+ * Host tests for the board-identity strings and the framebuffer reservation
+ * policy. No IDF, no CMake, no mocks — both files keep their decisions as
+ * plain C so a laptop compiler can argue with them.
+ *
+ * Build and run (from embedded/esp32/):
+ *
+ *   cc -std=c11 -Wall -Wextra -Werror -O2 -Imain \
+ *      main/fos_board.c main/fos_framebuffer.c main/tests/test_fos_board.c \
+ *      -o /tmp/test_fos_board && /tmp/test_fos_board
+ *
+ * (backend/app/tasks/tests/test_esp32_board.py does exactly that in CI.)
+ *
+ * Both halves come from one bug report: an XTEINK X4 — an ESP32-C3 thin
+ * client — logged `"board":{"target":"esp32-s3"}` and then died with "out of
+ * memory for 96000 byte framebuffer". The target was a hardcoded literal, so
+ * the log sent its reader looking for a broken S3; the OOM was a C3 asking
+ * its fragmented internal heap for 96000 contiguous bytes. The assertions
+ * below are what stops either from coming back quietly.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "fos_board.h"
+#include "fos_framebuffer.h"
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond, ...)                                                       \
+    do {                                                                       \
+        g_checks++;                                                            \
+        if (!(cond)) {                                                         \
+            g_failures++;                                                      \
+            printf("FAIL %s:%d: ", __func__, __LINE__);                        \
+            printf(__VA_ARGS__);                                               \
+            printf("\n");                                                      \
+        }                                                                      \
+    } while (0)
+
+static void expect_target(const char *idf, const char *want)
+{
+    const char *got = fos_board_target_name(idf);
+    CHECK(strcmp(got, want) == 0, "target(%s) = %s, want %s", idf, got, want);
+}
+
+static void test_target_names(void)
+{
+    /* The two chips FrameOS actually ships: the whole point of the change is
+     * that these are no longer the same string. */
+    expect_target("esp32c3", "esp32-c3");
+    expect_target("esp32s3", "esp32-s3");
+    CHECK(strcmp(fos_board_target_name("esp32c3"),
+                 fos_board_target_name("esp32s3")) != 0,
+          "a C3 and an S3 must not report the same target");
+
+    /* Dashed to match the backend's `platform` keys and the hardware presets,
+     * which is what makes a status line comparable to a build config. */
+    expect_target("esp32", "esp32");
+    expect_target("esp32s2", "esp32-s2");
+    expect_target("esp32c2", "esp32-c2");
+    expect_target("esp32c5", "esp32-c5");
+    expect_target("esp32c6", "esp32-c6");
+    expect_target("esp32c61", "esp32-c61");
+    expect_target("esp32h2", "esp32-h2");
+    expect_target("esp32p4", "esp32-p4");
+
+    /* An unmapped chip stays readable rather than becoming a wrong guess. */
+    expect_target("esp32c99", "esp32c99");
+    expect_target("", "unknown");
+    expect_target(NULL, "unknown");
+}
+
+static void test_module_label(void)
+{
+    /* The preset key is the only field that names the physical board. */
+    CHECK(strcmp(fos_board_module("xteink_x4"), "xteink_x4") == 0,
+          "a baked-in preset must be reported verbatim");
+    /* The generic published binary carries no preset; fall back to the chip
+     * rather than to a board nobody flashed. */
+    CHECK(strcmp(fos_board_module(""), fos_board_target()) == 0,
+          "an empty preset must fall back to the chip");
+    CHECK(fos_board_module(NULL) != NULL, "NULL preset must not return NULL");
+}
+
+/* The 4.26" 800x480 four-grey panel on the XTEINK X4 — the case that failed. */
+#define PANEL_4IN26_BYTES 96000u
+/* A C3 at the point in boot where the reservation is taken. */
+#define C3_BOOT_FREE 280000u
+
+static void test_reservation_policy(void)
+{
+    CHECK(fos_framebuffer_should_reserve(PANEL_4IN26_BYTES, 0, C3_BOOT_FREE),
+          "a C3 with a whole heap must reserve the 4.26in panel buffer");
+
+    /* PSRAM boards keep the old per-render path: PSRAM is where these buffers
+     * belong and a malloc there has never been the failing step. */
+    CHECK(!fos_framebuffer_should_reserve(PANEL_4IN26_BYTES, 8u * 1024 * 1024, C3_BOOT_FREE),
+          "a PSRAM board must not reserve internal RAM");
+
+    /* Reserving must never cost the frame its network stack: a frame that
+     * renders but cannot fetch is not better than one that retries. */
+    CHECK(!fos_framebuffer_should_reserve(PANEL_4IN26_BYTES, 0,
+                                          PANEL_4IN26_BYTES + FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE - 1),
+          "must not reserve when too little heap would survive it");
+    CHECK(fos_framebuffer_should_reserve(PANEL_4IN26_BYTES, 0,
+                                         PANEL_4IN26_BYTES + FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE),
+          "must reserve at exactly the floor");
+
+    /* Free heap smaller than the buffer: no underflow, just no. */
+    CHECK(!fos_framebuffer_should_reserve(PANEL_4IN26_BYTES, 0, 1024),
+          "must not reserve more than the heap holds");
+    CHECK(!fos_framebuffer_should_reserve(0, 0, C3_BOOT_FREE),
+          "a headless board has no panel buffer to reserve");
+}
+
+int main(void)
+{
+    test_target_names();
+    test_module_label();
+    test_reservation_policy();
+    printf("%s: %d checks, %d failures\n", g_failures ? "FAILED" : "ok",
+           g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Where this came from

A user's XTEINK X4 — an **ESP32-C3** thin client driving a 4.26" 800x480
four-grey panel — failed every render:

```
{"board":{"target":"esp32-s3","module":"Seeed XIAO ESP32-S3 class",...},
 "memory":{"internalFree":120168,"psramFree":0,"psramTotal":0}, ...}
W (102709) fos_http: https server skipped: internal=23848 largest=15872 ...
E (103329) fos_client: out of memory for 96000 byte framebuffer
render #1 failed at allocate: out-of-memory
```

Two independent bugs, and the first one hid the second.

## 1. The status JSON was lying about the chip

`board.target` and `board.module` were **string literals** in
`fos_http.c` — true of the first board FrameOS supported and of nothing
since. Every board shares that one builder, so the field was wrong for all
but one of them, in the exact place someone looks first when a frame
misbehaves. "An S3 with 120 KB free" reads like a broken S3; "a C3 with
120 KB free" reads like a C3 doing what a C3 does.

- `board.target` now comes from `CONFIG_IDF_TARGET`, mapped to the dashed
  spelling the backend's `platform` keys already use (`esp32c3` →
  `esp32-c3`).
- `board.module` and a new `config.hardwarePreset` come from the preset the
  backend bakes into `generated_config.h` (`xteink_x4`, `trmnl_og`, …) —
  the only field that names the physical board. Unmapped chips report their
  raw IDF spelling rather than a wrong guess.

**The frame was already running as a C3 thin client** (`renderMode: remote`,
and an S3 binary would not boot on a RISC-V chip at all). Nothing was
mis-selected; the log just could not say so.

## 2. The OOM is what a C3 does

With no PSRAM, `fos_big_malloc` puts the packed panel buffer on the internal
heap. 96000 **contiguous** bytes is not something a ~380 KB chip can promise
once Wi-Fi, lwIP and httpd have carved it up: free bytes stay in six figures
while the largest block falls to ~16 KB. It works on the first boot and
stops working forever after.

`fos_framebuffer_reserve()` takes that buffer **once in `app_main`**, right
after the panel is known and before the network stack starts, and
`fos_framebuffer_acquire()/release()` lend the same pointer to every
full-frame call site — render, portal status screen, `display_test`. Those
sites were always mutually exclusive in practice, so **peak usage is
unchanged**; what changes is that the allocation can no longer fail later.

- PSRAM boards skip the reservation entirely and keep the current
  per-render path — PSRAM is where those buffers belong and a malloc there
  has never been the failing step.
- The reservation is skipped, with a log line saying why, if it would leave
  under 96 KB of internal heap for Wi-Fi and TLS. A frame that renders but
  cannot fetch is no better than one that retries.
- `acquire()` is non-blocking: a console `display_test` during a render
  fails immediately instead of stalling for the ~20 s an e-paper refresh
  takes.

## 3. So the next one is answerable from a log

- `memory.internalLargestBlock` and `memory.framebufferReserved` in
  `/status` — free bytes alone never explained this failure.
- The same pair in the deploy-failure summary
  (`frame_deploy_workflow`), which was reporting the misleading number.
- The render OOM now prints largest-block, PSRAM total and reservation
  state instead of just the size it wanted.

## Verification

- ESP32-**C3** and ESP32-**S3** images both build clean against IDF v5.5.4
  (16MB OTA profile).
- New host tests (`main/tests/test_fos_board.c`, run in CI by
  `backend/app/tasks/tests/test_esp32_board.py`): 23 checks over the target
  mapping, the module fallback, and the reservation policy — including a
  guard that a C3 and an S3 can never again report the same target, and one
  that the status builder contains no hardcoded chip name.
- `backend/app/tasks/` + embedded API suites: 424 passed, 4 skipped.
- `EMBEDDED_FIRMWARE_VERSION` 46 → 47 so existing "ready" images rebuild.

**Not verified on hardware** — I have no C3 board here. The thing to watch on
a real XTEINK X4 is the boot line `framebuffer reserved: 96000 bytes held for
the panel, N internal bytes left`: N should land near 190 KB, and the frame
should then render where it previously could not. If N comes out too low,
`FOS_FRAMEBUFFER_MIN_HEAP_AFTER_RESERVE` is the dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)