### PR TITLE
Dither the thin-client bitmaps instead of banding them

### DIFF
--- a/backend/app/api/embedded_device.py
+++ b/backend/app/api/embedded_device.py
@@ -111,66 +111,99 @@ def embedded_render_dimensions(frame: Frame) -> tuple[int, int]:
     return DEFAULT_WIDTH, DEFAULT_HEIGHT
 
 
-def _nearest_palette_index(rgb: tuple[int, int, int], palette: list[tuple[int, int, int]]) -> int:
-    r, g, b = rgb
-    return min(
-        range(len(palette)),
-        key=lambda i: abs(r - palette[i][0]) + abs(g - palette[i][1]) + abs(b - palette[i][2]),
-    )
+def _dithered_indices(image, palette: list[tuple[int, int, int]]) -> bytes:
+    """One palette index per pixel, Floyd-Steinberg dithered.
+
+    The on-device renderers dither before packing (``ditherPaletteIndexed`` in
+    frameos/src/frameos/utils/dither.nim), so thin clients must too: picking
+    the nearest colour per pixel turns every gradient and photo into flat
+    bands. Pillow diffuses the error in C — a Python loop over 800x480 would
+    dominate the render. Palette entries map 1:1 onto the returned indices.
+    """
+    from PIL import Image
+
+    flat: list[int] = []
+    for entry in palette:
+        flat.extend(entry)
+    reference = Image.new("P", (1, 1))
+    reference.putpalette(flat)
+    return image.convert("RGB").quantize(
+        palette=reference, dither=Image.Dither.FLOYDSTEINBERG).tobytes()
+
+
+def _dithered_gray_levels(image, levels: int) -> bytes:
+    """One gray level (0..levels-1) per pixel, Floyd-Steinberg dithered.
+
+    Luma uses the same weights as the Nim renderer's ``toGrayscaleFloat`` so a
+    scene looks the same whether it rendered on-device or here.
+    """
+    luma = image.convert("RGB").convert("L", (0.21, 0.72, 0.07, 0))
+    return _dithered_indices(luma, [(round(i * 255 / (levels - 1)),) * 3 for i in range(levels)])
 
 
 def _pack_1bpp(image) -> bytes:
-    return image.convert("1").tobytes()
+    row = (image.width + 7) // 8
+    out = bytearray(row * image.height)
+    levels = _dithered_gray_levels(image, 2)
+    for y in range(image.height):
+        base = y * image.width
+        for x in range(image.width):
+            if levels[base + x]:
+                out[y * row + (x >> 3)] |= 0x80 >> (x & 7)
+    return bytes(out)
 
 
 def _pack_dual_1bpp(image, accent: tuple[int, int, int]) -> bytes:
-    palette = [(0, 0, 0), accent, (255, 255, 255)]
     row = (image.width + 7) // 8
     black = bytearray([0xFF] * (row * image.height))
     color = bytearray([0xFF] * (row * image.height))
-    rgb = image.convert("RGB")
+    indices = _dithered_indices(image, [(0, 0, 0), accent, (255, 255, 255)])
     for y in range(image.height):
+        base = y * image.width
         for x in range(image.width):
-            index = _nearest_palette_index(rgb.getpixel((x, y)), palette)
-            bit = 0x80 >> (x & 7)
-            offset = y * row + (x >> 3)
-            if index == 0:
-                black[offset] &= ~bit
-            elif index == 1:
-                color[offset] &= ~bit
+            index = indices[base + x]
+            if index > 1:
+                continue
+            plane = black if index == 0 else color
+            plane[y * row + (x >> 3)] &= ~(0x80 >> (x & 7))
     return bytes(black + color)
 
 
 def _pack_2bpp_gray(image) -> bytes:
     row = (image.width + 3) // 4
     out = bytearray(row * image.height)
-    gray = image.convert("L")
+    levels = _dithered_gray_levels(image, 4)
     for y in range(image.height):
+        base = y * image.width
         for x in range(image.width):
-            value = round(gray.getpixel((x, y)) * 3 / 255)
-            out[y * row + (x >> 2)] |= (value & 0x03) << (6 - ((x & 3) * 2))
+            out[y * row + (x >> 2)] |= (levels[base + x] & 0x03) << (6 - ((x & 3) * 2))
     return bytes(out)
 
 
 def _pack_4bpp_gray(image) -> bytes:
     row = (image.width + 1) // 2
     out = bytearray(row * image.height)
-    gray = image.convert("L")
+    levels = _dithered_gray_levels(image, 16)
     for y in range(image.height):
+        base = y * image.width
         for x in range(image.width):
-            value = round(gray.getpixel((x, y)) * 15 / 255)
-            out[y * row + (x >> 1)] |= (value & 0x0F) << (4 if (x & 1) == 0 else 0)
+            out[y * row + (x >> 1)] |= (levels[base + x] & 0x0F) << (4 if (x & 1) == 0 else 0)
     return bytes(out)
 
 
 def _pack_palette(image, palette: list[tuple[int, int, int]], bits: int) -> bytes:
+    # Spectra 6 leaves a hole at index 4: dither against the real colours only,
+    # then map back to the wire indices the panel expects.
+    entries = [(index, rgb) for index, rgb in enumerate(palette) if max(rgb) <= 255]
+    wire = bytes(index for index, _ in entries)
+    indices = _dithered_indices(image, [rgb for _, rgb in entries])
     divider = 4 if bits == 2 else 2
     row = (image.width + divider - 1) // divider
     out = bytearray(row * image.height)
-    rgb = image.convert("RGB")
     for y in range(image.height):
+        base = y * image.width
         for x in range(image.width):
-            index = _nearest_palette_index(rgb.getpixel((x, y)), palette)
+            index = wire[indices[base + x]]
             if bits == 2:
                 out[y * row + (x >> 2)] |= (index & 0x03) << (6 - ((x & 3) * 2))
             else:

--- a/backend/app/api/tests/test_embedded_device.py
+++ b/backend/app/api/tests/test_embedded_device.py
@@ -6,7 +6,13 @@ from app.models.frame import Frame
 from app.models.settings import Settings
 from app.tasks.embedded_firmware import (
     EMBEDDED_FIRMWARE_VERSION,
+    FOS_PIXEL_1BPP,
+    FOS_PIXEL_2BPP_BWYR,
+    FOS_PIXEL_2BPP_GRAY,
+    FOS_PIXEL_4BPP_7COLOR,
+    FOS_PIXEL_4BPP_GRAY,
     FOS_PIXEL_4BPP_SPECTRA6,
+    FOS_PIXEL_DUAL_1BPP_RED,
     embedded_firmware_config_hash,
     embedded_panel_for_frame,
     ensure_embedded_frame_defaults,
@@ -498,3 +504,76 @@ async def test_generated_config_uses_frame_network_wifi(async_client, db):
     assert '#define FRAMEOS_DEFAULT_WIFI_PASS "hunter2"' in header
     assert f'#define FRAMEOS_DEFAULT_FRAME_ID {frame.id}' in header
     assert '#define FRAMEOS_DEFAULT_PANEL "EPD_7in5_V2"' in header
+
+
+def _unpack_levels(packed: bytes, width: int, height: int, bits: int) -> list[int]:
+    """Every pixel's packed index, for the sub-byte formats."""
+    per_byte = 8 // bits
+    row = (width + per_byte - 1) // per_byte
+    mask = (1 << bits) - 1
+    return [
+        (packed[y * row + (x // per_byte)] >> (8 - bits - (x % per_byte) * bits)) & mask
+        for y in range(height) for x in range(width)
+    ]
+
+
+@pytest.mark.parametrize('pixel_format,bits,fill', [
+    (FOS_PIXEL_1BPP, 1, (128, 128, 128)),
+    # Between the 85 and 170 levels: nearest-colour picks one flat level.
+    (FOS_PIXEL_2BPP_GRAY, 2, (128, 128, 128)),
+    (FOS_PIXEL_4BPP_GRAY, 4, (128, 128, 128)),
+    # Halfway between the palette's white and yellow.
+    (FOS_PIXEL_2BPP_BWYR, 2, (232, 222, 163)),
+    (FOS_PIXEL_4BPP_7COLOR, 4, (232, 222, 163)),
+    (FOS_PIXEL_4BPP_SPECTRA6, 4, (188, 190, 96)),
+])
+def test_packers_dither_a_flat_field(pixel_format, bits, fill):
+    """A flat off-palette field must come out as a mix, not one flat level.
+
+    The thin-client packers used to quantize to the nearest colour, which
+    turned gradients and photos into hard bands on the panel — the on-device
+    renderers Floyd-Steinberg dither before packing, and these must match.
+    """
+    from PIL import Image
+
+    from app.api.embedded_device import pack_image_for_panel
+
+    width, height = 64, 16
+    packed = pack_image_for_panel(Image.new('RGB', (width, height), fill), pixel_format)
+    levels = _unpack_levels(packed, width, height, bits)
+    assert len(set(levels)) > 1, 'flat field quantized to a single level — dithering is gone'
+
+
+def test_dual_1bpp_dithers_a_flat_field():
+    from PIL import Image
+
+    from app.api.embedded_device import pack_image_for_panel
+
+    width, height = 64, 16
+    # Halfway between black and red: must mix the two planes, not pick one.
+    packed = pack_image_for_panel(
+        Image.new('RGB', (width, height), (128, 0, 0)), FOS_PIXEL_DUAL_1BPP_RED)
+    plane = len(packed) // 2
+    black_bits = sum(bin(byte).count('1') for byte in packed[:plane])
+    red_bits = sum(bin(byte).count('1') for byte in packed[plane:])
+    total = plane * 8
+    assert 0 < black_bits < total
+    assert 0 < red_bits < total
+
+
+def test_spectra6_packer_skips_the_missing_palette_index():
+    """Index 4 is a hole in the Spectra 6 wire palette — never emit it."""
+    from PIL import Image
+
+    from app.api.embedded_device import SPECTRA6_PALETTE, pack_image_for_panel
+
+    width, height = 60, 4
+    image = Image.new('RGB', (width, height))
+    colors = [rgb for rgb in SPECTRA6_PALETTE if max(rgb) <= 255]
+    for x in range(width):
+        for y in range(height):
+            image.putpixel((x, y), colors[(x * len(colors)) // width])
+    levels = _unpack_levels(
+        pack_image_for_panel(image, FOS_PIXEL_4BPP_SPECTRA6), width, height, 4)
+    assert 4 not in levels
+    assert set(levels) == {0, 1, 2, 3, 5, 6}

--- a/backend/app/api/virtual_frame.py
+++ b/backend/app/api/virtual_frame.py
@@ -42,7 +42,6 @@ from .embedded_device import (
     SEVEN_COLOR_PALETTE,
     SPECTRA6_PALETTE,
     _active_scene_id,
-    _nearest_palette_index,
     embedded_diagnostic_image,
     embedded_settings_payload,
 )


### PR DESCRIPTION
Photo of an XTEINK X4 rendering a weather scene showed virtually no dithering — flat gray bands where there should be texture. It turned out to be a real bug in the backend packer, not a panel limitation.

## Root cause

The X4 is PSRAM-less, so it is always a thin client: the backend renders the scene in wasm and packs the bitmap in `backend/app/api/embedded_device.py`. Every packer there did plain nearest-colour quantization, with no error diffusion:

```python
value = round(gray.getpixel((x, y)) * 3 / 255)   # _pack_2bpp_gray, the X4's format
```

The X4's panel (`EPD_4in26` → `FourGray` → 2bpp) has 4 gray levels, so any smooth gradient collapsed into 4 flat bands. On a gradient row:

```
before: 0000000000011111111111111111111122222222222222222222233333333333
after:  1001001010101010101010101101010110110101101010101011011011011101
```

Meanwhile the on-device Nim renderers (`frameos/src/frameos/utils/dither.nim`) *do* Floyd–Steinberg before packing — so the same scene looked right on a PSRAM board and banded on a thin client.

**Why it went unnoticed:** the only 1bpp path used `image.convert("1")`, and PIL applies Floyd–Steinberg there for free. So TRMNL OG and the other pure B/W boards looked fine, and the single existing dithering assertion in the test suite only exercised that format. Virtual frames (added later) already dither correctly — the pattern just never got backported to the device packers.

## The fix

All packers now dither through Pillow's C quantizer, using the same luma weights (0.21/0.72/0.07) as the Nim `toGrayscaleFloat`, so both render paths agree. It is also ~10x *faster* than the old per-pixel `getpixel` loops (0.04s for 800x480). `_pack_palette` now maps around the hole at Spectra 6 index 4 explicitly instead of relying on a sentinel never being nearest.

## Affected presets

`xteink_x4`, `trmnl_4in26_diy_kit`, `trmnl_bwry`, the Inky Frame / Pico family, `elecrow_crowpanel_5in79`, `seeed_reterminal_e1002`, and the S3 boards when switched to remote render mode. Pure 1bpp boards (TRMNL OG, reTerminal Sticky/E1001) were already fine.

**No reflash needed** — rendering is server-side, so devices pick this up on their next poll once the backend is deployed.

## Verification

- 7 new regression tests covering all 8 pixel formats, including the Spectra 6 index hole.
- **6 of 8 fail against the pre-fix packers** (verified by stashing the fix and re-running); the 2 that pass are 1bpp, which already dithered, and the orthogonal index-hole test.
- Full backend suite: **1121 passed, 5 skipped**.
- Visually confirmed by decoding the packed X4 payload back to an image — bar-chart steps that were previously indistinguishable are now distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)