### PR TITLE
A link code on the panel: claim a frame by reading its display

### DIFF
--- a/cloud/docs/cloud-frames.md
+++ b/cloud/docs/cloud-frames.md
@@ -588,7 +588,10 @@ different subtrees):
 4. Signed release verification in `upgrade.nim`.
 5. Boot-partition personalization file support in the buildroot image +
    portal claim-token handoff.
-6. Panel-displayed link code for flow 2.
+6. Panel-displayed link code for flow 2 — **done**: pending device flows
+   render the user code + QR on the panel, the hub thread polls them, and
+   the setup portal can queue one without a claim code
+   (`frameos/cloud/device_flow.nim`).
 7. Local ceremony to switch a frame between backend-managed and
    cloud-managed (exactly one control plane at a time).
 

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -199,6 +199,26 @@ the ownership proof, so a frame enrolled this way is born `active`, not
 `{"public_key": …, "hardware": …}` and the device-flow Bearer token instead
 of a claim token, to register its key and fetch `frame_id`/`ws_path`.
 
+**The code shows on the panel.** While a flow is pending, the runner draws
+the user code plus a QR of `verification_uri_complete` over whatever the
+frame is showing (`frameos/cloud/device_flow.nim` `activeLinkCode()`, drawn
+in `runner.nim` beside the local-presence overlay), so the person in front
+of the frame can claim it without ever opening the local admin page — the
+same possession ceremony as the LAN-access code, in the other direction.
+The hub thread polls the flow in the background (`deviceFlowTick`), so a
+link started from the admin page completes even after the browser tab
+closes, and the code comes down the moment the flow resolves or its window
+lapses.
+
+**Starting one without a browser.** The setup portal's cloud option no
+longer requires a claim code: saved without one, it queues
+`state/cloud_link_code_pending.json`, and once the frame is online the hub
+thread starts the device flow and the panel shows the code. An unclaimed
+window restarts a fresh code (each start is a provider round trip; after 12
+unclaimed starts the frame gives up until the next boot or admin-page
+retry). Picking another control mode in the portal, or `POST
+/api/cloud/disconnect`, retires the queue.
+
 ### Scopes
 
 `frame:managed` is the base scope: connect the WS, receive scene/settings

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,19 +19,6 @@ Two rules that shape most entries:
 
 ---
 
-## Cloud-managed frames
-
-A cloud frame talks to `frame-hub` over one outbound WebSocket. The provider
-can push scenes, a short allowlist of declarative settings and a handful of
-commands; everything else stays local to the device.
-
-- **Panel-displayed link code.** Show the enrollment code/QR on the e-ink panel
-  itself, as proof of possession, rather than only on the portal and admin
-  pages. The private-network elevation already does exactly this ceremony
-  (`frameos/local_access.nim`) and is the model to copy.
-
----
-
 ## Frame privileges and FrameOS Remote
 
 Audited 2026-08-16; findings and the full reasoning in

--- a/frameos/src/frameos/cloud/device_flow.nim
+++ b/frameos/src/frameos/cloud/device_flow.nim
@@ -1,0 +1,488 @@
+## The device-flow ("link code") half of this frame's direct link to FrameOS
+## Cloud (docs/cloud-link.md, docs/cloud-frames.md "B. Link code on the
+## device").
+##
+## Three callers share it:
+## - the local admin routes (`POST /api/cloud/connect` / `/poll`) — the
+##   browser-driven flow the shared settings page uses;
+## - the hub thread's idle pass (`deviceFlowTick`) — a background poller, so a
+##   flow started from the admin page keeps advancing after the tab is closed,
+##   and a flow queued by the setup portal ("show a link code on the display")
+##   starts by itself once the network is up and restarts when it expires;
+## - the runner (`activeLinkCode`) — while a flow is pending the user code and
+##   a QR of `verification_uri_complete` are drawn over whatever the frame is
+##   showing, the same way `local_access.nim` puts the presence code on the
+##   panel. Someone who can see the panel can claim the frame; that is the
+##   ownership proof the consent screen then records.
+##
+## Concurrency: link state read-modify-writes hold `cloudLinkLock` and never
+## span a network call (link_state.nim). The background tick's own timers live
+## in module-level vars touched only by the hub thread.
+
+import json
+import locks
+import os
+import strutils
+import std/httpclient
+import times
+
+import frameos/channels
+import frameos/types
+import frameos/upgrade
+import frameos/utils/http_client
+import frameos/cloud/enrollment
+import frameos/cloud/link_state
+
+const
+  CLOUD_REQUEST_TIMEOUT_MS = 15000
+  CLOUD_REQUEST_MAX_SECONDS = 20.0
+  CLOUD_REQUEST_MAX_REDIRECTS = 1
+  CLOUD_LINK_CODE_PENDING_PATH = "./state/cloud_link_code_pending.json"
+  # Scopes a panel-initiated link asks for: the managed profile plus cloud
+  # login, i.e. what the portal's "cloud" control mode means.
+  LINK_CODE_DEFAULT_SCOPES* = @["frame:link", "frame:managed", "auth:login"]
+  # A queued link code restarts when its 10-minute window lapses unclaimed;
+  # after this many starts the frame stops asking (each start is a provider
+  # row) and waits for a reboot or the admin page.
+  LINK_CODE_MAX_STARTS* = 12
+  LINK_CODE_START_BACKOFF_MIN_SECONDS = 10.0
+  LINK_CODE_START_BACKOFF_MAX_SECONDS = 300.0
+
+proc jsonOrNull*(node: JsonNode): JsonNode =
+  ## `state{...}` yields nil for missing keys, and a nil embedded in `%*`
+  ## segfaults std/json's serializer.
+  if node == nil: newJNull() else: node
+
+proc cloudRequest*(providerUrl, path: string, httpMethod = HttpPost,
+                   accessToken = "", body: JsonNode = nil): (int, JsonNode) =
+  var headers = newHttpHeaders({"Accept": "application/json"})
+  if body != nil:
+    headers["Content-Type"] = "application/json"
+  if accessToken.len > 0:
+    headers["Authorization"] = "Bearer " & accessToken
+  let url = providerUrl & "/" & path.strip(leading = true, chars = {'/'})
+  let response = boundedRequest(
+    url,
+    httpMethod = httpMethod,
+    body = (if body != nil: $body else: ""),
+    headers = headers,
+    timeoutMs = CLOUD_REQUEST_TIMEOUT_MS,
+    maxSeconds = CLOUD_REQUEST_MAX_SECONDS,
+    # A provider's API answers directly; every extra hop is another connect
+    # (and another resolution) charged to a worker thread, so allow one for a
+    # host or scheme move and no more.
+    maxRedirects = CLOUD_REQUEST_MAX_REDIRECTS,
+  )
+  var payload: JsonNode = nil
+  try:
+    payload = parseJson(response.body)
+  except CatchableError:
+    discard
+  if payload == nil or payload.kind != JObject:
+    payload = %*{}
+  (response.code, payload)
+
+proc fetchConnectSync*(providerUrl, accessToken: string): JsonNode =
+  ## Best effort: report inventory and learn which account owns us. Returns the
+  ## fields to merge into the link state rather than mutating it: both requests
+  ## below can take tens of seconds, so callers MUST run this WITHOUT holding
+  ## cloudLinkLock and merge the result afterwards.
+  var state = newJObject()
+  try:
+    let (inventoryCode, _) = cloudRequest(providerUrl, "/api/backends/inventory",
+      accessToken = accessToken, body = %*{
+        "reported_frameos_version": installedFrameOSVersion(),
+        "capabilities": {"localFallback": true, "frame": true},
+        "health": {"status": "ok"},
+      })
+    if inventoryCode == 200:
+      state["last_inventory_sync_at"] = %isoTimestamp(int64(epochTime()))
+  except CatchableError:
+    discard
+  try:
+    let (grantsCode, grants) = cloudRequest(providerUrl, "/api/backends/grants",
+      httpMethod = HttpGet, accessToken = accessToken)
+    if grantsCode == 200 and grants{"grants"} != nil and grants{"grants"}.kind == JArray:
+      for grant in grants{"grants"}:
+        if grant.kind == JObject and grant{"role"}.getStr("") == "owner":
+          state["account_id"] = grant{"account_id"}
+          state["account_email"] = grant{"account_email"}
+          break
+  except CatchableError:
+    discard
+  return state
+
+proc requestRender() {.gcsafe.} =
+  ## A sleeping scene renders on its own schedule; every state change that
+  ## puts a code on the panel or takes one off asks for a frame right away.
+  {.gcsafe.}:
+    sendEvent("render", %*{})
+
+# ---------------------------------------------------------------------------
+# Start
+
+type DeviceFlowStart* = object
+  ok*: bool
+  status*: int          # HTTP status from the provider (0 = unreachable)
+  error*: string        # human-readable, for the admin route's 502 detail
+  networkError*: bool   # retry later rather than give up
+
+proc startDeviceFlow*(providerUrl, displayName, localOrigin: string,
+                      scopes: seq[string]): DeviceFlowStart {.gcsafe.} =
+  ## Asks the provider for a device code and puts the link into `connecting`.
+  ## Replaces any pending flow. Callers check for `connected` first (the admin
+  ## route answers 409; the background tick never starts over a live link).
+  {.gcsafe.}:
+    var scopesJson = newJArray()
+    for scope in scopes:
+      scopesJson.add(%scope)
+    var startResponse: JsonNode
+    var startCode = 0
+    try:
+      (startCode, startResponse) = cloudRequest(providerUrl, "/api/device/start", body = %*{
+        "public_display_name": displayName,
+        "local_origin": localOrigin,
+        "reported_frameos_version": installedFrameOSVersion(),
+        "capabilities": {"localFallback": true, "frame": true},
+        "client_kind": "frame",
+        "scopes": scopesJson,
+      })
+    except CatchableError as error:
+      return DeviceFlowStart(ok: false, status: 0, networkError: true,
+        error: "Could not reach " & providerUrl & ": " & error.msg)
+    if startCode != 200 or startResponse{"device_code"}.getStr("") == "":
+      let detail = startResponse{"error"}.getStr("unexpected status " & $startCode)
+      return DeviceFlowStart(ok: false, status: startCode,
+        networkError: startCode == 429 or startCode >= 500,
+        error: "FrameOS Cloud rejected the request: " & detail)
+
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      resetLinkState(state)
+      state["provider_url"] = %providerUrl
+      state["status"] = %"connecting"
+      # The provider only accepts login-handoff redirects on this origin.
+      state["local_origin"] = %localOrigin
+      state["device_code"] = jsonOrNull(startResponse{"device_code"})
+      state["user_code"] = jsonOrNull(startResponse{"user_code"})
+      state["verification_uri"] = jsonOrNull(startResponse{"verification_uri"})
+      state["verification_uri_complete"] = jsonOrNull(startResponse{"verification_uri_complete"})
+      state["interval_seconds"] = %startResponse{"interval"}.getInt(5)
+      state["scope"] = %scopes.join(" ")
+      # Remember what THIS device asked for. The poll response reports what
+      # the provider says it granted, and managed mode — the one scope that
+      # hands a provider remote control of the frame — is only entered when
+      # both agree (managedEnrollmentRequested).
+      state["requested_scope"] = %scopes.join(" ")
+      let expiresIn = startResponse{"expires_in"}.getInt(0)
+      if expiresIn > 0:
+        state["expires_epoch"] = %int(epochTime() + float(expiresIn))
+      saveCloudLinkState(state)
+    requestRender()
+    DeviceFlowStart(ok: true, status: startCode)
+
+# ---------------------------------------------------------------------------
+# Poll
+
+type DeviceFlowPoll* = object
+  polled*: bool     # a request went to the provider
+  changed*: bool    # the link left `connecting` (connected, denied, expired)
+  startHub*: bool   # managed enrollment succeeded: the caller starts the hub
+
+proc pollDeviceFlow*(frameConfig: FrameConfig): DeviceFlowPoll {.gcsafe.} =
+  ## One poll of a pending device flow. No-op unless the link is `connecting`.
+  ## On approval: stores the token, syncs inventory/grants, and — when
+  ## frame:managed was both requested and granted — registers the device key
+  ## with the provider (flow B) so the hub thread can take over.
+  {.gcsafe.}:
+    var providerUrl = ""
+    var deviceCode = ""
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      if expireIfNeeded(state):
+        saveCloudLinkState(state)
+        requestRender()
+        return DeviceFlowPoll(changed: true)
+      if state{"status"}.getStr("") != "connecting" or state{"device_code"}.getStr("") == "":
+        return DeviceFlowPoll()
+      providerUrl = providerUrlFromState(state)
+      deviceCode = state{"device_code"}.getStr("")
+
+    var pollCode = 0
+    var pollResponse: JsonNode = %*{}
+    var networkError = false
+    try:
+      (pollCode, pollResponse) = cloudRequest(providerUrl, "/api/device/poll",
+        body = %*{"device_code": deviceCode})
+    except CatchableError:
+      networkError = true
+    result.polled = true
+
+    var syncAccessToken = ""
+    var grantedManagedScope = false
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      if state{"status"}.getStr("") != "connecting" or state{"device_code"}.getStr("") != deviceCode:
+        return
+      if networkError:
+        state["poll_error"] = %"network_error"
+        saveCloudLinkState(state)
+        return
+      let error = pollResponse{"error"}.getStr("")
+      if error == "authorization_pending":
+        if state.hasKey("poll_error"):
+          state.delete("poll_error")
+          saveCloudLinkState(state)
+        return
+      if pollCode == 200 and pollResponse{"access_token"}.getStr("") != "":
+        let accessToken = pollResponse{"access_token"}.getStr("")
+        state["status"] = %"connected"
+        state["access_token"] = %accessToken
+        state["token_reference"] = jsonOrNull(pollResponse{"token_reference"})
+        state["linked_client_id"] = jsonOrNull(pollResponse{"linked_client_id"})
+        if pollResponse{"scope"}.getStr("") != "":
+          state["scope"] = pollResponse{"scope"}
+        for key in ["device_code", "user_code", "verification_uri",
+                    "verification_uri_complete", "expires_epoch", "poll_error"]:
+          if state.hasKey(key):
+            state.delete(key)
+        state["connected_at"] = %isoTimestamp(int64(epochTime()))
+        saveCloudLinkState(state)
+        # The inventory/grants sync is two more cloud round trips; do it
+        # after releasing the lock so a slow or unreachable provider cannot
+        # hold cloudLinkLock — and with it every cloud route — for minutes.
+        syncAccessToken = accessToken
+        # Granted AND locally requested: a provider cannot upgrade a
+        # backups-only link into cloud-managed mode by claiming the scope.
+        grantedManagedScope = managedEnrollmentRequested(state)
+        if linkHasScope(state, "frame:managed") and not grantedManagedScope:
+          log(%*{"event": "cloud:enroll:refused", "reason": "scope_not_requested",
+                 "message": "The provider granted frame:managed but this frame " &
+                            "never asked for it; not entering managed mode."})
+      else:
+        resetLinkState(state, pollError = (if error.len > 0: error else: "unexpected status " & $pollCode))
+        saveCloudLinkState(state)
+        result.changed = true
+        requestRender()
+        return
+    result.changed = true
+    # The code is off the panel from here on, whatever the sync below does.
+    requestRender()
+
+    let synced = fetchConnectSync(providerUrl, syncAccessToken)
+
+    # Flow B (docs/cloud-frames.md): a device-flow link granted the
+    # frame:managed scope registers the device keypair with the provider and
+    # becomes cloud-managed. Runs without cloudLinkLock — it is another
+    # provider round trip — and persists mode/frame_id/ws_path itself.
+    if grantedManagedScope:
+      if otherControlPlaneActive(frameConfig):
+        log(%*{"event": "cloud:enroll:refused", "reason": "backend_managed",
+               "message": "This frame is managed by a self-hosted backend; " &
+                          "remove serverHost from frame.json before enrolling with a cloud provider"})
+      else:
+        let outcome = enrollManagedFrame(providerUrl, "", syncAccessToken, "", frameConfig)
+        if outcome.ok:
+          result.startHub = true
+        else:
+          log(%*{"event": "cloud:enroll:error", "flow": "device_flow",
+                 "status": outcome.status, "error": outcome.error})
+          withLock cloudLinkLock:
+            let state = loadCloudLinkState()
+            state["managed_enroll_error"] = %outcome.error
+            saveCloudLinkState(state)
+
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      for key, value in synced:
+        state[key] = value
+      if synced.len > 0:
+        saveCloudLinkState(state)
+
+# ---------------------------------------------------------------------------
+# A link code queued for the display (setup portal "cloud" mode without a
+# claim token). The marker survives reboots; the hub thread starts the flow
+# once the provider is reachable and restarts it when a window lapses.
+
+proc pendingLinkCodePath*(): string =
+  let override = getEnv("FRAMEOS_CLOUD_LINK_CODE_PENDING_PATH")
+  if override.len > 0: override else: CLOUD_LINK_CODE_PENDING_PATH
+
+proc loadPendingLinkCode*(): JsonNode {.gcsafe.} =
+  ## nil when no link code is queued.
+  {.gcsafe.}:
+    let path = pendingLinkCodePath()
+    if not fileExists(path):
+      return nil
+    try:
+      let parsed = parseJson(readFile(path))
+      if parsed.kind == JObject:
+        return parsed
+    except CatchableError:
+      discard
+    # Unreadable marker: drop it so the thread never loops on junk.
+    try:
+      removeFile(path)
+    except CatchableError:
+      discard
+    nil
+
+proc savePendingLinkCode(pending: JsonNode) {.gcsafe.} =
+  {.gcsafe.}:
+    let path = pendingLinkCodePath()
+    createDir(parentDir(path))
+    let tmp = path & ".tmp"
+    writeFile(tmp, $pending & "\n")
+    moveFile(tmp, path)
+
+proc writePendingLinkCode*(providerUrl: string): bool {.gcsafe.} =
+  ## Queues a panel-displayed link: the next hub pass starts the device flow
+  ## and the runner draws the code. Entry point for the setup portal.
+  {.gcsafe.}:
+    var url = normalizeProviderUrl(providerUrl)
+    if url.len == 0:
+      url = DEFAULT_CLOUD_PROVIDER_URL
+    try:
+      savePendingLinkCode(%*{"provider_url": url, "starts": 0})
+      true
+    except CatchableError:
+      false
+
+proc clearPendingLinkCode*() {.gcsafe.} =
+  {.gcsafe.}:
+    try:
+      removeFile(pendingLinkCodePath())
+    except CatchableError:
+      discard
+
+proc pendingLinkCodeQueued*(): bool {.gcsafe.} =
+  {.gcsafe.}:
+    fileExists(pendingLinkCodePath())
+
+# ---------------------------------------------------------------------------
+# Background tick (hub thread, idle pass every ~2 s)
+
+var
+  nextDeviceFlowPollAt = 0.0
+  nextLinkCodeStartAt = 0.0
+  linkCodeStartBackoff = LINK_CODE_START_BACKOFF_MIN_SECONDS
+
+proc headlessLocalOrigin*(frameConfig: FrameConfig): string =
+  ## The origin the provider may redirect cloud-login handoffs to when no
+  ## browser request started the flow: the frame's own admin page.
+  let host = if frameConfig != nil and frameConfig.frameHost.len > 0: frameConfig.frameHost
+             else: "localhost"
+  let port = if frameConfig != nil and frameConfig.framePort > 0: frameConfig.framePort
+             else: 8787
+  "http://" & host & ":" & $port
+
+proc deviceFlowTick*(frameConfig: FrameConfig): bool {.gcsafe.} =
+  ## Advances a pending device flow without a browser: polls while
+  ## `connecting`, starts (and restarts) a queued panel link while
+  ## `disconnected`. Returns true when managed enrollment just succeeded and
+  ## the caller should make sure the hub session starts.
+  {.gcsafe.}:
+    var status = ""
+    var intervalSeconds = 5
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      if expireIfNeeded(state):
+        saveCloudLinkState(state)
+        requestRender()
+      status = state{"status"}.getStr("disconnected")
+      intervalSeconds = max(1, state{"interval_seconds"}.getInt(5))
+    let now = epochTime()
+    case status
+    of "connecting":
+      if now >= nextDeviceFlowPollAt:
+        nextDeviceFlowPollAt = now + float(intervalSeconds)
+        let poll = pollDeviceFlow(frameConfig)
+        if poll.changed:
+          nextDeviceFlowPollAt = 0.0
+        return poll.startHub
+    of "connected":
+      if pendingLinkCodeQueued():
+        clearPendingLinkCode()
+    else:
+      nextDeviceFlowPollAt = 0.0
+      if now < nextLinkCodeStartAt:
+        return false
+      let pending = loadPendingLinkCode()
+      if pending == nil:
+        return false
+      let starts = pending{"starts"}.getInt(0)
+      if starts >= LINK_CODE_MAX_STARTS:
+        log(%*{"event": "cloud:linkCode:gaveUp", "starts": starts,
+               "message": "No one claimed the link code shown on the display; " &
+                          "restart the link from the admin page or reboot to show it again."})
+        clearPendingLinkCode()
+        return false
+      var displayName = "FrameOS frame"
+      if frameConfig != nil and frameConfig.name.len > 0:
+        displayName = "FrameOS frame (" & frameConfig.name & ")"
+      let outcome = startDeviceFlow(
+        pending{"provider_url"}.getStr(DEFAULT_CLOUD_PROVIDER_URL),
+        displayName, headlessLocalOrigin(frameConfig), LINK_CODE_DEFAULT_SCOPES)
+      if outcome.ok:
+        pending["starts"] = %(starts + 1)
+        try:
+          savePendingLinkCode(pending)
+        except CatchableError:
+          discard
+        linkCodeStartBackoff = LINK_CODE_START_BACKOFF_MIN_SECONDS
+        nextLinkCodeStartAt = 0.0
+        log(%*{"event": "cloud:linkCode:shown", "start": starts + 1})
+      elif outcome.networkError:
+        # Wi-Fi not up yet, or the provider is away: try again, more slowly.
+        nextLinkCodeStartAt = now + linkCodeStartBackoff
+        linkCodeStartBackoff = min(linkCodeStartBackoff * 2, LINK_CODE_START_BACKOFF_MAX_SECONDS)
+      else:
+        log(%*{"event": "cloud:linkCode:refused", "status": outcome.status, "error": outcome.error})
+        clearPendingLinkCode()
+    false
+
+# ---------------------------------------------------------------------------
+# What the panel should be showing
+
+type LinkCodeView* = object
+  active*: bool
+  userCode*: string
+  verificationUri*: string
+  verificationUriComplete*: string
+  secondsLeft*: int
+
+var
+  linkCodeCache: LinkCodeView
+  linkCodeCacheGeneration = -1
+  linkCodeCacheLock: Lock
+initLock(linkCodeCacheLock)
+
+proc activeLinkCode*(): LinkCodeView {.gcsafe.} =
+  ## The pending link code, or `active = false`. Re-read only when the link
+  ## state changed (generation counter), so the render loop pays one atomic
+  ## load per frame, not a file parse.
+  {.gcsafe.}:
+    let generation = currentCloudLinkGeneration()
+    withLock linkCodeCacheLock:
+      if generation != linkCodeCacheGeneration:
+        var view = LinkCodeView()
+        withLock cloudLinkLock:
+          let state = loadCloudLinkState()
+          if state{"status"}.getStr("") == "connecting" and
+              state{"user_code"}.getStr("").len > 0:
+            view.active = true
+            view.userCode = state{"user_code"}.getStr("")
+            view.verificationUri = state{"verification_uri"}.getStr("")
+            view.verificationUriComplete = state{"verification_uri_complete"}.getStr("")
+            view.secondsLeft = state{"expires_epoch"}.getInt(0)
+        linkCodeCache = view
+        linkCodeCacheGeneration = generation
+      result = linkCodeCache
+    if result.active:
+      # secondsLeft caches the deadline; turn it into a countdown here, and
+      # take the code down the moment the window lapses even if nothing has
+      # rewritten the state file yet.
+      let left = result.secondsLeft - int(epochTime())
+      if result.secondsLeft > 0 and left <= 0:
+        return LinkCodeView()
+      result.secondsLeft = max(0, left)

--- a/frameos/src/frameos/cloud/hub_client.nim
+++ b/frameos/src/frameos/cloud/hub_client.nim
@@ -63,6 +63,7 @@ import frameos/server/state
 import frameos/types
 import frameos/upgrade
 import frameos/utils/http_client
+import ./device_flow
 import ./enrollment
 import ./identity
 import ./link_state
@@ -2095,6 +2096,14 @@ proc cloudHubThreadMain(frameConfig: FrameConfig) {.thread.} =
         # have succeeded, so start over.
         nextEnrollAttemptAt = 0.0
         enrollBackoff = HubEnrollBackoffMinSeconds
+      # ---- device-flow ("link code") handoff -----------------------------
+      # Polls a pending flow so a link started from the admin page (or queued
+      # by the setup portal for the panel) completes without a browser tab
+      # driving it; starts a queued panel link once the network is up. When
+      # managed enrollment succeeds this thread IS the hub client, so the
+      # next pass picks the new link state up by itself.
+      if deviceFlowTick(frameConfig):
+        log(%*{"event": "cloud:enroll:linkCode", "ok": true})
       if epochTime() >= nextEnrollAttemptAt and fileExists(pendingEnrollmentPath()):
         # Announced BEFORE the attempt, because the attempt is what changes
         # state: a successful or permanently-rejected enrollment deletes the

--- a/frameos/src/frameos/cloud/tests/test_device_flow.nim
+++ b/frameos/src/frameos/cloud/tests/test_device_flow.nim
@@ -1,0 +1,229 @@
+## Device-flow ("link code") behavior tests: a tiny mummy server plays the
+## provider, so the start/poll/tick lifecycle runs for real with no network.
+## Chdirs into a temp dir so ./state/cloud_link.json stays isolated.
+
+import std/[json, locks, net, os, strutils, tables, times, unittest]
+import mummy
+import mummy/routers
+
+import ../device_flow
+import ../link_state
+import ../../types
+
+const TestPort = 19462
+
+let workDir = getTempDir() / ("frameos-test-device-flow-" & $(epochTime().int64) & "-" & $getCurrentProcessId())
+createDir(workDir)
+setCurrentDir(workDir)
+putEnv("FRAMEOS_CLOUD_DEVICE_KEY_PATH", workDir / "cloud_device_key")
+putEnv("FRAMEOS_CLOUD_LINK_CODE_PENDING_PATH", workDir / "cloud_link_code_pending.json")
+
+# ---------------------------------------------------------------------------
+# Provider stub: per-path canned responses, requests recorded.
+# ---------------------------------------------------------------------------
+
+var stubLock: Lock
+initLock(stubLock)
+var responses = initTable[string, (int, string)]()
+var requestCounts = initTable[string, int]()
+
+proc setStubResponse(path: string, code: int, body: JsonNode) =
+  withLock stubLock:
+    responses[path] = (code, $body)
+    requestCounts[path] = 0
+
+proc requestCount(path: string): int =
+  withLock stubLock:
+    result = requestCounts.getOrDefault(path, 0)
+
+proc stubHandler(request: Request) {.gcsafe.} =
+  {.gcsafe.}:
+    var code = 404
+    var body = "{}"
+    withLock stubLock:
+      requestCounts[request.path] = requestCounts.getOrDefault(request.path, 0) + 1
+      if responses.hasKey(request.path):
+        (code, body) = responses[request.path]
+    var headers: mummy.HttpHeaders
+    headers["Content-Type"] = "application/json"
+    request.respond(code, headers, body)
+
+var router: Router
+router.post("/**", stubHandler)
+router.get("/**", stubHandler)
+
+var server = newServer(router.toHandler(), workerThreads = 1)
+var serverThread: Thread[(mummy.Server, Port)]
+proc serveStub(args: (mummy.Server, Port)) {.thread.} =
+  try:
+    args[0].serve(args[1], "127.0.0.1")
+  except CatchableError:
+    discard
+createThread(serverThread, serveStub, (server, Port(TestPort)))
+sleep(200)
+
+let providerUrl = "http://127.0.0.1:" & $TestPort
+
+proc standaloneConfig(): FrameConfig =
+  FrameConfig(name: "Test frame", mode: "buildroot", device: "web_only",
+              width: 800, height: 480, serverHost: "", frameHost: "test.local",
+              framePort: 8787)
+
+proc linkStateNow(): JsonNode =
+  withLock cloudLinkLock:
+    result = loadCloudLinkState()
+
+proc clearLinkState() =
+  withLock cloudLinkLock:
+    if fileExists(CLOUD_LINK_STATE_PATH):
+      removeFile(CLOUD_LINK_STATE_PATH)
+    let state = loadCloudLinkState()
+    saveCloudLinkState(state)
+
+proc startResponse(): JsonNode =
+  %*{
+    "device_code": "dev-code-1",
+    "user_code": "ABCD-2345",
+    "verification_uri": providerUrl & "/device",
+    "verification_uri_complete": providerUrl & "/device?user_code=ABCD-2345",
+    "interval": 1,
+    "expires_in": 600,
+  }
+
+suite "device flow start and panel view":
+  test "a successful start pends the link and puts the code on the panel":
+    clearLinkState()
+    clearPendingLinkCode()
+    setStubResponse("/api/device/start", 200, startResponse())
+    let outcome = startDeviceFlow(providerUrl, "Test frame", "http://test.local:8787",
+      @["frame:link"])
+    check outcome.ok
+    let state = linkStateNow()
+    check state{"status"}.getStr("") == "connecting"
+    check state{"user_code"}.getStr("") == "ABCD-2345"
+    let view = activeLinkCode()
+    check view.active
+    check view.userCode == "ABCD-2345"
+    check view.verificationUriComplete.contains("user_code=ABCD-2345")
+    check view.secondsLeft > 0
+
+  test "a provider rejection reports the error and pends nothing":
+    clearLinkState()
+    setStubResponse("/api/device/start", 400, %*{"error": "nope"})
+    let outcome = startDeviceFlow(providerUrl, "Test frame", "http://test.local:8787",
+      @["frame:link"])
+    check not outcome.ok
+    check not outcome.networkError
+    check outcome.error.contains("nope")
+    check linkStateNow(){"status"}.getStr("disconnected") == "disconnected"
+    check not activeLinkCode().active
+
+  test "an unreachable provider is a retryable network error":
+    let outcome = startDeviceFlow("http://127.0.0.1:1", "Test frame",
+      "http://test.local:8787", @["frame:link"])
+    check not outcome.ok
+    check outcome.networkError
+
+suite "device flow poll":
+  setup:
+    clearLinkState()
+    clearPendingLinkCode()
+    setStubResponse("/api/device/start", 200, startResponse())
+    discard startDeviceFlow(providerUrl, "Test frame", "http://test.local:8787",
+      @["frame:link"])
+
+  test "authorization_pending keeps the code up":
+    setStubResponse("/api/device/poll", 428, %*{"error": "authorization_pending"})
+    let poll = pollDeviceFlow(standaloneConfig())
+    check poll.polled
+    check not poll.changed
+    check linkStateNow(){"status"}.getStr("") == "connecting"
+    check activeLinkCode().active
+
+  test "approval connects the link and takes the code down":
+    setStubResponse("/api/device/poll", 200, %*{
+      "access_token": "link-token-1",
+      "token_reference": "ref-1",
+      "linked_client_id": "client-1",
+      "scope": "frame:link",
+    })
+    setStubResponse("/api/backends/inventory", 200, %*{"status": "ok"})
+    setStubResponse("/api/backends/grants", 200, %*{"grants": []})
+    let poll = pollDeviceFlow(standaloneConfig())
+    check poll.changed
+    check not poll.startHub
+    let state = linkStateNow()
+    check state{"status"}.getStr("") == "connected"
+    check state{"access_token"}.getStr("") == "link-token-1"
+    check not state.hasKey("user_code")
+    check not activeLinkCode().active
+
+  test "denial resets the link and records why":
+    setStubResponse("/api/device/poll", 403, %*{"error": "access_denied"})
+    let poll = pollDeviceFlow(standaloneConfig())
+    check poll.changed
+    let state = linkStateNow()
+    check state{"status"}.getStr("") == "disconnected"
+    check state{"poll_error"}.getStr("") == "access_denied"
+    check not activeLinkCode().active
+
+  test "an expired window takes the code down before any poll":
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      state["expires_epoch"] = %(int(epochTime()) - 5)
+      saveCloudLinkState(state)
+    check not activeLinkCode().active
+    let poll = pollDeviceFlow(standaloneConfig())
+    check poll.changed
+    check linkStateNow(){"status"}.getStr("") == "disconnected"
+
+suite "queued panel link code":
+  test "the tick starts a device flow for a queued link code":
+    clearLinkState()
+    setStubResponse("/api/device/start", 200, startResponse())
+    check writePendingLinkCode(providerUrl)
+    check pendingLinkCodeQueued()
+    discard deviceFlowTick(standaloneConfig())
+    check linkStateNow(){"status"}.getStr("") == "connecting"
+    check activeLinkCode().active
+    # The marker survives (it restarts the flow when the window lapses) and
+    # counts the start.
+    check loadPendingLinkCode(){"starts"}.getInt(0) == 1
+
+  test "connecting ticks poll without a browser":
+    setStubResponse("/api/device/poll", 428, %*{"error": "authorization_pending"})
+    discard deviceFlowTick(standaloneConfig())
+    # interval is 1 s; wait it out so the tick actually polls.
+    sleep(1100)
+    discard deviceFlowTick(standaloneConfig())
+    check requestCount("/api/device/poll") >= 1
+    check linkStateNow(){"status"}.getStr("") == "connecting"
+
+  test "a connected link retires the queued marker":
+    clearLinkState()
+    withLock cloudLinkLock:
+      let state = loadCloudLinkState()
+      state["status"] = %"connected"
+      saveCloudLinkState(state)
+    check writePendingLinkCode(providerUrl)
+    discard deviceFlowTick(standaloneConfig())
+    check not pendingLinkCodeQueued()
+
+  test "a permanent provider refusal retires the queued marker":
+    clearLinkState()
+    setStubResponse("/api/device/start", 400, %*{"error": "invalid_request"})
+    check writePendingLinkCode(providerUrl)
+    discard deviceFlowTick(standaloneConfig())
+    check not pendingLinkCodeQueued()
+    check linkStateNow(){"status"}.getStr("disconnected") == "disconnected"
+
+  test "the tick gives up after the start budget is spent":
+    clearLinkState()
+    setStubResponse("/api/device/start", 200, startResponse())
+    check writePendingLinkCode(providerUrl)
+    let pending = loadPendingLinkCode()
+    pending["starts"] = %LINK_CODE_MAX_STARTS
+    writeFile(pendingLinkCodePath(), $pending & "\n")
+    discard deviceFlowTick(standaloneConfig())
+    check not pendingLinkCodeQueued()
+    check linkStateNow(){"status"}.getStr("disconnected") == "disconnected"

--- a/frameos/src/frameos/portal.nim
+++ b/frameos/src/frameos/portal.nim
@@ -8,6 +8,7 @@ import frameos/setup_proxy
 import frameos/utils/process
 import frameos/network/backend as netbackend
 import frameos/network/supplicant as wpa
+import frameos/cloud/device_flow
 import frameos/cloud/enrollment
 import frameos/cloud/link_state
 import drivers/drivers as frameDrivers
@@ -778,7 +779,7 @@ proc defaultControlMode*(frameConfig: FrameConfig): string {.gcsafe.} =
   ## enrollment wins, then a configured self-hosted backend; a frame with
   ## neither — including the release-image "localhost" placeholder — runs
   ## standalone until the user picks something.
-  if pendingCloudEnrollment() != nil or cloudLinkIsManaged():
+  if pendingCloudEnrollment() != nil or cloudLinkIsManaged() or pendingLinkCodeQueued():
     return "cloud"
   if otherControlPlaneActive(frameConfig):
     return "backend"
@@ -953,14 +954,27 @@ proc persistPortalSetup*(frameOS: FrameOS, options: PortalSetupOptions): bool =
     writeFile(filename, pretty(data, indent = 4) & "\n")
     writeHostnameBestEffort(hostnameBase)
 
-    if options.controlMode == "cloud" and options.claimToken.len > 0:
-      # A fresh claim code replaces whatever enrollment was queued; blank
-      # keeps the boot-provisioned one. The hub thread redeems it once the
-      # network is up (connectToWifi nudges it).
-      if not writePendingEnrollment(options.claimToken, options.cloudUrl, hostnameBase):
-        rememberError("Failed to save the cloud claim code.")
-        pLog("portal:setup:cloudEnrollError", %*{"providerUrl": options.cloudUrl})
-        return false
+    if options.controlMode == "cloud":
+      if options.claimToken.len > 0:
+        # A fresh claim code replaces whatever enrollment was queued; blank
+        # keeps the boot-provisioned one. The hub thread redeems it once the
+        # network is up (connectToWifi nudges it).
+        if not writePendingEnrollment(options.claimToken, options.cloudUrl, hostnameBase):
+          rememberError("Failed to save the cloud claim code.")
+          pLog("portal:setup:cloudEnrollError", %*{"providerUrl": options.cloudUrl})
+          return false
+      elif pendingCloudEnrollment() == nil and not cloudLinkIsManaged():
+        # No claim code at all: queue a panel-displayed link code instead
+        # (docs/cloud-frames.md, flow B). Once online, the hub thread starts
+        # a device flow and the display shows the code + QR to claim this
+        # frame — reading it off the panel is the ownership proof.
+        if not writePendingLinkCode(options.cloudUrl):
+          rememberError("Failed to queue the cloud link code.")
+          pLog("portal:setup:linkCodeError", %*{"providerUrl": options.cloudUrl})
+          return false
+    else:
+      # Picking a backend or standalone retires a queued panel link code.
+      clearPendingLinkCode()
 
     pLog("portal:setup:persisted", %*{
       "controlMode": options.controlMode,
@@ -1667,7 +1681,9 @@ proc setupHtml*(frameOS: FrameOS): string =
                data-pending="{claimPending}"
                placeholder="{htmlEscape(claimPlaceholder)}">
       </label>
-      <p class="muted">Claim codes come from "Add frame" in your cloud account.</p>
+      <p class="muted">Claim codes come from "Add frame" in your cloud account.
+        Leave this empty to show a link code on the display instead: claim the
+        frame by scanning it once the frame is online.</p>
     </div>
     <div id="backend-fields"{backendFieldsClass}>
       <label>Server Host
@@ -1714,7 +1730,9 @@ function updateControlUi() {
   cloudFields.classList.toggle('hidden', mode !== 'cloud');
   backendFields.classList.toggle('hidden', mode !== 'backend');
   serverHostInput.required = mode === 'backend';
-  claimTokenInput.required = mode === 'cloud' && claimTokenInput.dataset.pending !== '1';
+  // Optional either way: with no claim code, saving queues a link code that
+  // the frame shows on its own display once online.
+  claimTokenInput.required = false;
 }
 
 function currentDeviceMeta() {

--- a/frameos/src/frameos/runner.nim
+++ b/frameos/src/frameos/runner.nim
@@ -11,6 +11,7 @@ import frameos/config
 import frameos/device_setup
 import frameos/driver_render_hint
 import frameos/local_access
+import frameos/cloud/device_flow
 import frameos/logger
 import frameos/metrics
 import frameos/types
@@ -95,6 +96,51 @@ proc configureLocalAccessOverlay(self: RunnerThread) =
     overflow: "fit-bounds",
   ))
 
+proc configureLinkCodeOverlay(self: RunnerThread) =
+  ## Always built, like the presence-code overlay: a device-flow link can be
+  ## started at any moment (admin page, setup portal queue) and the code has
+  ## to be on the panel for the possession ceremony to mean anything.
+  self.linkCodeRender = render_textApp.App(nodeName: "render/text", nodeId: -3.NodeId,
+    frameConfig: self.frameConfig, appConfig: render_textApp.AppConfig(
+    text: "",
+    richText: "disabled",
+    inputImage: none(Image),
+    position: "center",
+    vAlign: "top",
+    offsetX: 0.0,
+    offsetY: 0.0,
+    padding: 16.0,
+    fontColor: parseHtmlColor("#ffffff"),
+    fontSize: 32.0,
+    borderColor: parseHtmlColor("#000000"),
+    borderWidth: 3,
+    overflow: "fit-bounds",
+  ))
+  self.linkCodeQrRender = render_imageApp.App(nodeName: "render/image", nodeId: -4.NodeId,
+    frameConfig: self.frameConfig, appConfig: render_imageApp.AppConfig(
+    placement: "center",
+    offsetX: 0,
+    offsetY: 40,
+    blendMode: "normal",
+  ))
+  self.linkCodeQrData = data_qrApp.App(nodeName: "data/qr", nodeId: -4.NodeId,
+    frameConfig: self.frameConfig, appConfig: data_qrApp.AppConfig(
+    codeType: "Custom",
+    code: "",
+    # A third of the shorter panel edge: readable from in front of the frame
+    # on the small panels, without covering the whole scene on the large ones.
+    size: 33.0,
+    sizeUnit: "percent",
+    alRad: 30.0,
+    moRad: 0.0,
+    moSep: 0.0,
+    padding: 1,
+    qrCodeColor: parseHtmlColor("#000000"),
+    backgroundColor: parseHtmlColor("#ffffff"),
+  ))
+  self.linkCodeQrImage = nil
+  self.linkCodeQrKey = ""
+
 proc configureControlCode(self: RunnerThread) =
   if self.frameConfig.controlCode.enabled:
     let controlCode = self.frameConfig.controlCode
@@ -156,6 +202,27 @@ proc renderSceneImage*(self: RunnerThread, exportedScene: ExportedScene, scene: 
       render_textApp.App(self.localAccessRender).appConfig.text =
         "Local network access\n" & presenceCode
       render_textApp.App(self.localAccessRender).run(context)
+    # A pending FrameOS Cloud link code (cloud/device_flow.nim): the user code
+    # plus a QR of the claim URL, drawn over the scene for the same reason as
+    # the presence code — reading it off the panel is the ownership proof.
+    let linkCode = activeLinkCode()
+    if linkCode.active:
+      let qrPayload = if linkCode.verificationUriComplete.len > 0:
+          linkCode.verificationUriComplete
+        else:
+          linkCode.verificationUri
+      if qrPayload.len > 0:
+        if self.linkCodeQrImage == nil or self.linkCodeQrKey != qrPayload:
+          data_qrApp.App(self.linkCodeQrData).appConfig.code = qrPayload
+          self.linkCodeQrImage = data_qrApp.App(self.linkCodeQrData).get(context)
+          self.linkCodeQrKey = qrPayload
+        render_imageApp.App(self.linkCodeQrRender).appConfig.image = self.linkCodeQrImage
+        render_imageApp.App(self.linkCodeQrRender).run(context)
+      var linkText = "Connect to FrameOS Cloud\n" & linkCode.userCode
+      if linkCode.verificationUri.len > 0:
+        linkText.add("\n" & linkCode.verificationUri)
+      render_textApp.App(self.linkCodeRender).appConfig.text = linkText
+      render_textApp.App(self.linkCodeRender).run(context)
     let image = context.image
 
     var outImage: Image
@@ -584,6 +651,7 @@ proc startMessageLoop*(self: RunnerThread, maxIterations = -1): Future[void] {.a
             self.currentSceneId = getFirstSceneId()
             self.configureControlCode()
             self.configureLocalAccessOverlay()
+            self.configureLinkCodeOverlay()
             self.forceSceneReload = true
             self.triggerRenderNext = true
             continue # don't dispatch this event to the scene
@@ -645,6 +713,7 @@ proc createRunnerThread*(args: (FrameConfig, Logger, Option[SceneId])) =
     )
     runnerThread.configureControlCode()
     runnerThread.configureLocalAccessOverlay()
+    runnerThread.configureLinkCodeOverlay()
 
     waitFor runnerThread.startRenderLoop() and runnerThread.startMessageLoop()
 

--- a/frameos/src/frameos/server/routes/cloud_api_routes.nim
+++ b/frameos/src/frameos/server/routes/cloud_api_routes.nim
@@ -20,26 +20,14 @@ import mummy/routers
 import httpcore
 import std/httpclient
 import frameos/channels
-import frameos/upgrade
-import frameos/utils/http_client
 import frameos/cloud/link_state
+import frameos/cloud/device_flow
 import frameos/cloud/enrollment
 import frameos/cloud/hub_client
 import ../api
 import ../auth
 import ../rate_limit
 import ../state
-
-const
-  CLOUD_REQUEST_TIMEOUT_MS = 15000
-  CLOUD_REQUEST_MAX_SECONDS = 20.0
-  CLOUD_REQUEST_MAX_REDIRECTS = 1
-
-proc jsonOrNull(node: JsonNode): JsonNode =
-  ## `state{...}` yields nil for missing keys, and a nil embedded in `%*`
-  ## segfaults std/json's serializer. A claim-token enrollment (flow A) has no
-  ## account_id/linked_client_id, so every optional field must go through this.
-  if node == nil: newJNull() else: node
 
 proc cloudStatusPayload(state: JsonNode): JsonNode =
   let status = state{"status"}.getStr("disconnected")
@@ -90,35 +78,6 @@ proc cloudStatusPayload(state: JsonNode): JsonNode =
     if state{"mode"}.getStr("") == "managed":
       result["mode"] = %"managed"
       result["link"]["frame_id"] = jsonOrNull(state{"frame_id"})
-
-proc cloudRequest(providerUrl, path: string, httpMethod = HttpPost,
-                  accessToken = "", body: JsonNode = nil): (int, JsonNode) =
-  var headers = newHttpHeaders({"Accept": "application/json"})
-  if body != nil:
-    headers["Content-Type"] = "application/json"
-  if accessToken.len > 0:
-    headers["Authorization"] = "Bearer " & accessToken
-  let url = providerUrl & "/" & path.strip(leading = true, chars = {'/'})
-  let response = boundedRequest(
-    url,
-    httpMethod = httpMethod,
-    body = (if body != nil: $body else: ""),
-    headers = headers,
-    timeoutMs = CLOUD_REQUEST_TIMEOUT_MS,
-    maxSeconds = CLOUD_REQUEST_MAX_SECONDS,
-    # A provider's API answers directly; every extra hop is another connect
-    # (and another resolution) charged to a worker thread, so allow one for a
-    # host or scheme move and no more.
-    maxRedirects = CLOUD_REQUEST_MAX_REDIRECTS,
-  )
-  var payload: JsonNode = nil
-  try:
-    payload = parseJson(response.body)
-  except CatchableError:
-    discard
-  if payload == nil or payload.kind != JObject:
-    payload = %*{}
-  (response.code, payload)
 
 proc requestedScopes(payload: JsonNode): seq[string] =
   if payload{"scopes"} != nil and payload{"scopes"}.kind == JArray:
@@ -214,36 +173,6 @@ proc loginStateCookieHeader(request: Request, value: string): string =
   # /api/cloud/login, expires in CLOUD_LOGIN_STATE_TTL_SECONDS, is overwritten
   # by the next /start, and its server-side state entry is single-use.
 
-proc fetchConnectSync(providerUrl, accessToken: string): JsonNode =
-  ## Best effort: report inventory and learn which account owns us. Returns the
-  ## fields to merge into the link state rather than mutating it: both requests
-  ## below can take tens of seconds, so callers MUST run this WITHOUT holding
-  ## cloudLinkLock and merge the result afterwards.
-  var state = newJObject()
-  try:
-    let (inventoryCode, _) = cloudRequest(providerUrl, "/api/backends/inventory",
-      accessToken = accessToken, body = %*{
-        "reported_frameos_version": installedFrameOSVersion(),
-        "capabilities": {"localFallback": true, "frame": true},
-        "health": {"status": "ok"},
-      })
-    if inventoryCode == 200:
-      state["last_inventory_sync_at"] = %isoTimestamp(int64(epochTime()))
-  except CatchableError:
-    discard
-  try:
-    let (grantsCode, grants) = cloudRequest(providerUrl, "/api/backends/grants",
-      httpMethod = HttpGet, accessToken = accessToken)
-    if grantsCode == 200 and grants{"grants"} != nil and grants{"grants"}.kind == JArray:
-      for grant in grants{"grants"}:
-        if grant.kind == JObject and grant{"role"}.getStr("") == "owner":
-          state["account_id"] = grant{"account_id"}
-          state["account_email"] = grant{"account_email"}
-          break
-  except CatchableError:
-    discard
-  return state
-
 proc addCloudApiRoutes*(router: var Router) =
   router.get("/api/cloud/status", proc(request: Request) {.gcsafe.} =
     if not hasAdminAccess(request):
@@ -309,53 +238,16 @@ proc addCloudApiRoutes*(router: var Router) =
       if globalFrameConfig != nil and globalFrameConfig.name.len > 0:
         displayName = "FrameOS frame (" & globalFrameConfig.name & ")"
 
-      let scopes = requestedScopes(payload)
-      var scopesJson = newJArray()
-      for scope in scopes:
-        scopesJson.add(%scope)
-      var startResponse: JsonNode
-      var startCode = 0
-      let origin = localOrigin(request)
-      try:
-        (startCode, startResponse) = cloudRequest(providerUrl, "/api/device/start", body = %*{
-          "public_display_name": displayName,
-          "local_origin": origin,
-          "reported_frameos_version": installedFrameOSVersion(),
-          "capabilities": {"localFallback": true, "frame": true},
-          "client_kind": "frame",
-          "scopes": scopesJson,
-        })
-      except CatchableError as error:
-        jsonResponse(request, Http502, %*{"detail": "Could not reach " & providerUrl & ": " & error.msg})
+      # The shared start (cloud/device_flow.nim) also puts the code on the
+      # panel and lets the hub thread poll, so closing this browser tab no
+      # longer strands the flow.
+      let outcome = startDeviceFlow(providerUrl, displayName, localOrigin(request),
+        requestedScopes(payload))
+      if not outcome.ok:
+        jsonResponse(request, Http502, %*{"detail": outcome.error})
         return
-      if startCode != 200 or startResponse{"device_code"}.getStr("") == "":
-        let detail = startResponse{"error"}.getStr("unexpected status " & $startCode)
-        jsonResponse(request, Http502, %*{"detail": "FrameOS Cloud rejected the request: " & detail})
-        return
-
       withLock cloudLinkLock:
-        let state = loadCloudLinkState()
-        resetLinkState(state)
-        state["provider_url"] = %providerUrl
-        state["status"] = %"connecting"
-        # The provider only accepts login-handoff redirects on this origin.
-        state["local_origin"] = %origin
-        state["device_code"] = jsonOrNull(startResponse{"device_code"})
-        state["user_code"] = jsonOrNull(startResponse{"user_code"})
-        state["verification_uri"] = jsonOrNull(startResponse{"verification_uri"})
-        state["verification_uri_complete"] = jsonOrNull(startResponse{"verification_uri_complete"})
-        state["interval_seconds"] = %startResponse{"interval"}.getInt(5)
-        state["scope"] = %scopes.join(" ")
-        # Remember what THIS device asked for. The poll response below reports
-        # what the provider says it granted, and managed mode — the one scope
-        # that hands a provider remote control of the frame — is only entered
-        # when both agree (managedEnrollmentRequested).
-        state["requested_scope"] = %scopes.join(" ")
-        let expiresIn = startResponse{"expires_in"}.getInt(0)
-        if expiresIn > 0:
-          state["expires_epoch"] = %int(epochTime() + float(expiresIn))
-        saveCloudLinkState(state)
-        jsonResponse(request, Http200, cloudStatusPayload(state))
+        jsonResponse(request, Http200, cloudStatusPayload(loadCloudLinkState()))
   )
 
   router.post("/api/cloud/poll", proc(request: Request) {.gcsafe.} =
@@ -363,108 +255,14 @@ proc addCloudApiRoutes*(router: var Router) =
       jsonResponse(request, Http401, %*{"detail": "Unauthorized"})
       return
     {.gcsafe.}:
-      var providerUrl = ""
-      var deviceCode = ""
+      # Shared with the hub thread's background tick; both sides are safe to
+      # run concurrently (the poll is a no-op unless the link is connecting,
+      # and the provider treats a duplicate poll as authorization_pending).
+      let poll = pollDeviceFlow(globalFrameConfig)
+      if poll.startHub:
+        startCloudHubClient(globalFrameConfig)
       withLock cloudLinkLock:
         let state = loadCloudLinkState()
-        if expireIfNeeded(state):
-          saveCloudLinkState(state)
-        if state{"status"}.getStr("") != "connecting" or state{"device_code"}.getStr("") == "":
-          jsonResponse(request, Http200, cloudStatusPayload(state))
-          return
-        providerUrl = providerUrlFromState(state)
-        deviceCode = state{"device_code"}.getStr("")
-
-      var pollCode = 0
-      var pollResponse: JsonNode = %*{}
-      var networkError = false
-      try:
-        (pollCode, pollResponse) = cloudRequest(providerUrl, "/api/device/poll",
-          body = %*{"device_code": deviceCode})
-      except CatchableError:
-        networkError = true
-
-      var syncAccessToken = ""
-      var grantedManagedScope = false
-      withLock cloudLinkLock:
-        let state = loadCloudLinkState()
-        if state{"status"}.getStr("") != "connecting" or state{"device_code"}.getStr("") != deviceCode:
-          jsonResponse(request, Http200, cloudStatusPayload(state))
-          return
-        if networkError:
-          state["poll_error"] = %"network_error"
-          saveCloudLinkState(state)
-          jsonResponse(request, Http200, cloudStatusPayload(state))
-          return
-        let error = pollResponse{"error"}.getStr("")
-        if error == "authorization_pending":
-          if state.hasKey("poll_error"):
-            state.delete("poll_error")
-          saveCloudLinkState(state)
-          jsonResponse(request, Http200, cloudStatusPayload(state))
-          return
-        if pollCode == 200 and pollResponse{"access_token"}.getStr("") != "":
-          let accessToken = pollResponse{"access_token"}.getStr("")
-          state["status"] = %"connected"
-          state["access_token"] = %accessToken
-          state["token_reference"] = jsonOrNull(pollResponse{"token_reference"})
-          state["linked_client_id"] = jsonOrNull(pollResponse{"linked_client_id"})
-          if pollResponse{"scope"}.getStr("") != "":
-            state["scope"] = pollResponse{"scope"}
-          for key in ["device_code", "user_code", "verification_uri",
-                      "verification_uri_complete", "expires_epoch", "poll_error"]:
-            if state.hasKey(key):
-              state.delete(key)
-          state["connected_at"] = %isoTimestamp(int64(epochTime()))
-          saveCloudLinkState(state)
-          # The inventory/grants sync is two more cloud round trips; do it
-          # after releasing the lock (below) so a slow or unreachable provider
-          # cannot hold cloudLinkLock — and with it every cloud route — for
-          # minutes.
-          syncAccessToken = accessToken
-          # Granted AND locally requested: a provider cannot upgrade a
-          # backups-only link into cloud-managed mode by claiming the scope.
-          grantedManagedScope = managedEnrollmentRequested(state)
-          if linkHasScope(state, "frame:managed") and not grantedManagedScope:
-            log(%*{"event": "cloud:enroll:refused", "reason": "scope_not_requested",
-                   "message": "The provider granted frame:managed but this frame " &
-                              "never asked for it; not entering managed mode."})
-        else:
-          resetLinkState(state, pollError = (if error.len > 0: error else: "unexpected status " & $pollCode))
-          saveCloudLinkState(state)
-          jsonResponse(request, Http200, cloudStatusPayload(state))
-          return
-
-      let synced = fetchConnectSync(providerUrl, syncAccessToken)
-
-      # Flow B (docs/cloud-frames.md): a device-flow link granted the
-      # frame:managed scope registers the device keypair with the provider and
-      # becomes cloud-managed. Runs without cloudLinkLock — it is another
-      # provider round trip — and persists mode/frame_id/ws_path itself.
-      if grantedManagedScope:
-        {.gcsafe.}:
-          if otherControlPlaneActive(globalFrameConfig):
-            log(%*{"event": "cloud:enroll:refused", "reason": "backend_managed",
-                   "message": "This frame is managed by a self-hosted backend; " &
-                              "remove serverHost from frame.json before enrolling with a cloud provider"})
-          else:
-            let outcome = enrollManagedFrame(providerUrl, "", syncAccessToken, "", globalFrameConfig)
-            if outcome.ok:
-              startCloudHubClient(globalFrameConfig)
-            else:
-              log(%*{"event": "cloud:enroll:error", "flow": "device_flow",
-                     "status": outcome.status, "error": outcome.error})
-              withLock cloudLinkLock:
-                let state = loadCloudLinkState()
-                state["managed_enroll_error"] = %outcome.error
-                saveCloudLinkState(state)
-
-      withLock cloudLinkLock:
-        let state = loadCloudLinkState()
-        for key, value in synced:
-          state[key] = value
-        if synced.len > 0:
-          saveCloudLinkState(state)
         jsonResponse(request, Http200, cloudStatusPayload(state))
   )
 
@@ -813,6 +611,10 @@ proc addCloudApiRoutes*(router: var Router) =
         resetLinkState(state)
         saveCloudLinkState(state)
         jsonResponse(request, Http200, cloudStatusPayload(state))
+      # Cancelling a pending panel link must also stop the background tick
+      # from starting a fresh one, and take the code off the display.
+      clearPendingLinkCode()
+      sendEvent("render", %*{})
       # Leaving managed mode lifts the private-network HTTP deny immediately.
       refreshLocalNetworkPolicy(globalFrameConfig)
   )

--- a/frameos/src/frameos/tests/test_portal.nim
+++ b/frameos/src/frameos/tests/test_portal.nim
@@ -1,6 +1,7 @@
 import std/[json, os, strutils, tables, unittest]
 
 import ../channels
+import ../cloud/device_flow
 import ../network/backend
 import ../portal
 import ../types
@@ -598,14 +599,17 @@ suite "portal setup control mode":
     createDir(setupDir)
     putEnv("FRAMEOS_CONFIG", setupDir / "frame.json")
     putEnv("FRAMEOS_CLOUD_ENROLL_PENDING_PATH", setupDir / "pending.json")
+    putEnv("FRAMEOS_CLOUD_LINK_CODE_PENDING_PATH", setupDir / "link_code_pending.json")
 
   teardown:
     resetPortalHooksForTest()
     resetHookState()
     removeFile(setupDir / "frame.json")
     removeFile(setupDir / "pending.json")
+    removeFile(setupDir / "link_code_pending.json")
     delEnv("FRAMEOS_CONFIG")
     delEnv("FRAMEOS_CLOUD_ENROLL_PENDING_PATH")
+    delEnv("FRAMEOS_CLOUD_LINK_CODE_PENDING_PATH")
 
   test "the localhost placeholder no longer preselects a self-hosted backend":
     let frame = makeFrameOS()
@@ -673,6 +677,40 @@ suite "portal setup control mode":
     let pending = parseFile(setupDir / "pending.json")
     check pending{"claim_token"}.getStr() == "FRCT-pending"
     check frame.frameConfig.serverHost == ""
+
+  test "cloud mode with no claim code queues a panel link code":
+    let frame = makeFrameOS()
+    frame.frameConfig.serverHost = "localhost"
+    let params = {
+      "ssid": "home-wifi",
+      "hostname": "kitchen",
+      "controlMode": "cloud",
+      "cloudUrl": "https://cloud.example.com",
+    }.toTable
+    let options = parseSetupOptions(params, frame.frameConfig)
+    check persistPortalSetup(frame, options)
+    # No claim-token enrollment was queued...
+    check not fileExists(setupDir / "pending.json")
+    # ...a panel link code was: the hub thread starts the device flow once
+    # online, and the display shows the code to claim the frame.
+    let queued = parseFile(setupDir / "link_code_pending.json")
+    check queued{"provider_url"}.getStr() == "https://cloud.example.com"
+    check frame.frameConfig.serverHost == ""
+    # A queued link code preselects the cloud on a portal revisit.
+    check defaultControlMode(frame.frameConfig) == "cloud"
+
+  test "leaving cloud mode retires a queued panel link code":
+    check writePendingLinkCode("https://cloud.example.com")
+    let frame = makeFrameOS()
+    let params = {
+      "ssid": "home-wifi",
+      "hostname": "office",
+      "controlMode": "backend",
+      "serverHost": "backend.example.com",
+    }.toTable
+    let options = parseSetupOptions(params, frame.frameConfig)
+    check persistPortalSetup(frame, options)
+    check not fileExists(setupDir / "link_code_pending.json")
 
   test "backend mode still persists the server connection":
     let frame = makeFrameOS()

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -488,6 +488,13 @@ type
     controlCodeRender*: AppRoot
     controlCodeData*: AppRoot
     localAccessRender*: AppRoot
+    linkCodeRender*: AppRoot
+    linkCodeQrRender*: AppRoot
+    linkCodeQrData*: AppRoot
+    # data/qr regenerates on every get(); cache the rendered image keyed on
+    # the payload so a pending link code costs one QR render, not one per frame.
+    linkCodeQrImage*: Image
+    linkCodeQrKey*: string
 
   RunnerControl* = ref object
     start*: proc(firstSceneId: Option[SceneId])


### PR DESCRIPTION
> Based on #378 (re-auth) — merge that first; this diff is the last commit only.

## Summary

Closes the **"Panel-displayed link code"** todo: the RFC 8628 device flow now shows itself on the e-ink panel as proof of possession, instead of only on the portal and admin pages.

- **Panel overlay.** While a link is pending, the runner draws the user code plus a QR of `verification_uri_complete` over the current scene — the same overlay pattern as the local-presence code (`local_access.nim`), and the same ceremony in the other direction: whoever can see the panel owns the frame. The QR is cached on the payload (one render per code, not per frame) and comes down the moment the flow resolves or its 10-minute window lapses.
- **Shared flow module.** Start/poll moves out of the admin routes into `frameos/cloud/device_flow.nim`, used by three callers: the admin routes (`/api/cloud/connect|poll`, unchanged API), the hub thread's idle pass (`deviceFlowTick` — a background poller, so a flow started from the admin page completes **after the browser tab closes**; previously the browser was the only poller and closing the tab stranded the flow), and the runner (`activeLinkCode()`, cached on the link-state generation so the render loop pays one atomic load).
- **Portal: cloud without a claim code.** The setup portal's cloud option no longer requires a claim code. Saved without one it queues `state/cloud_link_code_pending.json`; once online, the hub thread starts the device flow and the panel shows the code. An unclaimed window restarts a fresh code (bounded at 12 starts, then a loud log and give-up until reboot/admin retry). Picking another control mode or `POST /api/cloud/disconnect` retires the queue.

Not in scope: the ESP32 (its C status screen has no device flow today; claim-token-only stands) and any admin-page UI change (the SPA's existing connecting view keeps working — it now merely isn't load-bearing).

## Test plan

- [x] New `test_device_flow.nim` (12 tests, stub provider): start success/rejection/unreachable, poll pending/approved/denied/expired, panel view lifecycle, queued-link-code tick (start, background poll, retire on connect / permanent refusal / spent budget)
- [x] Two new portal tests: no-claim-code queues a panel link code (+ preselects cloud on revisit); leaving cloud mode retires it
- [x] Existing suites pass: cloud API routes behavior, link state, enrollment (20), local access (12), portal (all)
- [x] Full `nim c src/frameos.nim` compiles clean
- [ ] Hardware: see a real panel render the code + QR and complete a claim (not done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsuLSip3u6ZDCiERggiXdm