### PR TITLE
ESP32-C3: stop counting every failed render as a PSRAM rescue

### DIFF
--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -828,6 +828,15 @@ void fos_client_render_recovery_boot(void)
         s_render_recovery_restarts = 0;
         return;
     }
+    if (heap_caps_get_total_size(MALLOC_CAP_SPIRAM) == 0) {
+        /* No PSRAM, so no rescue ever fires (see render_failure_recover) and
+         * nothing to stay paused for. Also clears a streak left in RTC memory
+         * by a firmware that still counted on such boards: an OTA reboot is a
+         * software reset, so that frame would otherwise come up paused. */
+        s_render_recovery_magic = FOS_RENDER_RECOVERY_MAGIC;
+        s_render_recovery_restarts = 0;
+        return;
+    }
     if (s_render_recovery_magic != FOS_RENDER_RECOVERY_MAGIC) {
         /* First boot on this board, or RTC memory that was never stamped. */
         s_render_recovery_magic = FOS_RENDER_RECOVERY_MAGIC;
@@ -863,6 +872,16 @@ void fos_client_clear_render_pause(void)
 
 static void render_failure_recover(const char *scene_name)
 {
+    /* The rescue exists for boards where a failed render can leave PSRAM
+     * held forever. A board with no PSRAM at all (ESP32-C3 thin clients)
+     * cannot be in that state, yet its free-PSRAM reading is 0 — below any
+     * threshold — so without this check every ordinary render failure (a
+     * fetch that timed out, the server not ready yet) counted as a memory
+     * rescue: reboot, and after two in a row the frame paused rendering
+     * blaming "exhausted PSRAM". Seen in the field on a C3. */
+    if (heap_caps_get_total_size(MALLOC_CAP_SPIRAM) == 0) {
+        return;
+    }
     size_t free_psram = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (free_psram >= FOS_RENDER_RECOVERY_MIN_PSRAM) {
         return; /* memory came back; nothing to recover from */

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -2316,6 +2316,7 @@ static void ws_event_handler(void *arg, esp_event_base_t base, int32_t event_id,
             s_metrics_granted = false;
             s_ws_backoff_advanced = false; /* a new attempt got this far */
             ESP_LOGI(TAG, "ws: connected, sending hello");
+            FOS_MEM_LOG_MILESTONE(TAG, "cloud-connected");
             ws_send_hello();
             break;
         case WEBSOCKET_EVENT_ERROR:

--- a/embedded/esp32/main/fos_mem.h
+++ b/embedded/esp32/main/fos_mem.h
@@ -2,6 +2,7 @@
 #define FOS_MEM_H
 
 #include "esp_heap_caps.h"
+#include "esp_log.h"
 
 // Large-buffer allocation. On boards with PSRAM these buffers must come from
 // PSRAM only: exhausting it is contained there, and internal SRAM stays free
@@ -23,5 +24,19 @@ static inline void *fos_big_realloc(void *ptr, size_t size)
     }
     return heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT);
 }
+
+// One always-on heap line per boot milestone: internal free / largest block /
+// lowest-ever free, plus PSRAM free when the module has any. Cheap enough to
+// keep on in shipping firmware — the point is that a field log answers "what
+// ate the heap on this board" without a -DFRAMEOS_BOOTMEM=1 rebuild. On a
+// PSRAM-less C3 the whole system lives in ~170 KB after static data, and the
+// difference between "renders" and "httpd_start failed" is a few KB.
+#define FOS_MEM_LOG_MILESTONE(tag, stage)                                              \
+    ESP_LOGI(tag, "heap %-16s internal free=%u largest=%u min-ever=%u psram free=%u", \
+             stage,                                                                    \
+             (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT), \
+             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT), \
+             (unsigned)heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT), \
+             (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM))
 
 #endif // FOS_MEM_H

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -38,6 +38,7 @@
 #include "fos_scenes.h"
 #include "fos_schedule.h"
 #include "fos_status_screen.h"
+#include "fos_mem.h"
 #include "fos_wifi.h"
 #include "frameos_display.h"
 #include "frameos_nim.h"
@@ -168,6 +169,7 @@ void app_main(void)
      * below) — a mount failure must never be a serial-only event, or "why are
      * my assets empty?" has no remote answer. */
     BOOTMEM("after-display");
+    FOS_MEM_LOG_MILESTONE(TAG, "after-display");
     if (fos_assets_sd_mount(config) != ESP_OK) {
         ESP_LOGW(TAG, "SD assets unavailable, continuing without %s: %s",
                  config->assets_path[0] ? config->assets_path : "/srv/assets",
@@ -234,10 +236,12 @@ void app_main(void)
     /* Before any render: decides whether the previous boot was a memory
      * rescue and whether rendering should stay paused this time. */
     BOOTMEM("after-wifi");
+    FOS_MEM_LOG_MILESTONE(TAG, "after-wifi");
     fos_client_render_recovery_boot();
     fos_client_start();
 
     BOOTMEM("after-client-start");
+    FOS_MEM_LOG_MILESTONE(TAG, "after-client-start");
     if (frameos_nim_available() && local_render_ok) {
         int width = fos_display_present() ? fos_display_width() : 800;
         int height = fos_display_present() ? fos_display_height() : 480;
@@ -319,6 +323,7 @@ void app_main(void)
         fos_http_start(false);
         fos_ota_start_periodic_task(24);
         BOOTMEM("after-http+ota");
+        FOS_MEM_LOG_MILESTONE(TAG, "after-http+ota");
     } else {
         frameos_nim_set_log_upload_enabled(false);
         if (!fos_config_wifi_ready()) {


### PR DESCRIPTION
## Summary
- On boards with no PSRAM (ESP32-C3 thin clients), `render_failure_recover()` read 0 bytes of free PSRAM after *any* failed render, treated it as "PSRAM did not recover", and rebooted. Two in a row and the frame booted into "rendering paused: the active scene exhausted PSRAM 2 times in a row" until power-cycled. Reported from the field on an XTEINK X4 as "the frame can only handle one scene at a time" (selecting a scene clears the pause; the next transient failure starts the loop again).
- Skip the rescue when `heap_caps_get_total_size(MALLOC_CAP_SPIRAM) == 0`, and clear a leftover RTC-memory streak at boot on such boards so an OTA (software reset) brings a currently-paused frame back rendering.
- Always-on heap line (`heap <stage> internal free/largest/min-ever/psram free`) after display init, after Wi-Fi, after render-task start, after httpd+OTA, and on cloud WS connect — so the next field log says what ate the heap without a `-DFRAMEOS_BOOTMEM=1` build.

## Why the X4 is tight (budget from `idf.py size`, C3 build)
~168 KB heap after static data. The 4.26" panel is 800×480 2‑bpp gray = 96 KB framebuffer, Wi‑Fi station + lwIP ≈ 45–60 KB, the render task stack is 40 KB (sized for Nim+QuickJS, which the C3 never runs), console 8 KB, cloud 8 KB. That adds up to more than the heap, which matches the 12 KB / `httpd_start failed` in the report. The 40 KB client stack is the obvious candidate to shrink on thin clients, but that wants the high-water number from a real X4 first (`render task stack free at low-water mark` is already logged after render #1) — not done in this PR.

## Test plan
- [x] `idf.py` C3 build (`build-agent-c3`) compiles
- [ ] Flash a C3 frame, force a render failure (unreachable server) twice → no reboot, no pause
- [ ] OTA a currently-paused C3 frame → comes up rendering
- [ ] Read the new `heap ...` lines from an X4 boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)