### PR TITLE
Sweep the leftover scene copies, minus the tags mistake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,42 @@
 - There are TWO control planes for frames: the self-hosted backend (`backend/` + `frontend/`) and FrameOS Cloud (`cloud/` + `cloud-frontend/`). **Any frame-facing feature or fix must land on both, or explicitly note why it's one-sided** — unless the task says otherwise. When you touch frame panels, frame APIs, device verbs, or provisioning/flashing, check the other control plane before calling the work done. The current push is porting all ESP32 backend capabilities to the cloud (see `docs/todo.md`, "ESP32 backend→cloud parity").
 - The frame workspace UI is SHARED code (`frontend/src`), wrapped for cloud by `cloud-frontend/`. A fix that "doesn't show on cloud" is usually NOT a fork — check the `workspaceSurfaces` gating (`frontend/src/scenes/workspace/`) and remember the cloud serves a PREBUILT bundle: auth-web's predev rebuilds it via turbo (`scripts/build-frames-app.mjs`), but a long-running `pnpm dev` session keeps serving the bundle from its start.
 
+## Cloud tests before you push (`verify` is the gate)
+
+- The cloud CI job named **`verify`** (`.github/workflows/cloud-ci.yml`) runs
+  `turbo run lint typecheck test build --filter='@frameos-cloud/*'` and then
+  TWO integration suites against a real Postgres: `@frameos-cloud/auth-web`
+  and `@frameos-cloud/frame-hub`. Run the same three locally from `cloud/`
+  before pushing — a green `pnpm test` alone proves little, because the
+  integration suites are where the interesting failures live:
+
+  ```
+  pnpm exec turbo run lint typecheck test build --filter='@frameos-cloud/*'
+  pnpm --filter @frameos-cloud/auth-web test:integration
+  pnpm --filter @frameos-cloud/frame-hub test:integration
+  ```
+
+- **Never run two copies of one integration suite at once.** All of a suite's
+  files share ONE database and truncate between files (`fileParallelism: false`
+  exists for exactly this), so a background loop plus a foreground run will
+  produce unrelated "failures" in both. The two suites use different databases
+  and may run side by side. If tests you did not touch fail, check what else
+  was running before you believe the result.
+- **A `verify` failure is often not a type error.** Read the log before
+  concluding: the frame/device suites drive fake devices over the real command
+  queue with `setTimeout` poll loops, so they are timing-sensitive, and a
+  loaded CI runner surfaces races that a developer laptop never does — the
+  chunked-upload assertion in `frame-assets.integration.test.ts` failed on CI
+  and passed 15/15 locally.
+- **When one of those races bites, fix what the assertion measures — do not
+  add a retry, a sleep, or a widened tolerance.** The pattern that has already
+  caught us: asserting on *all* pending commands for a frame when the claim was
+  about one verb. Every asset write also queues an `assets_list` refresh, so a
+  frame legitimately has unrelated commands in flight; count per type
+  (`fakeDevice().maxPendingOfType(...)`) and record which commands were in
+  flight together, so the next failure explains itself instead of printing
+  `expected 2 to be 1`.
+
 ## Top-level layout
 - `backend/` – Python FastAPI application that exposes REST/WS APIs, schedules background jobs, and manages persistence via SQLAlchemy. Includes Alembic migrations, ARQ worker tasks, and pytest suites. 【F:backend/app/fastapi.py†L1-L101】【F:backend/app/tasks/worker.py†L1-L64】【F:backend/app/models/user.py†L1-L16】
 - `frontend/` – React + TypeScript single-page application built with esbuild, Tailwind, and kea state management. Compiled assets live in `frontend/dist` and are served by the backend when present. 【F:frontend/package.json†L1-L66】【F:backend/app/fastapi.py†L38-L86】

--- a/cloud/apps/auth-web/scripts/sweep-duplicate-scene-copies.mjs
+++ b/cloud/apps/auth-web/scripts/sweep-duplicate-scene-copies.mjs
@@ -11,8 +11,12 @@
 // What counts as a leftover copy here — all of these, together:
 //   - owned by the account, private, active,
 //   - never republished (latest_version = 1, exactly one version row),
-//   - never given a life of its own: no description, no tags, no gallery
-//     image beyond what the fork carried, not published anywhere,
+//   - never given a life of its own: no description, never published,
+//     nothing but the one version the copy was born with.
+//     NOT "no tags": publishing auto-classifies a new scene and assigns
+//     suggested tags, so every copy carries 4-5 inherited ones while the
+//     originals it was copied from all have descriptions. The absent
+//     description is the discriminator; the tags are noise.
 //   - named "<base> <n>" with n >= 2, where the account also has "<base>"
 //     or another copy of the same run,
 //   - created before --before (default: the #367 deploy).
@@ -173,13 +177,9 @@ try {
     if (!partOfARun) {
       continue;
     }
-    // A copy someone went on to describe, tag or re-publish is work, not
-    // litter. One version only: a second means it was saved over deliberately.
-    if (
-      scene.description ||
-      (scene.tags ?? []).length > 0 ||
-      scene.version_count !== 1
-    ) {
+    // A copy someone went on to describe or re-publish is work, not litter.
+    // One version only: a second means it was saved over deliberately.
+    if (scene.description || scene.version_count !== 1) {
       continue;
     }
 

--- a/cloud/apps/auth-web/src/test/integration/frame-assets.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frame-assets.integration.test.ts
@@ -440,7 +440,15 @@ function fakeDevice(
 ) {
   const seen: (typeof frameCommands.$inferSelect)[] = [];
   let stopped = false;
-  const state = { maxPendingSeen: 0 };
+  // Per TYPE, not overall: the asset routes queue an assets_list refresh
+  // after every write, so "pending commands for this frame" briefly includes
+  // one that has nothing to do with the upload under test. Counting all of
+  // them made "one chunk in flight" fail on a loaded runner whenever that
+  // refresh was still unacked as the next chunk went out.
+  const state = {
+    maxPendingByType: new Map<string, number>(),
+    overlaps: new Set<string>(),
+  };
   const loop = (async () => {
     while (!stopped) {
       const pending = await db
@@ -448,7 +456,22 @@ function fakeDevice(
         .from(frameCommands)
         .where(and(eq(frameCommands.frameId, frameId), eq(frameCommands.status, "pending")))
         .orderBy(frameCommands.createdAt);
-      state.maxPendingSeen = Math.max(state.maxPendingSeen, pending.length);
+      if (pending.length > 1) {
+        // Kept for the next time this trips on CI and not locally: the
+        // failure message then names WHICH commands were in flight together,
+        // instead of leaving "expected 2 to be 1" to be re-derived.
+        state.overlaps.add(pending.map((command) => command.type).sort().join(" + "));
+      }
+      const byType = new Map<string, number>();
+      for (const command of pending) {
+        byType.set(command.type, (byType.get(command.type) ?? 0) + 1);
+      }
+      for (const [type, count] of byType) {
+        state.maxPendingByType.set(
+          type,
+          Math.max(state.maxPendingByType.get(type) ?? 0, count),
+        );
+      }
       for (const command of pending) {
         seen.push(command);
         const reply = answer(command);
@@ -466,8 +489,13 @@ function fakeDevice(
   })();
   return {
     seen,
-    get maxPendingSeen() {
-      return state.maxPendingSeen;
+    /** Every combination of types seen pending together in one poll. */
+    get overlaps() {
+      return [...state.overlaps];
+    },
+    /** Most commands of this type seen pending in a single poll. */
+    maxPendingOfType(type: string) {
+      return state.maxPendingByType.get(type) ?? 0;
     },
     stop: async () => {
       stopped = true;
@@ -551,8 +579,13 @@ describe("POST /api/frames/{id}/assets/upload", () => {
     expect(reassembled[8192]).toBe(2);
     expect(reassembled[linuxAssetUploadChunkBytes + 4096]).toBe((linuxAssetUploadChunkBytes / 4096 + 1) & 0xff);
     // One chunk in flight at a time: the fake device only ever saw one
-    // pending asset_put_chunk per poll.
-    expect(device.maxPendingSeen).toBe(1);
+    // pending asset_put_chunk per poll. Counted per TYPE on purpose — every
+    // asset write also queues an assets_list refresh, so the frame legitimately
+    // has two unrelated commands in flight now and then.
+    expect(
+      device.maxPendingOfType("asset_put_chunk"),
+      `chunks were pipelined; commands seen together: ${device.overlaps.join(", ") || "none"}`,
+    ).toBe(1);
   });
 
   it("restarts once on chunk_gap and reports firmware that lacks the verb", async () => {

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -63,18 +63,17 @@ commands; everything else stays local to the device.
   remotely, redesign them as bounded toggles on fixed FrameOS-owned
   directories. Hardware identity reported by the frame stays authoritative.
 
-- **Sweep the private-scene copies the old save flow left behind.** The copies
-  are still there (33 in the founder account, 4 of them still assigned to a
-  frame); the flow that made them is fixed (PR #367) and the name race behind
-  the duplicate "7"s is closed (`withAccountSceneNameLock` serialises the
-  "pick a free name, then insert" against every other save for that account).
-  What is left is running the cleanup on production:
-  `pnpm scene:sweep-duplicate-copies -- --account=<id>` reports the copies it
-  judges to be litter (private, single-version, undescribed, untagged, part of
-  a "<name> N" run, created before the fix) and deletes them with `--apply`.
-  It never touches a copy a frame is running — those four want the frame
-  re-pointed at the original in the UI and deployed first, then the script
-  again. Run `scripts/object-store-sweep.sh` afterwards.
+- **Four assigned scene copies still to re-point.** The duplicate-copy sweep
+  ran on production 2026-08-18: 33 of the 37 leftover copies are gone
+  (`pnpm scene:sweep-duplicate-copies`, dump at `/root/pre-sweep-*.sql.gz`).
+  The four it deliberately left alone are the ones a frame is running —
+  "GitHub stars 2", "SD card image 3" and "Wikimedia Commons 3" on Wood7.3,
+  "SD card image 4" on SuurESP — because un-assigning a scene changes what a
+  wall displays and wants a deploy. Re-point each frame at the original scene
+  in the UI, deploy, then re-run the script to remove the freed copies, and
+  `scripts/object-store-sweep.sh --apply` (7-day min age) to free their bytes.
+  The flow that made them is fixed (PR #367) and the name race behind the
+  duplicate "7"s is closed (`withAccountSceneNameLock`).
 
 - **Account hardening.** Passkeys/TOTP 2FA, re-authentication before sensitive
   actions (revoking frames, bulk assignment changes, scope grants), and a


### PR DESCRIPTION
Follow-up to #369, which merged while the sweep was running against production.

### The filter was wrong

`scripts/sweep-duplicate-scene-copies.mjs` skipped any copy carrying tags, on the theory that a tagged copy is one someone made something of. Run against production it matched **nothing at all**: publishing auto-classifies a new scene and assigns suggested tags, so all 37 copies carry 4–5 inherited ones.

The real discriminator runs the other way round — every original has a description and no copy does — so the tags condition goes and the comment says why, to stop it coming back.

### The run

Against the founder account, dump taken first at `/root/pre-sweep-2026-08-18-2056.sql.gz`:

- **33 copies deleted**, 67 scenes → 34, no orphaned assignments.
- Both racing-save pairs cleared: `Abstract Architecture 7` ×2, and the orphan `Wikimedia Commons 3` whose assigned twin was correctly kept.
- **4 copies left alone as designed**, each one a frame is running: `GitHub stars 2`, `SD card image 3` and `Wikimedia Commons 3` on Wood7.3, `SD card image 4` on SuurESP.

`docs/todo.md` now names those four and what they need: re-point each frame at the original in the UI, deploy, re-run the script, then `scripts/object-store-sweep.sh --apply` for the bytes (it ignores anything younger than 7 days, so there is no rush).

🤖 Generated with [Claude Code](https://claude.com/claude-code)