### PR TITLE
Less ceremony adding frames: first enrollment auto-confirms, approvals ride a 2h window

### DIFF
--- a/cloud/apps/auth-web/app/api/device/authorize/route.ts
+++ b/cloud/apps/auth-web/app/api/device/authorize/route.ts
@@ -19,7 +19,10 @@ import {
   identityRateLimitResponse,
   rateLimitResponse,
 } from "../../../../src/lib/rate-limit";
-import { requireRecentAuth } from "../../../../src/lib/recent-auth";
+import {
+  recentApprovalMaxAgeSeconds,
+  requireRecentAuth,
+} from "../../../../src/lib/recent-auth";
 import { createEncryptedSecretToken, hashUserCode } from "../../../../src/lib/secrets";
 import { readSession } from "../../../../src/lib/session";
 import { reportError } from "../../../../src/lib/log";
@@ -61,9 +64,11 @@ export async function POST(request: NextRequest) {
     return response;
   }
   // Granting a device (or widening its scopes) is sensitive: the session must
-  // have proved its credentials recently. /device sends the user through
-  // /login/reauth before showing the approve button; this is the backstop.
-  const stale = await requireRecentAuth(db, accountId);
+  // have proved its credentials recently — within the wider approval window,
+  // sized for an afternoon of setting up frames. /device sends the user
+  // through /login/reauth before showing the approve button; this is the
+  // backstop.
+  const stale = await requireRecentAuth(db, accountId, recentApprovalMaxAgeSeconds);
   if (stale) {
     return stale;
   }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/confirm/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/confirm/route.ts
@@ -4,12 +4,8 @@ import { recordAuditEvent } from "../../../../../src/lib/audit";
 import { NextRequest, NextResponse } from "next/server";
 import { csrfResponse } from "../../../../../src/lib/csrf";
 import { jsonError, requireDatabase } from "../../../../../src/lib/device-flow";
-import {
-  assignScenesToFrame,
-  currentSceneAssignments,
-} from "../../../../../src/lib/frame-scenes";
+import { applyProvisioningScenes } from "../../../../../src/lib/frame-provisioning";
 import { frameForAccount, frameSummary } from "../../../../../src/lib/frames";
-import { reportError } from "../../../../../src/lib/log";
 import { rateLimitResponse } from "../../../../../src/lib/rate-limit";
 import { readSession } from "../../../../../src/lib/session";
 
@@ -64,76 +60,17 @@ export async function POST(
       eventType: "frame.confirmed",
       target: { frameId: frame.id },
     });
-    await applyProvisioningScenes(
-      db,
-      { accountId: session.accountId, providerSubject: session.providerSubject },
-      { ...frame, status: "active" },
-    );
-  }
-  return NextResponse.json({
-    frame: { ...frameSummary(frame), status: "active" },
-    status: "active",
-  });
-}
-
-/**
- * "Start this frame with the scenes from <that frame>", chosen while building
- * the SD image or flashing the board and carried here on the frame row.
- *
- * Deliberately AT confirmation, not at enrollment: enrollment is
- * unauthenticated (anything holding the claim code can run it), so it must
- * never be the step that decides whose scenes reach a device. By the time
- * this runs the owner has clicked Confirm, the frame is active, and the copy
- * goes through the same assignScenesToFrame gates a workspace deploy does —
- * accessibility, pinned version, shell-risk refusal.
- *
- * Best effort, and the intent is cleared either way: the confirmation itself
- * has already committed, the frame is usable without its scenes, and a copy
- * that retried on every subsequent call would fight the owner's own edits.
- * Failures are reported, never raised.
- */
-async function applyProvisioningScenes(
-  db: NonNullable<ReturnType<typeof requireDatabase>["db"]>,
-  session: { accountId: string; providerSubject?: string },
-  frame: typeof frames.$inferSelect,
-) {
-  const sourceFrameId = frame.sceneSourceFrameId;
-  if (!sourceFrameId) {
-    return;
-  }
-  try {
-    await db
-      .update(frames)
-      .set({ sceneSourceFrameId: null })
-      .where(eq(frames.id, frame.id));
-    // Re-check ownership at use time, not just at mint time: the source frame
-    // may have been deleted, or the account may have changed hands, in the
-    // days between building the card and booting it.
-    const source = await frameForAccount(db, session.accountId, sourceFrameId);
-    if (!source || source.id === frame.id) {
-      return;
-    }
-    const requested = await currentSceneAssignments(db, source.id);
-    if (requested.length === 0) {
-      return;
-    }
-    const outcome = await assignScenesToFrame(db, {
+    await applyProvisioningScenes(db, {
       accountId: session.accountId,
       actor: {
         accountId: session.accountId,
         providerSubject: session.providerSubject,
       },
-      frame,
-      requested,
-      via: "provisioning",
+      frame: { ...frame, status: "active" },
     });
-    if (!outcome.ok) {
-      reportError(
-        "frames.provisioning_scene_copy_refused",
-        new Error(outcome.failure.code),
-      );
-    }
-  } catch (error) {
-    reportError("frames.provisioning_scene_copy_failed", error);
   }
+  return NextResponse.json({
+    frame: { ...frameSummary(frame), status: "active" },
+    status: "active",
+  });
 }

--- a/cloud/apps/auth-web/app/api/frames/enroll/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/enroll/route.ts
@@ -1,6 +1,7 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, or, sql } from "drizzle-orm";
 import { frameEnrollmentTokens, frames, linkedClients } from "@frameos-cloud/db";
 import { recordAuditEvent } from "../../../../src/lib/audit";
+import { applyProvisioningScenes } from "../../../../src/lib/frame-provisioning";
 import { NextRequest, NextResponse } from "next/server";
 import {
   authenticateLinkedClient,
@@ -105,9 +106,17 @@ function parseHardware(value: unknown): Record<string, unknown> | null {
 
 // Device enrollment (wire contract: docs/cloud-frames.md "Enrollment").
 //
-// Flow A — unauthenticated, with a single-use claim token from "Add frame".
-//   The frame is born `pending`; the owner confirms it in the account UI
-//   before any scene push is accepted.
+// Flow A — unauthenticated, with a claim token from "Add frame".
+//   The FIRST enrollment of a token is born `active`: minting the token was
+//   the owner's deliberate, authenticated act, and the overwhelmingly common
+//   first redeemer is the owner's own board booting minutes later (SD images
+//   mint multi-use tokens so a card can be reflashed, so "single-use only"
+//   would miss exactly that case). If a stolen token or leaked image beats
+//   the owner to it, the owner's own card lands `pending` behind a foreign
+//   active frame — loud, auditable, and revocable. Every LATER enrollment of
+//   a multi-use token is born `pending` and needs the owner's confirmation
+//   click: any card holding a fleet image can enroll, so each additional
+//   board brings its own proof.
 // Flow B — Bearer token from the RFC 8628 device flow (client_kind "frame").
 //   The consent screen was the ownership proof, so the frame is born
 //   `active`; this call registers the device public key.
@@ -282,7 +291,9 @@ async function enrollWithClaimToken(
           // card enrolls many frames, and the token's own frame_id records
           // only the last one, so the intent has to ride the frame row.
           sceneSourceFrameId: token.sceneSourceFrameId,
-          status: "pending",
+          // redeemClaimToken returned the post-spend row, so use_count 1 is
+          // the token's first enrollment.
+          status: token.useCount === 1 ? "active" : "pending",
         })
         .returning();
       if (!insertedFrame) {
@@ -315,12 +326,28 @@ async function enrollWithClaimToken(
     accountId: result.frame.accountId,
     actor: { claimTokenId: result.tokenId, kind: "frame_enrollment" },
     eventType: "frame.enrolled",
-    metadata: { via: "claim_token" },
+    metadata: {
+      via: "claim_token",
+      ...(result.frame.status === "active" ? { auto_confirmed: true } : {}),
+    },
     target: {
       frameId: result.frame.id,
       linkedClientId: result.frame.linkedClientId,
     },
   });
+
+  // A single-use enrollment is born active, so the provisioning scene copy
+  // ("start with the scenes from <that frame>") runs here instead of at the
+  // Confirm click. The source rides the token the owner minted — the
+  // unauthenticated caller chooses nothing — and the ownership re-check plus
+  // the deploy gates live inside applyProvisioningScenes.
+  if (result.frame.status === "active") {
+    await applyProvisioningScenes(db, {
+      accountId: result.frame.accountId,
+      actor: { claimTokenId: result.tokenId, kind: "frame_enrollment" },
+      frame: result.frame,
+    });
+  }
 
   return NextResponse.json({
     access_token: result.accessTokenValue,
@@ -333,10 +360,18 @@ async function enrollWithClaimToken(
   });
 }
 
-// Has this exact device already enrolled with this exact claim token? Only a
-// still-pending frame on a live linked client counts; the claim token itself
-// is the secret that authorizes the lookup, so this grants nothing a fresh
-// enrollment would not have granted.
+// A retry may arrive minutes after the response was lost, so a frame that is
+// no longer pending must still be replayable for a while.
+const replayActiveWindowSeconds = 15 * 60;
+
+// Has this exact device already enrolled with this exact claim token? The
+// claim token itself is the secret that authorizes the lookup, so this grants
+// nothing a fresh enrollment would not have granted. A still-pending frame on
+// a live linked client always counts; an ACTIVE frame counts only briefly
+// after its enrollment (a token's first enrollment is born active, so its
+// lost-response retry would otherwise find nothing) — never beyond that
+// window, or a claim token captured after the fact could mint fresh
+// credentials for a frame that has long been in service.
 async function replayEnrollment(
   db: NonNullable<ReturnType<typeof requireDatabase>["db"]>,
   wsUrl: string | undefined,
@@ -352,6 +387,16 @@ async function replayEnrollment(
     return undefined;
   }
 
+  const replayableStatus = or(
+    eq(frames.status, "pending"),
+    and(
+      eq(frames.status, "active"),
+      gt(
+        frames.createdAt,
+        new Date(Date.now() - replayActiveWindowSeconds * 1000),
+      ),
+    ),
+  );
   const [existing] = await db
     .select({ frame: frames })
     .from(frames)
@@ -360,7 +405,7 @@ async function replayEnrollment(
       and(
         eq(frames.accountId, token.accountId),
         eq(frames.publicKey, input.publicKey),
-        eq(frames.status, "pending"),
+        replayableStatus,
         isNull(linkedClients.revokedAt),
       ),
     )

--- a/cloud/apps/auth-web/app/device/page.tsx
+++ b/cloud/apps/auth-web/app/device/page.tsx
@@ -3,7 +3,11 @@ import { createDb } from "@frameos-cloud/db";
 import { AppShell } from "../../src/components/AppShell";
 import { DeviceApprovalPanel } from "../../src/components/DeviceApprovalPanel";
 import { hasDatabaseUrl } from "../../src/lib/env";
-import { hasRecentAuth, reauthPath } from "../../src/lib/recent-auth";
+import {
+  hasRecentAuth,
+  reauthPath,
+  recentApprovalMaxAgeSeconds,
+} from "../../src/lib/recent-auth";
 import { readSession } from "../../src/lib/session";
 
 export const metadata = { title: "Connect this FrameOS backend" };
@@ -35,7 +39,10 @@ export default async function DevicePage({ searchParams }: DevicePageProps) {
   if (!session?.accountId) {
     redirect(`/login?return_to=${encodeURIComponent(target)}`);
   }
-  if (hasDatabaseUrl() && !(await hasRecentAuth(createDb()))) {
+  if (
+    hasDatabaseUrl() &&
+    !(await hasRecentAuth(createDb(), recentApprovalMaxAgeSeconds))
+  ) {
     redirect(`${reauthPath}?return_to=${encodeURIComponent(target)}`);
   }
 

--- a/cloud/apps/auth-web/src/lib/frame-provisioning.ts
+++ b/cloud/apps/auth-web/src/lib/frame-provisioning.ts
@@ -1,0 +1,71 @@
+// "Start this frame with the scenes from <that frame>", chosen while building
+// the SD image or flashing the board and carried on the frame row
+// (frames.scene_source_frame_id).
+//
+// Runs when the frame turns active: at the owner's Confirm click for
+// multi-use-token enrollments, and at enrollment itself for single-use
+// tokens (which are born active — the mint was the owner's deliberate act,
+// and a single-use budget means only one device can ever redeem it). In both
+// cases the source frame is the token minter's, re-checked at use time, and
+// the copy goes through the same assignScenesToFrame gates a workspace
+// deploy does — accessibility, pinned version, shell-risk refusal.
+//
+// Best effort, and the intent is cleared either way: the activation itself
+// has already committed, the frame is usable without its scenes, and a copy
+// that retried on every subsequent call would fight the owner's own edits.
+// Failures are reported, never raised.
+
+import { eq } from "drizzle-orm";
+import { type createDb, frames } from "@frameos-cloud/db";
+import {
+  assignScenesToFrame,
+  currentSceneAssignments,
+} from "./frame-scenes";
+import { frameForAccount } from "./frames";
+import { reportError } from "./log";
+
+export async function applyProvisioningScenes(
+  db: ReturnType<typeof createDb>,
+  input: {
+    accountId: string;
+    actor: unknown;
+    frame: typeof frames.$inferSelect;
+  },
+) {
+  const sourceFrameId = input.frame.sceneSourceFrameId;
+  if (!sourceFrameId) {
+    return;
+  }
+  try {
+    await db
+      .update(frames)
+      .set({ sceneSourceFrameId: null })
+      .where(eq(frames.id, input.frame.id));
+    // Re-check ownership at use time, not just at mint time: the source frame
+    // may have been deleted, or the account may have changed hands, in the
+    // days between building the card and booting it.
+    const source = await frameForAccount(db, input.accountId, sourceFrameId);
+    if (!source || source.id === input.frame.id) {
+      return;
+    }
+    const requested = await currentSceneAssignments(db, source.id);
+    if (requested.length === 0) {
+      return;
+    }
+    const outcome = await assignScenesToFrame(db, {
+      accountId: input.accountId,
+      actor: input.actor,
+      frame: input.frame,
+      requested,
+      via: "provisioning",
+    });
+    if (!outcome.ok) {
+      reportError(
+        "frames.provisioning_scene_copy_refused",
+        new Error(outcome.failure.code),
+      );
+    }
+  } catch (error) {
+    reportError("frames.provisioning_scene_copy_failed", error);
+  }
+}

--- a/cloud/apps/auth-web/src/lib/recent-auth.ts
+++ b/cloud/apps/auth-web/src/lib/recent-auth.ts
@@ -20,10 +20,16 @@ import { readSessionToken } from "./session";
 import { hashSecret } from "./secrets";
 import { secondFactorStatus } from "./two-factor";
 
-// Fifteen minutes: long enough to revoke a handful of frames or approve a
-// scope change without re-proving between each, short enough that a cookie
-// picked up from an unattended session cannot do it hours later.
+// Two windows, matched to what the action can do. Revoking is destructive
+// and rare — fifteen minutes: long enough to revoke a handful of frames
+// without re-proving between each, short enough that a cookie picked up from
+// an unattended session cannot do it hours later. Approving a device link is
+// additive and happens in batches ("I'm setting up frames this afternoon") —
+// two hours, the same order GitHub's sudo mode uses; the gate still matters
+// because an approval converts a transient stolen cookie into a durable
+// token, but a fresh-that-afternoon login is proof enough for it.
 export const recentAuthMaxAgeSeconds = 15 * 60;
+export const recentApprovalMaxAgeSeconds = 2 * 60 * 60;
 
 export const reauthPath = "/login/reauth";
 
@@ -74,18 +80,28 @@ export async function sessionAuthenticatedAt(
   return row?.authenticatedAt;
 }
 
-export function isRecent(authenticatedAt: Date | undefined, now = new Date()) {
+export function isRecent(
+  authenticatedAt: Date | undefined,
+  maxAgeSeconds: number = recentAuthMaxAgeSeconds,
+  now = new Date(),
+) {
   return (
     authenticatedAt !== undefined &&
-    now.getTime() - authenticatedAt.getTime() <= recentAuthMaxAgeSeconds * 1000
+    now.getTime() - authenticatedAt.getTime() <= maxAgeSeconds * 1000
   );
 }
 
 // True when the request's session proved its credentials recently enough for
 // a sensitive action. Pages use it to send the user through /login/reauth
 // before showing an approve button they could not press.
-export async function hasRecentAuth(db: ReturnType<typeof createDb>) {
-  return isRecent(await sessionAuthenticatedAt(db, await readSessionToken()));
+export async function hasRecentAuth(
+  db: ReturnType<typeof createDb>,
+  maxAgeSeconds: number = recentAuthMaxAgeSeconds,
+) {
+  return isRecent(
+    await sessionAuthenticatedAt(db, await readSessionToken()),
+    maxAgeSeconds,
+  );
 }
 
 // The response a sensitive route sends instead of acting, or undefined when
@@ -94,15 +110,16 @@ export async function hasRecentAuth(db: ReturnType<typeof createDb>) {
 export async function requireRecentAuth(
   db: ReturnType<typeof createDb>,
   accountId: string,
+  maxAgeSeconds: number = recentAuthMaxAgeSeconds,
 ): Promise<NextResponse | undefined> {
-  if (await hasRecentAuth(db)) {
+  if (await hasRecentAuth(db, maxAgeSeconds)) {
     return undefined;
   }
   return NextResponse.json(
     {
       error: "reauth_required",
       reauth: {
-        max_age_seconds: recentAuthMaxAgeSeconds,
+        max_age_seconds: maxAgeSeconds,
         methods: await reauthMethods(db, accountId),
         path: reauthPath,
       },

--- a/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/frames.integration.test.ts
@@ -182,6 +182,32 @@ async function enrolledFrame() {
   return { accountId, keys, ...payload };
 }
 
+// A frame that is still PENDING: a token's first enrollment is born active,
+// so pending only exists from the second enrollment of a multi-use token on.
+async function enrolledPendingFrame() {
+  const accountId = await signIn();
+  const keys = deviceKeypair();
+  const minted = await mintClaimToken(
+    postJson("/api/frames/claim-tokens", { multi_use: true }, { origin: baseUrl }),
+  );
+  expect(minted.status).toBe(200);
+  const { claim_token: claimToken } = (await minted.json()) as {
+    claim_token: string;
+  };
+  // The first card auto-confirms; the frame under test is the second.
+  const first = await enroll(claimToken, deviceKeypair().publicKeyBase64);
+  expect(first.status).toBe(200);
+  const response = await enroll(claimToken, keys.publicKeyBase64);
+  expect(response.status).toBe(200);
+  const payload = (await response.json()) as {
+    access_token: string;
+    frame_id: string;
+    status: string;
+  };
+  expect(payload.status).toBe("pending");
+  return { accountId, keys, ...payload };
+}
+
 // Fill an account up to `count` frames without going through enrollment, so
 // quota tests do not need `count` round trips through the route.
 async function seedFrames(accountId: string, count: number) {
@@ -302,7 +328,7 @@ async function publishSceneVersion(
 }
 
 describe("cloud-managed frame enrollment", () => {
-  it("enrolls with a claim token, single-use, pending until confirmed", async () => {
+  it("enrolls with a single-use claim token, born active (auto-confirmed)", async () => {
     const accountId = await signIn();
     const keys = deviceKeypair();
     const claimToken = await mintToken("Kitchen frame");
@@ -315,7 +341,9 @@ describe("cloud-managed frame enrollment", () => {
     });
     expect(response.status).toBe(200);
     const payload = (await response.json()) as Record<string, unknown>;
-    expect(payload.status).toBe("pending");
+    // Minting the single-use token was the owner's deliberate act; no extra
+    // Confirm click.
+    expect(payload.status).toBe("active");
     expect(payload.token_type).toBe("Bearer");
     // The FULL grant, not just frame:managed — the device stores this string
     // as its local scope list and gates its telemetry push loops (and its
@@ -462,7 +490,11 @@ describe("cloud-managed frame enrollment", () => {
       .from(frames)
       .where(eq(frames.accountId, accountId));
     expect(rows).toHaveLength(2);
-    expect(rows.every((row) => row.status === "pending")).toBe(true);
+    // The first card off the image auto-confirms (the mint was the owner's
+    // deliberate act); every later card needs the owner's click.
+    const byFrameId = new Map(rows.map((row) => [row.id, row.status]));
+    expect(byFrameId.get(firstPayload.frame_id)).toBe("active");
+    expect(byFrameId.get(secondPayload.frame_id)).toBe("pending");
     expect(rows[0]?.publicKey).not.toBe(rows[1]?.publicKey);
 
     // The budget is spent: the third card gets invalid_claim_token.
@@ -750,7 +782,9 @@ describe("cloud-managed frame enrollment", () => {
       status: string;
     };
     expect(retryPayload.frame_id).toBe(firstPayload.frame_id);
-    expect(retryPayload.status).toBe("pending");
+    // Single-use enrollments are born active; the replay window still hands
+    // the same frame back for a lost response.
+    expect(retryPayload.status).toBe("active");
     // No orphan frame, no orphan linked client, no extra use spent.
     expect(
       await db.select().from(frames).where(eq(frames.accountId, accountId)),
@@ -1273,7 +1307,7 @@ describe("frame management API", () => {
   });
 
   it("refuses scene pushes while the frame is pending", async () => {
-    const { accountId, frame_id } = await enrolledFrame();
+    const { accountId, frame_id } = await enrolledPendingFrame();
     const scene = await createStoreScene(accountId, { name: "Early" });
     const refused = await assignFrameScenes(
       postJson(
@@ -1372,15 +1406,29 @@ describe("frame management API", () => {
       claim_token: string;
     };
 
+    // The image's first card auto-confirms and takes its scenes right away.
+    const firstCard = await enroll(claimToken, deviceKeypair().publicKeyBase64);
+    expect(firstCard.status).toBe(200);
+    const { frame_id: firstFrameId, status: firstStatus } =
+      (await firstCard.json()) as { frame_id: string; status: string };
+    expect(firstStatus).toBe("active");
+    expect(
+      (
+        await db
+          .select()
+          .from(frameSceneAssignments)
+          .where(eq(frameSceneAssignments.frameId, firstFrameId))
+      ).map((row) => row.sceneId),
+    ).toEqual([scene.id]);
+
     const enrolled = await enroll(claimToken, deviceKeypair().publicKeyBase64);
     expect(enrolled.status).toBe(200);
     const { frame_id: newFrameId } = (await enrolled.json()) as {
       frame_id: string;
     };
 
-    // Nothing yet: a board nobody confirmed has been sent nothing, which is
-    // the whole reason the intent waits on the frame row rather than being
-    // applied at enrollment.
+    // A LATER card is pending, and a board nobody confirmed has been sent
+    // nothing — the intent waits on the frame row until the owner's click.
     expect(
       await db
         .select()
@@ -1407,6 +1455,48 @@ describe("frame management API", () => {
     expect(queued.map((row) => row.type)).toContain("set_scenes");
     // Consumed exactly once — a re-confirm must not fight the owner's own
     // later edits.
+    expect((await frameRow(newFrameId)).sceneSourceFrameId).toBeNull();
+  });
+
+  it("copies the chosen scenes at enrollment for a single-use token (no confirm)", async () => {
+    const source = await enrolledFrame();
+    const scene = await createStoreScene(source.accountId, { name: "Hall clock" });
+    const assigned = await assignFrameScenes(
+      postJson(
+        `/api/frames/${source.frame_id}/scenes`,
+        { scenes: [{ scene_id: scene.id }] },
+        { origin: baseUrl },
+      ),
+      routeParams(source.frame_id),
+    );
+    expect(assigned.status).toBe(200);
+
+    const minted = await mintClaimToken(
+      postJson(
+        "/api/frames/claim-tokens",
+        { scene_source_frame_id: source.frame_id },
+        { origin: baseUrl },
+      ),
+    );
+    expect(minted.status).toBe(200);
+    const { claim_token: claimToken } = (await minted.json()) as {
+      claim_token: string;
+    };
+
+    const enrolled = await enroll(claimToken, deviceKeypair().publicKeyBase64);
+    expect(enrolled.status).toBe(200);
+    const { frame_id: newFrameId, status } = (await enrolled.json()) as {
+      frame_id: string;
+      status: string;
+    };
+    // Born active, scenes copied right away — no Confirm click in between.
+    expect(status).toBe("active");
+    const copied = await db
+      .select()
+      .from(frameSceneAssignments)
+      .where(eq(frameSceneAssignments.frameId, newFrameId));
+    expect(copied.map((row) => row.sceneId)).toEqual([scene.id]);
+    // Consumed exactly once.
     expect((await frameRow(newFrameId)).sceneSourceFrameId).toBeNull();
   });
 
@@ -2189,7 +2279,7 @@ describe("frame management API", () => {
   });
 
   it("refuses schedule pushes while the frame is pending, and without an app origin", async () => {
-    const { frame_id } = await enrolledFrame();
+    const { frame_id } = await enrolledPendingFrame();
 
     const pending = await pushFrameSchedule(
       postJson(

--- a/cloud/apps/auth-web/src/test/integration/reauth.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/reauth.integration.test.ts
@@ -26,6 +26,7 @@ import { resetRateLimitForTests } from "../../lib/rate-limit";
 import {
   markSessionReauthenticated,
   reauthMethods,
+  recentApprovalMaxAgeSeconds,
   recentAuthMaxAgeSeconds,
 } from "../../lib/recent-auth";
 import { hashSecret } from "../../lib/secrets";
@@ -234,7 +235,8 @@ describe("sensitive routes require a recent credential check", () => {
 
   it("a stale session gets 403 reauth_required with the proofs on offer", async () => {
     const user = await passwordUser();
-    await ageSession(user.token);
+    // Older than BOTH windows, so revoke and approve alike refuse.
+    await ageSession(user.token, recentApprovalMaxAgeSeconds + 60);
     const { frameId, linkedClientId } = await seedFrame(user.accountId);
 
     const frameResponse = await revokeFrame(
@@ -265,7 +267,30 @@ describe("sensitive routes require a recent credential check", () => {
       request("/api/device/authorize", { body: { user_code: userCode } }),
     );
     expect(authorizeResponse.status).toBe(403);
-    expect(await authorizeResponse.json()).toMatchObject({ error: "reauth_required" });
+    expect(await authorizeResponse.json()).toMatchObject({
+      error: "reauth_required",
+      reauth: { max_age_seconds: recentApprovalMaxAgeSeconds },
+    });
+  });
+
+  it("approving rides the wider window; revoking does not", async () => {
+    // Signed in twenty minutes ago: stale for a revoke (15 min window),
+    // fresh enough to approve a device link (2 h window) — an afternoon of
+    // setting up frames must not re-prompt on every board.
+    const user = await passwordUser();
+    await ageSession(user.token, 20 * 60);
+    const { frameId } = await seedFrame(user.accountId);
+
+    const revoke = await revokeFrame(request(`/api/frames/${frameId}/revoke`, { body: {} }), {
+      params: Promise.resolve({ frameId }),
+    });
+    expect(revoke.status).toBe(403);
+
+    const { user_code: userCode } = await startDeviceRequest();
+    const approve = await authorizeDevice(
+      request("/api/device/authorize", { body: { user_code: userCode } }),
+    );
+    expect(approve.status).toBe(200);
   });
 
   it("the password re-proves the session and the action goes through", async () => {

--- a/cloud/docs/auth.md
+++ b/cloud/docs/auth.md
@@ -145,15 +145,20 @@ device therefore re-check the credentials even with a valid session: every
 `sessions` row remembers when it last proved them (`authenticated_at`,
 migration 0036 — set at sign-in, pushed forward by a successful re-check),
 and the routes below refuse with `403 {"error": "reauth_required", "reauth":
-{"methods": …, "path": "/login/reauth", "max_age_seconds": 900}}` when that
-is older than **15 minutes** (`recentAuthMaxAgeSeconds`,
-`src/lib/recent-auth.ts`). Gated today:
+{"methods": …, "path": "/login/reauth", "max_age_seconds": …}}` when that is
+older than the route's window (`src/lib/recent-auth.ts`). Two windows,
+matched to what the action can do:
 
-- `POST /api/frames/{id}/revoke` — revoking a cloud-managed frame;
-- `POST /api/device/revoke` — revoking a linked backend or frame;
-- `POST /api/device/authorize` — approving a device link or a scope change
-  (the `/device` page sends a stale session through `/login/reauth` *before*
-  showing the approve button; the route check is the backstop).
+- **15 minutes** (`recentAuthMaxAgeSeconds`) for the destructive pair:
+  `POST /api/frames/{id}/revoke` (revoking a cloud-managed frame) and
+  `POST /api/device/revoke` (revoking a linked backend or frame).
+- **2 hours** (`recentApprovalMaxAgeSeconds`) for
+  `POST /api/device/authorize` — approving a device link or a scope change.
+  Approvals are additive and come in batches ("setting up frames this
+  afternoon"); the gate still matters because an approval converts a stolen
+  cookie into a durable token, but a login fresh that afternoon is proof
+  enough. The `/device` page sends a stale session through `/login/reauth`
+  *before* showing the approve button; the route check is the backstop.
 
 Routes call `requireRecentAuth(db, accountId)` right after `readSession()`;
 pages call `hasRecentAuth(db)`. The client components behind those buttons

--- a/cloud/docs/cloud-frames.md
+++ b/cloud/docs/cloud-frames.md
@@ -375,10 +375,10 @@ An account that controls physical devices needs more than email + password:
   session-minting routes gate on it; a passkey with user verification also
   signs in passwordlessly.
 - Re-authentication for sensitive actions — **shipped.** Revoking a frame
-  or a linked backend and approving a device link / scope change need a
-  session that proved its credentials within the last 15 minutes
-  (`403 reauth_required` → `/login/reauth`; design in `auth.md`,
-  "Re-authentication"). Scene assignment is deliberately not gated: it is
+  or a linked backend needs a session that proved its credentials within
+  the last 15 minutes; approving a device link / scope change rides a wider
+  2-hour window (`403 reauth_required` → `/login/reauth`; design in
+  `auth.md`, "Re-authentication"). Scene assignment is deliberately not gated: it is
   the workspace's save path. The account-weakening routes (removing a
   second factor, deleting the account) keep their own in-body proof.
 - Per-frame audit trail surfaced in the UI — **shipped.** Every
@@ -413,8 +413,10 @@ One button, three tiles, one shared enrollment endpoint.
   the image contains network credentials. Default flow leaves WiFi out and
   relies on the existing captive portal (`FrameOS-Setup` hotspot).
 - Boot sequence: flash → boot → portal if no network → dial cloud with
-  claim token → keypair enrollment → frame appears as **pending** in the
-  account → owner confirms.
+  claim token → keypair enrollment → the token's first enrollment activates
+  the frame right away (the mint was the owner's deliberate act); each later
+  enrollment of the image's multi-use token stays **pending** until the
+  owner confirms it.
 - Initial hardware support is whatever buildroot supports (today: Raspberry
   Pi Zero 2 W); `rpios` users can enroll via flow 2 instead.
 

--- a/cloud/docs/frameos-integration.md
+++ b/cloud/docs/frameos-integration.md
@@ -220,9 +220,10 @@ The response is `{ "status": "unlinked" }`. The link token stops
 authenticating immediately; a repeat call (or any other API call) with the
 same token returns `401 invalid_link_token`. The user-facing counterpart that
 revokes a link from the cloud account page is `POST /api/device/revoke`
-(session cookie, not the link token; like approving a link, it answers
-`403 reauth_required` unless the session proved its credentials within the
-last 15 minutes — see `auth.md`, "Re-authentication").
+(session cookie, not the link token; it answers `403 reauth_required`
+unless the session proved its credentials within the last 15 minutes —
+approving a link rides a wider 2-hour window; see `auth.md`,
+"Re-authentication").
 
 ## Backend Login Handoff
 

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -106,9 +106,24 @@ a usable access token, so a response lost in flight does not strand the
 device. The same token presented with a *different* device key is refused —
 `409 public_key_mismatch` — since that is a different device, not a retry.
 
-The frame stores its access token in a `0600` state file and appears as
-**pending** in the owner's account; the owner confirms it there (a deliberate
-click, showing hardware details) before any scene push is accepted.
+The frame stores its access token in a `0600` state file. Whether it needs a
+confirmation click depends on whether it is the token's first enrollment:
+
+- **The first enrollment of a token is born active.** Minting the token was
+  the owner's deliberate, authenticated act, and the overwhelmingly common
+  first redeemer is the owner's own board booting minutes later — asking the
+  owner to confirm their own two-minute-old token again is ceremony without
+  proof. (SD images mint multi-use tokens so a card can be reflashed, which
+  is why the rule keys on first use, not on a single-use budget.) If a
+  stolen token or leaked image beats the owner's board to it, the owner's
+  own card lands pending behind a foreign active frame — loud, auditable,
+  revocable. Provisioning scene intent (`scene_source_frame_id`) is applied
+  right at enrollment.
+- **Every later enrollment of a multi-use token appears as pending** and the
+  owner confirms it (a deliberate click, showing hardware details) before
+  any scene push is accepted — any card holding a fleet image can enroll, so
+  each additional board brings its own proof.
+
 Re-enrolling a revoked frame needs a fresh claim token.
 
 ### A2. Re-enrollment (a claim token bound to an existing frame)
@@ -722,7 +737,8 @@ curl -fsSL {provider}/install.sh | \
 The script installs the prebuilt release binaries and services as usual,
 then writes the same `state/cloud_enroll_pending.json` handoff (mode `0600`,
 dir `0700`) the SD-image flow uses, so the frame enrolls via flow A on first
-start and appears as pending. Setting a claim token forces the backend
+start (the token's first enrollment is active right away; later enrollments
+of a multi-use image token stay pending behind a confirmation). Setting a claim token forces the backend
 connection off and refuses an explicit `FRAMEOS_BACKEND_ENABLED=true` — one
 control plane at a time. Display questions stay interactive (the script
 keeps its prompts); every prompt can be pre-answered with the script's


### PR DESCRIPTION
Follow-up to #378, addressing two frictions in adding frames.

## Summary

**First enrollment of a claim token is born active — no Confirm click.** Minting the token was the owner's deliberate, authenticated act, and the overwhelmingly common first redeemer is the owner's own board booting minutes later. The rule keys on *first use*, not on a single-use budget, because the SD-image builder always mints multi-use tokens (so a card can be reflashed after a failed boot) — a single-use-only rule would have missed exactly the "just built an SD card" case. Every **later** enrollment of a multi-use token stays pending behind the owner's click: any card holding a fleet image can enroll, so each additional board brings its own proof. Failure mode if a token/image leaks and beats the owner's board: the owner's own card lands pending behind a foreign active frame — loud, auditable, revocable.

Supporting changes:
- Provisioning scene intent (`scene_source_frame_id`) applies at enrollment for auto-confirmed frames; `applyProvisioningScenes` moved to `src/lib/frame-provisioning.ts`, shared with the confirm route (route files export only handlers). The ownership re-check and deploy gates (shell-risk refusal etc.) are unchanged.
- The enrollment replay (lost-response retry) also matches an *active* frame for 15 minutes after creation — an auto-confirmed enrollment's retry must still find its frame — and never longer, so a claim token captured later cannot mint fresh credentials for a frame in service.

**Re-auth gets two windows matched to the action.** 15 minutes stays for the destructive pair (`frames/{id}/revoke`, `device/revoke`); approving a device link or scope change (`device/authorize`, and the `/device` page pre-check) rides a **2-hour** window (`recentApprovalMaxAgeSeconds`, GitHub-sudo-sized). Approvals are additive and come in batches — an afternoon of setting up frames must not re-prompt per board — while the gate still stops a stolen cookie from becoming a durable token hours later.

Docs updated: `cloud/docs/auth.md` (two windows), `docs/cloud-frames.md` + `cloud/docs/cloud-frames.md` (enrollment activation rules), `cloud/docs/frameos-integration.md`.

## Test plan

- [x] Enrollment suite updated: single-use born active; multi-use first card active + later cards pending; scene copy at enrollment for the first card and at confirm for later cards; lost-response replay after auto-confirm
- [x] New reauth test: 20-minute-old session can approve but not revoke; both refuse past 2 h; 403 payload advertises the per-route window
- [x] Full auth-web integration suite 308/308, unit 772/772, `tsc`, `eslint`
- [ ] Boot a real SD card and watch it appear active with no Confirm (not done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsuLSip3u6ZDCiERggiXdm