### PR TITLE
CI: move billed runner minutes to the self-hosted EPYC pool

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -13,14 +13,21 @@ permissions:
   contents: write
 
 jobs:
-  # Runner sizing: every job runs on Depot. The bookkeeping jobs (version
-  # bump, npm dispatch, release notes, matrix, addon repo, GitHub release) are
-  # I/O bound and take the default Depot size; only the two jobs that actually
-  # compute (Buildroot images, ESP32 firmware) take 16 cores. The one
-  # exception is the armhf leg of build-prebuilt-cross, which stays on
-  # GitHub's ARM runners — see backend/bin/cross for the measurements.
+  # Runner sizing (post-Depot-runners, 2026-08): the bookkeeping jobs
+  # (version bump, npm dispatch, release notes, matrix, addon repo, GitHub
+  # release, the push-multiarch orchestrator) are I/O bound and run on free
+  # GitHub-hosted runners. The compute-heavy jobs run on the self-hosted
+  # EPYC pool ("epyc-32" / "epyc-8" = ephemeral Incus VMs on the monster
+  # host, see /srv/gha-runners/README.md there): Buildroot release image on
+  # the 32-core slot, ESP32 firmware on an 8-core slot. Cross builds split
+  # per-arch — amd64/armv6 on epyc-8, arm64+armhf on GitHub's free ARM
+  # runners — see backend/bin/cross for the mapping and measurements. Depot
+  # is still used, deliberately, for the container image builds themselves
+  # (depot/build-push-action: the esp32-ci layer cache shared with
+  # e2e-docker.yml, and push-multiarch's remote amd64+arm64 builders) — only
+  # the billed runner minutes moved off Depot.
   update-versions:
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       release_sha: ${{ steps.release-ref.outputs.release_sha }}
       docker_version: ${{ steps.release-ref.outputs.docker_version }}
@@ -77,7 +84,7 @@ jobs:
   publish-npm:
     name: Publish FrameOS npm packages
     needs: update-versions
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       # npm auth uses trusted publishing (OIDC), which matches on the
       # top-level workflow file — so publishing lives in npm-publish.yml and
@@ -96,7 +103,7 @@ jobs:
   release-notes:
     name: Generate Release Notes
     needs: update-versions
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout release commit
         uses: actions/checkout@v4
@@ -126,7 +133,7 @@ jobs:
 
   determine-release-targets:
     needs: update-versions
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set-matrix.outputs.targets }}
     steps:
@@ -235,7 +242,10 @@ jobs:
   build-buildroot-release-image:
     name: Build Buildroot Release Image
     needs: [update-versions, build-prebuilt-cross]
-    runs-on: depot-ubuntu-24.04-16
+    # The one 32-core slot on the self-hosted pool; assembles the release
+    # image from the prebuilt R2 base image, so it queues behind nothing
+    # else in this workflow (the ESP32 job uses an epyc-8 slot).
+    runs-on: epyc-32
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -357,7 +367,9 @@ jobs:
   build-esp32-generic-firmware:
     name: Build ESP32 firmware (generic, all panels)
     needs: [update-versions]
-    runs-on: depot-ubuntu-24.04-16
+    # Self-hosted 8-core slot; the esp32-ci image itself still comes from
+    # Depot's builders below (warm layer cache), only idf.py runs here.
+    runs-on: epyc-8
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -561,9 +573,9 @@ jobs:
   # image build and pushes the multi-arch manifest directly.
   push-multiarch:
     needs: [update-versions, build-prebuilt-cross, build-buildroot-release-image]
-    # The image itself is built on Depot's remote builders, so this runner only
-    # orchestrates: the default size is plenty.
-    runs-on: depot-ubuntu-24.04
+    # The image itself is built on Depot's remote builders, so this runner
+    # only orchestrates: a free GitHub-hosted runner is plenty.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -617,7 +629,7 @@ jobs:
   update-addon-repo:
     name: Update Home Assistant Addon
     needs: [update-versions, push-multiarch, release-notes]
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout frameos
         uses: actions/checkout@v4
@@ -696,7 +708,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     needs: [update-versions, push-multiarch, build-prebuilt-cross, build-buildroot-release-image, build-esp32-generic-firmware, build-pico-firmware, update-addon-repo, release-notes]
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       # Shallow: this job only needs a working directory for `gh` and the
       # downloaded artifacts. Release notes come from an artifact and the tag

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -23,7 +23,14 @@ permissions:
 jobs:
   nim:
     name: FrameOS Nim Tests (shard ${{ matrix.shard }})
-    runs-on: ubuntu-latest
+    # Self-hosted 4-core slots (ephemeral Incus VMs on the monster host; see
+    # /srv/gha-runners/README.md there): same 4-vcpu shape as ubuntu-latest,
+    # faster cores, and the eight shards skip the account-wide GitHub-hosted
+    # queue. Pure compute — no browser rendering. The visual-regression jobs
+    # stay on GitHub-hosted runners on purpose: their auto-committed
+    # Playwright/snapshot baselines must keep rendering on the image that
+    # produced them.
+    runs-on: epyc-4
     strategy:
       fail-fast: false
       matrix:
@@ -582,7 +589,9 @@ jobs:
 
   deploy-e2e:
     name: Deploy E2E SSH
-    runs-on: ubuntu-latest
+    # Self-hosted 8-core slot: docker + SSH loopback deploy, no rendering.
+    # The redis service container runs via the VM's own docker daemon.
+    runs-on: epyc-8
     # Redis for the runtime E2E test. A service container comes up during job
     # setup instead of costing an `apt-get update && apt-get install` step
     # (~30 s) inside it; the tests reach it through REDIS_URL, and the runtime

--- a/backend/bin/cross
+++ b/backend/bin/cross
@@ -31,7 +31,7 @@ class TargetDefinition:
     arch: str
     platform: str
     image: str
-    runner: str = "depot-ubuntu-24.04-16"
+    runner: str = "epyc-8"
 
     @property
     def slug(self) -> str:
@@ -49,22 +49,24 @@ class TargetDefinition:
         }
 
 
-# armhf (linux/arm/v7) is the one target that must NOT go to a Depot ARM
-# runner. Depot's ARM runners are AWS Graviton, which cannot execute AArch32
-# at EL0, so the arm/v7 build container falls back to QEMU: measured 773s and
-# 825s on depot-ubuntu-24.04-arm-16 versus 349-377s for arm64 on the same
-# runner. GitHub's ubuntu-24.04-arm runners are Ampere Altra, which does run
-# AArch32 natively — there armhf costs the same as arm64 (501s vs 507s and
-# 516s vs 507s across two releases), so 4 native cores beat 16 emulated ones.
+# Runner assignment (post-Depot, 2026-08): amd64 and the armv6
+# cross-toolchain targets build on the self-hosted EPYC pool ("epyc-8" =
+# ephemeral 8-core Incus VMs on the monster host; see the host's
+# /srv/gha-runners/README.md). Both ARM targets build on GitHub's free
+# ubuntu-24.04-arm runners (Ampere Altra): arm64 natively, and armhf too —
+# Ampere runs AArch32 at EL0, unlike AWS Graviton (Depot), where armhf fell
+# back to QEMU (measured 773-825s emulated vs 501-516s native across two
+# releases, on par with arm64's 507s).
 # The permanent fix is to give linux/arm/v7 the same treatment as arm/v6 (an
 # amd64 container plus the arm-linux-gnueabihf cross toolchain that
 # cross_toolchain_packages.py already defines and the Modal executor already
 # uses); until that is validated, keep armhf on GitHub's ARM runners.
 ARMHF_RUNNER = "ubuntu-24.04-arm"
+ARM64_RUNNER = "ubuntu-24.04-arm"
 
 TARGETS: tuple[TargetDefinition, ...] = (
     TargetDefinition("debian", "bookworm", "armhf", "linux/arm/v7", "debian:bookworm", runner=ARMHF_RUNNER),
-    TargetDefinition("debian", "bookworm", "arm64", "linux/arm64", "debian:bookworm", runner="depot-ubuntu-24.04-arm-16"),
+    TargetDefinition("debian", "bookworm", "arm64", "linux/arm64", "debian:bookworm", runner=ARM64_RUNNER),
     TargetDefinition("debian", "bookworm", "amd64", "linux/amd64", "debian:bookworm"),
     # ARMv6 hard-float for the Raspberry Pi Zero W Buildroot image. Debian has
     # no ARMv6 port, so this builds in an amd64 container with the Bootlin
@@ -72,16 +74,16 @@ TARGETS: tuple[TargetDefinition, ...] = (
     # only provide headers and link stubs.
     TargetDefinition("debian", "bookworm", "armv6", "linux/arm/v6", "debian:bookworm"),
     TargetDefinition("debian", "trixie", "armhf", "linux/arm/v7", "debian:trixie", runner=ARMHF_RUNNER),
-    TargetDefinition("debian", "trixie", "arm64", "linux/arm64", "debian:trixie", runner="depot-ubuntu-24.04-arm-16"),
+    TargetDefinition("debian", "trixie", "arm64", "linux/arm64", "debian:trixie", runner=ARM64_RUNNER),
     TargetDefinition("debian", "trixie", "amd64", "linux/amd64", "debian:trixie"),
     # Same Bootlin-toolchain build as bookworm armv6 (Raspberry Pi OS trixie
     # still supports the Pi Zero W / Pi 1). Trixie's OpenSSL stubs pull
     # libz/libzstd transitively at link time — needs the -rpath-link mirror
     # flag in cross_compile.py.
     TargetDefinition("debian", "trixie", "armv6", "linux/arm/v6", "debian:trixie"),
-    TargetDefinition("ubuntu", "24.04", "arm64", "linux/arm64", "ubuntu:24.04", runner="depot-ubuntu-24.04-arm-16"),
+    TargetDefinition("ubuntu", "24.04", "arm64", "linux/arm64", "ubuntu:24.04", runner=ARM64_RUNNER),
     TargetDefinition("ubuntu", "24.04", "amd64", "linux/amd64", "ubuntu:24.04"),
-    TargetDefinition("ubuntu", "26.04", "arm64", "linux/arm64", "ubuntu:26.04", runner="depot-ubuntu-24.04-arm-16"),
+    TargetDefinition("ubuntu", "26.04", "arm64", "linux/arm64", "ubuntu:26.04", runner=ARM64_RUNNER),
     TargetDefinition("ubuntu", "26.04", "amd64", "linux/amd64", "ubuntu:26.04"),
     # TODO(rockchip/allwinner): 32-bit ARMv7 targets for Luckfox Pico
     # (RV1103/RV1106) and T113-S3/S4 boards can reuse the armhf toolchain:


### PR DESCRIPTION
## Summary
Depot runner minutes took the CI bill from ~$15 to $250+/month. This routes the compute to the self-hosted pool on the `monster` box (ephemeral, single-job Incus VMs — one fresh VM per job, destroyed after; JIT registration, the GitHub token never enters a VM; pool docs in `/srv/gha-runners/README.md` on the host) and returns I/O-bound bookkeeping to free GitHub-hosted runners.

| Job | Was | Now |
|---|---|---|
| `build-prebuilt-cross` amd64 + armv6 legs | `depot-ubuntu-24.04-16` | `epyc-8` (4 slots) |
| `build-prebuilt-cross` arm64 legs | `depot-ubuntu-24.04-arm-16` | `ubuntu-24.04-arm` (free, native) |
| `build-buildroot-release-image` | `depot-ubuntu-24.04-16` | `epyc-32` |
| `build-esp32-generic-firmware` | `depot-ubuntu-24.04-16` | `epyc-8` |
| version/npm/notes/matrix/addon/release + `push-multiarch` orchestrator | `depot-ubuntu-24.04` | `ubuntu-latest` (free) |

**Deliberately kept on Depot** (rare/manual, or where Depot's layer cache is the point): the `depot/build-push-action` image builds (esp32-ci cache shared with `e2e-docker.yml`, `push-multiarch`'s remote amd64+arm64 builders) and the manually-dispatched `buildroot-base-image.yml`. `DEPOT_TOKEN` stays.

Fork-PR safety: "require approval for outside collaborators" is enabled on the repo, and every self-hosted job runs in a throwaway VM.

## Test plan
- [x] 1× `epyc-32` + 4× `epyc-8` runners online and idle (`gh api .../actions/runners`)
- [x] Runner VM dry-run: agent 18 s, docker + runner 2.336.0 + `/mnt/cache` virtiofs verified, VM destroyed after
- [x] `python3 backend/bin/cross matrix` emits the new slug→runner mapping (table above)
- [x] Workflow YAML parses
- [ ] This PR touches `backend/bin/cross`, so its own **FrameOS cross compilation** run exercises the new mapping end to end — watch the 6 `epyc-8` legs pick up on the pool
- [ ] First real release (`docker-publish-multi`) after merge validates `epyc-32` + the Depot-built esp32-ci path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbJFY7vcTA9fqUccearzp4