### PR TITLE
A 16-bit render canvas on ESP32: 1200x1600 renders on 8 MB of PSRAM (reTerminal E1004)

### DIFF
--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -211,9 +211,12 @@ def test_embedded_firmware_layout_tracks_flash_and_ram():
     assert layout['ram']['width'] == 1200
     assert layout['ram']['height'] == 1600
     assert layout['ram']['pixelFormat'] == FOS_PIXEL_4BPP_SPECTRA6
-    assert layout['ram']['rgbaBufferBytes'] == 1200 * 1600 * 4
+    # The canvas is 16-bit RGB (2 B/px); the old key name stays for the UI.
+    assert layout['ram']['canvasBytesPerPixel'] == 2
+    assert layout['ram']['canvasBufferBytes'] == 1200 * 1600 * 2
+    assert layout['ram']['rgbaBufferBytes'] == layout['ram']['canvasBufferBytes']
     assert layout['ram']['packedBufferBytes'] == 960_000
-    assert layout['ram']['renderWorkingBytes'] > layout['ram']['rgbaBufferBytes']
+    assert layout['ram']['renderWorkingBytes'] > layout['ram']['canvasBufferBytes']
 
 
 def test_embedded_firmware_layout_keeps_large_16mb_state_partition():
@@ -555,9 +558,13 @@ def test_embedded_panel_formats_and_buffer_sizes():
 
 
 def test_embedded_render_psram_estimate():
-    # 800x480 RGBA (1.5MB) + default packed 1bpp + ~1.5MB reserve is ~3MB.
+    # 800x480 at 2 B/px (768KB) + default packed 1bpp + ~1.5MB reserve is ~2.4MB.
     need = embedded_render_psram_bytes(800, 480)
-    assert 2_900_000 < need < 3_200_000
+    assert 2_300_000 < need < 2_500_000
+    # 1200x1600 Spectra 6: 3.84MB canvas + 960KB packed + 1.5MB reserve, under 8MB.
+    need = embedded_render_psram_bytes(1200, 1600, FOS_PIXEL_4BPP_SPECTRA6)
+    assert 6_300_000 < need < 6_400_000
+    assert need < 8 * 1024 * 1024
 
 
 def test_panel_fits_default_8mb_module():
@@ -575,14 +582,22 @@ def test_panel_too_large_for_small_psram_is_rejected():
     assert "PSRAM" in str(exc.value)
 
 
-def test_large_spectra_panel_requires_16mb_for_local_rendering():
+def test_large_spectra_panel_renders_locally_on_8mb_module():
+    # 1200x1600 used to need the 16MB module (7.3MB RGBA canvas); with the
+    # 16-bit canvas it fits the stock 8MB one — the reTerminal E1004 case.
     frame = Frame(device="waveshare.EPD_13in3e")
-    with pytest.raises(ValueError) as exc:
-        check_embedded_panel_fits_memory(frame)
-    assert "13in3e" in str(exc.value)
+    assert embedded_module_psram_bytes(frame) == 8 * 1024 * 1024
+    check_embedded_panel_fits_memory(frame)  # must not raise
 
     frame.device_config = {"psramMB": 16, "pins": {"cs2": 8}}
     check_embedded_panel_fits_memory(frame)
+
+    # A module that really is too small is still refused with a clear reason.
+    frame.device_config = {"psramMB": 4}
+    with pytest.raises(ValueError) as exc:
+        check_embedded_panel_fits_memory(frame)
+    assert "13in3e" in str(exc.value)
+    assert "PSRAM" in str(exc.value)
 
 
 def test_embedded_defaults_choose_response_limit_and_pin_layout():
@@ -871,6 +886,37 @@ def test_embedded_hardware_preset_for_seeed_reterminal_e10xx():
             {"pin": 5, "label": "RIGHT"},
         ]
         assert embedded_sd_card_assets_for_frame(frame)["enabled"] is False
+
+
+def test_embedded_hardware_preset_for_seeed_reterminal_e1004():
+    frame = Frame(id=9, embedded={"hardwarePreset": "seeed_reterminal_e1004"})
+
+    ensure_embedded_frame_defaults(frame)
+
+    assert embedded_panel_for_frame(frame) == "EPD_13in3e"
+    assert embedded_platform_for_frame(frame) == "esp32-s3"
+    assert embedded_flash_size_for_frame(frame) == "32MB"
+    # 8MB PSRAM and a 1200x1600 panel: renders on-device thanks to the
+    # 16-bit canvas; this is the whole reason that canvas exists.
+    assert embedded_module_psram_bytes(frame) == 8 * 1024 * 1024
+    assert embedded_render_mode_for_frame(frame) != EMBEDDED_RENDER_REMOTE
+    check_embedded_panel_fits_memory(frame)
+    assert embedded_pins_for_frame(frame) == {
+        "rst": 38, "dc": 11, "cs": 10, "cs2": 2,
+        "busy": 13, "sck": 7, "mosi": 9, "pwr": 12,
+    }
+    assert not frame.gpio_buttons  # none published for this board yet
+    assert embedded_sd_card_assets_for_frame(frame)["enabled"] is False
+    plan = embedded_provisioning_plan(frame)
+    settings = _provisioned(plan)
+    assert plan["settings"][0]["key"] == "hardware"
+    assert settings["hardware"] == "seeed_reterminal_e1004"
+    assert settings["panel"] == "EPD_13in3e"
+    assert settings["pins"] == "rst=38,dc=11,cs=10,cs2=2,busy=13,sck=7,mosi=9,pwr=12"
+    assert settings["render_mode"] == "local"
+    assert embedded_sdkconfig_defaults_for_frame(frame) == (
+        "sdkconfig.defaults;sdkconfig.defaults.32mb-ota"
+    )
 
 
 def test_embedded_hardware_preset_for_elecrow_crowpanel_5in79():

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -111,7 +111,7 @@ EMBEDDED_PLATFORMS: dict[str, dict[str, Any]] = {
 EMBEDDED_PLATFORM_ALIASES = EMBEDDED_PLATFORMS[SUPPORTED_EMBEDDED_PLATFORM]["aliases"]
 EMBEDDED_PROJECT_DIR = REPO_ROOT / "embedded" / "esp32"
 # Bump when the firmware project changes so existing "ready" images rebuild on next request
-EMBEDDED_FIRMWARE_VERSION = 47  # boot-time framebuffer reservation (C3 thin-client OOM), honest board.target
+EMBEDDED_FIRMWARE_VERSION = 48  # 16-bit render canvas reserved at boot, streamed packers, E1004 (T133A01) preset
 EMBEDDED_DEFAULT_PANEL = "EPD_7in5_V2"
 EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES = 4 * 1024 * 1024
 EMBEDDED_PIN_KEYS = ("rst", "dc", "cs", "cs2", "busy", "sck", "mosi", "pwr")
@@ -257,6 +257,24 @@ EMBEDDED_SEEED_RETERMINAL_E10XX_GPIO_BUTTONS = [
     {"pin": 4, "label": "LEFT"},
     {"pin": 5, "label": "RIGHT"},
 ]
+# Seeed reTerminal E1004 (ESP32-S3, 32MB flash, 8MB PSRAM): 13.3" 1200x1600
+# Spectra 6 (T133A01) on the E-series SPI bus — SCK7/MOSI9, CS10, DC11,
+# BUSY13 as the E1001/E1002 — but with the panel's second chip-select on
+# GPIO2, reset on GPIO38 and a panel power enable on GPIO12 (the pins
+# ESPHome's integrated-board definition for this model bakes in). Buttons
+# and the microSD slot are not published; they stay unset until read off
+# the schematic. The panel is driven as EPD_13in3e with the T133A01 tuning
+# the firmware selects from this preset (components/frameos_display).
+EMBEDDED_SEEED_RETERMINAL_E1004_PINS = {
+    "rst": 38,
+    "dc": 11,
+    "cs": 10,
+    "cs2": 2,
+    "busy": 13,
+    "sck": 7,
+    "mosi": 9,
+    "pwr": 12,
+}
 # Elecrow CrowPanel 5.79" (ESP32-S3-WROOM-1-N8R8): dual-SSD1683 792x272 panel
 # on SCK12/MOSI11, CS45, DC46, RST47, BUSY48 (vendor demo code spi.h).
 # Buttons: HOME=2, EXIT=1, rotary NEXT=4, OK=5, PREV=6.
@@ -392,6 +410,14 @@ EMBEDDED_HARDWARE_PRESETS: dict[str, dict[str, Any]] = {
         "psramMB": 8,
         "pins": EMBEDDED_SEEED_RETERMINAL_E10XX_PINS,
         "gpioButtons": EMBEDDED_SEEED_RETERMINAL_E10XX_GPIO_BUTTONS,
+    },
+    "seeed_reterminal_e1004": {
+        # 1200x1600 on an 8MB module: the 16-bit render canvas is what makes
+        # this render on-device (3.7MB instead of 7.3MB RGBA).
+        "device": "waveshare.EPD_13in3e",
+        "flashSize": "32MB",
+        "psramMB": 8,
+        "pins": EMBEDDED_SEEED_RETERMINAL_E1004_PINS,
     },
     "elecrow_crowpanel_5in79": {
         "device": "waveshare.EPD_5in79",
@@ -545,10 +571,14 @@ EMBEDDED_RELEASE_FIRMWARE: dict[str, dict[str, str]] = {
     "esp32-s3": {"asset": "esp32-s3-generic", "flashSize": "8MB"},
     "esp32-c3": {"asset": "esp32-c3-generic", "flashSize": "4MB"},
 }
-# Memory guardrail (M4): the on-device renderer composites into an RGBA pixie
-# buffer (4 B/px), packs it to the selected panel format, and needs headroom
-# for the Nim heap + QuickJS. Keep the reserve in sync with
-# FOS_RENDER_PSRAM_RESERVE in components/frameos_display/frameos_display.c.
+# Memory guardrail (M4): the on-device renderer composites into a pixie canvas
+# (16-bit RGB 5/6/5, 2 B/px — frameos/src/embedded/embedded_runtime.nim
+# `renderCanvas`), packs it to the selected panel format, and needs headroom
+# for the Nim heap + QuickJS. Keep both constants in sync with
+# FOS_RENDER_CANVAS_BYTES_PER_PIXEL / FOS_RENDER_PSRAM_RESERVE in
+# components/frameos_display (the firmware's boot-time fit check) and
+# EmbeddedReserveBytes in frameos/src/frameos/utils/memory.nim.
+EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL = 2
 EMBEDDED_RENDER_PSRAM_RESERVE_BYTES = 1536 * 1024
 EMBEDDED_QUICKJS_HEAP_LIMIT_BYTES = 4 * 1024 * 1024
 EMBEDDED_PREVIEW_SNAPSHOT_RESERVE_BYTES = 1024 * 1024
@@ -1169,9 +1199,9 @@ def embedded_buffer_size(width: int, height: int, pixel_format: int) -> int:
 
 def embedded_render_psram_bytes(width: int, height: int, pixel_format: int = FOS_PIXEL_1BPP) -> int:
     """PSRAM the on-device renderer needs for a width×height panel."""
-    rgba = width * height * 4
+    canvas = width * height * EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL
     packed = embedded_buffer_size(width, height, pixel_format)
-    return rgba + packed + EMBEDDED_RENDER_PSRAM_RESERVE_BYTES
+    return canvas + packed + EMBEDDED_RENDER_PSRAM_RESERVE_BYTES
 
 
 def _parse_embedded_size(value: str) -> int:
@@ -1287,11 +1317,13 @@ def embedded_firmware_layout_for_frame(frame: Frame, firmware: dict[str, Any] | 
     dims = device_dimensions(frame.device) or (0, 0)
     width, height = dims
     pixel_format = embedded_pixel_format_for_panel(panel)
-    rgba_bytes = width * height * 4 if width > 0 and height > 0 else 0
+    canvas_bytes = (
+        width * height * EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL if width > 0 and height > 0 else 0
+    )
     packed_bytes = embedded_buffer_size(width, height, pixel_format) if width > 0 and height > 0 else 0
     render_mode = embedded_render_mode_for_frame(frame)
     render_working_bytes = (
-        rgba_bytes + packed_bytes + EMBEDDED_RENDER_PSRAM_RESERVE_BYTES
+        canvas_bytes + packed_bytes + EMBEDDED_RENDER_PSRAM_RESERVE_BYTES
         if render_mode == EMBEDDED_RENDER_LOCAL and panel != "none"
         else 0
     )
@@ -1317,7 +1349,10 @@ def embedded_firmware_layout_for_frame(frame: Frame, firmware: dict[str, Any] | 
             "pixelFormat": pixel_format,
             "pixelFormatName": _pixel_format_name(pixel_format),
             "renderMode": "local" if render_mode == EMBEDDED_RENDER_LOCAL else "remote",
-            "rgbaBufferBytes": rgba_bytes,
+            # Historical key name: the canvas is 16-bit RGB now, not RGBA.
+            "rgbaBufferBytes": canvas_bytes,
+            "canvasBufferBytes": canvas_bytes,
+            "canvasBytesPerPixel": EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL,
             "packedBufferBytes": packed_bytes,
             "renderReserveBytes": EMBEDDED_RENDER_PSRAM_RESERVE_BYTES,
             "renderWorkingBytes": render_working_bytes,

--- a/cloud-frontend/src/components/Esp32CloudFlasher.tsx
+++ b/cloud-frontend/src/components/Esp32CloudFlasher.tsx
@@ -78,6 +78,11 @@ const boardChoices = [
     platform: genericPlatform,
   },
   {
+    label: 'Seeed reTerminal E1004 (13.3" color ESP32-S3)',
+    value: 'hw:seeed_reterminal_e1004',
+    platform: genericPlatform,
+  },
+  {
     label: 'Elecrow CrowPanel 5.79" (ESP32-S3)',
     value: 'hw:elecrow_crowpanel_5in79',
     platform: genericPlatform,

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-esp32-flasher.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-esp32-flasher.test.tsx
@@ -592,6 +592,7 @@ describe("Esp32CloudFlasher", () => {
         "hw:seeed_reterminal_sticky",
         "hw:seeed_reterminal_e1001",
         "hw:seeed_reterminal_e1002",
+        "hw:seeed_reterminal_e1004",
         "hw:elecrow_crowpanel_5in79",
       ]),
     );

--- a/docs/esp32-memory.md
+++ b/docs/esp32-memory.md
@@ -25,6 +25,30 @@ Measured 2026-08-14 on v2026.8.19 with `-d:memProbe`:
 The first render after a boot — the one that also pays the scene parse and
 the app transpiles — no longer touches the emergency reserve.
 
+## The canvas is 2 bytes per pixel (2026.8.31)
+
+The scene canvas became a 16-bit RGB 5/6/5 pixie image (`embedded/esp32/README.md`,
+"The render canvas is 16-bit"). The budget arithmetic that moved with it, in
+its four mirrors — `FOS_RENDER_CANVAS_BYTES_PER_PIXEL` in
+`components/frameos_display/include/frameos_display.h`,
+`EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL` in `backend/app/tasks/embedded_firmware.py`,
+the `byteSize` the interpreter's cache limits use, and the 1.5 MiB reserve
+shared with `frameos/src/frameos/utils/memory.nim`:
+
+| panel | canvas (was RGBA) | packed | reserve | total (was) |
+|---|---|---|---|---|
+| 800×480 4bpp | 0.73 MiB (1.46) | 0.18 | 1.50 | 2.42 MiB (3.15) |
+| 792×272 2bpp | 0.41 MiB (0.82) | 0.05 | 1.50 | 1.96 MiB (2.37) |
+| 1200×1600 4bpp | 3.66 MiB (7.32) | 0.92 | 1.50 | **6.08 MiB** (9.74) |
+
+The 13.3" row is the one that changed category: it fits the 8 MB module now.
+The measured ~1.3 MB non-canvas render peak above was taken at 800×480; the
+pieces of it that scale with canvas width (pixie's per-row scratch, SVG
+bands) are small, but a 1200×1600 measurement on an 8 MB board is still the
+number to take before trusting the margin. The canvas block is claimed at
+boot (`frameos_nim_reserve_canvas`) and never freed, so "largest free block"
+no longer has to hold it at render time.
+
 ## The 1 MB emergency reserve stays
 
 `FOS_NIM_EMERGENCY_RESERVE_BYTES` (frameos_nim_glue.c) was sized when a

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -169,6 +169,7 @@ for the two Spectra boards most of the bench work runs on:
 | `seeed_reterminal_sticky` | S3 | EPD_3in97 3.97" | reTerminal Sticky, 32MB flash |
 | `seeed_reterminal_e1001` | S3 | EPD_7in5_V2 7.5" mono | reTerminal E1001, 32MB flash |
 | `seeed_reterminal_e1002` | S3 | EPD_7in3e 7.3" Spectra | reTerminal E1002, 32MB flash |
+| `seeed_reterminal_e1004` | S3 | EPD_13in3e 13.3" Spectra (T133A01 tuning) | reTerminal E1004, 32MB flash, 8MB PSRAM — renders on-device on the 16-bit canvas |
 | `elecrow_crowpanel_5in79` | S3 | EPD_5in79 5.79" 4-gray | CrowPanel, dual SSD1683 |
 
 The TRMNL X (10.3" 1872×1404 parallel e-ink over EPDIY/FastEPD) is not yet
@@ -385,6 +386,32 @@ all. The id ↔ slot mapping lives in the index. Every failure path (an
 unsplittable payload, more than 32 scenes, a full partition) falls back to
 loading the combined file whole, so a frame cannot lose its scenes to a
 failed optimization.
+
+## The render canvas is 16-bit (2026.8.31)
+
+The scene canvas the Nim renderer composites into is a pixie `pfRgb565`
+image — packed RGB 5/6/5, 2 bytes per pixel — not RGBA. Every panel this
+firmware drives is a dithered e-paper, and the dither keeps its own
+full-precision error rows beside the canvas (`forEachPaletteDithered` /
+`forEachGrayDithered` in `frameos/src/frameos/utils/dither.nim`), so the
+5/6-bit colour the canvas holds is a precision the output cannot show: a
+6-colour Floyd–Steinberg field has per-pixel error dozens of times the 565
+step. What it buys is the **13.3" 1200×1600 panel on an 8 MB module** — the
+RGBA canvas was 7.3 MiB and did not fit, the 565 one is 3.7 MiB and does
+(`fos_display_render_psram_bytes`: canvas + packed + 1.5 MiB reserve =
+6.1 MiB). Every other board gains 0.4–0.7 MiB of headroom, and half the
+PSRAM traffic per render.
+
+The canvas is also **one block for the device's uptime**: `main.c` calls
+`frameos_nim_reserve_canvas(fos_display_canvas_bytes())` right after the
+fit check and before `fos_wifi_init`, so the multi-MB contiguous run exists
+before Wi-Fi and TLS fragment the heap, and `embedded_runtime.nim`'s
+`renderCanvas()` wraps it with `newImage565Over` and reuses it every render.
+Nothing aliases the canvas across renders (the value pipeline never caches
+the live canvas), so reuse is safe, and the per-render allocate/collect
+churn is gone. `-d:frameosCanvasRgbx` in `FRAMEOS_EXTRA_NIM_FLAGS` keeps the
+old RGBA canvas for A/B measurement. The Pi runtime and the wasm preview are
+untouched and keep full RGBA.
 
 Two allocation facts worth knowing before profiling anything here:
 

--- a/embedded/esp32/components/frameos_display/frameos_display.c
+++ b/embedded/esp32/components/frameos_display/frameos_display.c
@@ -12,6 +12,9 @@
 static const char *TAG = "fos_display";
 
 void EPD_7IN3E_SetPhotoPainterMode(int enabled) __attribute__((weak));
+void EPD_13IN3E_SetVariant(int variant) __attribute__((weak));
+#define FOS_EPD_13IN3E_VARIANT_WAVESHARE 0
+#define FOS_EPD_13IN3E_VARIANT_T133A01 1
 
 static const fos_panel_entry_t *s_panel = NULL;
 static bool s_module_ready = false;
@@ -20,6 +23,17 @@ static bool is_photo_painter_hardware(const fos_display_config_t *config)
 {
     return config && config->hardware_preset &&
            strcmp(config->hardware_preset, "waveshare_esp32_s3_photopainter") == 0;
+}
+
+/* Seeed reTerminal E1004: the same 1200x1600 Spectra 6 panel class as the
+ * Waveshare 13.3" E6 and driven by the same EPD_13in3e code, but its T133A01
+ * panel wants the vendor's own analogue tuning in the init sequence. Like the
+ * PhotoPainter PMIC, that is a fact about the board, so the preset selects
+ * it; the panel key stays EPD_13in3e everywhere else. */
+static bool is_reterminal_e1004_hardware(const fos_display_config_t *config)
+{
+    return config && config->hardware_preset &&
+           strcmp(config->hardware_preset, "seeed_reterminal_e1004") == 0;
 }
 
 static size_t panel_buffer_size(int width, int height, fos_pixel_format_t format)
@@ -73,6 +87,11 @@ esp_err_t fos_display_init(const fos_display_config_t *config)
     bool photo_painter = is_photo_painter_hardware(config);
     if (EPD_7IN3E_SetPhotoPainterMode) {
         EPD_7IN3E_SetPhotoPainterMode(photo_painter ? 1 : 0);
+    }
+    if (EPD_13IN3E_SetVariant) {
+        EPD_13IN3E_SetVariant(is_reterminal_e1004_hardware(config)
+                                  ? FOS_EPD_13IN3E_VARIANT_T133A01
+                                  : FOS_EPD_13IN3E_VARIANT_WAVESHARE);
     }
 
     if (photo_painter) {
@@ -136,14 +155,23 @@ fos_pixel_format_t fos_display_panel_format(size_t index)
 /* Headroom beyond the two framebuffers for the Nim heap, QuickJS (capped at
  * 4MB but typically far less), pixie temporaries (fonts, gradients) and
  * allocator fragmentation. Empirically ~1.5MB is comfortable for the 800x480
- * scenes have been verified on an 8MB module. */
+ * scenes have been verified on an 8MB module; the 2026-08-14 probe on that
+ * module measured ~1.3 MB of non-canvas render peak. Keep in sync with
+ * EMBEDDED_RENDER_PSRAM_RESERVE_BYTES (backend) and EmbeddedReserveBytes
+ * (frameos/src/frameos/utils/memory.nim). */
 #define FOS_RENDER_PSRAM_RESERVE (1536u * 1024u)
+
+size_t fos_display_canvas_bytes(void)
+{
+    if (!s_panel) return 0;
+    return (size_t)fos_display_width() * (size_t)fos_display_height() *
+           (size_t)FOS_RENDER_CANVAS_BYTES_PER_PIXEL;
+}
 
 size_t fos_display_render_psram_bytes(void)
 {
     if (!s_panel) return 0;
-    size_t rgba = (size_t)fos_display_width() * (size_t)fos_display_height() * 4u;
-    return rgba + fos_display_buffer_size() + FOS_RENDER_PSRAM_RESERVE;
+    return fos_display_canvas_bytes() + fos_display_buffer_size() + FOS_RENDER_PSRAM_RESERVE;
 }
 
 static esp_err_t ensure_module(void)

--- a/embedded/esp32/components/frameos_display/include/frameos_display.h
+++ b/embedded/esp32/components/frameos_display/include/frameos_display.h
@@ -47,7 +47,17 @@ const char *fos_display_panel_name(size_t index);
 int fos_display_panel_width(size_t index);
 int fos_display_panel_height(size_t index);
 fos_pixel_format_t fos_display_panel_format(size_t index);
-/* PSRAM the on-device renderer needs for this panel: the RGBA scene buffer
+/* Bytes per pixel of the scene canvas the Nim renderer composites into.
+ * 2: pixie's 16-bit RGB 5/6/5 surface (frameos/src/embedded/embedded_runtime.nim,
+ * `renderCanvas`). Every panel here is a dithered e-paper and the dither keeps
+ * its own full-precision error rows, so the canvas's 5/6-bit colour is
+ * below what the output can show — and it is what fits a 1200x1600 canvas
+ * in an 8 MB module (3.7 MiB instead of 7.3 MiB). Mirrored by
+ * EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL in backend embedded_firmware.py. */
+#define FOS_RENDER_CANVAS_BYTES_PER_PIXEL 2u
+/* Bytes of the scene canvas for the selected panel (0 when headless). */
+size_t fos_display_canvas_bytes(void);
+/* PSRAM the on-device renderer needs for this panel: the scene canvas
  * pixie composites into, the selected packed panel output, plus headroom for
  * the Nim heap and QuickJS interpreter. 0 when headless. Used to refuse panels
  * that won't fit the module's PSRAM (they'd OOM mid-render). */

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -105,6 +105,48 @@ static void nim_lock_give(void)
     if (s_nim_lock != NULL) xSemaphoreGive(s_nim_lock);
 }
 
+/* ------------------------------------------------------- the scene canvas
+ *
+ * One PSRAM block for the Nim renderer's scene canvas, claimed at boot and
+ * never freed. A 1200x1600 canvas is a 3.7 MB contiguous run; after hours of
+ * Wi-Fi, TLS and heap churn the allocator may not have one, and "largest free
+ * block" is exactly the number the render budget keys on. Claiming it before
+ * fos_wifi_init (main.c) is what guarantees it exists, the same way the
+ * thin-client framebuffer is reserved. The Nim side wraps it with pixie's
+ * newImage565Over and reuses it every render (embedded_runtime.nim). */
+static void *s_canvas = NULL;
+static size_t s_canvas_len = 0;
+
+bool frameos_nim_reserve_canvas(size_t len)
+{
+    if (len == 0) return false;
+    if (s_canvas != NULL && s_canvas_len >= len) return true;
+    void *next = heap_caps_malloc(len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (next == NULL) {
+        ESP_LOGW("fos_nim", "canvas: could not reserve %u KB of PSRAM (largest free block %u KB)",
+                 (unsigned)(len / 1024),
+                 (unsigned)(heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) / 1024));
+        return false;
+    }
+    if (s_canvas != NULL) heap_caps_free(s_canvas);
+    s_canvas = next;
+    s_canvas_len = len;
+    ESP_LOGI("fos_nim", "canvas: reserved %u KB of PSRAM", (unsigned)(len / 1024));
+    return true;
+}
+
+void *frameos_nim_canvas_buffer(size_t len)
+{
+    /* Late or larger than reserved (a panel change at runtime): claim now. */
+    if (!frameos_nim_reserve_canvas(len)) return NULL;
+    return s_canvas;
+}
+
+size_t frameos_nim_canvas_reserved(void)
+{
+    return s_canvas_len;
+}
+
 /* The packed buffer allocated during fos_nim_render_alloc_impl is invisible
  * to the OOM longjmp handler, so remember the newest one here (all Nim
  * calls are serialized by s_nim_lock) and free it if the render aborts. */

--- a/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_stub.c
@@ -3,6 +3,9 @@
 #include "frameos_nim.h"
 
 bool frameos_nim_available(void) { return false; }
+bool frameos_nim_reserve_canvas(size_t len) { (void)len; return false; }
+void *frameos_nim_canvas_buffer(size_t len) { (void)len; return NULL; }
+size_t frameos_nim_canvas_reserved(void) { return 0; }
 bool frameos_nim_init(int width, int height, const char *frame_name,
                       uint32_t max_http_response_bytes, const char *backend_url,
                       const char *api_key, bool server_send_logs, int rotate)

--- a/embedded/esp32/components/frameos_nim/include/frameos_nim.h
+++ b/embedded/esp32/components/frameos_nim/include/frameos_nim.h
@@ -18,6 +18,16 @@ extern "C" {
 
 /* True when the Nim runtime is compiled in. */
 bool frameos_nim_available(void);
+/* The scene canvas: one PSRAM block of `len` bytes claimed once and kept for
+ * the device's uptime (fos_display_canvas_bytes() for the selected panel).
+ * Call at boot, before Wi-Fi, so the multi-MB contiguous run exists before
+ * the heap fragments; the Nim renderer draws every frame into it. Returns
+ * false (and keeps any earlier reservation) when PSRAM cannot supply it;
+ * the renderer then falls back to its heap. */
+bool frameos_nim_reserve_canvas(size_t len);
+/* The reserved block, claiming (or growing) it on demand. NULL on failure. */
+void *frameos_nim_canvas_buffer(size_t len);
+size_t frameos_nim_canvas_reserved(void);
 /* One-time init: panel dimensions + the backend credentials the runtime's own
  * uploads use. Safe to call when unavailable (returns false). Allocates the
  * Nim heap (PSRAM via malloc). */

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -434,6 +434,14 @@ static int cmd_set(int argc, char **argv)
               "rst=12,dc=11,cs=10,cs2=-1,busy=13,sck=7,mosi=9,pwr=-1",
               "3:REFRESH\n4:LEFT\n5:RIGHT",
               "", -1, 2.0f },
+            /* Seeed reTerminal E1004: 13.3" 1200x1600 Spectra 6 (T133A01) on
+             * the E-series bus, second CS on GPIO2, reset 38, panel power 12.
+             * The display component selects the T133A01 init tuning from this
+             * preset name. Buttons/SD not published yet. */
+            { "seeed_reterminal_e1004", "EPD_13in3e",
+              "rst=38,dc=11,cs=10,cs2=2,busy=13,sck=7,mosi=9,pwr=12",
+              "",
+              "", -1, 2.0f },
             /* Elecrow CrowPanel 5.79" (ESP32-S3-WROOM-1-N8R8). */
             { "elecrow_crowpanel_5in79", "EPD_5in79",
               "rst=47,dc=46,cs=45,cs2=-1,busy=48,sck=12,mosi=11,pwr=-1",

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -203,6 +203,13 @@ void app_main(void)
         }
     }
 
+    /* The renderer's scene canvas, claimed now for the same reason the thin-
+     * client framebuffer was above: it is the one multi-MB contiguous PSRAM
+     * run the device needs, and before Wi-Fi/TLS there is always one. */
+    if (local_render_ok && frameos_nim_available() && fos_display_present()) {
+        frameos_nim_reserve_canvas(fos_display_canvas_bytes());
+    }
+
     BOOTMEM("after-sd");
     ESP_ERROR_CHECK(fos_wifi_init());
     fos_http_set_actions(action_render_now, action_ota_now);

--- a/frameos/frameos.nimble
+++ b/frameos/frameos.nimble
@@ -16,7 +16,7 @@ bin           = @["frameos"]
 requires "chrono >= 0.3.1"
 requires "checksums >= 0.2.1"
 requires "nim >= 2.2.4"
-requires "https://github.com/FrameOS/pixie#f80412d2473ee994ece88aa4e2fbf094240e0f33"
+requires "https://github.com/FrameOS/pixie#64ce3c9d50170ba5c1e879b414710650a2811423"
 requires "mummy >= 0.4.7"
 requires "linuxfb >= 0.1.0"
 requires "QRgen >= 3.1.0"

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "73412a41067633cc3d1289d0a69bdc0072a3cfd7",
+      "vcsRevision": "64ce3c9d50170ba5c1e879b414710650a2811423",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "c21e1b1bd95f2815342554e26f9c3e7fb16d9484"
+        "sha1": "cbe7b87a3e146d49033d260a0ee8dba7a08b22b5"
       }
     }
   },

--- a/frameos/src/drivers/waveshare/epd13in3e/EPD_13in3e.c
+++ b/frameos/src/drivers/waveshare/epd13in3e/EPD_13in3e.c
@@ -96,6 +96,40 @@ const UBYTE TFT_VCOM_POWER_V[1] = {
 	0x02
 };
 
+/* T133A01 (Seeed reTerminal E1004) tuning, from the vendor's Arduino driver
+ * (T133A01_Defines.h, EPD_INIT) as mirrored by ESPHome's epaper_spi T133A01
+ * model. Same register map and dual-CS routing as above; only these values
+ * and the two structural differences in EPD_13IN3E_Init change. */
+const UBYTE AN_TM_V_T133A01[9] = {
+	0x00, 0x0C, 0x0C, 0xD9, 0xDD, 0xDD, 0x15, 0x15, 0x55
+};
+const UBYTE CDI_V_T133A01[1] = {
+	0x37
+};
+const UBYTE BTST_P_V_T133A01[2] = {
+	0xE0, 0x20
+};
+const UBYTE BTST_N_V_T133A01[2] = {
+	0xE0, 0x20
+};
+#define DCDC_T133A01 0xA5
+const UBYTE DCDC_V_T133A01[3] = {
+	0x44, 0x54, 0x00
+};
+
+static int s_variant = EPD_13IN3E_VARIANT_WAVESHARE;
+
+void EPD_13IN3E_SetVariant(int variant)
+{
+    s_variant = (variant == EPD_13IN3E_VARIANT_T133A01) ? EPD_13IN3E_VARIANT_T133A01
+                                                         : EPD_13IN3E_VARIANT_WAVESHARE;
+}
+
+int EPD_13IN3E_GetVariant(void)
+{
+    return s_variant;
+}
+
 
 static void EPD_13IN3E_CS_ALL(UBYTE Value)
 {
@@ -221,8 +255,14 @@ void EPD_13IN3E_Init(void)
         return;
     }
 
+    const int t133a01 = (s_variant == EPD_13IN3E_VARIANT_T133A01);
+
     DEV_Digital_Write(EPD_CS_M_PIN, 0);
-	EPD_13IN3E_SPI_Sand(AN_TM, AN_TM_V, sizeof(AN_TM_V));
+    if (t133a01) {
+        EPD_13IN3E_SPI_Sand(AN_TM, AN_TM_V_T133A01, sizeof(AN_TM_V_T133A01));
+    } else {
+        EPD_13IN3E_SPI_Sand(AN_TM, AN_TM_V, sizeof(AN_TM_V));
+    }
     EPD_13IN3E_CS_ALL(1);
 
     EPD_13IN3E_CS_ALL(0);
@@ -233,8 +273,19 @@ void EPD_13IN3E_Init(void)
 	EPD_13IN3E_SPI_Sand(PSR, PSR_V, sizeof(PSR_V));
     EPD_13IN3E_CS_ALL(1);
 
+    if (t133a01) {
+        /* DC/DC setting, master only — the T133A01 sequence's one extra step. */
+        DEV_Digital_Write(EPD_CS_M_PIN, 0);
+        EPD_13IN3E_SPI_Sand(DCDC_T133A01, DCDC_V_T133A01, sizeof(DCDC_V_T133A01));
+        EPD_13IN3E_CS_ALL(1);
+    }
+
     EPD_13IN3E_CS_ALL(0);
-	EPD_13IN3E_SPI_Sand(CDI, CDI_V, sizeof(CDI_V));
+    if (t133a01) {
+        EPD_13IN3E_SPI_Sand(CDI, CDI_V_T133A01, sizeof(CDI_V_T133A01));
+    } else {
+        EPD_13IN3E_SPI_Sand(CDI, CDI_V, sizeof(CDI_V));
+    }
     EPD_13IN3E_CS_ALL(1);
 
     EPD_13IN3E_CS_ALL(0);
@@ -249,9 +300,12 @@ void EPD_13IN3E_Init(void)
 	EPD_13IN3E_SPI_Sand(PWS, PWS_V, sizeof(PWS_V));
     EPD_13IN3E_CS_ALL(1);
 
-    EPD_13IN3E_CS_ALL(0);
-	EPD_13IN3E_SPI_Sand(CCSET, CCSET_V, sizeof(CCSET_V));
-    EPD_13IN3E_CS_ALL(1);
+    if (!t133a01) {
+        /* The T133A01 vendor sequence does not program CCSET. */
+        EPD_13IN3E_CS_ALL(0);
+        EPD_13IN3E_SPI_Sand(CCSET, CCSET_V, sizeof(CCSET_V));
+        EPD_13IN3E_CS_ALL(1);
+    }
 
     EPD_13IN3E_CS_ALL(0);
 	EPD_13IN3E_SPI_Sand(TRES, TRES_V, sizeof(TRES_V));
@@ -266,7 +320,11 @@ void EPD_13IN3E_Init(void)
     EPD_13IN3E_CS_ALL(1);
 
     DEV_Digital_Write(EPD_CS_M_PIN, 0);
-	EPD_13IN3E_SPI_Sand(BTST_P, BTST_P_V, sizeof(BTST_P_V));
+    if (t133a01) {
+        EPD_13IN3E_SPI_Sand(BTST_P, BTST_P_V_T133A01, sizeof(BTST_P_V_T133A01));
+    } else {
+        EPD_13IN3E_SPI_Sand(BTST_P, BTST_P_V, sizeof(BTST_P_V));
+    }
     EPD_13IN3E_CS_ALL(1);
 
     DEV_Digital_Write(EPD_CS_M_PIN, 0);
@@ -274,7 +332,11 @@ void EPD_13IN3E_Init(void)
     EPD_13IN3E_CS_ALL(1);
 
     DEV_Digital_Write(EPD_CS_M_PIN, 0);
-	EPD_13IN3E_SPI_Sand(BTST_N, BTST_N_V, sizeof(BTST_N_V));
+    if (t133a01) {
+        EPD_13IN3E_SPI_Sand(BTST_N, BTST_N_V_T133A01, sizeof(BTST_N_V_T133A01));
+    } else {
+        EPD_13IN3E_SPI_Sand(BTST_N, BTST_N_V, sizeof(BTST_N_V));
+    }
     EPD_13IN3E_CS_ALL(1);
 
     DEV_Digital_Write(EPD_CS_M_PIN, 0);

--- a/frameos/src/drivers/waveshare/epd13in3e/EPD_13in3e.h
+++ b/frameos/src/drivers/waveshare/epd13in3e/EPD_13in3e.h
@@ -68,6 +68,15 @@
 
 
 
+/* Panel tuning variants. The same controller family drives the Waveshare
+ * 13.3" E6 HAT and the panel in Seeed's reTerminal E1004 (T133A01), but the
+ * vendors' init sequences differ in the analogue tuning registers (0x74,
+ * 0x50, 0x05/0x06, and an extra 0xA5 on the T133A01). Select before Init;
+ * the default is the Waveshare tuning this driver always had. */
+#define EPD_13IN3E_VARIANT_WAVESHARE 0
+#define EPD_13IN3E_VARIANT_T133A01   1
+void EPD_13IN3E_SetVariant(int variant);
+int EPD_13IN3E_GetVariant(void);
 void EPD_13IN3E_Init(void);
 void EPD_13IN3E_Clear(UBYTE color);
 void EPD_13IN3E_Display(const UBYTE *Image);

--- a/frameos/src/embedded/embedded_main.nim
+++ b/frameos/src/embedded/embedded_main.nim
@@ -96,7 +96,7 @@ proc packImage1bpp(image: Image; buf: ptr UncheckedArray[uint8]; bufLen: int): b
   # image); each output bit lands at its rotated panel position.
   for y in 0 ..< height:
     for x in 0 ..< width:
-      let pixel = image.data[image.dataIndex(x, y)]
+      let pixel = image.unsafe[x, y]
       let gray = (pixel.r.float32 * 0.299f + pixel.g.float32 * 0.587f +
                   pixel.b.float32 * 0.114f) / 255.0f + currentError[x + 1]
       let white = gray >= 0.5f
@@ -123,20 +123,13 @@ proc copyPacked(pixels: seq[uint8]; buf: ptr UncheckedArray[uint8]; bufLen: int)
     buf[i] = pixels[i]
   true
 
-proc grayLevel(value: float32; maxValue: uint8): uint8 {.inline.} =
-  let rounded = round(value).int
-  if rounded < 0:
-    return 0
-  if rounded > maxValue.int:
-    return maxValue
-  rounded.uint8
-
-proc clip8(value: int): uint8 {.inline.} =
-  if value < 0:
-    return 0
-  if value > 255:
-    return 255
-  value.uint8
+# The packers below all stream: two rows of dither state beside the canvas
+# (`forEachPaletteDithered` / `forEachGrayDithered` in utils/dither), the
+# canvas read through pixie's accessors and never written. That is what lets
+# the canvas be a 16-bit image — the colour it holds stays 5/6-bit while the
+# diffused error keeps full precision — and it is also what removed the
+# per-render full-frame scratch the old versions needed (an 8-byte float per
+# pixel for grey, a full RGBA copy for the two-plane panels).
 
 proc packImageGray(image: Image; buf: ptr UncheckedArray[uint8]; bufLen: int; maxValue: uint8): bool =
   let
@@ -149,24 +142,16 @@ proc packImageGray(image: Image; buf: ptr UncheckedArray[uint8]; bufLen: int; ma
     log(&"pack gray: buffer mismatch, want {rowBytes * frameHeight} bytes, got {bufLen}")
     return false
 
-  var
-    gray = newSeq[float](width * height)
-  image.toGrayscaleFloat(gray, maxValue.float)
-  gray.floydSteinberg(width, height)
-
   for i in 0 ..< bufLen:
     buf[i] = 0
-  for y in 0 ..< height:
-    for x in 0 ..< width:
-      let
-        inputIndex = y * width + x
-        (px, py) = panelCoords(x, y, width, height)
-        outIndex = py * rowBytes + px div pixelsPerByte
-        level = grayLevel(gray[inputIndex].float32, maxValue)
-      if bits == 2:
-        buf[outIndex] = buf[outIndex] or ((level and 0b11'u8) shl (6 - (px mod 4) * 2))
-      else:
-        buf[outIndex] = buf[outIndex] or ((level and 0x0F'u8) shl (if (px mod 2) == 0: 4 else: 0))
+  image.forEachGrayDithered(maxValue.int, x, y, level):
+    let
+      (px, py) = panelCoords(x, y, width, height)
+      outIndex = py * rowBytes + px div pixelsPerByte
+    if bits == 2:
+      buf[outIndex] = buf[outIndex] or ((level.uint8 and 0b11'u8) shl (6 - (px mod 4) * 2))
+    else:
+      buf[outIndex] = buf[outIndex] or ((level.uint8 and 0x0F'u8) shl (if (px mod 2) == 0: 4 else: 0))
   true
 
 proc packImageDual1bpp(
@@ -178,29 +163,24 @@ proc packImageDual1bpp(
   let
     width = image.width
     height = image.height
-    inputRowBytes = (width + 3) div 4
     packedRowBytes = (frameWidth + 7) div 8
     planeBytes = packedRowBytes * frameHeight
   if planeBytes * 2 != bufLen:
     log(&"pack dual: buffer mismatch, want {planeBytes * 2} bytes, got {bufLen}")
     return false
 
-  let pixels = ditherPaletteIndexed(image, @[(0, 0, 0), (255, if accentIsRed: 0 else: 255, 0), (255, 255, 255)])
+  let palette = @[(0, 0, 0), (255, if accentIsRed: 0 else: 255, 0), (255, 255, 255)]
   for i in 0 ..< bufLen:
     buf[i] = 0
-
-  for y in 0 ..< height:
-    for x in 0 ..< width:
-      let
-        pixelByte = pixels[y * inputRowBytes + x div 4]
-        pixelValue = (pixelByte shr ((3 - x mod 4) * 2)) and 0b11
-        black: uint8 = if pixelValue == 0: 0'u8 else: 1'u8
-        accent: uint8 = if pixelValue == 1: 0'u8 else: 1'u8
-        (px, py) = panelCoords(x, y, width, height)
-        outputIndex = py * packedRowBytes + px div 8
-        shift = 7 - (px mod 8)
-      buf[outputIndex] = buf[outputIndex] or (black shl shift)
-      buf[planeBytes + outputIndex] = buf[planeBytes + outputIndex] or (accent shl shift)
+  image.forEachPaletteDithered(palette, x, y, index):
+    let
+      black: uint8 = if index == 0: 0'u8 else: 1'u8
+      accent: uint8 = if index == 1: 0'u8 else: 1'u8
+      (px, py) = panelCoords(x, y, width, height)
+      outputIndex = py * packedRowBytes + px div 8
+      shift = 7 - (px mod 8)
+    buf[outputIndex] = buf[outputIndex] or (black shl shift)
+    buf[planeBytes + outputIndex] = buf[planeBytes + outputIndex] or (accent shl shift)
   true
 
 proc packImagePalette(
@@ -215,9 +195,6 @@ proc packImagePalette(
     bits = if palette.len <= 2: 1 elif palette.len <= 4: 2 elif palette.len <= 16: 4 else: 8
     pixelsPerByte = if palette.len <= 2: 8 elif palette.len <= 4: 4 elif palette.len <= 16: 2 else: 1
     rowBytes = (frameWidth + pixelsPerByte - 1) div pixelsPerByte
-    distribution = [7, 3, 5, 1]
-    dy = [0, 1, 1, 1]
-    dx = [1, -1, 0, 1]
 
   if rowBytes * frameHeight != bufLen:
     log(&"pack palette: buffer mismatch, want {rowBytes * frameHeight} bytes, got {bufLen}")
@@ -226,47 +203,24 @@ proc packImagePalette(
   for i in 0 ..< bufLen:
     buf[i] = 0
 
-  # Mutate the rendered image in-place while packing. The image is discarded
-  # immediately after this step, and avoiding an extra pixie image copy plus a
-  # packed output seq keeps ESP32 renders inside PSRAM headroom.
-  for y in 0 ..< height:
-    for x in 0 ..< width:
-      let
-        dataIndex = y * width + x
-        (px, py) = panelCoords(x, y, width, height)
-        outputIndex = py * rowBytes + px div pixelsPerByte
-        imageR = image.data[dataIndex].r.int
-        imageG = image.data[dataIndex].g.int
-        imageB = image.data[dataIndex].b.int
-        (index, palR, palG, palB) = closestPalette(palette, imageR, imageG, imageB)
-        errorR = imageR - palR
-        errorG = imageG - palG
-        errorB = imageB - palB
-
-      case bits:
-      of 8:
-        buf[outputIndex] = index.uint8
-      of 4:
-        let bitPosition = (1 - (px mod 2)) * 4
-        buf[outputIndex] = buf[outputIndex] or (index shl bitPosition).uint8
-      of 2:
-        let bitPosition = (3 - (px mod 4)) * 2
-        buf[outputIndex] = buf[outputIndex] or (index shl bitPosition).uint8
-      of 1:
-        let bitPosition = (7 - px) mod 8
-        buf[outputIndex] = buf[outputIndex] or (index shl bitPosition).uint8
-      else:
-        discard
-
-      for i in 0 ..< 4:
-        let
-          nextX = x + dx[i]
-          nextY = y + dy[i]
-        if nextX >= 0 and nextX < width and nextY < height:
-          let errorIndex = nextY * width + nextX
-          image.data[errorIndex].r = clip8(image.data[errorIndex].r.int + (errorR * distribution[i] div 16))
-          image.data[errorIndex].g = clip8(image.data[errorIndex].g.int + (errorG * distribution[i] div 16))
-          image.data[errorIndex].b = clip8(image.data[errorIndex].b.int + (errorB * distribution[i] div 16))
+  image.forEachPaletteDithered(palette, x, y, index):
+    let
+      (px, py) = panelCoords(x, y, width, height)
+      outputIndex = py * rowBytes + px div pixelsPerByte
+    case bits:
+    of 8:
+      buf[outputIndex] = index.uint8
+    of 4:
+      let bitPosition = (1 - (px mod 2)) * 4
+      buf[outputIndex] = buf[outputIndex] or (index shl bitPosition).uint8
+    of 2:
+      let bitPosition = (3 - (px mod 4)) * 2
+      buf[outputIndex] = buf[outputIndex] or (index shl bitPosition).uint8
+    of 1:
+      let bitPosition = (7 - px) mod 8
+      buf[outputIndex] = buf[outputIndex] or (index shl bitPosition).uint8
+    else:
+      discard
 
   true
 
@@ -274,7 +228,7 @@ proc renderFrameImage(): tuple[image: Image, source: string] =
   let interpreted = renderCurrentScene()
   if interpreted.isSome:
     return (interpreted.get(), "interpreted scene \"" & currentSceneName() & "\"")
-  (render(sceneWidth(), sceneHeight(), frameName, renderCount + 1), "demo scene")
+  (renderDemoInto(renderCanvas(), frameName, renderCount + 1), "demo scene")
 
 proc packImageForFormat(
     image: Image;
@@ -427,7 +381,10 @@ proc renderErrorFallback(
   ## the previous panel contents) when it does not.
   try:
     GC_fullCollect()
-    let image = renderError(sceneWidth(), sceneHeight(), message)
+    # Into the persistent canvas: a fresh full-frame image here is exactly
+    # the allocation an OOM-aborted render could not afford.
+    let image = renderCanvas()
+    image.renderErrorInto(image.width, image.height, message)
     if not packImageForFormat(image, buf, bufLen, pixelFormat):
       return 1
     GC_fullCollect()
@@ -457,6 +414,9 @@ proc fos_nim_render_impl(
     let renderedAt = getMonoTime()
     if not packImageForFormat(image, buf, bufLen.int, pixelFormat.int):
       return 1
+    # The image is the persistent canvas (or, for a scene that produced its
+    # own, a one-off); dropping our reference and collecting frees the latter
+    # and costs the former nothing.
     image = nil
     GC_fullCollect()
     let packed = getMonoTime()
@@ -494,7 +454,8 @@ proc renderErrorFallbackAlloc(
     let raw = renderBufferAlloc(packedLen.csize_t)
     if raw == nil:
       return 1
-    let image = renderError(sceneWidth(), sceneHeight(), message)
+    let image = renderCanvas()
+    image.renderErrorInto(image.width, image.height, message)
     if not packImageForFormat(image, cast[ptr UncheckedArray[uint8]](raw), packedLen, pixelFormat):
       renderBufferFree(raw)
       return 1

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -463,6 +463,73 @@ proc fos_nim_set_fusion_impl(enabled: cint) {.exportc, cdecl.} =
   renderRequested = true
   log("image fusion " & (if wanted: "enabled" else: "disabled") & "; scene will re-plan")
 
+# ------------------------------------------------------------- the canvas
+#
+# One scene canvas for the device's uptime, not one per render.
+#
+# Two decisions live here. The format: a 16-bit RGB 5/6/5 pixie image, half
+# the bytes of RGBA. Every panel the ESP32 firmware drives is a dithered
+# e-paper, and the dither (`forEachPaletteDithered`, `forEachGrayDithered`)
+# keeps its error state in its own rows at full precision, so the 5/6-bit
+# colour the canvas holds is a precision the output cannot show: a 6-colour
+# Floyd–Steinberg field has per-pixel error dozens of times the 565 step. It
+# is what makes 1200x1600 fit an 8 MB module — RGBA is 7.3 MiB and does not,
+# 565 is 3.7 MiB and does. `-d:frameosCanvasRgbx` keeps the old RGBA canvas
+# for A/B measurement; the Pi runtime and the wasm preview are untouched
+# either way and keep full RGBA.
+#
+# The lifetime: the memory comes from one PSRAM block the firmware claims at
+# boot (`frameos_nim_reserve_canvas`, before Wi-Fi and TLS have carved the
+# heap up) and hands back through `frameos_nim_canvas_buffer`. A multi-MB
+# contiguous run is the one allocation fragmentation can deny a long-running
+# device; claiming it once and never freeing it is how that cannot happen —
+# and it also removes the per-render allocate/GC churn of the old scheme.
+# Nothing aliases the canvas across renders (docs/value-pipeline.md: the
+# cache never stores the live canvas), so reusing it is safe.
+
+proc canvasBuffer(len: csize_t): pointer {.importc: "frameos_nim_canvas_buffer", cdecl.}
+
+var sceneCanvas: Image
+
+proc sceneCanvasFormat*(): PixelFormat =
+  when defined(frameosCanvasRgbx): pfRgbx
+  else: pfRgb565
+
+proc sceneCanvasWidth*(): int =
+  if frameConfig.isNil: 0
+  elif frameConfig.rotate in [90, 270]: frameConfig.height
+  else: frameConfig.width
+
+proc sceneCanvasHeight*(): int =
+  if frameConfig.isNil: 0
+  elif frameConfig.rotate in [90, 270]: frameConfig.width
+  else: frameConfig.height
+
+proc renderCanvas*(): Image =
+  ## The canvas the next render draws into, at the scene's (rotated)
+  ## dimensions. Made on first use, reused for every render after.
+  let
+    width = sceneCanvasWidth()
+    height = sceneCanvasHeight()
+    format = sceneCanvasFormat()
+  if not sceneCanvas.isNil and sceneCanvas.width == width and
+      sceneCanvas.height == height and sceneCanvas.format == format:
+    return sceneCanvas
+  let bytesPerPixel = if format == pfRgb565: 2 else: 4
+  let buffer = canvasBuffer(csize_t(width * height * bytesPerPixel))
+  if buffer != nil:
+    sceneCanvas =
+      if format == pfRgb565: newImage565Over(width, height, buffer)
+      else: newImageOver(width, height, buffer)
+  else:
+    # No firmware block (a host build, or the reservation failed): the Nim
+    # heap is PSRAM too, so this is the same memory without the guarantee.
+    log(&"canvas: no reserved block for {width}x{height}, allocating from the heap")
+    sceneCanvas =
+      if format == pfRgb565: newImage565(width, height)
+      else: newImage(width, height)
+  sceneCanvas
+
 proc sceneRefreshSeconds*(): float =
   if not currentScene.isNil and currentScene.refreshInterval > 0:
     return currentScene.refreshInterval
@@ -484,11 +551,14 @@ proc renderCurrentScene*(): Option[Image] =
   lastNextSleep = -1
   if not ensureScene():
     return none(Image)
+  # The persistent canvas goes in with the event; the interpreter's "render"
+  # handler fills it with the scene background and draws into it.
   let context = ExecutionContext(
     scene: currentScene,
     event: "render",
     payload: %*{},
-    hasImage: false,
+    image: renderCanvas(),
+    hasImage: true,
     loopIndex: 0,
     loopKey: ".",
     nextSleep: -1

--- a/frameos/src/embedded/embedded_scene.nim
+++ b/frameos/src/embedded/embedded_scene.nim
@@ -34,8 +34,13 @@ proc newFont(size: float32; color: Color): Font =
   result.paint = newPaint(SolidPaint)
   result.paint.color = color
 
-proc render*(width, height: int; frameName: string; renderCount: int): Image =
-  result = newImage(width, height)
+proc renderDemoInto*(canvas: Image; frameName: string; renderCount: int): Image =
+  ## Draws the baked demo scene into `canvas` (the persistent canvas) and
+  ## returns it.
+  result = canvas
+  let
+    width = result.width
+    height = result.height
   result.fill(try: parseHtmlColor(frameosSceneBackground) except CatchableError: color(1, 1, 1, 1))
 
   let

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -98,14 +98,16 @@ proc trySpillCachedImage(scene: InterpretedFrameScene, nodeId: NodeId,
   if imageSpillDisabled:
     return refuse("spill disabled after an earlier storage failure")
   if context != nil and context.hasImage and not context.image.isNil and
-      image.data == context.image.data:
+      image.bufferPointer == context.image.bufferPointer:
     return refuse("value aliases the live canvas")
   # The disk tier exists for canvas-shaped values. A native-resolution decode
   # that some unfused shape materialized (tens of MB) would cost a huge write
   # on every miss and could never be read back under the render budget anyway.
-  let bytes = image.width * image.height * 4
+  let bytes = image.byteSize
   var cap = 4 * cachedImageMemoryLimit()
   if context != nil and context.hasImage and not context.image.isNil:
+    # The disk tier stores RGBX rows whatever the canvas format, so the cap
+    # is the canvas's pixel count at 4 bytes, not its own byte size.
     cap = max(cap, context.image.width * context.image.height * 4)
   if bytes > cap:
     return refuse($(bytes div 1024) & "K is over the " &
@@ -308,7 +310,7 @@ proc withCache(scene: InterpretedFrameScene,
   var toStore = fresh
   let memoryLimit = cachedImageMemoryLimit()
   if memoryLimit > 0 and fresh.kind == fkImage and not fresh.img.isNil and
-      fresh.img.width * fresh.img.height * 4 > memoryLimit:
+      fresh.img.byteSize > memoryLimit:
     # Never retain a frame-sized image in memory on embedded: pinning a
     # canvas-sized RGBA buffer (7.7MB at 1200x1600) across renders means the
     # next render needs a second canvas and OOMs the module — and when the

--- a/frameos/src/frameos/utils/dither.nim
+++ b/frameos/src/frameos/utils/dither.nim
@@ -62,9 +62,10 @@ proc toGrayscaleFloat*(image: Image, grayscale: var seq[float], multiple: float 
     height = image.height
   for y in 0..<height:
     for x in 0..<width:
-      let index = y * width + x
-      grayscale[index] = multiple * (image.data[index].r.float * 0.21 + image.data[index].g.float * 0.72 + image.data[
-          index].b.float * 0.07) / 255.0
+      let
+        index = y * width + x
+        p = image.unsafe[x, y]
+      grayscale[index] = multiple * (p.r.float * 0.21 + p.g.float * 0.72 + p.b.float * 0.07) / 255.0
 
 proc floydSteinberg*(pixels: var seq[float], width, height: int) =
   let
@@ -94,54 +95,151 @@ proc closestPalette*(palette: seq[(int, int, int)], r, g, b: int): (int, int, in
       index = i
   return (index, palette[index][0], palette[index][1], palette[index][2])
 
+# ---------------------------------------------------------------------------
+# Row-streamed dithering.
+#
+# Floyd–Steinberg only ever reaches one row ahead, so the error state is two
+# rows, not a canvas. The templates below walk an image top to bottom with
+# exactly that — a few KB for any panel width — and hand each quantised pixel
+# to the caller's body. They read the image through pixie's accessors, so
+# they work on a view and on a 16-bit canvas as well as on RGBX, and they
+# never write to the image: a 565 canvas keeps its 5/6-bit colour and the
+# error accumulates at full precision beside it.
+#
+# The palette walk keeps the arithmetic of the in-place version it replaces
+# — integer error split with `div 16`, distributed in the order right,
+# down-left, down, down-right, and *clipped into the neighbouring pixel value
+# at every step* — so the packed bytes are the same as before on every
+# existing panel. The grey walk keeps `toGrayscaleFloat` + `floydSteinberg`
+# float64 arithmetic the same way.
+
+template forEachPaletteDithered*(
+  image: Image, palette: seq[(int, int, int)],
+  x, y, index: untyped, body: untyped
+) =
+  ## Runs `body` for every pixel in scan order with `x`, `y` and the
+  ## palette `index` the dither chose for it.
+  block:
+    let
+      ditherWidth = image.width
+      ditherHeight = image.height
+    if ditherWidth > 0 and ditherHeight > 0:
+      # Adjusted RGB of the current row and the next: the pixel values after
+      # the error already pushed into them, which is what the in-place
+      # version stored back into the image.
+      var
+        curRow = newSeq[uint8](ditherWidth * 3)
+        nextRow = newSeq[uint8](ditherWidth * 3)
+      template loadRow(row: var seq[uint8], ry: int) =
+        for rx in 0 ..< ditherWidth:
+          let p = image.unsafe[rx, ry]
+          row[rx * 3 + 0] = p.r
+          row[rx * 3 + 1] = p.g
+          row[rx * 3 + 2] = p.b
+      template push(row: var seq[uint8], rx: int, er, eg, eb: int, weight: int) =
+        row[rx * 3 + 0] = clip8(row[rx * 3 + 0].int + (er * weight div 16))
+        row[rx * 3 + 1] = clip8(row[rx * 3 + 1].int + (eg * weight div 16))
+        row[rx * 3 + 2] = clip8(row[rx * 3 + 2].int + (eb * weight div 16))
+      loadRow(curRow, 0)
+      for yy in 0 ..< ditherHeight:
+        let hasNext = yy + 1 < ditherHeight
+        if hasNext:
+          loadRow(nextRow, yy + 1)
+        for xx in 0 ..< ditherWidth:
+          let
+            imageR = curRow[xx * 3 + 0].int
+            imageG = curRow[xx * 3 + 1].int
+            imageB = curRow[xx * 3 + 2].int
+            (palIndex, palR, palG, palB) = closestPalette(palette, imageR, imageG, imageB)
+            errorR = imageR - palR
+            errorG = imageG - palG
+            errorB = imageB - palB
+          block:
+            let
+              x {.inject.} = xx
+              y {.inject.} = yy
+              index {.inject.} = palIndex
+            body
+          if xx + 1 < ditherWidth:
+            push(curRow, xx + 1, errorR, errorG, errorB, 7)
+          if hasNext:
+            if xx - 1 >= 0:
+              push(nextRow, xx - 1, errorR, errorG, errorB, 3)
+            push(nextRow, xx, errorR, errorG, errorB, 5)
+            if xx + 1 < ditherWidth:
+              push(nextRow, xx + 1, errorR, errorG, errorB, 1)
+        swap(curRow, nextRow)
+
+template forEachGrayDithered*(
+  image: Image, maxLevel: int,
+  x, y, level: untyped, body: untyped
+) =
+  ## Runs `body` for every pixel in scan order with the dithered grey
+  ## `level` in 0 .. maxLevel. Same numbers as `toGrayscaleFloat(maxLevel)`
+  ## followed by `floydSteinberg`, without the float-per-pixel canvas.
+  block:
+    let
+      ditherWidth = image.width
+      ditherHeight = image.height
+      multiple = maxLevel.float
+    if ditherWidth > 0 and ditherHeight > 0:
+      var
+        curRow = newSeq[float](ditherWidth)
+        nextRow = newSeq[float](ditherWidth)
+      template loadRow(row: var seq[float], ry: int) =
+        for rx in 0 ..< ditherWidth:
+          let p = image.unsafe[rx, ry]
+          row[rx] = multiple * (p.r.float * 0.21 + p.g.float * 0.72 + p.b.float * 0.07) / 255.0
+      loadRow(curRow, 0)
+      for yy in 0 ..< ditherHeight:
+        let hasNext = yy + 1 < ditherHeight
+        if hasNext:
+          loadRow(nextRow, yy + 1)
+        for xx in 0 ..< ditherWidth:
+          let
+            value = round(curRow[xx])
+            error = curRow[xx] - value
+          block:
+            let
+              x {.inject.} = xx
+              y {.inject.} = yy
+              level {.inject.} = max(0, min(maxLevel, value.int))
+            body
+          if xx + 1 < ditherWidth:
+            curRow[xx + 1] += error * (7.0 / 16.0)
+          if hasNext:
+            if xx - 1 >= 0:
+              nextRow[xx - 1] += error * (3.0 / 16.0)
+            nextRow[xx] += error * (5.0 / 16.0)
+            if xx + 1 < ditherWidth:
+              nextRow[xx + 1] += error * (1.0 / 16.0)
+        swap(curRow, nextRow)
 
 proc ditherPaletteIndexed*(image: Image, palette: seq[(int, int, int)]): seq[uint8] =
+  ## Dithers to the palette and packs indices MSB-first at 1/2/4/8 bits per
+  ## pixel, rows padded to whole bytes. Streams; the image is not modified.
   let
-    img = image.copy
-    width = img.width
-    height = img.height
-    distribution = [7, 3, 5, 1]
-    dy = [0, 1, 1, 1]
-    dx = [1, -1, 0, 1]
+    width = image.width
+    height = image.height
     bits = if palette.len <= 2: 1 elif palette.len <= 4: 2 elif palette.len <= 16: 4 else: 8
     divider = if palette.len <= 2: 8 elif palette.len <= 4: 4 elif palette.len <= 16: 2 else: 1
 
   let rowWidth = ceil(width.float / divider.float).int
   var output = newSeq[uint8](height * rowWidth)
 
-  for y in 0..<height:
-    for x in 0..<width:
-      let dataIndex = y * width + x
-      let outputIndex = y * rowWidth + x div divider
-
-      let imageR = img.data[dataIndex].r.int
-      let imageG = img.data[dataIndex].g.int
-      let imageB = img.data[dataIndex].b.int
-
-      let (index, palR, palG, palB) = closestPalette(palette, imageR, imageG, imageB)
-
-      let errorR = imageR - palR
-      let errorG = imageG - palG
-      let errorB = imageB - palB
-
-      case bits:
-        of 8: output[outputIndex] = index.uint8
-        of 4:
-          let bitPosition = (1 - (x mod 2)) * 4
-          output[outputIndex] = output[outputIndex] or (index shl bitPosition).uint8
-        of 2:
-          let bitPosition = (3 - (x mod 4)) * 2
-          output[outputIndex] = output[outputIndex] or (index shl bitPosition).uint8
-        of 1:
-          let bitPosition = (7 - x) mod 8
-          output[outputIndex] = output[outputIndex] or (index shl bitPosition).uint8
-        else: discard
-
-      for i in 0..<4:
-        if (x + dx[i] >= 0) and (x + dx[i] < width) and (y + dy[i] < height):
-          let errorIndex = (y + dy[i]) * width + (x + dx[i])
-          img.data[errorIndex].r = clip8(img.data[errorIndex].r.int + (errorR * distribution[i] div 16))
-          img.data[errorIndex].g = clip8(img.data[errorIndex].g.int + (errorG * distribution[i] div 16))
-          img.data[errorIndex].b = clip8(img.data[errorIndex].b.int + (errorB * distribution[i] div 16))
+  image.forEachPaletteDithered(palette, x, y, index):
+    let outputIndex = y * rowWidth + x div divider
+    case bits:
+      of 8: output[outputIndex] = index.uint8
+      of 4:
+        let bitPosition = (1 - (x mod 2)) * 4
+        output[outputIndex] = output[outputIndex] or (index shl bitPosition).uint8
+      of 2:
+        let bitPosition = (3 - (x mod 4)) * 2
+        output[outputIndex] = output[outputIndex] or (index shl bitPosition).uint8
+      of 1:
+        let bitPosition = (7 - x) mod 8
+        output[outputIndex] = output[outputIndex] or (index shl bitPosition).uint8
+      else: discard
 
   return output

--- a/frameos/src/frameos/utils/image.nim
+++ b/frameos/src/frameos/utils/image.nim
@@ -1122,23 +1122,23 @@ proc getExifMetadataFromData*(data: string): Option[JsonNode] =
 proc rotateDegrees*(image: Image, degrees: int): Image {.raises: [PixieError].} =
   case (degrees + 1080) mod 360: # TODO: yuck
   of 90:
-    result = newImage(image.height, image.width)
+    result = image.newImageLike(image.height, image.width)
     for y in 0 ..< result.height:
       for x in 0 ..< result.width:
-        result.data[result.dataIndex(x, y)] =
-          image.data[image.dataIndex(y, image.height - x - 1)]
+        result.setPixel(result.dataIndex(x, y),
+          image.getPixel(image.dataIndex(y, image.height - x - 1)))
   of 180:
-    result = newImage(image.width, image.height)
+    result = image.newImageLike(image.width, image.height)
     for y in 0 ..< result.height:
       for x in 0 ..< result.width:
-        result.data[result.dataIndex(x, y)] =
-          image.data[image.dataIndex(image.width - x - 1, image.height - y - 1)]
+        result.setPixel(result.dataIndex(x, y),
+          image.getPixel(image.dataIndex(image.width - x - 1, image.height - y - 1)))
   of 270:
-    result = newImage(image.height, image.width)
+    result = image.newImageLike(image.height, image.width)
     for y in 0 ..< result.height:
       for x in 0 ..< result.width:
-        result.data[result.dataIndex(x, y)] =
-          image.data[image.dataIndex(image.width - y - 1, x)]
+        result.setPixel(result.dataIndex(x, y),
+          image.getPixel(image.dataIndex(image.width - y - 1, x)))
   else:
     result = image
 
@@ -1212,7 +1212,7 @@ when defined(frameosEmbedded):
       return
     for py in y0 ..< y1:
       for px in x0 ..< x1:
-        image.data[image.dataIndex(px, py)] = color
+        image.setPixel(image.dataIndex(px, py), color)
 
   proc writeEmbeddedErrorMarker(image: Image, width, height: int) =
     let black = rgbx(0, 0, 0, 255)
@@ -1298,10 +1298,23 @@ proc spillImageToSpool*(image: Image, name: string, preferredDir = ""): ImageSpo
     return nil
   var ok = true
   try:
-    image.forEachSpan:
-      if ok:
-        let bytes = spanLen * 4
-        if file.writeBuffer(addr image.data[spanStart], bytes) != bytes:
+    if image.format == pfRgbx:
+      image.forEachSpan:
+        if ok:
+          let bytes = spanLen * 4
+          if file.writeBuffer(addr image.data[spanStart], bytes) != bytes:
+            ok = false
+    else:
+      # The file format is RGBX rows whatever the image is; a 565 image is
+      # expanded a row at a time on the way out.
+      var row = newSeq[ColorRGBX](image.width)
+      let bytes = image.width * 4
+      for y in 0 ..< image.height:
+        if not ok:
+          break
+        for x in 0 ..< image.width:
+          row[x] = image.unsafe[x, y]
+        if file.writeBuffer(addr row[0], bytes) != bytes:
           ok = false
   except CatchableError:
     ok = false
@@ -1398,8 +1411,8 @@ when defined(frameosEmbedded):
           continue
         let srcX = min(srcImage.width - 1, srcXFloat.int)
         let targetIndex = targetImage.dataIndex(x, y)
-        targetImage.data[targetIndex] = blend(targetImage.data[targetIndex],
-          srcImage.data[srcImage.dataIndex(srcX, srcY)])
+        targetImage.setPixel(targetIndex, blend(targetImage.getPixel(targetIndex),
+          srcImage.getPixel(srcImage.dataIndex(srcX, srcY))))
     true
 
 proc scaleAndDrawImage*(targetImage: Image, srcImage: Image, scalingMode: string, offsetX: int = 0,

--- a/frameos/src/frameos/utils/memory.nim
+++ b/frameos/src/frameos/utils/memory.nim
@@ -16,8 +16,11 @@ when defined(frameosEmbedded):
 
   const
     # Keep headroom for the packed framebuffer, preview snapshot and the
-    # C-side HTTP/TLS buffers that also live in PSRAM.
-    EmbeddedReserveBytes = 1_536_000
+    # C-side HTTP/TLS buffers that also live in PSRAM. The same 1.5 MiB as
+    # FOS_RENDER_PSRAM_RESERVE (frameos_display.c) and
+    # EMBEDDED_RENDER_PSRAM_RESERVE_BYTES (backend): it was 1_536_000 here,
+    # a decimal-MB slip 36 KB short of the other two.
+    EmbeddedReserveBytes = 1536 * 1024
 elif defined(linux) and not defined(frameosWasm):
   import std/[strutils, os]
 

--- a/frameos/src/frameos/utils/tests/test_dither.nim
+++ b/frameos/src/frameos/utils/tests/test_dither.nim
@@ -65,3 +65,102 @@ suite "dither helpers":
     setPixel(image8Bit, 1, 0, 16, 16, 16)
     let packed8 = ditherPaletteIndexed(image8Bit, palette8Bit)
     check packed8 == @[0'u8, 16'u8]
+
+# ---------------------------------------------------------------------------
+# The row-streamed dither must produce the bytes the in-place version did.
+# The reference below IS the old implementation, kept here so the equivalence
+# is checked rather than remembered.
+
+proc referencePaletteIndexed(image: Image, palette: seq[(int, int, int)]): seq[uint8] =
+  let
+    img = image.copy
+    width = img.width
+    height = img.height
+    distribution = [7, 3, 5, 1]
+    dy = [0, 1, 1, 1]
+    dx = [1, -1, 0, 1]
+    bits = if palette.len <= 2: 1 elif palette.len <= 4: 2 elif palette.len <= 16: 4 else: 8
+    divider = if palette.len <= 2: 8 elif palette.len <= 4: 4 elif palette.len <= 16: 2 else: 1
+  proc clip8(value: int): uint8 =
+    if value < 0: 0'u8 elif value > 255: 255'u8 else: value.uint8
+  let rowWidth = ceil(width.float / divider.float).int
+  var output = newSeq[uint8](height * rowWidth)
+  for y in 0..<height:
+    for x in 0..<width:
+      let dataIndex = y * width + x
+      let outputIndex = y * rowWidth + x div divider
+      let imageR = img.data[dataIndex].r.int
+      let imageG = img.data[dataIndex].g.int
+      let imageB = img.data[dataIndex].b.int
+      let (index, palR, palG, palB) = closestPalette(palette, imageR, imageG, imageB)
+      let errorR = imageR - palR
+      let errorG = imageG - palG
+      let errorB = imageB - palB
+      case bits:
+        of 8: output[outputIndex] = index.uint8
+        of 4: output[outputIndex] = output[outputIndex] or (index shl ((1 - (x mod 2)) * 4)).uint8
+        of 2: output[outputIndex] = output[outputIndex] or (index shl ((3 - (x mod 4)) * 2)).uint8
+        of 1: output[outputIndex] = output[outputIndex] or (index shl ((7 - x) mod 8)).uint8
+        else: discard
+      for i in 0..<4:
+        if (x + dx[i] >= 0) and (x + dx[i] < width) and (y + dy[i] < height):
+          let errorIndex = (y + dy[i]) * width + (x + dx[i])
+          img.data[errorIndex].r = clip8(img.data[errorIndex].r.int + (errorR * distribution[i] div 16))
+          img.data[errorIndex].g = clip8(img.data[errorIndex].g.int + (errorG * distribution[i] div 16))
+          img.data[errorIndex].b = clip8(img.data[errorIndex].b.int + (errorB * distribution[i] div 16))
+  output
+
+proc noisyImage(width, height: int, seed: uint32): Image =
+  ## Deterministic pseudo-random colours, with smooth regions too so the
+  ## error diffusion has saturating runs to clip on.
+  result = newImage(width, height)
+  var s = seed
+  for y in 0 ..< height:
+    for x in 0 ..< width:
+      s = s * 1664525'u32 + 1013904223'u32
+      let noise = (s shr 24).int
+      let grad = (x * 255) div max(1, width - 1)
+      let r = if y < height div 2: grad else: noise
+      let g = if x < width div 2: 255 - grad else: (noise * 3) mod 256
+      let b = (grad + noise) mod 256
+      result.unsafe[x, y] = rgbx(r.uint8, g.uint8, b.uint8, 255)
+
+suite "row-streamed dither equals the in-place reference":
+  test "palette dither, every bit depth, RGBX and 565 canvases":
+    let palettes = @[
+      @[(0, 0, 0), (255, 255, 255)],
+      saturated4ColorPalette,
+      spectra6ColorPalette,
+      saturated7ColorPalette,
+      (block:
+        var p: seq[(int, int, int)] = @[]
+        for i in 0 .. 16: p.add((i * 15, i * 15, i * 15))
+        p),
+    ]
+    for (w, h) in [(37, 23), (64, 8), (1, 5), (9, 1)]:
+      let image = noisyImage(w, h, uint32(w * 31 + h))
+      for palette in palettes:
+        check ditherPaletteIndexed(image, palette) == referencePaletteIndexed(image, palette)
+        # A 565 canvas holding the quantised picture dithers like the RGBX
+        # image holding that same quantised picture.
+        let packed = image.toRgb565Image()
+        check ditherPaletteIndexed(packed, palette) ==
+          referencePaletteIndexed(packed.toRgbxImage(), palette)
+        # And a view dithers as the sub-image it addresses.
+        if w >= 8 and h >= 4:
+          let v = image.view(2, 1, w - 4, h - 2)
+          check ditherPaletteIndexed(v, palette) == referencePaletteIndexed(v.copy(), palette)
+
+  test "grey dither equals toGrayscaleFloat + floydSteinberg":
+    for maxLevel in [1, 3, 15]:
+      for (w, h) in [(37, 23), (64, 8), (1, 5)]:
+        let image = noisyImage(w, h, uint32(maxLevel * 7 + w))
+        var gray = newSeq[float](w * h)
+        image.toGrayscaleFloat(gray, maxLevel.float)
+        gray.floydSteinberg(w, h)
+        var streamed = newSeq[int](w * h)
+        image.forEachGrayDithered(maxLevel, x, y, level):
+          streamed[y * w + x] = level
+        for i in 0 ..< w * h:
+          let reference = max(0, min(maxLevel, round(gray[i]).int))
+          check streamed[i] == reference

--- a/frameos/src/frameos/values.nim
+++ b/frameos/src/frameos/values.nim
@@ -122,7 +122,7 @@ proc approxByteSize*(v: Value): int =
     if v.sp.isFileBacked(): DefaultWindowBytes else: v.sp.len
   of fkJson: approxByteSize(v.j)
   of fkImage:
-    if v.img.isNil: 0 else: v.img.width * v.img.height * 4
+    if v.img.isNil: 0 else: v.img.byteSize
   of fkImageSpool:
     # Pixels on disk cost nothing to hold; that is the tier's whole point.
     0

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -699,6 +699,17 @@ const ESP32_SEEED_RETERMINAL_E10XX_PIN_LAYOUT: Esp32PinLayout = {
   pwr: -1,
 }
 
+const ESP32_SEEED_RETERMINAL_E1004_PIN_LAYOUT: Esp32PinLayout = {
+  rst: 38,
+  dc: 11,
+  cs: 10,
+  cs2: 2,
+  busy: 13,
+  sck: 7,
+  mosi: 9,
+  pwr: 12,
+}
+
 const ESP32_ELECROW_CROWPANEL_5IN79_PIN_LAYOUT: Esp32PinLayout = {
   rst: 47,
   dc: 46,
@@ -858,6 +869,14 @@ const ESP32_HARDWARE_PRESET_CONFIGS: Partial<Record<FrameEmbeddedHardwarePreset,
     flashSize: '32MB',
     psramMB: 8,
     pins: ESP32_SEEED_RETERMINAL_E10XX_PIN_LAYOUT,
+  },
+  seeed_reterminal_e1004: {
+    label: 'Seeed reTerminal E1004 (13.3" color ESP32-S3)',
+    platform: EMBEDDED_ESP32_S3,
+    device: 'waveshare.EPD_13in3e',
+    flashSize: '32MB',
+    psramMB: 8,
+    pins: ESP32_SEEED_RETERMINAL_E1004_PIN_LAYOUT,
   },
   elecrow_crowpanel_5in79: {
     label: 'Elecrow CrowPanel 5.79" (ESP32-S3)',
@@ -1076,6 +1095,11 @@ const ESP32_PIN_LAYOUT_PRESETS: { value: string; label: string; pins: Esp32PinLa
     value: 'seeed-reterminal-e10xx',
     label: 'Seeed reTerminal E1001/E1002',
     pins: ESP32_SEEED_RETERMINAL_E10XX_PIN_LAYOUT,
+  },
+  {
+    value: 'seeed-reterminal-e1004',
+    label: 'Seeed reTerminal E1004 (13.3")',
+    pins: ESP32_SEEED_RETERMINAL_E1004_PIN_LAYOUT,
   },
   {
     value: 'elecrow-crowpanel-5in79',

--- a/frontend/src/scenes/frames/NewFrame.tsx
+++ b/frontend/src/scenes/frames/NewFrame.tsx
@@ -347,6 +347,18 @@ const SEEED_RETERMINAL_E10XX_PINS: NonNullable<NonNullable<NewFrameFormType['dev
   mosi: 9,
   pwr: -1,
 }
+// reTerminal E1004: the E-series SPI bus with the 13.3" panel's second chip
+// select on GPIO2, reset on 38 and panel power on 12.
+const SEEED_RETERMINAL_E1004_PINS: NonNullable<NonNullable<NewFrameFormType['device_config']>['pins']> = {
+  rst: 38,
+  dc: 11,
+  cs: 10,
+  cs2: 2,
+  busy: 13,
+  sck: 7,
+  mosi: 9,
+  pwr: 12,
+}
 const ELECROW_CROWPANEL_5IN79_PINS: NonNullable<NonNullable<NewFrameFormType['device_config']>['pins']> = {
   rst: 47,
   dc: 46,
@@ -495,6 +507,15 @@ const EMBEDDED_HARDWARE_PRESET_CONFIGS: Partial<Record<FrameEmbeddedHardwarePres
       { pin: 4, label: 'LEFT' },
       { pin: 5, label: 'RIGHT' },
     ],
+  },
+  seeed_reterminal_e1004: {
+    label: 'Seeed reTerminal E1004 (13.3" color ESP32-S3)',
+    platform: EMBEDDED_ESP32_S3,
+    device: 'waveshare.EPD_13in3e',
+    flashSize: '32MB',
+    psramMB: 8,
+    pins: SEEED_RETERMINAL_E1004_PINS,
+    gpioButtons: [],
   },
   elecrow_crowpanel_5in79: {
     label: 'Elecrow CrowPanel 5.79" (ESP32-S3)',

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -222,7 +222,7 @@ function FirmwareFootprintVisualization({ frame }: { frame: FrameType }): JSX.El
   const appBinaryBytes = flash?.appBinaryBytes ?? firmware?.appSize ?? firmware?.otaSize ?? null
   const mergedBinaryBytes = flash?.mergedBinaryBytes ?? firmware?.size ?? null
   const ramSegments = [
-    { label: 'RGBA render', bytes: ram?.rgbaBufferBytes ?? 0, color: '#2563eb' },
+    { label: 'Render canvas', bytes: ram?.canvasBufferBytes ?? ram?.rgbaBufferBytes ?? 0, color: '#2563eb' },
     { label: 'Packed panel', bytes: ram?.packedBufferBytes ?? 0, color: '#16a34a' },
     { label: 'Reserve', bytes: ram?.renderReserveBytes ?? 0, color: '#b45309' },
     { label: 'Spare', bytes: renderSpareBytes, color: '#e2e8f0' },

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -21,6 +21,7 @@ export type FrameEmbeddedHardwarePreset =
   | 'seeed_reterminal_sticky'
   | 'seeed_reterminal_e1001'
   | 'seeed_reterminal_e1002'
+  | 'seeed_reterminal_e1004'
   | 'elecrow_crowpanel_5in79'
   | 'pimoroni_inky_frame_4'
   | 'pimoroni_inky_frame_5_7'
@@ -1307,6 +1308,8 @@ export interface FrameEmbeddedConfig {
         pixelFormatName?: string
         renderMode?: 'local' | 'remote'
         rgbaBufferBytes?: number
+        canvasBufferBytes?: number
+        canvasBytesPerPixel?: number
         packedBufferBytes?: number
         renderReserveBytes?: number
         renderWorkingBytes?: number


### PR DESCRIPTION
## A 16-bit render canvas on ESP32: 1200×1600 renders on 8 MB of PSRAM

The goal: the **Seeed reTerminal E1004** (13.3" 1200×1600 Spectra 6, ESP32-S3, **8 MB PSRAM**) rendering scenes on-device, full resolution, no quality compromise. Before this PR the 13.3" class needed the 16 MB module: the RGBA canvas alone is 7.3 MiB.

### What changed

**Leg 1 — pixie (FrameOS/pixie#rgb565-surface, pinned here).** `Image` gains a `format`: `pfRgbx` (everything as before) or `pfRgb565`, a packed 16-bit RGB surface with no alpha. Every drawing operation works on one — fills, antialiased paths and text, `draw` with any blend mode, gradients, opacity, views, copies, the scaled and streamed decoders writing straight into it. `shadow`/`spread` raise; minify/magnify convert; the opaque/transparent predicates answer truthfully. RGBX output is untouched — every xray score in the pixie suite is identical to before. `tests/test_rgb565.nim` is an oracle: each scenario is drawn onto an RGBX and a 565 canvas and the quantised RGBX result must match — bit-exact for a single layer over a representable backdrop, one 5-bit step for compound cases. The SIMD variants guard on the format too (on amd64/arm64 `hasSimd` replaces the scalar body outright).

**Leg 2 — the dither streams (`utils/dither.nim`).** `forEachPaletteDithered` / `forEachGrayDithered` walk any image with two rows of error state beside it, reading through pixie's accessors and never writing the canvas. **Bit-exact** with the in-place version they replace — including its clip-per-step semantics — tested against the old algorithm (kept verbatim in the test) across bit depths, RGBX/565 canvases and views. The ESP32 packers are rewritten on top of them: the grey packer lost an 8-byte-per-pixel float scratch, the two-plane packer a full RGBA copy, the palette packer stops mutating the canvas. The Pi drivers get the same streamed `ditherPaletteIndexed` (same bytes out, one less full RGBA copy).

**Leg 3 — the canvas is 565, claimed once at boot.** `embedded_runtime.nim`'s `renderCanvas()` wraps a PSRAM block the firmware reserves in `main.c` right after the fit check and **before `fos_wifi_init`** (`frameos_nim_reserve_canvas`), so the multi-MB contiguous run exists before Wi-Fi/TLS fragment the heap, and reuses it every render — no per-render allocate/collect churn. Nothing aliases the canvas across renders (the value pipeline never caches the live canvas), so reuse is safe. Error frames and the demo scene render into it too. `-d:frameosCanvasRgbx` keeps the RGBA canvas for A/B. **The Pi runtime, HDMI/framebuffer and the wasm preview are untouched and keep full RGBA.**

**Leg 4 — the E1004 itself.** Preset `seeed_reterminal_e1004` (EPD_13in3e on the E-series bus: cs2=2, rst=38, pwr=12 — the pins ESPHome's integrated-board definition bakes in) in the backend table, the console `presets[]`, both frontends and the cloud flasher. Its T133A01 panel wants the vendor's analogue tuning, so `EPD_13in3e.c` gains a runtime variant (`EPD_13IN3E_SetVariant`: 0x74/0x50/0x05/0x06 values, an extra 0xA5, no CCSET) that `frameos_display` selects from the preset — the panel key stays `EPD_13in3e` everywhere, the same way the PhotoPainter PMIC is selected.

**Budget math** moved 4→2 in its mirrors: `FOS_RENDER_CANVAS_BYTES_PER_PIXEL` (boot fit check), `EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL` (backend guard + deploy drawer, `canvasBufferBytes` key; `rgbaBufferBytes` kept as an alias), and `EmbeddedReserveBytes` aligned to the `1536*1024` the other two always were. `EMBEDDED_FIRMWARE_VERSION` 48.

| panel | canvas (was) | + packed + 1.5 MiB reserve | total (was) |
|---|---|---|---|
| 800×480 4bpp | 0.73 MiB (1.46) | | 2.42 MiB (3.15) |
| **1200×1600 4bpp** | **3.66 MiB (7.32)** | | **6.08 MiB (9.74)** — fits 8 MB |

### Why it is not a quality compromise

Every panel the firmware drives is a dithered e-paper, and the dither keeps its own full-precision error rows; the 5/6-bit colour the canvas holds is below what the output can show (a 6-colour Floyd–Steinberg field has per-pixel error dozens of times the 565 step). Measured on a 1200×1600 scene (mandrill photo + colour and grey gradients + AA text) dithered to Spectra 6 through both canvases: canvas delta before dither max 8/255, mean 2.4/255; palette population per colour identical within **0.05%**; the panel renders are visually indistinguishable at 1:1 — including the grey ramp, where the 565 *canvas* shows visible steps and the dithered output does not. (Dithered dot positions differ on 38% of pixels, which is what error diffusion does to any input perturbation; the picture is the same.)

### Verified

- pixie: full suite, 273 xrays identical to baseline; `test_rgb565` (31 scenarios); scalar path with `-d:pixieNoSimd`.
- FrameOS Nim: 122 test files green against the new pixie (utils, interpreter, cache/spool, decode, all render/data apps, drivers); `test_dither` bit-exactness suite.
- Backend: `test_embedded_firmware.py` 83 passed (incl. "13.3" fits 8 MB", E1004 preset + provisioning plan).
- Frontend `tsc` clean; cloud flasher vitest 25 passed; auth-web typecheck clean.
- Firmware: `idf.py build` (S3 32 MB profile) clean; `ci_build_image.sh` + QEMU boot smoke.

### Not verified (no hardware on this desk)

- A real E1004 render. The T133A01 tuning values come from the vendor driver via ESPHome's model; wrong tuning values mean ghosting or a failed refresh, not a brick. The E1004's buttons and microSD pins are not published and stay unset.
- A 1200×1600 PSRAM low-water measurement on an 8 MB board — the 1.5 MiB reserve was sized at 800×480; the pieces that scale with width are small, but this is the number to take first.

### Notes

- Commits are unsigned: the signing agent needs an interactive touch I could not give it. `git rebase --exec 'git commit --amend --no-edit -S' main` re-signs them.
- Possible follow-ups, deliberately not in this PR: noise-shaped quantisation on write (would make even the canvas band-free — not needed for any dithered output), a 565 owned scratch so cached full-bleed producers keep their cache on 8 MB, streaming packed rows to the panel driver to drop the packed buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
