### PR TITLE
Take ~2 minutes off the Deploy E2E SSH job

### DIFF
--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -583,6 +583,20 @@ jobs:
   deploy-e2e:
     name: Deploy E2E SSH
     runs-on: ubuntu-latest
+    # Redis for the runtime E2E test. A service container comes up during job
+    # setup instead of costing an `apt-get update && apt-get install` step
+    # (~30 s) inside it; the tests reach it through REDIS_URL, and the runtime
+    # test's skip guard probes that port rather than looking for a binary.
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -640,12 +654,6 @@ jobs:
         if: steps.cache_nim_toolchain.outputs.cache-hit == 'true'
         run: echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
-      - name: Install redis
-        run: |
-          sudo apt-get -y update
-          sudo apt-get install -y redis-server
-          redis-server --daemonize yes
-
       - name: Verify Docker
         run: docker version
 
@@ -693,19 +701,44 @@ jobs:
           nimble build
 
       # The test builds a Debian image with a toolchain in it (~54 s). Its tag
-      # is a hash of the build context, so building it here with a layer cache
-      # means the test finds it already present and skips the build; an edit to
-      # the context changes the tag and both this and the test rebuild.
-      - name: Pre-build SSH target image
+      # is a hash of the build context, so an image by that name can only have
+      # come from exactly these files: the test finds it in the daemon and
+      # skips the build, and an edit to the context changes the tag so both
+      # this and the test rebuild.
+      #
+      # The whole image is cached as one tarball rather than as buildx layers.
+      # With a layer cache every run still paid buildx's export-then-import
+      # round trip into the daemon (~68 s for a 175 MB image, more than the
+      # build it was saving); `docker load` of a cached tar is ~10 s.
+      - name: Compute SSH target image tag
+        id: ssh_target_tag
+        run: echo "tag=$(python3 backend/app/tasks/tests/deploy_ssh_target/context_tag.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SSH target image
+        id: cache_ssh_target
+        uses: actions/cache@v4
+        with:
+          path: .tmp/ssh-target-image.tar
+          key: ${{ runner.os }}-ssh-target-image-${{ steps.ssh_target_tag.outputs.tag }}
+
+      - name: Load cached SSH target image
+        if: steps.cache_ssh_target.outputs.cache-hit == 'true'
+        run: docker load -i .tmp/ssh-target-image.tar
+
+      - name: Build SSH target image
+        if: steps.cache_ssh_target.outputs.cache-hit != 'true'
         run: |
-          TAG="$(python3 backend/app/tasks/tests/deploy_ssh_target/context_tag.py)"
+          TAG="${{ steps.ssh_target_tag.outputs.tag }}"
           echo "SSH target image: $TAG"
-          docker buildx build \
-            --load \
-            --cache-from type=gha,scope=deploy-e2e-ssh-target \
-            --cache-to type=gha,mode=max,scope=deploy-e2e-ssh-target \
-            -t "$TAG" \
-            backend/app/tasks/tests/deploy_ssh_target
+          docker build -t "$TAG" backend/app/tasks/tests/deploy_ssh_target
+          mkdir -p .tmp
+          docker save -o .tmp/ssh-target-image.tar "$TAG"
+
+      - name: Verify SSH target image is present under the tag the test computes
+        run: |
+          TAG="${{ steps.ssh_target_tag.outputs.tag }}"
+          docker image inspect "$TAG" > /dev/null
+          echo "SSH target image present: $TAG"
 
       - name: Run SSH deploy E2E test
         run: |

--- a/backend/app/tasks/tests/deploy_ssh_target/.dockerignore
+++ b/backend/app/tasks/tests/deploy_ssh_target/.dockerignore
@@ -1,0 +1,7 @@
+# Kept in step with _is_context_input in context_tag.py: neither the tag
+# helper nor Python bytecode is part of the image.
+context_tag.py
+__pycache__/
+*.pyc
+*.pyo
+.dockerignore

--- a/backend/app/tasks/tests/deploy_ssh_target/context_tag.py
+++ b/backend/app/tasks/tests/deploy_ssh_target/context_tag.py
@@ -22,14 +22,39 @@ from pathlib import Path
 IMAGE_NAME = "frameos-deploy-e2e-ssh-target"
 
 
+# Files that live in the context directory but never reach the image, so they
+# must not move the tag. `.dockerignore` keeps them out of Docker's build
+# context; this list keeps them out of the digest — the two say the same thing.
+_NOT_PART_OF_THE_IMAGE = {".dockerignore", Path(__file__).name}
+_NOT_PART_OF_THE_IMAGE_DIRS = {"__pycache__"}
+_NOT_PART_OF_THE_IMAGE_SUFFIXES = {".pyc", ".pyo"}
+
+
+def _is_context_input(path: Path, root: Path) -> bool:
+    if path.name in _NOT_PART_OF_THE_IMAGE:
+        return False
+    if path.suffix in _NOT_PART_OF_THE_IMAGE_SUFFIXES:
+        return False
+    return not any(
+        part in _NOT_PART_OF_THE_IMAGE_DIRS for part in path.relative_to(root).parts
+    )
+
+
 def context_digest(context_dir: Path | None = None) -> str:
-    """Short digest over every file in the build context, path names included."""
+    """Short digest over every file in the build context, path names included.
+
+    "Every file" once meant literally every file, and that cost the CI job the
+    whole point of pre-building: the workflow computed the tag by RUNNING this
+    file, then the test computed it again by IMPORTING it — and importing
+    writes ``__pycache__/context_tag.cpython-*.pyc`` into this very directory,
+    so the second digest disagreed with the first, the pre-built image was
+    never found, and the test rebuilt it from scratch on every run (~48 s on
+    top of the ~68 s pre-build). Only what Docker actually sends counts.
+    """
     root = context_dir or Path(__file__).parent
     digest = hashlib.sha256()
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
-        # This helper is part of the context but not part of the image, so
-        # changing the tag logic must not invalidate the image it names.
-        if path.name == Path(__file__).name:
+        if not _is_context_input(path, root):
             continue
         digest.update(path.relative_to(root).as_posix().encode())
         digest.update(b"\0")

--- a/backend/app/tasks/tests/test_deploy_ssh_target_context_tag.py
+++ b/backend/app/tasks/tests/test_deploy_ssh_target_context_tag.py
@@ -1,0 +1,77 @@
+"""The SSH target image tag must be the same whichever way it is computed.
+
+CI computes it twice: the workflow runs context_tag.py as a script to name
+the image it pre-builds, and the E2E test imports the module to decide
+whether that image is already present. Importing writes ``__pycache__`` into
+the build context, and a digest over "every file" moved with it — so the two
+disagreed, the pre-built image was never found, and every run rebuilt it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import py_compile
+import shutil
+import sys
+from pathlib import Path
+
+CONTEXT_DIR = Path(__file__).with_name("deploy_ssh_target")
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("context_tag", CONTEXT_DIR / "context_tag.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _copy_context(tmp_path: Path) -> Path:
+    target = tmp_path / "ctx"
+    shutil.copytree(CONTEXT_DIR, target, ignore=shutil.ignore_patterns("__pycache__"))
+    return target
+
+
+def test_bytecode_and_ignore_files_do_not_move_the_tag(tmp_path: Path) -> None:
+    helper = _load_helper()
+    ctx = _copy_context(tmp_path)
+    clean = helper.context_tag(ctx)
+
+    # What `import context_tag` leaves behind on a machine that writes bytecode.
+    py_compile.compile(str(ctx / "context_tag.py"), cfile=str(ctx / "__pycache__" / "context_tag.cpython-312.pyc"))
+    (ctx / "__pycache__" / "stray.pyo").write_bytes(b"\x00")
+    assert helper.context_tag(ctx) == clean
+
+    # The two files that are in the directory but never in the image.
+    (ctx / ".dockerignore").write_text("# rewritten\n")
+    (ctx / "context_tag.py").write_text("# rewritten helper\n")
+    assert helper.context_tag(ctx) == clean
+
+
+def test_image_inputs_do_move_the_tag(tmp_path: Path) -> None:
+    helper = _load_helper()
+    ctx = _copy_context(tmp_path)
+    clean = helper.context_tag(ctx)
+
+    with (ctx / "Dockerfile").open("a") as handle:
+        handle.write("\n# a change to the image\n")
+    assert helper.context_tag(ctx) != clean
+
+
+def test_dockerignore_agrees_with_the_digest() -> None:
+    """Whatever the digest skips, Docker must not send either — and vice
+    versa — or the tag would name an image built from different inputs."""
+    ignored = {
+        line.strip()
+        for line in (CONTEXT_DIR / ".dockerignore").read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+    assert ignored == {"context_tag.py", "__pycache__/", "*.pyc", "*.pyo", ".dockerignore"}
+
+
+def test_helper_is_importable_by_the_e2e_test() -> None:
+    sys.path.insert(0, str(CONTEXT_DIR))
+    try:
+        import context_tag  # noqa: F401
+    finally:
+        sys.path.remove(str(CONTEXT_DIR))

--- a/backend/app/tasks/tests/test_real_frameos_runtime_e2e.py
+++ b/backend/app/tasks/tests/test_real_frameos_runtime_e2e.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import shutil
 import socket
 import subprocess
 import threading
@@ -226,9 +225,30 @@ def _runtime_logs(db, frame: Frame) -> list[str]:
     ]
 
 
+def _redis_reachable() -> bool:
+    """Whether something answers on the Redis the backend is configured for.
+
+    Asks the question that matters — is there a Redis to talk to — instead of
+    "is a redis-server binary on PATH", which said no to a perfectly good
+    Redis in a CI service container and skipped the test.
+    """
+    from urllib.parse import urlparse
+
+    from app.config import config
+
+    parsed = urlparse(config.REDIS_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6379
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
 def test_real_frameos_runtime_posts_render_done_to_backend(db, tmp_path: Path) -> None:
-    if not shutil.which("redis-server") and os.environ.get("REDIS_URL", "").startswith("redis://localhost"):
-        pytest.skip("redis-server is required for the runtime HTTP backend test")
+    if not _redis_reachable():
+        pytest.skip("a reachable Redis (REDIS_URL) is required for the runtime HTTP backend test")
 
     server_port = _free_port()
     frame_port = _free_port()

--- a/backend/app/tasks/tests/test_real_ssh_deploy_e2e.py
+++ b/backend/app/tasks/tests/test_real_ssh_deploy_e2e.py
@@ -477,7 +477,14 @@ async def test_real_ssh_full_fast_cross_and_precompiled_deploy(
     nim_path = find_nim_v2()
     _say(f"using Nim compiler at {nim_path}")
     monkeypatch.setenv("FRAMEOS_CROSS_CACHE", str(tmp_path / "cross-cache"))
-    monkeypatch.setenv("FRAMEOS_CROSS_MAKE_JOBS", os.environ.get("FRAMEOS_CROSS_MAKE_JOBS", "2"))
+    # Production cross-compiles use every core (`nproc` inside the toolchain
+    # container); this used to pin the test to 2 and left half of a 4-core
+    # runner idle for the ~50 s C compile. The env override stays for anyone
+    # who needs to throttle it on a shared machine.
+    monkeypatch.setenv(
+        "FRAMEOS_CROSS_MAKE_JOBS",
+        os.environ.get("FRAMEOS_CROSS_MAKE_JOBS") or str(os.cpu_count() or 2),
+    )
     monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "precompiled-cache"))
 
     with _phase("full deploy with compile on device"):


### PR DESCRIPTION
The **Deploy E2E SSH** job is the slowest in the PR workflow — ~9–10 min, with the SSH deploy test itself at ~4 min. I profiled it from the step and phase timestamps of two green runs (32188374744, 32185531909) rather than guessing. Three things dominate, and all three are waste.

### 1. The pre-built target image was never used (−48 s)

The workflow names the image by **running** `context_tag.py`; the test names it by **importing** the module. Importing writes `__pycache__/context_tag.cpython-*.pyc` into the build context — which "a digest over every file in the context" duly counted. Result, every run:

```
SSH target image: frameos-deploy-e2e-ssh-target:cb129a8c0c28    ← workflow pre-builds this (68 s)
docker build -q -t frameos-deploy-e2e-ssh-target:a22176742c7c   ← test can't find it, rebuilds (48 s)
```

The digest now counts only what Docker actually sends, and a `.dockerignore` says the same on Docker's side. This was invisible locally: `PYTHONDONTWRITEBYTECODE=1` in a dev shell hides it — my first check looked fine until I forced bytecode on and reproduced the drift.

### 2. The pre-build itself was mostly export/import (−~55 s)

With a buildx layer cache, the "pre-build" was ~68 s of exporting a 175 MB image and importing it into the daemon — more than the ~54 s build it saved. The whole image is now cached as **one tarball** via `actions/cache`, keyed by the tag; `docker load` is ~10 s. A context edit changes the tag, misses the cache, and rebuilds.

### 3. Cross-compile pinned to 2 jobs on a 4-core runner (−~20 s)

Production defaults to `nproc` inside the toolchain container; the test hard-coded `2`. ~50 s of C compilation at half speed. Follows the machine now; the env override is intact.

### 4. Redis via apt (−~25 s)

`apt-get update && apt-get install redis-server` was ~30 s inside the job. A `services:` container comes up during job setup for free. The runtime test's skip guard looked for a `redis-server` **binary** — which would have skipped the test against a service container — so it now probes the port `REDIS_URL` names, which is the actual question.

### Expected

Job ~9.5 min → ~7.5 min; the SSH test ~4 min → ~2.5 min. Not touched: the ~50 s native `nimble build` (the runtime E2E needs the binary) and the on-device compile (already `nproc`, memory permitting).

### Guarded

`test_deploy_ssh_target_context_tag.py` — **fails against the old helper, passes against the new** (verified both directions), and pins `.dockerignore` to the digest's skip list so the two cannot drift. Runtime E2E re-run locally against a real Redis with the new guard: passes. The 8 ruff findings in the touched test files all pre-exist on `main` unchanged.

The real proof is this PR's own Deploy E2E SSH run — the log should now say `reusing SSH target image` and the job time should drop. I'll compare once it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)