### PR TITLE
Sweep the build's process group, not just its shell

### DIFF
--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+import shlex
+import sys
 
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -1749,6 +1751,63 @@ async def test_terminating_a_build_kills_the_processes_it_spawned():
             break
         await asyncio.sleep(0.1)
     assert not _process_is_running(child_pid)
+
+
+@pytest.mark.asyncio
+async def test_terminating_a_build_kills_children_that_ignore_sigterm(tmp_path):
+    """The escalation to SIGKILL must not hinge on the shell outliving SIGTERM.
+
+    ``bash -c`` dies on SIGTERM at once, so a cancel that waits for the shell
+    and then declares victory leaves behind exactly the process worth worrying
+    about: a compiler that traps SIGTERM. Only a SIGKILL aimed at the GROUP
+    ends that one, and the group is what a build cancel promises to clear.
+
+    Three details make this able to tell a fixed cancel from a broken one, each
+    of which silently made an earlier version of this test pass either way:
+      * `read` and not `wait` — bash defers SIGTERM until a job it is `wait`ing
+        on finishes, keeping the shell alive long enough for ANY implementation
+        to escalate on its own timeout;
+      * the grandchild's output goes to /dev/null instead of inheriting the
+        shell's stdout — asyncio's `wait()` also waits for the pipes to close,
+        and a process refusing to die holds them open, hiding the difference
+        behind that same timeout;
+      * the readiness handshake — a python that has not yet reached
+        `signal()` dies of the default SIGTERM like anything else, so without
+        waiting for it the test proves nothing.
+    """
+    ready = tmp_path / "ready"
+    ignores_sigterm = (
+        "import pathlib, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "pathlib.Path(sys.argv[1]).write_text('ready'); "
+        "time.sleep(120)"
+    )
+    process = await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(ignores_sigterm)} "
+        f"{shlex.quote(str(ready))} >/dev/null 2>&1 & echo $!; read _",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        start_new_session=True,
+    )
+    stubborn_pid = int((await process.stdout.readline()).strip())
+    for _ in range(100):
+        if ready.exists():
+            break
+        await asyncio.sleep(0.05)
+    assert ready.exists(), "grandchild never armed its SIGTERM handler"
+    assert _process_is_running(stubborn_pid)
+
+    await embedded_firmware_module._terminate_process_group(process)
+
+    assert process.returncode is not None
+    for _ in range(50):
+        if not _process_is_running(stubborn_pid):
+            break
+        await asyncio.sleep(0.1)
+    assert not _process_is_running(stubborn_pid)
 
 
 def test_build_root_is_redirectable_to_a_persistent_volume(monkeypatch, tmp_path):

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -2264,28 +2264,78 @@ async def _iter_process_lines(stream: asyncio.StreamReader):
         yield buffer
 
 
+# How long the group gets to finish on SIGTERM before SIGKILL, once the shell
+# itself is gone. Nothing waits on this in the common case: the loop below
+# stops as soon as the group is empty, which is normally within milliseconds.
+EMBEDDED_GROUP_KILL_GRACE_SECONDS = 3.0
+
+
+def _process_group_is_empty(group: int) -> bool:
+    """Whether *group* has no members left to signal."""
+    try:
+        os.killpg(group, 0)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        return False
+    return False
+
+
 async def _terminate_process_group(process: asyncio.subprocess.Process) -> None:
     """Kill the build and everything it spawned. The task runs ``bash -c``, so
     signalling the child alone would leave ninja and its compilers running:
     they would keep burning the machine's CPU and, worse, collide with the
-    next attempt inside the same build directory."""
+    next attempt inside the same build directory.
+
+    Escalating on "did the shell exit?" is not enough, and that is the bug this
+    shape exists to avoid: ``bash`` dies on SIGTERM at once, so waiting for it
+    and returning happy leaves behind anything in the group that blocks SIGTERM
+    or was forked in the instant before the signal landed. The shell's death is
+    the START of the question, so after it we watch the GROUP and SIGKILL
+    whatever is still there."""
     if process.returncode is not None:
         return
     try:
         group = os.getpgid(process.pid)
     except (ProcessLookupError, OSError):
         group = None
-    for sig in (signal.SIGTERM, signal.SIGKILL):
+
+    def signal_all(sig: int) -> bool:
+        """Signal the whole group (or just the child); False if it is gone."""
         try:
             if group is not None:
                 os.killpg(group, sig)
             else:
                 process.send_signal(sig)
         except (ProcessLookupError, OSError):
-            return
+            return False
+        return True
+
+    if not signal_all(signal.SIGTERM):
+        return
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(process.wait(), timeout=10)
+
+    if group is None:
+        # No group to sweep: the child is all there is to kill.
+        if process.returncode is None and signal_all(signal.SIGKILL):
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(process.wait(), timeout=10)
+        return
+
+    deadline = asyncio.get_running_loop().time() + EMBEDDED_GROUP_KILL_GRACE_SECONDS
+    while not _process_group_is_empty(group):
+        if asyncio.get_running_loop().time() >= deadline:
+            # Whatever is left has had its chance to exit cleanly. SIGKILL is
+            # a no-op against the zombies an unreaping PID 1 leaves behind, so
+            # this is safe to fire blind rather than parsing /proc for states.
+            signal_all(signal.SIGKILL)
+            break
+        await asyncio.sleep(0.05)
+
+    if process.returncode is None:
         with contextlib.suppress(asyncio.TimeoutError):
             await asyncio.wait_for(process.wait(), timeout=10)
-            return
 
 
 async def _build_firmware(db: Session, redis: Redis, frame: Frame, request_id: str | None) -> None:


### PR DESCRIPTION
`test_terminating_a_build_kills_the_processes_it_spawned` failed on the `python` job of an unrelated PR ([run](https://github.com/FrameOS/frameos/actions/runs/32188280761/job/95876828599)). It is not a flaky test — it was pointing at a real hole.

### The bug

`_terminate_process_group` signalled the group with SIGTERM, then escalated to SIGKILL **only if the shell outlived a 10s wait**:

```python
for sig in (signal.SIGTERM, signal.SIGKILL):
    ...
    with contextlib.suppress(asyncio.TimeoutError):
        await asyncio.wait_for(process.wait(), timeout=10)
        return          # ← the shell is reaped, so we return after SIGTERM
```

`bash -c` dies on SIGTERM at once, so the escalation almost never fired. Anything in the group that ignored SIGTERM, or was forked in the instant before it landed, was left running — precisely the "ninja and its compilers keep burning CPU and collide with the next build" case the docstring exists to prevent. On CI a slow runner widened that fork-before-exec window and the existing test caught it.

### The fix

The shell's death is now the *start* of the question. After it, watch the group and SIGKILL whatever is still there, with a 3s grace that costs nothing in the common case — the loop exits as soon as the group is empty (milliseconds), and SIGKILL is a no-op against the zombies an unreaping PID 1 leaves behind, so there is no /proc state parsing.

### The regression test took four tries to become one

Each failed attempt is a way this can look fixed while being broken, and all three are documented beside the test:

1. **`wait` vs `read`** — bash defers SIGTERM while `wait`ing on a job, so the shell survives to any timeout and *every* implementation escalates and looks correct.
2. **Inherited stdout** — asyncio's `wait()` does not return until the pipes close as well, and a process refusing to die holds them open, hiding the difference behind that same timeout.
3. **No readiness handshake** — a grandchild signalled before it installs its handler dies of the default action, proving nothing.

With the handshake and the child's output detached, the test fails against the old implementation with the exact CI symptom (`assert not True where True = _process_is_running(...)`) and passes against the new one. I verified both directions.

`app/api/tests/test_embedded_firmware.py`: 82 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)