### PR TITLE
Let the AI chat fork a scene instead of orphaning a copy

### DIFF
--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/fork/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/fork/route.ts
@@ -1,42 +1,13 @@
-import { and, desc, eq, isNull, sql } from "drizzle-orm";
-import {
-  storeSceneImages,
-  storeScenes,
-  storeSceneVersions,
-} from "@frameos-cloud/db";
-import { recordAuditEvent } from "../../../../../../src/lib/audit";
-import { NextRequest, NextResponse } from "next/server";
-import {
-  blobNamespaces,
-  readBlob,
-  storeBlob,
-} from "../../../../../../src/lib/blobs";
+import { NextRequest } from "next/server";
 import { csrfResponse } from "../../../../../../src/lib/csrf";
 import {
   jsonError,
   readJsonObject,
   requireDatabase,
 } from "../../../../../../src/lib/device-flow";
-import { moderateStoreContent } from "../../../../../../src/lib/moderation";
-import {
-  identityRateLimitResponse,
-  rateLimitResponse,
-} from "../../../../../../src/lib/rate-limit";
+import { rateLimitResponse } from "../../../../../../src/lib/rate-limit";
 import { readSession } from "../../../../../../src/lib/session";
-import {
-  maxNewScenesPerDay,
-  maxSceneZipBytes,
-  maxScenesPerAccount,
-  rebuildZipWithScenes,
-  sceneSummary,
-  slugifyName,
-  slugSuffix,
-  validateSceneZip,
-} from "../../../../../../src/lib/store";
-import {
-  maxPrivateSceneBytesPerAccount,
-  privateSceneBytesForAccount,
-} from "../../../../../../src/lib/usage";
+import { forkStoreScene } from "../../../../../../src/lib/store-fork";
 
 export const runtime = "nodejs";
 
@@ -44,9 +15,9 @@ type RouteContext = { params: Promise<{ sceneId: string }> };
 
 // Fork a scene: create a NEW private store scene under the caller's account,
 // seeded with the posted scenes JSON inside a copy of the source's latest
-// zip (manifest renamed, preview image carried over). Any signed-in user can
-// fork a public scene — that is the "save an edited playground copy" path —
-// and owners can fork their own scenes regardless of visibility.
+// zip (manifest renamed, preview image carried over). The body lives in
+// src/lib/store-fork.ts so the AI chat's save_scene tool forks through the
+// exact same path (quotas, moderation, lineage in the audit event).
 export async function POST(request: NextRequest, context: RouteContext) {
   const csrf = csrfResponse(request);
   if (csrf) {
@@ -73,247 +44,15 @@ export async function POST(request: NextRequest, context: RouteContext) {
   }
 
   const { sceneId } = await context.params;
-  if (!/^[0-9a-f-]{36}$/i.test(sceneId)) {
-    return jsonError("scene_not_found", 404);
-  }
-
-  const [source] = await db
-    .select()
-    .from(storeScenes)
-    .where(eq(storeScenes.id, sceneId))
-    .limit(1);
-  const sourceVisible =
-    source &&
-    (source.accountId === accountId ||
-      (source.visibility === "public" && source.status === "active"));
-  if (!source || !sourceVisible) {
-    return jsonError("scene_not_found", 404);
-  }
-
   const body = await readJsonObject(request);
   if (!Array.isArray(body.scenes) || body.scenes.length === 0) {
     return jsonError("invalid_scenes", 400);
   }
 
-  // Same per-account quotas as publishing a new scene. Forks are born
-  // private, so their bytes always count against the private-scene quota.
-  const [quota] = await db
-    .select({ scenes: sql<number>`count(*)::int` })
-    .from(storeScenes)
-    .where(eq(storeScenes.accountId, accountId));
-  if ((quota?.scenes ?? 0) >= maxScenesPerAccount) {
-    return jsonError("scene_quota_exceeded", 403, {
-      max_scenes: maxScenesPerAccount,
-    });
-  }
-  const privateBytes = await privateSceneBytesForAccount(db, accountId);
-  const dailyLimited = await identityRateLimitResponse(accountId, "store:fork", {
-    limit: maxNewScenesPerDay,
-    windowMs: 24 * 60 * 60 * 1000,
-  });
-  if (dailyLimited) {
-    return dailyLimited;
-  }
-
-  const [latest] = await db
-    .select({
-      content: storeSceneVersions.content,
-      frameosVersion: storeSceneVersions.frameosVersion,
-      objectKey: storeSceneVersions.objectKey,
-    })
-    .from(storeSceneVersions)
-    .where(
-      and(
-        eq(storeSceneVersions.sceneId, source.id),
-        isNull(storeSceneVersions.yankedAt),
-      ),
-    )
-    .orderBy(desc(storeSceneVersions.version))
-    .limit(1);
-  if (!latest) {
-    return jsonError("version_not_found", 404);
-  }
-  const latestContent = await readBlob(latest);
-  if (!latestContent) {
-    return jsonError("version_not_found", 404);
-  }
-
-  // Copied by reference, not by value: object keys are content digests, so a
-  // fork of a 6 MB scene pack re-uses the same objects and uploads nothing.
-  // Legacy rows that still hold their bytes in Postgres copy those instead.
-  const sourceImages = await db
-    .select({
-      content: storeSceneImages.content,
-      contentType: storeSceneImages.contentType,
-      createdAt: storeSceneImages.createdAt,
-      objectKey: storeSceneImages.objectKey,
-      position: storeSceneImages.position,
-      sizeBytes: storeSceneImages.sizeBytes,
-    })
-    .from(storeSceneImages)
-    .where(eq(storeSceneImages.sceneId, source.id))
-    .orderBy(storeSceneImages.position, storeSceneImages.createdAt);
-
-  // "<name> (copy)", with a counter when the account already owns that name
-  // (the publish flow treats same-owner names as new versions; a fork must
-  // always be a distinct scene).
-  const ownedNames = new Set(
-    (
-      await db
-        .select({ name: storeScenes.name })
-        .from(storeScenes)
-        .where(eq(storeScenes.accountId, accountId))
-    ).map((row) => row.name.toLowerCase()),
-  );
-  let name = `${source.name} (copy)`.slice(0, 128);
-  for (let counter = 2; ownedNames.has(name.toLowerCase()); counter += 1) {
-    if (counter > 50) {
-      return jsonError("too_many_copies", 400);
-    }
-    name = `${source.name} (copy ${counter})`.slice(0, 128);
-  }
-
-  const content = rebuildZipWithScenes(
-    Buffer.from(latestContent),
-    JSON.stringify(body.scenes, null, 2),
-    name,
-  );
-  if (!content) {
-    return jsonError("invalid_scene_zip", 500);
-  }
-  if (content.length > maxSceneZipBytes) {
-    return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
-  }
-  if (privateBytes + content.length > maxPrivateSceneBytesPerAccount) {
-    return jsonError("storage_quota_exceeded", 403, {
-      max_bytes: maxPrivateSceneBytesPerAccount,
-      private_bytes: Math.round(privateBytes),
-    });
-  }
-
-  const validated = validateSceneZip(content);
-  if (!validated.ok) {
-    return jsonError(validated.error, 400);
-  }
-
-  // The name is new text on a (future) public page; the description and
-  // preview image carry over from an already-hosted scene.
-  const moderation = await moderateStoreContent({
-    texts: [name, source.description],
-  });
-  if (!moderation.ok) {
-    if (moderation.error === "content_rejected") {
-      return jsonError("content_rejected", 422, {
-        categories: moderation.categories,
-      });
-    }
-    return jsonError("moderation_unavailable", 503);
-  }
-
-  const storedFork = await storeBlob(
-    blobNamespaces.sceneVersion,
-    content,
-    "application/zip",
-    { extension: "zip" },
-  );
-
-  const base = slugifyName(name);
-  const result = await db.transaction(async (tx) => {
-    // Globally unique slug, random suffix on collision (same as publishing).
-    let created;
-    for (const candidate of [
-      base,
-      `${base}-${slugSuffix()}`,
-      `${base}-${slugSuffix()}`,
-    ]) {
-      [created] = await tx
-        .insert(storeScenes)
-        .values({ accountId, name, slug: candidate })
-        .onConflictDoNothing({ target: storeScenes.slug })
-        .returning();
-      if (created) {
-        break;
-      }
-    }
-    if (!created) {
-      return { error: "scene_create_failed" as const };
-    }
-
-    await tx.insert(storeSceneVersions).values({
-      contentType: "application/zip",
-      frameosVersion: validated.value.frameosVersion ?? latest.frameosVersion,
-      objectKey: storedFork.objectKey,
-      riskFlags: validated.value.riskFlags,
-      sceneId: created.id,
-      sha256: storedFork.sha256,
-      sizeBytes: storedFork.sizeBytes,
-      version: 1,
-    });
-
-    const [updated] = await tx
-      .update(storeScenes)
-      .set({
-        description: source.description,
-        frameosVersion: validated.value.frameosVersion ?? latest.frameosVersion,
-        latestVersion: 1,
-        previewImage: source.previewImage,
-        previewImageHeight: source.previewImageHeight,
-        previewImageSizeBytes: source.previewImageSizeBytes,
-        previewImageType: source.previewImageType,
-        previewImageWidth: source.previewImageWidth,
-        previewObjectKey: source.previewObjectKey,
-        riskFlags: validated.value.riskFlags,
-        tags: source.tags,
-        updatedAt: new Date(),
-        visibility: "private",
-      })
-      .where(eq(storeScenes.id, created.id))
-      .returning();
-    if (!updated) {
-      return { error: "scene_fork_failed" as const };
-    }
-
-    if (sourceImages.length > 0) {
-      await tx.insert(storeSceneImages).values(
-        sourceImages.map((image) => ({
-          content: image.content,
-          contentType: image.contentType,
-          createdAt: image.createdAt,
-          objectKey: image.objectKey,
-          position: image.position,
-          sceneId: updated.id,
-          sizeBytes: image.sizeBytes,
-        })),
-      );
-    }
-
-    return { updated };
-  });
-
-  if ("error" in result) {
-    return jsonError(result.error, 500);
-  }
-  const { updated } = result;
-
-  await recordAuditEvent(db, {
+  return forkStoreScene(db, {
     accountId,
-    actor: {
-      accountId,
-      providerSubject: session.providerSubject,
-    },
-    eventType: "store.scene_forked",
-    metadata: {
-      name: updated.name,
-      imageCount: sourceImages.length,
-      sceneCount: validated.value.sceneCount,
-      sourceSceneId: source.id,
-      sourceSceneName: source.name,
-    },
-    target: { sceneId: updated.id },
-  });
-
-  return NextResponse.json({
-    scene: sceneSummary({ ...updated, latestVersion: 1 }),
-    status: "forked",
+    actor: { accountId, providerSubject: session.providerSubject },
+    scenes: body.scenes,
+    sourceSceneId: sceneId,
   });
 }

--- a/cloud/apps/auth-web/package.json
+++ b/cloud/apps/auth-web/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "prestart": "node scripts/require-database-url.mjs production",
     "scene:scrub-transparent-previews": "node scripts/scrub-transparent-previews.mjs",
+    "scene:sweep-duplicate-copies": "node scripts/sweep-duplicate-scene-copies.mjs",
     "scene:set-preview": "node scripts/set-scene-preview.mjs",
     "scene:sync-preview": "node scripts/sync-scene-preview.mjs",
     "start": "next start",

--- a/cloud/apps/auth-web/scripts/sweep-duplicate-scene-copies.mjs
+++ b/cloud/apps/auth-web/scripts/sweep-duplicate-scene-copies.mjs
@@ -1,0 +1,228 @@
+/* global console */
+// One-off sweep for the private-scene copies the pre-#367 cloud settings save
+// left behind.
+//
+// The bug: every settings save byte-compared the workspace's sanitized scene
+// with the raw store JSON, so every assigned scene looked edited. Scenes the
+// account did not own were forked into a fresh private copy per save, giving
+// runs of "<name> 2", "<name> 3" … "<name> 8". The save flow no longer does
+// this (#367); the copies it already made are still there.
+//
+// What counts as a leftover copy here — all of these, together:
+//   - owned by the account, private, active,
+//   - never republished (latest_version = 1, exactly one version row),
+//   - never given a life of its own: no description, no tags, no gallery
+//     image beyond what the fork carried, not published anywhere,
+//   - named "<base> <n>" with n >= 2, where the account also has "<base>"
+//     or another copy of the same run,
+//   - created before --before (default: the #367 deploy).
+//
+// It never guesses about anything a frame is running: a copy assigned to a
+// frame is REPORTED and left alone, because un-assigning it changes what a
+// physical frame displays and wants a deploy afterwards. Re-point those four
+// in the UI (frame → Scenes → swap the copy for the original → Save/Deploy),
+// then re-run this with --apply to remove the freed copies.
+//
+// DRY RUN BY DEFAULT — pass --apply to delete. Deleting a scene row cascades
+// to its versions, images and assignments; the objects its versions point at
+// are freed by scripts/object-store-sweep.sh, which is worth running after.
+//
+//   DATABASE_URL=... node scripts/sweep-duplicate-scene-copies.mjs \
+//     [--account=<uuid>] [--before=2026-08-18] [--apply] \
+//     [--only=<uuid,uuid>] [--except=<uuid,uuid>]
+import process from "node:process";
+import postgres from "postgres";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const flag = (name) => {
+  const match = args.find((arg) => arg.startsWith(`--${name}=`));
+  return match ? match.slice(name.length + 3).trim() : undefined;
+};
+const idList = (name) => {
+  const raw = flag(name);
+  if (!raw) {
+    return undefined;
+  }
+  const ids = raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  for (const id of ids) {
+    if (!/^[0-9a-f-]{36}$/i.test(id)) {
+      throw new Error(`--${name} takes scene uuids; got "${id}"`);
+    }
+  }
+  return new Set(ids);
+};
+
+const accountId = flag("account");
+if (accountId && !/^[0-9a-f-]{36}$/i.test(accountId)) {
+  throw new Error("--account takes an account uuid");
+}
+// The pre-#367 window. Anything created after the fix shipped is a copy the
+// user made on purpose, so the default cut-off is the deploy date.
+const before = flag("before") ?? "2026-08-18";
+if (!/^\d{4}-\d{2}-\d{2}$/.test(before)) {
+  throw new Error("--before takes an ISO date (YYYY-MM-DD)");
+}
+const only = idList("only");
+const except = idList("except");
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const sql = postgres(process.env.DATABASE_URL, {
+  max: 1,
+  ...(process.env.DATABASE_SSL === "require" ||
+  process.env.DATABASE_SSL === "true"
+    ? { ssl: "require" }
+    : {}),
+});
+
+// "Abstract Architecture 2" → { base: "Abstract Architecture", n: 2 }. The
+// fork route's own "(copy N)" names are deliberately NOT matched: those came
+// from someone pressing Fork, not from the save loop.
+function copySuffix(name) {
+  const match = /^(.+?) (\d+)$/.exec(name);
+  if (!match) {
+    return undefined;
+  }
+  const n = Number(match[2]);
+  return n >= 2 && n <= 99 ? { base: match[1], n } : undefined;
+}
+
+const summary = {
+  before,
+  deleted: [],
+  dryRun: !apply,
+  keptAssigned: [],
+  scanned: 0,
+};
+
+try {
+  const scenes = await sql`
+    select
+      s.account_id,
+      s.created_at,
+      s.description,
+      s.id,
+      s.latest_version,
+      s.name,
+      s.slug,
+      s.status,
+      s.tags,
+      s.visibility,
+      (
+        select count(*)::int from store_scene_versions v
+        where v.scene_id = s.id
+      ) as version_count,
+      (
+        select coalesce(
+          json_agg(json_build_object('frameId', a.frame_id, 'frameName', f.name)),
+          '[]'::json
+        )
+        from frame_scene_assignments a
+        join frames f on f.id = a.frame_id
+        where a.scene_id = s.id
+      ) as assignments
+    from store_scenes s
+    where s.visibility = 'private'
+      and s.status = 'active'
+      and s.latest_version = 1
+      and s.created_at < ${`${before}T00:00:00Z`}
+      ${accountId ? sql`and s.account_id = ${accountId}` : sql``}
+    order by s.account_id, s.name
+  `;
+
+  // Every private name the account holds, so "<base> 7" can be tied to the
+  // run it belongs to: either the original "<base>" or its siblings.
+  const namesByAccount = new Map();
+  for (const scene of scenes) {
+    if (!namesByAccount.has(scene.account_id)) {
+      const owned = await sql`
+        select lower(name) as name
+        from store_scenes
+        where account_id = ${scene.account_id}
+      `;
+      namesByAccount.set(
+        scene.account_id,
+        new Set(owned.map((row) => row.name)),
+      );
+    }
+  }
+
+  for (const scene of scenes) {
+    summary.scanned += 1;
+    if (only && !only.has(scene.id)) {
+      continue;
+    }
+    if (except?.has(scene.id)) {
+      continue;
+    }
+    const suffix = copySuffix(scene.name);
+    if (!suffix) {
+      continue;
+    }
+    const owned = namesByAccount.get(scene.account_id);
+    const partOfARun =
+      owned.has(suffix.base.toLowerCase()) ||
+      owned.has(`${suffix.base} ${suffix.n - 1}`.toLowerCase()) ||
+      owned.has(`${suffix.base} ${suffix.n + 1}`.toLowerCase());
+    if (!partOfARun) {
+      continue;
+    }
+    // A copy someone went on to describe, tag or re-publish is work, not
+    // litter. One version only: a second means it was saved over deliberately.
+    if (
+      scene.description ||
+      (scene.tags ?? []).length > 0 ||
+      scene.version_count !== 1
+    ) {
+      continue;
+    }
+
+    const record = {
+      accountId: scene.account_id,
+      base: suffix.base,
+      createdAt: scene.created_at,
+      id: scene.id,
+      name: scene.name,
+      slug: scene.slug,
+    };
+
+    const assignments = scene.assignments ?? [];
+    if (assignments.length > 0) {
+      // Left alone on purpose: this one is on a wall somewhere.
+      summary.keptAssigned.push({ ...record, assignments });
+      continue;
+    }
+
+    summary.deleted.push(record);
+    if (apply) {
+      await sql`delete from store_scenes where id = ${scene.id}`;
+    }
+  }
+
+  console.log(JSON.stringify(summary, null, 2));
+  console.log(
+    `${summary.deleted.length} unassigned copies ${apply ? "deleted" : "would be deleted"}, ` +
+      `${summary.keptAssigned.length} assigned copies left alone.`,
+  );
+  if (summary.keptAssigned.length > 0) {
+    console.log(
+      "Assigned copies need a human: re-point each frame at the original scene " +
+        "in the UI and deploy, then re-run this script.",
+    );
+  }
+  if (!apply) {
+    console.log("Dry run — nothing was changed. Re-run with --apply to write.");
+  } else if (summary.deleted.length > 0) {
+    console.log(
+      "Run scripts/object-store-sweep.sh afterwards to free the orphaned objects.",
+    );
+  }
+} finally {
+  await sql.end({ timeout: 5 });
+}

--- a/cloud/apps/auth-web/src/lib/account-scene-create.ts
+++ b/cloud/apps/auth-web/src/lib/account-scene-create.ts
@@ -81,6 +81,45 @@ export async function createAccountScene(
   if (!Array.isArray(input.scenes) || input.scenes.length === 0) {
     return jsonError("invalid_scenes", 400);
   }
+  return withAccountSceneNameLock(db, input.accountId, (locked) =>
+    createAccountSceneLocked(locked, input),
+  );
+}
+
+// "Pick a free name, then insert" is a check-then-act, and two saves racing
+// for the same account both saw "Sunrise 7" as free and both created it. A
+// transaction-scoped advisory lock keyed on the account serialises the pick
+// and the insert against every other name-picking save for that account
+// (across replicas — it lives in Postgres, not in this process) and releases
+// itself when the transaction ends, however it ends. Other accounts are
+// unaffected: the key is the account id.
+//
+// The callback runs inside the transaction and receives the transaction
+// handle in place of the database; drizzle's nested `transaction()` becomes a
+// savepoint, so callees that open their own transactions still work.
+export async function withAccountSceneNameLock<T>(
+  db: Database,
+  accountId: string,
+  run: (db: Database) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`account-scene-name:${accountId}`}))`,
+    );
+    return run(tx as unknown as Database);
+  });
+}
+
+async function createAccountSceneLocked(
+  db: Database,
+  input: {
+    accountId: string;
+    actor: PublishActor;
+    description?: string | undefined;
+    name: string;
+    scenes: unknown[];
+  },
+) {
   const finalName = await availableSceneName(db, input.accountId, input.name);
   if (!finalName) {
     return jsonError("scene_name_taken", 409, { name: input.name });

--- a/cloud/apps/auth-web/src/lib/ai/prompts.ts
+++ b/cloud/apps/auth-web/src/lib/ai/prompts.ts
@@ -102,8 +102,10 @@ You can:
    these and ask you to change them. Prefer verified publishers when suggesting third-party scenes.
 5. Save a scene to the user's account with save_scene, when they ask you to save, keep or fork one. It
    always creates a NEW private scene — it never overwrites anything — so tell them the name it landed
-   under, and that the editor still holds their unsaved copy. Forking someone else's store scene is the
-   same call: read it with get_store_scene and pass it to save_scene.
+   under, and that the editor still holds their unsaved copy. Forking a store scene is the same call:
+   read it with get_store_scene, pass the (possibly modified) scenes to save_scene AND pass the store id
+   as source_scene_id, so the copy keeps the original's preview image, tags and description and records
+   its lineage. Do the same when the scene the user has open came from the store.
 6. Install a store scene on a frame yourself with add_scene_to_frame: it adds the scene to that frame's
    scenes and deploys the set to the device in one step. When the user asks to put a scene on a frame,
    DO IT with that tool — never answer with the manual steps (open the frame, Scenes tab, add, Save,

--- a/cloud/apps/auth-web/src/lib/ai/tools.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/tools.test.ts
@@ -37,6 +37,34 @@ describe("tool registration", () => {
   });
 });
 
+describe("save_scene", () => {
+  const tool = toolDefinitions.find(
+    (definition) => definition.name === "save_scene",
+  );
+
+  it("takes optional scenes, a name, a description and a source scene", () => {
+    const parameters = tool?.parameters as {
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(parameters.required ?? []).toEqual([]);
+    expect(Object.keys(parameters.properties).sort()).toEqual([
+      "description",
+      "name",
+      "scenes",
+      "source_scene_id",
+    ]);
+  });
+
+  // The lineage the tool exists to keep: without source_scene_id a fork of a
+  // store scene is indistinguishable from a scene invented in the chat, and
+  // the copy loses the original's preview image, tags and description.
+  it("tells the model to pass the store id when the scene came from the store", () => {
+    expect(tool?.description).toMatch(/source_scene_id/);
+    expect(tool?.description).toMatch(/fork/i);
+  });
+});
+
 describe("add_scene_to_frame", () => {
   const tool = toolDefinitions.find(
     (definition) => definition.name === "add_scene_to_frame",

--- a/cloud/apps/auth-web/src/lib/ai/tools.ts
+++ b/cloud/apps/auth-web/src/lib/ai/tools.ts
@@ -45,6 +45,7 @@ import {
   supersedePendingCommands,
 } from "../frames";
 import { createAccountScene } from "../account-scene-create";
+import { forkStoreScene, sceneIdPattern } from "../store-fork";
 import { readBlob } from "../blobs";
 import { extractScenesFromZip } from "../scene-title";
 
@@ -420,10 +421,12 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
     description:
       "Save a scene to the user's account as a NEW private store scene, so it survives closing the editor " +
       "and can be installed on a frame or forked later. With no arguments it saves whatever you just " +
-      "delivered with create_scenes/update_scene; pass `scenes` to save something else (for example a store " +
-      "scene from get_store_scene — that is how you fork one for them). It always creates a copy and never " +
-      "overwrites an existing saved scene, so say which name it landed under. Call it when the user asks to " +
-      "save, keep or fork — not on every build.",
+      "delivered with create_scenes/update_scene; pass `scenes` to save something else. When the scene " +
+      "started life as a store scene (you fetched it with get_store_scene, or the user opened it from the " +
+      "store), ALSO pass its id as `source_scene_id`: the copy is then a proper fork that keeps the " +
+      "original's preview image, tags and description and records where it came from. It always creates a " +
+      "copy and never overwrites an existing saved scene, so say which name it landed under. Call it when " +
+      "the user asks to save, keep or fork — not on every build.",
     name: "save_scene",
     parameters: {
       additionalProperties: false,
@@ -442,6 +445,12 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
             "Complete scene JSON to save. Omit to save the scene you just delivered.",
           items: { type: "object" },
           type: "array",
+        },
+        source_scene_id: {
+          description:
+            "Store scene id this is a copy of (from get_store_scene / search_store_scenes). Makes the save " +
+            "a fork with lineage: preview image, tags and description carry over. Omit for brand-new scenes.",
+          type: "string",
         },
       },
       type: "object",
@@ -606,17 +615,39 @@ async function saveSceneToAccount(
       : undefined) ??
     "Untitled scene";
   const description = asString(args.description);
-
-  const response = await createAccountScene(ctx.db, {
+  const sourceSceneId = asString(args.source_scene_id);
+  const actor = {
     accountId: ctx.accountId,
-    actor: {
-      accountId: ctx.accountId,
-      providerSubject: ctx.providerSubject ?? "",
-    },
-    ...(description ? { description } : {}),
-    name: requestedName,
-    scenes,
-  });
+    providerSubject: ctx.providerSubject ?? "",
+  };
+
+  if (sourceSceneId && !sceneIdPattern.test(sourceSceneId)) {
+    return JSON.stringify({
+      error: "source_scene_id must be a store scene uuid (or omit it for a brand-new scene)",
+      ok: false,
+    });
+  }
+  // A copy of a store scene is a FORK, and forks go through the same lib the
+  // workspace's fork button uses — so the audit event names the source, and
+  // the preview image, gallery, tags and description come along. Only the
+  // name is the model's to choose; the fork lib keeps it unique per account.
+  const response = sourceSceneId
+    ? await forkStoreScene(ctx.db, {
+        accountId: ctx.accountId,
+        actor,
+        ...(description ? { description } : {}),
+        ...(asString(args.name) ? { name: asString(args.name) } : {}),
+        scenes,
+        sourceSceneId,
+        via: "ai_chat",
+      })
+    : await createAccountScene(ctx.db, {
+        accountId: ctx.accountId,
+        actor,
+        ...(description ? { description } : {}),
+        name: requestedName,
+        scenes,
+      });
   const body = (await response.json().catch(() => ({}))) as {
     error?: string;
     scene?: { id?: string; name?: string; slug?: string };
@@ -631,8 +662,11 @@ async function saveSceneToAccount(
   }
   return JSON.stringify({
     note:
-      "Saved as a PRIVATE scene in the user's account. It is a copy — the editor still holds their unsaved " +
-      "version, and nothing was overwritten.",
+      (sourceSceneId
+        ? "Forked into a PRIVATE scene in the user's account, with the original's preview image, tags and " +
+          "description carried over. "
+        : "Saved as a PRIVATE scene in the user's account. ") +
+      "It is a copy — the editor still holds their unsaved version, and nothing was overwritten.",
     ok: true,
     scene: body.scene ?? null,
   });

--- a/cloud/apps/auth-web/src/lib/store-fork.ts
+++ b/cloud/apps/auth-web/src/lib/store-fork.ts
@@ -1,0 +1,340 @@
+// Fork a store scene into a NEW private scene under the caller's account.
+//
+// Extracted from app/api/account/scenes/[sceneId]/fork/route.ts so the AI
+// chat's save_scene tool (given a `source_scene_id`) records the SAME lineage
+// the workspace's fork button does: the source scene id in the audit event,
+// the carried-over preview image, gallery images, tags and description. A
+// tool with its own "save these bytes as a new scene" path would fork a store
+// scene in practice while recording none of that.
+//
+// The caller owns authentication, CSRF and per-IP rate limiting; pass an
+// accountId that is already proven. Per-account quotas and the daily fork
+// limit live here, because they are policy on the fork itself.
+
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import {
+  createDb,
+  storeSceneImages,
+  storeScenes,
+  storeSceneVersions,
+} from "@frameos-cloud/db";
+import { NextResponse } from "next/server";
+import {
+  availableSceneName,
+  withAccountSceneNameLock,
+} from "./account-scene-create";
+import { recordAuditEvent } from "./audit";
+import { blobNamespaces, readBlob, storeBlob } from "./blobs";
+import { jsonError } from "./device-flow";
+import { moderateStoreContent } from "./moderation";
+import { identityRateLimitResponse } from "./rate-limit";
+import {
+  maxNewScenesPerDay,
+  maxSceneZipBytes,
+  maxScenesPerAccount,
+  rebuildZipWithScenes,
+  sceneSummary,
+  slugifyName,
+  slugSuffix,
+  validateSceneZip,
+} from "./store";
+import type { PublishActor } from "./store-publish";
+import {
+  maxPrivateSceneBytesPerAccount,
+  privateSceneBytesForAccount,
+} from "./usage";
+
+type Database = ReturnType<typeof createDb>;
+
+export const sceneIdPattern = /^[0-9a-f-]{36}$/i;
+
+/** Returns the fork route's response (or a jsonError) — the route hands it
+ *  straight back, the AI tool reads its JSON body. */
+export async function forkStoreScene(
+  db: Database,
+  input: ForkInput,
+) {
+  if (!sceneIdPattern.test(input.sourceSceneId)) {
+    return jsonError("scene_not_found", 404);
+  }
+  if (!Array.isArray(input.scenes) || input.scenes.length === 0) {
+    return jsonError("invalid_scenes", 400);
+  }
+  // Same check-then-insert on the copy's name as the plain save path, same
+  // per-account lock so two racing forks cannot both land on "(copy 3)".
+  return withAccountSceneNameLock(db, input.accountId, (locked) =>
+    forkStoreSceneLocked(locked, input),
+  );
+}
+
+type ForkInput = {
+  accountId: string;
+  actor: PublishActor;
+  /** Optional description override; the source's carries over otherwise. */
+  description?: string | undefined;
+  /** Optional name for the copy; defaults to "<source name> (copy)". Either
+   *  way the account never ends up with two scenes of the same name. */
+  name?: string | undefined;
+  scenes: unknown[];
+  sourceSceneId: string;
+  /** Free-text tag for the audit event ("ai_chat"); the web route omits it. */
+  via?: string | undefined;
+};
+
+async function forkStoreSceneLocked(db: Database, input: ForkInput) {
+  const { accountId, actor, sourceSceneId } = input;
+
+  // Any signed-in user can fork a public scene — that is the "save an edited
+  // playground copy" path — and owners can fork their own scenes regardless
+  // of visibility.
+  const [source] = await db
+    .select()
+    .from(storeScenes)
+    .where(eq(storeScenes.id, sourceSceneId))
+    .limit(1);
+  const sourceVisible =
+    source &&
+    (source.accountId === accountId ||
+      (source.visibility === "public" && source.status === "active"));
+  if (!source || !sourceVisible) {
+    return jsonError("scene_not_found", 404);
+  }
+
+  // Same per-account quotas as publishing a new scene. Forks are born
+  // private, so their bytes always count against the private-scene quota.
+  const [quota] = await db
+    .select({ scenes: sql<number>`count(*)::int` })
+    .from(storeScenes)
+    .where(eq(storeScenes.accountId, accountId));
+  if ((quota?.scenes ?? 0) >= maxScenesPerAccount) {
+    return jsonError("scene_quota_exceeded", 403, {
+      max_scenes: maxScenesPerAccount,
+    });
+  }
+  const privateBytes = await privateSceneBytesForAccount(db, accountId);
+  const dailyLimited = await identityRateLimitResponse(accountId, "store:fork", {
+    limit: maxNewScenesPerDay,
+    windowMs: 24 * 60 * 60 * 1000,
+  });
+  if (dailyLimited) {
+    return dailyLimited;
+  }
+
+  const [latest] = await db
+    .select({
+      content: storeSceneVersions.content,
+      frameosVersion: storeSceneVersions.frameosVersion,
+      objectKey: storeSceneVersions.objectKey,
+    })
+    .from(storeSceneVersions)
+    .where(
+      and(
+        eq(storeSceneVersions.sceneId, source.id),
+        isNull(storeSceneVersions.yankedAt),
+      ),
+    )
+    .orderBy(desc(storeSceneVersions.version))
+    .limit(1);
+  if (!latest) {
+    return jsonError("version_not_found", 404);
+  }
+  const latestContent = await readBlob(latest);
+  if (!latestContent) {
+    return jsonError("version_not_found", 404);
+  }
+
+  // Copied by reference, not by value: object keys are content digests, so a
+  // fork of a 6 MB scene pack re-uses the same objects and uploads nothing.
+  // Legacy rows that still hold their bytes in Postgres copy those instead.
+  const sourceImages = await db
+    .select({
+      content: storeSceneImages.content,
+      contentType: storeSceneImages.contentType,
+      createdAt: storeSceneImages.createdAt,
+      objectKey: storeSceneImages.objectKey,
+      position: storeSceneImages.position,
+      sizeBytes: storeSceneImages.sizeBytes,
+    })
+    .from(storeSceneImages)
+    .where(eq(storeSceneImages.sceneId, source.id))
+    .orderBy(storeSceneImages.position, storeSceneImages.createdAt);
+
+  const name = await forkName(db, accountId, source.name, input.name);
+  if (!name) {
+    return jsonError("too_many_copies", 400);
+  }
+  const description = input.description?.trim() || source.description;
+
+  const content = rebuildZipWithScenes(
+    Buffer.from(latestContent),
+    JSON.stringify(input.scenes, null, 2),
+    name,
+  );
+  if (!content) {
+    return jsonError("invalid_scene_zip", 500);
+  }
+  if (content.length > maxSceneZipBytes) {
+    return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
+  }
+  if (privateBytes + content.length > maxPrivateSceneBytesPerAccount) {
+    return jsonError("storage_quota_exceeded", 403, {
+      max_bytes: maxPrivateSceneBytesPerAccount,
+      private_bytes: Math.round(privateBytes),
+    });
+  }
+
+  const validated = validateSceneZip(content);
+  if (!validated.ok) {
+    return jsonError(validated.error, 400);
+  }
+
+  // The name (and a caller-supplied description) is new text on a (future)
+  // public page; the preview image carries over from an already-hosted scene.
+  const moderation = await moderateStoreContent({
+    texts: [name, description],
+  });
+  if (!moderation.ok) {
+    if (moderation.error === "content_rejected") {
+      return jsonError("content_rejected", 422, {
+        categories: moderation.categories,
+      });
+    }
+    return jsonError("moderation_unavailable", 503);
+  }
+
+  const storedFork = await storeBlob(
+    blobNamespaces.sceneVersion,
+    content,
+    "application/zip",
+    { extension: "zip" },
+  );
+
+  const base = slugifyName(name);
+  const result = await db.transaction(async (tx) => {
+    // Globally unique slug, random suffix on collision (same as publishing).
+    let created;
+    for (const candidate of [
+      base,
+      `${base}-${slugSuffix()}`,
+      `${base}-${slugSuffix()}`,
+    ]) {
+      [created] = await tx
+        .insert(storeScenes)
+        .values({ accountId, name, slug: candidate })
+        .onConflictDoNothing({ target: storeScenes.slug })
+        .returning();
+      if (created) {
+        break;
+      }
+    }
+    if (!created) {
+      return { error: "scene_create_failed" as const };
+    }
+
+    await tx.insert(storeSceneVersions).values({
+      contentType: "application/zip",
+      frameosVersion: validated.value.frameosVersion ?? latest.frameosVersion,
+      objectKey: storedFork.objectKey,
+      riskFlags: validated.value.riskFlags,
+      sceneId: created.id,
+      sha256: storedFork.sha256,
+      sizeBytes: storedFork.sizeBytes,
+      version: 1,
+    });
+
+    const [updated] = await tx
+      .update(storeScenes)
+      .set({
+        description,
+        frameosVersion: validated.value.frameosVersion ?? latest.frameosVersion,
+        latestVersion: 1,
+        previewImage: source.previewImage,
+        previewImageHeight: source.previewImageHeight,
+        previewImageSizeBytes: source.previewImageSizeBytes,
+        previewImageType: source.previewImageType,
+        previewImageWidth: source.previewImageWidth,
+        previewObjectKey: source.previewObjectKey,
+        riskFlags: validated.value.riskFlags,
+        tags: source.tags,
+        updatedAt: new Date(),
+        visibility: "private",
+      })
+      .where(eq(storeScenes.id, created.id))
+      .returning();
+    if (!updated) {
+      return { error: "scene_fork_failed" as const };
+    }
+
+    if (sourceImages.length > 0) {
+      await tx.insert(storeSceneImages).values(
+        sourceImages.map((image) => ({
+          content: image.content,
+          contentType: image.contentType,
+          createdAt: image.createdAt,
+          objectKey: image.objectKey,
+          position: image.position,
+          sceneId: updated.id,
+          sizeBytes: image.sizeBytes,
+        })),
+      );
+    }
+
+    return { updated };
+  });
+
+  if ("error" in result) {
+    return jsonError(result.error, 500);
+  }
+  const { updated } = result;
+
+  await recordAuditEvent(db, {
+    accountId,
+    actor,
+    eventType: "store.scene_forked",
+    metadata: {
+      name: updated.name,
+      imageCount: sourceImages.length,
+      sceneCount: validated.value.sceneCount,
+      sourceSceneId: source.id,
+      sourceSceneName: source.name,
+      ...(input.via ? { via: input.via } : {}),
+    },
+    target: { sceneId: updated.id },
+  });
+
+  return NextResponse.json({
+    scene: sceneSummary({ ...updated, latestVersion: 1 }),
+    status: "forked",
+  });
+}
+
+// "<name> (copy)", with a counter when the account already owns that name
+// (the publish flow treats same-owner names as new versions; a fork must
+// always be a distinct scene). A requested name goes through the same
+// "name 2" disambiguation the plain "save to my account" path uses.
+async function forkName(
+  db: Database,
+  accountId: string,
+  sourceName: string,
+  requested: string | undefined,
+): Promise<string | undefined> {
+  if (requested?.trim()) {
+    return availableSceneName(db, accountId, requested);
+  }
+  const ownedNames = new Set(
+    (
+      await db
+        .select({ name: storeScenes.name })
+        .from(storeScenes)
+        .where(eq(storeScenes.accountId, accountId))
+    ).map((row) => row.name.toLowerCase()),
+  );
+  let name = `${sourceName} (copy)`.slice(0, 128);
+  for (let counter = 2; ownedNames.has(name.toLowerCase()); counter += 1) {
+    if (counter > 50) {
+      return undefined;
+    }
+    name = `${sourceName} (copy ${counter})`.slice(0, 128);
+  }
+  return name;
+}

--- a/cloud/apps/auth-web/src/test/integration/ai-save-scene.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/ai-save-scene.integration.test.ts
@@ -1,0 +1,311 @@
+// The chat agent's save_scene tool, against a real database.
+//
+// Two behaviours worth pinning. First, lineage: "save this store scene for
+// me" is a FORK, and a fork that records none of where it came from is how
+// the account ends up full of orphan copies. With `source_scene_id` the tool
+// must go through the same path the workspace's fork button uses — preview
+// image, tags and description carried over, `store.scene_forked` naming the
+// source — and must refuse a source the user cannot read. Second, the name
+// race: picking a free name and then inserting it is a check-then-act, and
+// two concurrent saves used to both land on the same "name 2".
+
+import { and, eq } from "drizzle-orm";
+import { zipSync } from "fflate";
+import {
+  auditEvents,
+  createDb,
+  storeSceneImages,
+  storeScenes,
+  storeSceneVersions,
+  upsertAccountFromIdentity,
+} from "@frameos-cloud/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readBlob } from "../../lib/blobs";
+import { extractScenesFromZip } from "../../lib/scene-title";
+import { executeTool, type ToolContext } from "../../lib/ai/tools";
+
+// recordAuditEvent reads request headers for the client IP; there is no
+// request scope here, and it already tolerates that.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: () => undefined }),
+  headers: async () => new Headers(),
+}));
+
+const db = createDb();
+const issuer = "https://accounts.google.com";
+let userCounter = 0;
+let sceneCounter = 0;
+
+async function account() {
+  userCounter += 1;
+  const { accountId } = await upsertAccountFromIdentity(db, {
+    displayName: `AI Save User ${userCounter}`,
+    email: `ai-save-${userCounter}@example.com`,
+    emailVerified: true,
+    providerIssuer: issuer,
+    providerKey: "google",
+    providerSubject: `ai-save-user-${userCounter}`,
+  });
+  return accountId;
+}
+
+const previewBytes = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 7]);
+
+function sceneZip(name: string, scenes: unknown[]) {
+  const encode = (value: unknown) =>
+    new TextEncoder().encode(JSON.stringify(value));
+  return Buffer.from(
+    zipSync({
+      "scene/scenes.json": encode(scenes),
+      "scene/template.json": encode({ name, scenes: "./scenes.json" }),
+    }),
+  );
+}
+
+/** A published-looking store scene with everything a fork should carry. */
+async function storeScene(
+  accountId: string,
+  options: { name: string; visibility?: "private" | "public" } = {
+    name: "Sunrise clock",
+  },
+) {
+  sceneCounter += 1;
+  const scenes = [
+    { edges: [], id: `source-${sceneCounter}`, name: options.name, nodes: [] },
+  ];
+  const [scene] = await db
+    .insert(storeScenes)
+    .values({
+      accountId,
+      description: "Wakes up with the sun",
+      latestVersion: 1,
+      name: options.name,
+      previewImage: previewBytes,
+      previewImageHeight: 448,
+      previewImageSizeBytes: previewBytes.length,
+      previewImageType: "image/jpeg",
+      previewImageWidth: 600,
+      slug: `${options.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${sceneCounter}`,
+      status: "active",
+      tags: ["clock", "sunrise"],
+      visibility: options.visibility ?? "public",
+    })
+    .returning();
+  if (!scene) {
+    throw new Error("scene insert failed");
+  }
+  await db.insert(storeSceneVersions).values({
+    content: sceneZip(options.name, scenes),
+    contentType: "application/zip",
+    riskFlags: [],
+    sceneId: scene.id,
+    sha256: `test-${sceneCounter}`,
+    sizeBytes: 1000,
+    version: 1,
+  });
+  await db.insert(storeSceneImages).values({
+    content: Buffer.from([0x89, 0x50, 0x4e, 0x47, 3]),
+    contentType: "image/png",
+    position: 1,
+    sceneId: scene.id,
+  });
+  return { scene, scenes };
+}
+
+function toolContext(accountId: string): ToolContext {
+  return {
+    accountId,
+    db,
+    emitScenes: () => undefined,
+    prompt: "save this one to my account",
+    providerSubject: `ai-save-user-${userCounter}`,
+  };
+}
+
+async function saveScene(accountId: string, args: Record<string, unknown>) {
+  const output = await executeTool("save_scene", args, toolContext(accountId));
+  return JSON.parse(output) as Record<string, unknown> & {
+    scene?: { id?: string; name?: string } | null;
+  };
+}
+
+async function savedScene(sceneId: string) {
+  const [row] = await db
+    .select()
+    .from(storeScenes)
+    .where(eq(storeScenes.id, sceneId));
+  return row;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("save_scene", () => {
+  it("saves a brand-new scene as a private scene of its own", async () => {
+    const accountId = await account();
+
+    const result = await saveScene(accountId, {
+      name: "Hand built",
+      scenes: [{ edges: [], id: "fresh", name: "Hand built", nodes: [] }],
+    });
+
+    expect(result.ok).toBe(true);
+    const saved = await savedScene(result.scene?.id as string);
+    expect(saved).toMatchObject({
+      accountId,
+      name: "Hand built",
+      visibility: "private",
+    });
+    // Nothing to inherit: a scene built in the chat has no source.
+    expect(saved?.previewImage).toBeNull();
+    expect(saved?.tags).toEqual([]);
+  });
+
+  it("forks with lineage when the scene came from the store", async () => {
+    const owner = await account();
+    const { scene: source, scenes } = await storeScene(owner, {
+      name: "Sunrise clock",
+    });
+    const forker = await account();
+
+    const result = await saveScene(forker, {
+      scenes: scenes.map((scene) => ({ ...scene, nodes: [{ id: "added" }] })),
+      source_scene_id: source.id,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.note).toMatch(/forked/i);
+    const forked = await savedScene(result.scene?.id as string);
+    expect(forked).toMatchObject({
+      accountId: forker,
+      description: source.description,
+      name: "Sunrise clock (copy)",
+      tags: ["clock", "sunrise"],
+      visibility: "private",
+    });
+    expect(forked?.previewImage).toEqual(previewBytes);
+    expect(forked?.previewImageWidth).toBe(600);
+
+    // The gallery comes along, by reference where the source used objects.
+    const images = await db
+      .select()
+      .from(storeSceneImages)
+      .where(eq(storeSceneImages.sceneId, forked!.id));
+    expect(images).toHaveLength(1);
+
+    // The edit the chat made is what got saved, not the source bytes.
+    const [version] = await db
+      .select()
+      .from(storeSceneVersions)
+      .where(eq(storeSceneVersions.sceneId, forked!.id));
+    const content = await readBlob(version!);
+    expect(content).toBeTruthy();
+    expect(JSON.stringify(extractScenesFromZip(content!))).toContain("added");
+
+    // The lineage the dedicated fork route records, from the chat too.
+    const [event] = await db
+      .select()
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.accountId, forker),
+          eq(auditEvents.eventType, "store.scene_forked"),
+        ),
+      );
+    expect(event?.metadata).toMatchObject({
+      name: "Sunrise clock (copy)",
+      sourceSceneId: source.id,
+      sourceSceneName: "Sunrise clock",
+      via: "ai_chat",
+    });
+    expect(event?.target).toMatchObject({ sceneId: forked!.id });
+  });
+
+  it("refuses a source the user cannot read, and saves nothing", async () => {
+    const owner = await account();
+    const { scene: source, scenes } = await storeScene(owner, {
+      name: "Private notes",
+      visibility: "private",
+    });
+    const stranger = await account();
+
+    const result = await saveScene(stranger, {
+      scenes,
+      source_scene_id: source.id,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("scene_not_found");
+    expect(
+      await db
+        .select()
+        .from(storeScenes)
+        .where(eq(storeScenes.accountId, stranger)),
+    ).toEqual([]);
+  });
+
+  it("rejects a source id that is not a scene id before touching the db", async () => {
+    const accountId = await account();
+
+    const result = await saveScene(accountId, {
+      scenes: [{ edges: [], id: "fresh", name: "Fresh", nodes: [] }],
+      source_scene_id: "the one we talked about",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/source_scene_id/);
+  });
+
+  // The bug this guards: availableSceneName checked, then the insert ran, and
+  // two saves racing through that gap both saw "Sunrise 7" free.
+  it("gives concurrent saves of the same name distinct names", async () => {
+    const accountId = await account();
+
+    const results = await Promise.all([
+      saveScene(accountId, {
+        name: "Racing scene",
+        scenes: [{ edges: [], id: "a", name: "Racing scene", nodes: [] }],
+      }),
+      saveScene(accountId, {
+        name: "Racing scene",
+        scenes: [{ edges: [], id: "b", name: "Racing scene", nodes: [] }],
+      }),
+    ]);
+
+    expect(results.every((result) => result.ok)).toBe(true);
+    const rows = await db
+      .select({ name: storeScenes.name })
+      .from(storeScenes)
+      .where(eq(storeScenes.accountId, accountId));
+    expect(rows.map((row) => row.name).sort()).toEqual([
+      "Racing scene",
+      "Racing scene 2",
+    ]);
+  });
+
+  // Same race on the fork path: both forks of one source want "(copy)".
+  it("gives concurrent forks of one scene distinct names", async () => {
+    const owner = await account();
+    const { scene: source, scenes } = await storeScene(owner, {
+      name: "Busy scene",
+    });
+    const forker = await account();
+
+    const results = await Promise.all([
+      saveScene(forker, { scenes, source_scene_id: source.id }),
+      saveScene(forker, { scenes, source_scene_id: source.id }),
+    ]);
+
+    expect(results.every((result) => result.ok)).toBe(true);
+    const rows = await db
+      .select({ name: storeScenes.name })
+      .from(storeScenes)
+      .where(eq(storeScenes.accountId, forker));
+    // ASCII order: the space in "(copy 2)" sorts before the ")".
+    expect(rows.map((row) => row.name).sort()).toEqual([
+      "Busy scene (copy 2)",
+      "Busy scene (copy)",
+    ]);
+  });
+});

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -63,27 +63,18 @@ commands; everything else stays local to the device.
   remotely, redesign them as bounded toggles on fixed FrameOS-owned
   directories. Hardware identity reported by the frame stays authoritative.
 
-- **Sweep the private-scene copies the old save flow left behind.** Until
-  PR #367 every cloud settings save byte-compared the workspace's sanitized
-  scene with the raw store JSON, so every assigned scene looked edited: owned
-  scenes were republished per save and scenes the account did not own were
-  forked into a private copy per save ("Abstract Architecture 2" … "8"). The
-  flow now uses the workspace's own scene equality, drops the Templates
-  panel's `origin` stamp (never persisted, never stamped on cloud installs,
-  no cloud "update available" badge), keeps unreadable packs claimed and
-  serializes saves per frame — but the copies already made are still there
-  (33 in the founder account, 4 of them still assigned to a frame). Two
-  pieces left: a one-off cleanup (delete the unassigned copies, re-point the
-  assigned ones at their originals), and a server-side guard so two racing
-  `POST /api/account/scenes` with the same name cannot both win
-  (`availableSceneName` checks then inserts — "7" and "7" happened).
-
-- **Cloud AI chat: fork with lineage.** `save_scene` writes whatever scene the
-  chat is holding into the account as a new private scene. That covers forking
-  a store scene in practice, but records none of the lineage the dedicated fork
-  route does: source scene id in the audit event, carried-over preview image,
-  tags, description. Extract that route's body into a lib and have `save_scene`
-  call it with a `source_scene_id`. *Small, self-contained.*
+- **Sweep the private-scene copies the old save flow left behind.** The copies
+  are still there (33 in the founder account, 4 of them still assigned to a
+  frame); the flow that made them is fixed (PR #367) and the name race behind
+  the duplicate "7"s is closed (`withAccountSceneNameLock` serialises the
+  "pick a free name, then insert" against every other save for that account).
+  What is left is running the cleanup on production:
+  `pnpm scene:sweep-duplicate-copies -- --account=<id>` reports the copies it
+  judges to be litter (private, single-version, undescribed, untagged, part of
+  a "<name> N" run, created before the fix) and deletes them with `--apply`.
+  It never touches a copy a frame is running — those four want the frame
+  re-pointed at the original in the UI and deployed first, then the script
+  again. Run `scripts/object-store-sweep.sh` afterwards.
 
 - **Account hardening.** Passkeys/TOTP 2FA, re-authentication before sensitive
   actions (revoking frames, bulk assignment changes, scope grants), and a


### PR DESCRIPTION
`save_scene` wrote whatever the chat was holding into the account as a new private scene. That forks a store scene in practice, but recorded none of the lineage the fork button does — the copy lost the original's preview image, tags and description, and nothing said where it came from.

### Fork with lineage

The fork route's body moves to `src/lib/store-fork.ts` — quotas, the daily fork limit, moderation, the blob-by-reference image copy, slug retry, and the `store.scene_forked` audit event — leaving `app/api/account/scenes/[sceneId]/fork/route.ts` as its auth/CSRF/rate-limit shell (281 lines → 57).

`save_scene` takes an optional `source_scene_id` and goes through the same lib when it has one, stamping `via: "ai_chat"` so chat forks stay distinguishable in the audit trail. Without it, behaviour is unchanged. Access control comes along for free: a source the user cannot read is `scene_not_found`, and writes nothing. The tool description and the system prompt now tell the model to pass the store id whenever the scene came from the store.

### The name race

Closes the racing-saves half of the duplicate-copies cleanup, since it is the same code path. Picking a free name and then inserting it is a check-then-act, and two saves racing through that gap both landed on `"<name> 7"`. `withAccountSceneNameLock` now holds `pg_advisory_xact_lock(hashtext('account-scene-name:<accountId>'))` across the pick and the insert, for plain saves and forks alike — in Postgres, so it holds across replicas, and keyed per account, so nobody else waits.

### The copies already made

Still there (33 in the founder account, 4 of them assigned to a frame). `scripts/sweep-duplicate-scene-copies.mjs` (`pnpm scene:sweep-duplicate-copies`) inventories them — private, active, single-version, undescribed, untagged, part of a `"<base> N"` run, created before the fix — and deletes them with `--apply`; `--only=`/`--except=` for surgical runs. **It never touches a copy a frame is assigned:** un-assigning changes what a wall displays and wants a deploy, so those are reported for a human to re-point first. Not run against production in this PR.

### Verification

- 6 new integration tests (`ai-save-scene.integration.test.ts`) against real Postgres: plain save, fork-with-lineage (preview/tags/description/gallery carried, audit metadata, the chat's edit is what got saved), unreadable source, malformed source id, and both race cases.
- The sweep script rehearsed end-to-end against the test database with a 9-scene fixture (original, two plain copies, an assigned copy, a described one, a republished one, a post-fix one, a public one, an unrelated `"Standalone 2"`). It selected exactly the two plain copies, kept the assigned one, skipped the rest; `--apply`, `--only`, `--except` and a second idempotent run all behaved. Fixture removed.
- Full suite green: 742 unit, 276 integration, `pnpm lint`, `pnpm typecheck`.

`docs/todo.md` updated: the fork item is deleted, the sweep item trimmed to the one remaining production step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)