### PR TITLE
Cloud UX polish: activity feed frame names, tab order, signup copy

### DIFF
--- a/backend/app/tasks/buildroot_image.py
+++ b/backend/app/tasks/buildroot_image.py
@@ -697,6 +697,29 @@ def stage_buildroot_network_manager_state(root: Path) -> None:
         os.chmod(connections_dir, 0o700)
 
 
+BUILDROOT_RESOLVED_DROPIN_PATH = "/etc/systemd/resolved.conf.d/10-frameos.conf"
+BUILDROOT_RESOLVED_DROPIN = """# FrameOS: no DNSSEC validation on frames.
+#
+# Buildroot builds resolved with default-dnssec=allow-downgrade, but the
+# downgrade heuristic is unreliable against the many consumer routers that
+# answer DO-flagged queries without RRSIGs: every lookup fails with
+# "DNSSEC validation failed ... no-signature" for tens of seconds after the
+# WiFi comes up. A first boot spent its whole 30 s network check that way,
+# then fell back to the setup hotspot and never enrolled with the cloud
+# (2026-08-20, Pi 5). A frame also boots with a clock years off until NTP
+# answers, which would fail signature validity checks anyway.
+[Resolve]
+DNSSEC=no
+"""
+
+
+def stage_buildroot_resolved_dropin(root: Path) -> None:
+    path = root / BUILDROOT_RESOLVED_DROPIN_PATH.lstrip("/")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(BUILDROOT_RESOLVED_DROPIN, encoding="utf-8")
+    os.chmod(path, 0o644)
+
+
 def _apply_boot_config_lines(content: str, requested_lines: list[str]) -> tuple[str, bool]:
     lines = content.splitlines()
     changed = False
@@ -847,7 +870,13 @@ def ensure_buildroot_frame_defaults(frame: Frame, platform: str | None = None) -
 
     network = dict(frame.network or {})
     network.setdefault("networkCheck", True)
-    network.setdefault("networkCheckTimeoutSeconds", 30)
+    # 90 s, not 30: the window only matters when WiFi credentials exist (with
+    # none the check bails after one attempt and the hotspot starts at once),
+    # and a Pi spends 5-10 s of it associating + DHCP before the first lookup
+    # can even succeed. A first boot on a Pi 5 burned all 30 s on a slow
+    # resolver, fell back to the setup hotspot and never reached the cloud.
+    # Wrong credentials now cost 90 s before the hotspot appears — acceptable.
+    network.setdefault("networkCheckTimeoutSeconds", 90)
     network.setdefault("networkCheckUrl", "https://networkcheck.frameos.net/")
     network["wifiHotspot"] = "bootOnly"
     network.setdefault("wifiHotspotSsid", "FrameOS-Setup")
@@ -1668,6 +1697,7 @@ class BuildrootImageBuilder:
         ):
             directory.mkdir(parents=True, exist_ok=True)
         stage_buildroot_network_manager_state(overlay_dir)
+        stage_buildroot_resolved_dropin(overlay_dir)
         stage_postboot_log(overlay_dir)
 
         if not frameos_build.binary_path:

--- a/backend/app/tasks/setup_json_reset.py
+++ b/backend/app/tasks/setup_json_reset.py
@@ -453,6 +453,15 @@ __WPA_SUPPLICANT_FROM_CLOUD__
     cloud_frame_json="$SRV_DIR"/frameos/current/frame.json
     if [ ! -f "$cloud_frame_json" ]; then
       echo "Warning: $cloud_frame_json missing; cannot apply display device '$cloud_device'"
+    elif [ -x "$SRV_DIR"/frameos/current/frameos ] && \\
+      "$SRV_DIR"/frameos/current/frameos set-display \\
+        --frame-json="$cloud_frame_json" --device="$cloud_device" \\
+        --width="$cloud_width" --height="$cloud_height" --rotate="$cloud_rotate" \\
+        --vcom="$cloud_vcom" --upload-url="$cloud_upload_url"; then
+      # The binary patches its own frame.json (Buildroot images ship neither
+      # python3 nor jq, so the python fallback below never ran there).
+      echo "Applied display device '$cloud_device' to $cloud_frame_json"
+      cloud_display_applied=1
     elif command -v python3 >/dev/null 2>&1 && \\
       FRAMEOS_FRAME_JSON="$cloud_frame_json" FRAMEOS_CLOUD_DEVICE="$cloud_device" \\
       FRAMEOS_CLOUD_WIDTH="$cloud_width" FRAMEOS_CLOUD_HEIGHT="$cloud_height" \\
@@ -495,7 +504,7 @@ os.replace(tmp, path)'; then
       echo "Applied display device '$cloud_device' to $cloud_frame_json"
       cloud_display_applied=1
     else
-      # Covers both "no python3" (busybox-only image) and invalid values.
+      # Both the binary and python3 refused (or are missing): invalid values.
       echo "Warning: could not apply display device '$cloud_device'; pick the display in the setup portal instead"
     fi
   fi

--- a/backend/app/tasks/tests/test_buildroot_image.py
+++ b/backend/app/tasks/tests/test_buildroot_image.py
@@ -2163,6 +2163,10 @@ def test_buildroot_stage_overlay_leaves_service_install_to_firstboot(tmp_path, m
     assert scenes_payload == [frame.scenes[0]]
     assert all_scenes_payload == frame.scenes
     assert (overlay_dir / "boot" / "frameos-hostname").read_text(encoding="utf-8") == "frame-one\n"
+    # Consumer routers that strip RRSIGs must not take DNS down for the boot
+    # network check; DNSSEC is off on frames.
+    resolved_dropin = overlay_dir / "etc" / "systemd" / "resolved.conf.d" / "10-frameos.conf"
+    assert "[Resolve]\nDNSSEC=no\n" in resolved_dropin.read_text(encoding="utf-8")
     remote_release_dir = overlay_dir / "srv" / "frameos" / "remote" / "releases" / "release_build123"
     assert (remote_release_dir / "frame.json").read_text(encoding="utf-8") == (
         release_dir / "frame.json"

--- a/backend/app/tasks/tests/test_setup_json_reset.py
+++ b/backend/app/tasks/tests/test_setup_json_reset.py
@@ -56,13 +56,19 @@ class Sandbox:
         path.write_text(content, encoding="utf-8")
         path.chmod(0o755)
 
-    def add_fake_frameos(self, exit_status: int = 0) -> Path:
+    def add_fake_frameos(self, exit_status: int = 0, set_display_exit_status: int = 1) -> Path:
+        # `set-display` exits 1 by default, like a release binary that predates
+        # the subcommand (unknown command → ValueError), so the python3
+        # fallback path stays covered; pass 0 to exercise the binary path.
         current = self.srv / "frameos" / "current"
         current.mkdir(parents=True, exist_ok=True)
         argv_log = self.root / "frameos-argv.log"
         frameos = current / "frameos"
         frameos.write_text(
-            f'#!/bin/sh\nprintf \'%s\\n\' "$@" > {argv_log}\nexit {exit_status}\n',
+            "#!/bin/sh\n"
+            f'printf \'%s\\n\' "$@" >> {argv_log}\n'
+            f'[ "$1" = set-display ] && exit {set_display_exit_status}\n'
+            f"exit {exit_status}\n",
             encoding="utf-8",
         )
         frameos.chmod(0o755)
@@ -264,6 +270,38 @@ def test_cloud_config_display_keys_patch_frame_json_and_run_driver_setup(tmp_pat
     # Enrollment still happened and the secrets are gone from /boot.
     assert sandbox.pending_file.exists()
     assert not (sandbox.boot / "frameos-cloud.txt").exists()
+
+
+def test_cloud_config_display_prefers_the_frameos_binary_over_python3(tmp_path):
+    # Buildroot images have no python3: the binary's own `set-display` patches
+    # frame.json. The fake only records argv, so assert the wiring, not the
+    # JSON (covered by frameos/src/frameos/tests/test_display_patch.nim).
+    sandbox = Sandbox(tmp_path)
+    argv_log = sandbox.add_fake_frameos(set_display_exit_status=0)
+    frame_json = sandbox.srv / "frameos" / "current" / "frame.json"
+    frame_json.write_text(json.dumps({"device": "framebuffer"}), encoding="utf-8")
+    sandbox.write_cloud_file(
+        "claim_token=FRCT-abc\n"
+        "device=http.upload\n"
+        "width=800\n"
+        "height=480\n"
+        "upload_url=https://frames.example.com/upload\n"
+    )
+
+    result = sandbox.run(disable_python3=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    argv = argv_log.read_text(encoding="utf-8")
+    assert "set-display" in argv
+    assert f"--frame-json={frame_json}" in argv
+    assert "--device=http.upload" in argv
+    assert "--width=800" in argv
+    assert "--height=480" in argv
+    assert "--upload-url=https://frames.example.com/upload" in argv
+    assert "driver-setup" in argv
+    log = (sandbox.boot / "frameos-setup-reset.log").read_text(encoding="utf-8")
+    assert "Applied display device 'http.upload'" in log
+    assert "could not apply display device" not in log
 
 
 def test_cloud_config_display_invalid_value_leaves_frame_json_untouched(tmp_path):

--- a/cloud-frontend/src/components/AccountHeader.tsx
+++ b/cloud-frontend/src/components/AccountHeader.tsx
@@ -4,7 +4,8 @@ import { accountNavUrls } from '../cloudConfig'
 
 // The FrameOS Cloud chrome, rendered from the same stylesheet as
 // cloud/apps/auth-web's shells (cloud-chrome.css, imported via src/index.css):
-// the cloud logo, the wordmark, then Scenes / Frames / Account / Sign out. It
+// the cloud logo, the wordmark (linking to /frames, the cloud's home), then
+// Frames / Scenes / Account / Sign out. It
 // sits ABOVE the workspace shell and never re-renders per route — App.tsx
 // renders it once, outside the scene Suspense boundary, and the shell below it
 // gets the rest of the viewport (see the .frameos-cloud-app rules in
@@ -30,7 +31,7 @@ export function AccountHeader(): ReactElement {
   return (
     <header className="frameos-account-header">
       <div className="frameos-account-header__lead">
-        <a aria-label="FrameOS Cloud" className="frameos-account-header__brand" href={accountUrl}>
+        <a aria-label="FrameOS Cloud" className="frameos-account-header__brand" href={framesUrl}>
           <img
             alt=""
             className="frameos-account-header__logo frameos-account-header__logo--light"
@@ -49,11 +50,11 @@ export function AccountHeader(): ReactElement {
         </a>
       </div>
       <nav aria-label="Primary" className="frameos-account-header__nav">
-        <a className="frameos-account-header__link" href={scenesUrl}>
-          Scenes
-        </a>
         <a className="frameos-account-header__link" href={framesUrl}>
           Frames
+        </a>
+        <a className="frameos-account-header__link" href={scenesUrl}>
+          Scenes
         </a>
         <a className="frameos-account-header__link" href={accountUrl}>
           Account

--- a/cloud-frontend/src/components/SdImageBuilder.tsx
+++ b/cloud-frontend/src/components/SdImageBuilder.tsx
@@ -839,8 +839,8 @@ export function SdImageBuilder({
                 </label>
               ) : (
                 <p className="frameos-muted text-xs">
-                  The card keeps working for as long as you keep it. Every frame it adds still waits for your
-                  confirmation here, and your frame limit caps how many it can ever add.
+                  You can flash and boot this image as many times as you like, forever. Each new frame shows up in your
+                  account within your frame limit.
                 </p>
               )}
             </div>

--- a/cloud-frontend/src/components/SdImageBuilder.tsx
+++ b/cloud-frontend/src/components/SdImageBuilder.tsx
@@ -300,6 +300,12 @@ export function SdImageBuilder({
   const showVcom = device === 'waveshare.EPD_10in3'
   const showUploadUrl = device === 'http.upload'
   const showDisplayDetails = displayChoice !== ''
+  // The framebuffer driver reads the panel size from the kernel, so the
+  // fields are optional overrides there. A driver with no native size in the
+  // catalog (http.upload, web_only) has nothing to fall back on and needs
+  // both numbers. Catalog panels arrive prefilled.
+  const dimensionsRequired = showDisplayDetails && device !== 'framebuffer' && !findDeviceOption(device)?.width
+  const dimensionsOptional = device === 'framebuffer'
 
   function pickDisplay(value: string): void {
     setDisplayChoice(value)
@@ -323,6 +329,9 @@ export function SdImageBuilder({
     ] as const) {
       if (value && !/^[1-9][0-9]{0,4}$/.test(value)) {
         return `${label} must be a whole number of pixels.`
+      }
+      if (dimensionsRequired && !value.trim()) {
+        return `${label} is required for this display — it has no default size.`
       }
     }
     if (vcom && !/^-?[0-9]+(\.[0-9]+)?$/.test(vcom)) {
@@ -681,6 +690,7 @@ export function SdImageBuilder({
                 maxLength={5}
                 onChange={(event) => setWidth(event.target.value)}
                 placeholder="Width"
+                required={dimensionsRequired}
                 value={width}
               />
               <input
@@ -691,6 +701,7 @@ export function SdImageBuilder({
                 maxLength={5}
                 onChange={(event) => setHeight(event.target.value)}
                 placeholder="Height"
+                required={dimensionsRequired}
                 value={height}
               />
               <select
@@ -707,6 +718,13 @@ export function SdImageBuilder({
                 ))}
               </select>
             </div>
+          ) : null}
+          {dimensionsOptional ? (
+            <p className="frameos-muted text-xs">
+              Width and height are optional for HDMI — the panel size is autodetected.
+            </p>
+          ) : dimensionsRequired ? (
+            <p className="frameos-muted text-xs">Width and height are required — this display has no default size.</p>
           ) : null}
           {showDisplayDetails && showVcom ? (
             <input

--- a/cloud/apps/auth-web/app/account/activity/page.tsx
+++ b/cloud/apps/auth-web/app/account/activity/page.tsx
@@ -1,8 +1,11 @@
-import { and, desc, eq, ne } from "drizzle-orm";
-import { auditEvents, createDb } from "@frameos-cloud/db";
+import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import Link from "next/link";
+import { auditEvents, createDb, frames, storeScenes } from "@frameos-cloud/db";
+import { cloudFrameUrl } from "@frameos/cloud-frontend/src/routes";
 import {
   auditEventDetail,
   auditEventLabel,
+  auditEventTarget,
 } from "../../../src/lib/audit-labels";
 import { formatDateTime } from "../../../src/lib/format";
 import { readSession } from "../../../src/lib/session";
@@ -15,27 +18,64 @@ export default async function AccountActivityPage() {
   const session = await readSession();
   const accountId = session?.accountId;
 
-  const activityRows = accountId
-    ? await createDb()
-        .select({
-          actor: auditEvents.actor,
-          createdAt: auditEvents.createdAt,
-          eventType: auditEvents.eventType,
-          id: auditEvents.id,
-          metadata: auditEvents.metadata,
-        })
-        .from(auditEvents)
-        // Inventory heartbeats fire every few minutes and would fill the
-        // whole feed; the installs page shows the last sync instead.
-        .where(
-          and(
-            eq(auditEvents.accountId, accountId),
-            ne(auditEvents.eventType, "backend.inventory_synced"),
-          ),
-        )
-        .orderBy(desc(auditEvents.createdAt))
-        .limit(activityLimit)
-    : [];
+  const db = accountId ? createDb() : undefined;
+  const activityRows =
+    db && accountId
+      ? await db
+          .select({
+            actor: auditEvents.actor,
+            createdAt: auditEvents.createdAt,
+            eventType: auditEvents.eventType,
+            id: auditEvents.id,
+            metadata: auditEvents.metadata,
+            target: auditEvents.target,
+          })
+          .from(auditEvents)
+          // Inventory heartbeats fire every few minutes and would fill the
+          // whole feed; the installs page shows the last sync instead.
+          .where(
+            and(
+              eq(auditEvents.accountId, accountId),
+              ne(auditEvents.eventType, "backend.inventory_synced"),
+            ),
+          )
+          .orderBy(desc(auditEvents.createdAt))
+          .limit(activityLimit)
+      : [];
+
+  // Resolve the frame / scene each row is about to a name. Two batched
+  // lookups, scoped to the account so a row can never label a foreign id.
+  // A frame deleted since the event keeps its row; it just shows no name.
+  const targets = activityRows.map((row) => auditEventTarget(row.target));
+  const frameIds = [
+    ...new Set(targets.flatMap((t) => (t.frameId ? [t.frameId] : []))),
+  ];
+  const sceneIds = [
+    ...new Set(targets.flatMap((t) => (t.sceneId ? [t.sceneId] : []))),
+  ];
+  const [frameRows, sceneRows] = await Promise.all([
+    db && accountId && frameIds.length > 0
+      ? db
+          .select({ id: frames.id, name: frames.name })
+          .from(frames)
+          .where(
+            and(eq(frames.accountId, accountId), inArray(frames.id, frameIds)),
+          )
+      : [],
+    db && accountId && sceneIds.length > 0
+      ? db
+          .select({ id: storeScenes.id, name: storeScenes.name })
+          .from(storeScenes)
+          .where(
+            and(
+              eq(storeScenes.accountId, accountId),
+              inArray(storeScenes.id, sceneIds),
+            ),
+          )
+      : [],
+  ]);
+  const frameNames = new Map(frameRows.map((f) => [f.id, f.name]));
+  const sceneNames = new Map(sceneRows.map((s) => [s.id, s.name]));
 
   return (
     <section className="section-block">
@@ -54,23 +94,46 @@ export default async function AccountActivityPage() {
             <tr>
               <th>When</th>
               <th>Event</th>
+              <th>Frame / scene</th>
               <th>Detail</th>
               <th>IP</th>
             </tr>
           </thead>
           <tbody>
-            {activityRows.map((event) => (
-              <tr key={event.id}>
-                <td>{formatDateTime(event.createdAt)}</td>
-                <td>{auditEventLabel(event.eventType)}</td>
-                <td>{auditEventDetail(event.metadata) ?? "—"}</td>
-                <td>
-                  {typeof (event.actor as { ip?: unknown })?.ip === "string"
-                    ? String((event.actor as { ip?: unknown }).ip)
-                    : "—"}
-                </td>
-              </tr>
-            ))}
+            {activityRows.map((event, index) => {
+              const target = targets[index] ?? {};
+              const frameName = target.frameId
+                ? frameNames.get(target.frameId)
+                : undefined;
+              const sceneName = target.sceneId
+                ? sceneNames.get(target.sceneId)
+                : undefined;
+              return (
+                <tr key={event.id}>
+                  <td>{formatDateTime(event.createdAt)}</td>
+                  <td>{auditEventLabel(event.eventType)}</td>
+                  <td>
+                    {frameName && target.frameId ? (
+                      <Link href={cloudFrameUrl(target.frameId)}>
+                        {frameName}
+                      </Link>
+                    ) : sceneName ? (
+                      sceneName
+                    ) : target.frameId ? (
+                      <span style={{ opacity: 0.6 }}>deleted frame</span>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td>{auditEventDetail(event.metadata) ?? "—"}</td>
+                  <td>
+                    {typeof (event.actor as { ip?: unknown })?.ip === "string"
+                      ? String((event.actor as { ip?: unknown }).ip)
+                      : "—"}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       ) : (

--- a/cloud/apps/auth-web/app/account/layout.tsx
+++ b/cloud/apps/auth-web/app/account/layout.tsx
@@ -105,7 +105,7 @@ export default async function AccountLayout({
     // noCapture: every /account page is the signed-in user's own data — their
     // name and email in the header here, and frame names, scene names and
     // images, install hostnames, backup names and activity in the subpages.
-    <AppShell isSuperadmin={isSuperadmin} noCapture title="FrameOS Account">
+    <AppShell isSuperadmin={isSuperadmin} noCapture>
       {session.accountId ? (
         <UserIdentifier
           email={session.email}

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/telemetry/enabled/route.test.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/telemetry/enabled/route.test.ts
@@ -1,0 +1,233 @@
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { recordAuditEvent } from '../../../../../../src/lib/audit'
+import { enqueueFrameCommand, frameForAccount } from '../../../../../../src/lib/frames'
+import { rateLimitResponse } from '../../../../../../src/lib/rate-limit'
+import { readSession } from '../../../../../../src/lib/session'
+import { POST } from './route'
+
+// The OWNER's per-frame telemetry switch — the explicit grant for frames
+// whose pre-2026-08-03 enrollment never received telemetry:logs/metrics.
+// Database stubbed so the gates, the scope arithmetic and the restart nudge
+// can be pinned; the sibling service-settings route carries the end-to-end
+// integration coverage for the scope-row mechanics.
+
+vi.mock('../../../../../../src/lib/rate-limit', () => ({
+  rateLimitResponse: vi.fn(() => Promise.resolve(undefined)),
+}))
+vi.mock('../../../../../../src/lib/csrf', () => ({
+  csrfResponse: vi.fn(() => undefined),
+}))
+vi.mock('../../../../../../src/lib/session', () => ({
+  readSession: vi.fn(),
+}))
+vi.mock('../../../../../../src/lib/audit', () => ({
+  recordAuditEvent: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('../../../../../../src/lib/frames', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  enqueueFrameCommand: vi.fn(() => Promise.resolve({ id: 'cmd-1' } as never)),
+  frameForAccount: vi.fn(),
+}))
+vi.mock('../../../../../../src/lib/device-flow', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  requireDatabase: () => ({ db: fakeDb as never, response: undefined }),
+}))
+
+const sessionMock = vi.mocked(readSession)
+const frameMock = vi.mocked(frameForAccount)
+const enqueueMock = vi.mocked(enqueueFrameCommand)
+const auditMock = vi.mocked(recordAuditEvent)
+const rateLimitMock = vi.mocked(rateLimitResponse)
+
+const frameId = '11111111-2222-3333-4444-555555555555'
+const accountId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+const linkedClientId = 'cccccccc-dddd-eeee-ffff-000000000000'
+
+let linkedClientRows: { id: string; providerClientMetadata: unknown }[] = []
+let updates: Record<string, unknown>[] = []
+
+const fakeDb = {
+  select: () => ({
+    from: () => ({
+      where: () => ({ limit: () => Promise.resolve(linkedClientRows) }),
+    }),
+  }),
+  update: () => ({
+    set: (values: Record<string, unknown>) => {
+      updates.push(values)
+      return { where: () => Promise.resolve(undefined) }
+    },
+  }),
+}
+
+function request(body: unknown) {
+  return new NextRequest(`https://cloud.example/api/frames/${frameId}/telemetry/enabled`, {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', origin: 'https://cloud.example' },
+    method: 'POST',
+  })
+}
+
+const routeParams = (id: string) => ({ params: Promise.resolve({ frameId: id }) })
+
+function grantedScopes() {
+  const metadata = updates.at(-1)?.providerClientMetadata as { requestedScopes?: string[] } | undefined
+  return metadata?.requestedScopes
+}
+
+beforeEach(() => {
+  updates = []
+  // A 2026-07 enrollment: frame:managed only, no telemetry.
+  linkedClientRows = [
+    {
+      id: linkedClientId,
+      providerClientMetadata: {
+        enrolledVia: 'claim_token',
+        requestedScopes: ['frame:managed', 'settings:services'],
+      },
+    },
+  ]
+  sessionMock.mockResolvedValue({
+    accountId,
+    providerSubject: 'subject',
+  } as never)
+  frameMock.mockResolvedValue({
+    accountId,
+    id: frameId,
+    linkedClientId,
+    status: 'active',
+  } as never)
+  enqueueMock.mockClear()
+  auditMock.mockClear()
+  rateLimitMock.mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('POST /api/frames/[frameId]/telemetry/enabled', () => {
+  const post = (body: unknown, id = frameId) => POST(request(body), routeParams(id))
+
+  it('grants both telemetry scopes, keeps the rest, and restarts the runtime', async () => {
+    const response = await post({ enabled: true })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      command_id: 'cmd-1',
+      enabled: true,
+      status: 'updated',
+    })
+    expect(grantedScopes()).toEqual(['frame:managed', 'settings:services', 'telemetry:logs', 'telemetry:metrics'])
+    expect((updates.at(-1)?.providerClientMetadata as Record<string, unknown>).enrolledVia).toBe('claim_token')
+    // Scopes are pinned at the WebSocket upgrade, so the grant is inert until
+    // the device reconnects — hence a short-lived restart_runtime.
+    expect(enqueueMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        createdByAccountId: accountId,
+        frameId,
+        type: 'restart_runtime',
+      })
+    )
+  })
+
+  it('fills in a half grant', async () => {
+    linkedClientRows[0]!.providerClientMetadata = {
+      requestedScopes: ['frame:managed', 'telemetry:logs'],
+    }
+
+    await post({ enabled: true })
+
+    expect(grantedScopes()).toEqual(['frame:managed', 'telemetry:logs', 'telemetry:metrics'])
+  })
+
+  it('revokes by removing both scopes, and restarts so the hub stops accepting', async () => {
+    linkedClientRows[0]!.providerClientMetadata = {
+      requestedScopes: ['frame:managed', 'telemetry:logs', 'telemetry:metrics', 'settings:services'],
+    }
+
+    const response = await post({ enabled: false })
+
+    expect(response.status).toBe(200)
+    expect(grantedScopes()).toEqual(['frame:managed', 'settings:services'])
+    expect(enqueueMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ type: 'restart_runtime' }))
+  })
+
+  it('is idempotent: a no-op toggle rewrites nothing and restarts nothing', async () => {
+    linkedClientRows[0]!.providerClientMetadata = {
+      requestedScopes: ['frame:managed', 'telemetry:logs', 'telemetry:metrics'],
+    }
+
+    const response = await post({ enabled: true })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ command_id: null })
+    expect(updates).toHaveLength(0)
+    expect(enqueueMock).not.toHaveBeenCalled()
+  })
+
+  it('audits the flag only', async () => {
+    await post({ enabled: true })
+
+    const event = auditMock.mock.calls[0]?.[1]
+    expect(event?.eventType).toBe('frame.telemetry_scope_changed')
+    expect(event?.metadata).toEqual({ enabled: true })
+    expect(event?.target).toEqual({ commandId: 'cmd-1', frameId })
+  })
+
+  it('grants but does not restart a frame that is not active', async () => {
+    frameMock.mockResolvedValue({
+      accountId,
+      id: frameId,
+      linkedClientId,
+      status: 'pending',
+    } as never)
+
+    const response = await post({ enabled: true })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ command_id: null })
+    expect(grantedScopes()).toContain('telemetry:logs')
+    expect(enqueueMock).not.toHaveBeenCalled()
+  })
+
+  it('401s without a session', async () => {
+    sessionMock.mockResolvedValue(undefined as never)
+
+    const response = await post({ enabled: true })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'login_required' })
+  })
+
+  it('404s a frame the session does not own', async () => {
+    frameMock.mockResolvedValue(undefined as never)
+
+    const response = await post({ enabled: true })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_frame' })
+  })
+
+  it('400s a body without a boolean `enabled`', async () => {
+    for (const body of [{}, { enabled: 'yes' }, { enabled: 1 }, { enabled: null }]) {
+      const response = await post(body)
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toEqual({
+        error: 'invalid_enabled',
+      })
+    }
+    expect(updates).toHaveLength(0)
+  })
+
+  it('relays the rate limiter', async () => {
+    rateLimitMock.mockResolvedValueOnce(new Response(null, { status: 429 }) as never)
+
+    const response = await post({ enabled: true })
+
+    expect(response.status).toBe(429)
+    expect(rateLimitMock.mock.calls[0]?.[1]).toBe('frames:telemetry-scope')
+  })
+})

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/telemetry/enabled/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/telemetry/enabled/route.ts
@@ -1,0 +1,136 @@
+import { eq } from 'drizzle-orm'
+import { linkedClients } from '@frameos-cloud/db'
+import { NextRequest, NextResponse } from 'next/server'
+import { recordAuditEvent } from '../../../../../../src/lib/audit'
+import { linkedClientScopes } from '../../../../../../src/lib/backend-auth'
+import { csrfResponse } from '../../../../../../src/lib/csrf'
+import { jsonError, readJsonObject, requireDatabase } from '../../../../../../src/lib/device-flow'
+import {
+  enqueueFrameCommand,
+  frameForAccount,
+  frameTelemetryLogsScope,
+  frameTelemetryMetricsScope,
+} from '../../../../../../src/lib/frames'
+import { rateLimitResponse } from '../../../../../../src/lib/rate-limit'
+import { readSession } from '../../../../../../src/lib/session'
+
+export const runtime = 'nodejs'
+
+// The OWNER's per-frame switch for telemetry (logs + metrics) shipping. Body:
+// {"enabled": true|false}. Sibling of service-settings/enabled, same shape.
+//
+// Why it exists: frames enrolled before 2026-08-03 (#288) hold links without
+// `telemetry:logs` / `telemetry:metrics`, and enrollment deliberately never
+// backfills scopes onto an existing link — adding a scope the owner did not
+// approve is exactly the silent escalation the device flow refuses. Such a
+// frame connects, deploys and renders normally but never ships a log line:
+// the device gates its push loops on the scope list in the hub's `ready`
+// message, and the hub answers any stray log_batch with insufficient_scope.
+// The Logs panel stays empty and nothing says why. This route is the owner
+// saying "yes, ship them" — an explicit grant, not a backfill.
+//
+// Scopes are captured once, at the WebSocket upgrade, and pinned on the
+// session for its lifetime (frame-hub attachDeviceSocket). So a change here
+// only takes effect at the device's NEXT connection, in either direction:
+// enabling without a reconnect leaves the device's push loops off; disabling
+// without one leaves the hub accepting batches until the socket drops. An
+// active frame is therefore asked to restart its runtime (the same
+// `restart_runtime` the canonical /restart route queues, same short TTL), so
+// the switch does what it says within the minute instead of "eventually".
+const restartTtlMs = 5 * 60 * 1000
+const telemetryScopes = [frameTelemetryLogsScope, frameTelemetryMetricsScope]
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ frameId: string }> }) {
+  const csrf = csrfResponse(request)
+  if (csrf) {
+    return csrf
+  }
+  const limited = await rateLimitResponse(request, 'frames:telemetry-scope', {
+    limit: 60,
+    windowMs: 15 * 60 * 1000,
+  })
+  if (limited) {
+    return limited
+  }
+  const session = await readSession()
+  if (!session?.accountId) {
+    return jsonError('login_required', 401)
+  }
+  const { db, response } = requireDatabase()
+  if (!db) {
+    return response
+  }
+  const { frameId } = await params
+  // Owner-only: frameForAccount is the ownership check.
+  const frame = await frameForAccount(db, session.accountId, frameId)
+  if (!frame) {
+    return jsonError('invalid_frame', 404)
+  }
+
+  const body = await readJsonObject(request)
+  if (typeof body.enabled !== 'boolean') {
+    return jsonError('invalid_enabled', 400)
+  }
+  const enabled = body.enabled
+
+  const [linkedClient] = await db
+    .select()
+    .from(linkedClients)
+    .where(eq(linkedClients.id, frame.linkedClientId))
+    .limit(1)
+  if (!linkedClient) {
+    return jsonError('invalid_frame', 404)
+  }
+
+  const current = linkedClientScopes(linkedClient)
+  const scopes = enabled
+    ? [...current, ...telemetryScopes.filter((scope) => !current.includes(scope))]
+    : current.filter((scope) => !telemetryScopes.includes(scope))
+
+  const changed = scopes.length !== current.length
+  if (changed) {
+    const metadata =
+      linkedClient.providerClientMetadata &&
+      typeof linkedClient.providerClientMetadata === 'object' &&
+      !Array.isArray(linkedClient.providerClientMetadata)
+        ? (linkedClient.providerClientMetadata as Record<string, unknown>)
+        : {}
+    await db
+      .update(linkedClients)
+      .set({
+        providerClientMetadata: { ...metadata, requestedScopes: scopes },
+        updatedAt: new Date(),
+      })
+      .where(eq(linkedClients.id, linkedClient.id))
+  }
+
+  // Only when something changed and only for an active frame: a pending one
+  // has no confirmed owner yet, a revoked one's queue is expired on sight,
+  // and a no-op toggle must not power-cycle anything.
+  let command: Awaited<ReturnType<typeof enqueueFrameCommand>> | undefined
+  if (changed && frame.status === 'active') {
+    command = await enqueueFrameCommand(db, {
+      createdByAccountId: session.accountId,
+      frameId: frame.id,
+      ttlMs: restartTtlMs,
+      type: 'restart_runtime',
+    })
+  }
+
+  await recordAuditEvent(db, {
+    accountId: session.accountId,
+    actor: {
+      accountId: session.accountId,
+      providerSubject: session.providerSubject,
+    },
+    eventType: 'frame.telemetry_scope_changed',
+    metadata: { enabled },
+    target: { commandId: command?.id, frameId: frame.id },
+  })
+
+  return NextResponse.json({
+    command_id: command?.id ?? null,
+    enabled,
+    status: 'updated',
+  })
+}

--- a/cloud/apps/auth-web/app/cloud-chrome.css
+++ b/cloud/apps/auth-web/app/cloud-chrome.css
@@ -34,8 +34,9 @@
   backdrop-filter: blur(16px);
 }
 
-/* Brand plus an optional page title (the Next pages show the current page's
-   heading in the name slot; the SPA always shows the wordmark). */
+/* Brand plus an optional page title. The wordmark always sits inside the
+   brand link, so it lands at the same offset on every surface; a page title
+   follows it as quieter text. */
 .frameos-account-header__lead {
   display: flex;
   align-items: center;
@@ -62,6 +63,14 @@
 .frameos-account-header__title {
   overflow: hidden;
   text-overflow: ellipsis;
+  font-weight: 500;
+  opacity: 0.7;
+}
+
+.frameos-account-header__title::before {
+  content: '/';
+  margin-right: 0.75rem;
+  opacity: 0.5;
 }
 
 .frameos-account-header__logo {

--- a/cloud/apps/auth-web/app/page.tsx
+++ b/cloud/apps/auth-web/app/page.tsx
@@ -187,11 +187,7 @@ export default async function HomePage({
   const totalPages = Math.max(1, Math.ceil(total / storePageSize));
 
   return (
-    <PublicShell
-      isSuperadmin={isSuperadmin}
-      signedIn={Boolean(session)}
-      title="FrameOS Scenes"
-    >
+    <PublicShell isSuperadmin={isSuperadmin} signedIn={Boolean(session)}>
       <div className="content-header">
         <div>
           <p className="copy">

--- a/cloud/apps/auth-web/app/publishers/[accountId]/page.tsx
+++ b/cloud/apps/auth-web/app/publishers/[accountId]/page.tsx
@@ -107,7 +107,6 @@ export default async function PublisherPage({
     <PublicShell
       isSuperadmin={await accountIsSuperadmin(session?.accountId)}
       signedIn={Boolean(session)}
-      title="FrameOS Scenes"
     >
       <div className="content-header">
         <div>

--- a/cloud/apps/auth-web/app/s/[slug]/page.tsx
+++ b/cloud/apps/auth-web/app/s/[slug]/page.tsx
@@ -293,7 +293,6 @@ export default async function ScenePage({
       // holds the link, and none of that should reach analytics.
       noCapture={isPrivate}
       signedIn={Boolean(session)}
-      title="FrameOS Scenes"
     >
       <SceneViewTracker sceneId={scene.id} visibility={scene.visibility} />
       {/* React hoists these into <head>. The frameos backend resolves a

--- a/cloud/apps/auth-web/app/signup/page.tsx
+++ b/cloud/apps/auth-web/app/signup/page.tsx
@@ -18,11 +18,7 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
   const returnTo = safeAuthReturnPath(rawReturnTo);
 
   return (
-    <AuthCard
-      copy="Create a FrameOS Cloud account to link and manage your FrameOS backends."
-      eyebrow="Sign up"
-      title="Create your account"
-    >
+    <AuthCard eyebrow="Sign up" title="Create your account">
       <SignupForm
         googleEnabled={hasGoogleOAuth()}
         returnTo={returnTo}

--- a/cloud/apps/auth-web/src/components/AccountNav.tsx
+++ b/cloud/apps/auth-web/src/components/AccountNav.tsx
@@ -5,8 +5,8 @@ import { usePathname } from "next/navigation";
 
 const sections = [
   { href: "/account/frames", key: "frames", label: "My frames" },
-  { href: "/account/installs", key: "installs", label: "Backends" },
   { href: "/account/scenes", key: "scenes", label: "My scenes" },
+  { href: "/account/installs", key: "installs", label: "Backends" },
   { href: "/account/backups", key: "backups", label: "Backups" },
   { href: "/account/activity", key: "activity", label: "Activity" },
   { href: "/account/security", key: "security", label: "Security" },

--- a/cloud/apps/auth-web/src/components/AppShell.test.tsx
+++ b/cloud/apps/auth-web/src/components/AppShell.test.tsx
@@ -7,7 +7,8 @@ import { PublicShell } from "./PublicShell";
 // The shells build absolute nav URLs from the deployment's origins.
 vi.mock("../lib/env", () => ({
   getAccountBaseUrl: () => "https://cloud.example.net",
-  getAccountUrl: (path?: string) => `https://cloud.example.net${path ?? "/account"}`,
+  getAccountUrl: (path?: string) =>
+    `https://cloud.example.net${path ?? "/account"}`,
   getCloudBaseUrl: () => "https://cloud.example.net",
   getScenesBaseUrl: () => "https://scenes.example.net",
   // The shells render LegalFooter, which needs the cookie domain for the
@@ -58,5 +59,71 @@ describe("PublicShell", () => {
     expect(container.querySelector("main")?.className).not.toContain(
       "ph-no-capture",
     );
+  });
+});
+
+// The two shells draw one header: the wordmark sits inside the brand link
+// on both (so it does not shift between scenes.* and cloud.*), the brand
+// links to the workspace for anyone signed in, and Frames leads the nav.
+function navLabels(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll(
+      "nav[aria-label='Primary'] a, nav[aria-label='Primary'] button",
+    ),
+  ).map((node) => node.textContent?.trim());
+}
+
+function brand(container: HTMLElement) {
+  const link = container.querySelector<HTMLAnchorElement>(
+    ".frameos-account-header__brand",
+  );
+  return {
+    href: link?.getAttribute("href"),
+    name: link?.querySelector(".frameos-account-header__name")?.textContent,
+  };
+}
+
+describe("the shared header", () => {
+  it("reads FrameOS Cloud and leads to the workspace on the account pages", () => {
+    const { container } = render(<AppShell title="Users">body</AppShell>);
+    expect(brand(container)).toEqual({
+      href: "https://cloud.example.net/frames",
+      name: "FrameOS Cloud",
+    });
+    // A page title follows the wordmark instead of replacing it.
+    expect(
+      container.querySelector(".frameos-account-header__title")?.textContent,
+    ).toBe("Users");
+    expect(navLabels(container)).toEqual([
+      "Frames",
+      "Scenes",
+      "Account",
+      "Sign out",
+    ]);
+  });
+
+  it("reads FrameOS Scenes with only Sign in for a signed-out store visitor", () => {
+    const { container } = render(
+      <PublicShell signedIn={false}>body</PublicShell>,
+    );
+    expect(brand(container)).toEqual({
+      href: "https://scenes.example.net/",
+      name: "FrameOS Scenes",
+    });
+    expect(navLabels(container)).toEqual(["Sign in"]);
+  });
+
+  it("shows the cloud header to a signed-in store visitor", () => {
+    const { container } = render(<PublicShell signedIn>body</PublicShell>);
+    expect(brand(container)).toEqual({
+      href: "https://cloud.example.net/frames",
+      name: "FrameOS Cloud",
+    });
+    expect(navLabels(container)).toEqual([
+      "Frames",
+      "Scenes",
+      "Account",
+      "Sign out",
+    ]);
   });
 });

--- a/cloud/apps/auth-web/src/components/AppShell.tsx
+++ b/cloud/apps/auth-web/src/components/AppShell.tsx
@@ -9,9 +9,11 @@ import {
   getScenesBaseUrl,
 } from "../lib/env";
 
-// `title` is the page's heading, shown in the top row next to the logo.
+// `title` is the page's heading, shown in the top row after the wordmark.
 // The header is the /frames fleet workspace's (cloud-frontend
-// AccountHeader.tsx + cloud-chrome.css): same chrome on every surface.
+// AccountHeader.tsx + cloud-chrome.css): same chrome on every surface. The
+// wordmark links to /frames — the workspace is the cloud's home — and the
+// nav starts there too: Frames, Scenes, Account, (Admin), Sign out.
 export function AppShell({
   children,
   isSuperadmin = false,
@@ -40,13 +42,13 @@ export function AppShell({
   return (
     <div className="shell">
       <header className="frameos-account-header">
-        <HeaderBrand href={accountUrl} title={title} />
+        <HeaderBrand href={framesUrl} title={title} />
         <nav aria-label="Primary" className="frameos-account-header__nav">
-          <Link className="frameos-account-header__link" href={scenesUrl}>
-            Scenes
-          </Link>
           <Link className="frameos-account-header__link" href={framesUrl}>
             Frames
+          </Link>
+          <Link className="frameos-account-header__link" href={scenesUrl}>
+            Scenes
           </Link>
           <Link className="frameos-account-header__link" href={accountUrl}>
             Account

--- a/cloud/apps/auth-web/src/components/HeaderBrand.tsx
+++ b/cloud/apps/auth-web/src/components/HeaderBrand.tsx
@@ -1,20 +1,25 @@
 import Link from "next/link";
 
 // The lead slot of the shared cloud header (cloud-chrome.css): the cloud
-// logo — light and dark renditions, CSS picks one — plus either the wordmark
-// or, when a page brings a `title`, that title in the wordmark's place. The
-// /frames SPA renders the same markup in cloud-frontend AccountHeader.tsx.
+// logo — light and dark renditions, CSS picks one — and the wordmark, both
+// inside one link. A page may add a `title` after the wordmark; it never
+// replaces it, so the wordmark sits at the same offset on every surface
+// (the store header and the workspace header used to differ by the gap
+// between the brand link and a detached title). The /frames SPA renders
+// the same markup in cloud-frontend AccountHeader.tsx.
 export function HeaderBrand({
   href,
+  name = "FrameOS Cloud",
   title,
 }: {
   href: string;
+  name?: string;
   title?: React.ReactNode;
 }) {
   return (
     <div className="frameos-account-header__lead">
       <Link
-        aria-label="FrameOS Cloud"
+        aria-label={name}
         className="frameos-account-header__brand"
         href={href}
       >
@@ -32,9 +37,7 @@ export function HeaderBrand({
           src="/logo-dark.svg"
           width={36}
         />
-        {title ? null : (
-          <span className="frameos-account-header__name">FrameOS Cloud</span>
-        )}
+        <span className="frameos-account-header__name">{name}</span>
       </Link>
       {title ? (
         <span className="frameos-account-header__title">{title}</span>

--- a/cloud/apps/auth-web/src/components/PublicShell.tsx
+++ b/cloud/apps/auth-web/src/components/PublicShell.tsx
@@ -10,9 +10,12 @@ import {
 } from "../lib/env";
 
 // Shell for the public store pages: same chrome as AppShell but usable
-// signed out — signed-in visitors get the same nav as the app shell
-// (Account / Admin / Sign out), everyone else gets Sign in.
-// `title` is the page's heading, shown in the top row next to the logo.
+// signed out. A signed-in visitor sees the cloud header exactly as the app
+// shell draws it — "FrameOS Cloud" linking to the workspace, then Frames /
+// Scenes / Account / (Admin) / Sign out. Signed out, the store stands on its
+// own: the wordmark reads "FrameOS Scenes" and links to the store root, and
+// the only action is Sign in.
+// `title` is the page's heading, shown in the top row after the wordmark.
 export function PublicShell({
   children,
   isSuperadmin = false,
@@ -43,18 +46,29 @@ export function PublicShell({
   return (
     <div className="shell">
       <header className="frameos-account-header">
-        <HeaderBrand href={scenesHomeUrl} title={title} />
+        {signedIn ? (
+          <HeaderBrand href={framesUrl} title={title} />
+        ) : (
+          <HeaderBrand
+            href={scenesHomeUrl}
+            name="FrameOS Scenes"
+            title={title}
+          />
+        )}
         <nav aria-label="Primary" className="frameos-account-header__nav">
-          <Link className="frameos-account-header__link" href={scenesHomeUrl}>
-            Scenes
-          </Link>
           {signedIn ? (
             <>
-              {/* Signed-in only, and ordered as in AppShell (Scenes, Frames,
-                  Account): a signed-out visitor has no frames, so the link
-                  would only bounce them through the login page. */}
+              {/* Ordered as in AppShell. Signed-out visitors get none of
+                  this: they have no frames, so the links would only bounce
+                  them through the login page. */}
               <Link className="frameos-account-header__link" href={framesUrl}>
                 Frames
+              </Link>
+              <Link
+                className="frameos-account-header__link"
+                href={scenesHomeUrl}
+              >
+                Scenes
               </Link>
               <Link className="frameos-account-header__link" href={accountUrl}>
                 Account

--- a/cloud/apps/auth-web/src/lib/audit-labels.test.ts
+++ b/cloud/apps/auth-web/src/lib/audit-labels.test.ts
@@ -35,6 +35,7 @@ const frameEventTypes = [
   "frame.service_settings_scope_changed",
   "frame.session_kicked",
   "frame.settings_pushed",
+  "frame.telemetry_scope_changed",
 ];
 
 describe("auditEventLabel", () => {

--- a/cloud/apps/auth-web/src/lib/audit-labels.ts
+++ b/cloud/apps/auth-web/src/lib/audit-labels.ts
@@ -51,7 +51,8 @@ const eventLabels: Record<string, string> = {
   "frame.scenes_applied": "Assigned scenes applied by the frame",
   "frame.scenes_assigned": "Scenes assigned to a frame",
   "frame.schedule_pushed": "Frame schedule updated",
-  "frame.service_settings_scope_changed": "Frame access to service API keys changed",
+  "frame.service_settings_scope_changed":
+    "Frame access to service API keys changed",
   "frame.session_kicked": "Frame session closed by the cloud",
   "frame.settings_pushed": "Frame settings updated",
   "linked_client.revoked": "Linked device revoked",
@@ -124,7 +125,9 @@ export function auditEventDetail(metadata: unknown): string | undefined {
       record.sceneNames.filter((s) => typeof s === "string").join(", "),
     );
   } else if (typeof record.sceneCount === "number") {
-    parts.push(`${record.sceneCount} scene${record.sceneCount === 1 ? "" : "s"}`);
+    parts.push(
+      `${record.sceneCount} scene${record.sceneCount === 1 ? "" : "s"}`,
+    );
   }
   if (typeof record.events === "number") {
     parts.push(
@@ -138,7 +141,9 @@ export function auditEventDetail(metadata: unknown): string | undefined {
   if (typeof record.uploaded === "number") {
     parts.push(
       `${record.uploaded} uploaded` +
-        (typeof record.skipped === "number" ? `, ${record.skipped} skipped` : "") +
+        (typeof record.skipped === "number"
+          ? `, ${record.skipped} skipped`
+          : "") +
         (typeof record.failed === "number" && record.failed > 0
           ? `, ${record.failed} failed`
           : ""),
@@ -195,10 +200,31 @@ export function summarizeAuditActor(actor: unknown): AuditActorSummary {
   const record = actor as Record<string, unknown>;
   const ip = typeof record.ip === "string" ? record.ip : undefined;
   if (typeof record.accountId === "string") {
-    return { kind: "account", accountId: record.accountId, ...(ip ? { ip } : {}) };
+    return {
+      kind: "account",
+      accountId: record.accountId,
+      ...(ip ? { ip } : {}),
+    };
   }
   if (record.kind === "device" || record.kind === "frame_enrollment") {
     return { kind: "device", ...(ip ? { ip } : {}) };
   }
   return { kind: "system", ...(ip ? { ip } : {}) };
+}
+
+// The frame / scene a row is about, read from the target the writer stamped
+// (frame-hub lifecycle rows and every frame route use `target.frameId`; the
+// scene routes use `target.sceneId`). The activity feed resolves these to
+// names so "Frame disconnected" says which frame.
+export type AuditTargetRef = { frameId?: string; sceneId?: string };
+
+export function auditEventTarget(target: unknown): AuditTargetRef {
+  if (!target || typeof target !== "object" || Array.isArray(target)) {
+    return {};
+  }
+  const record = target as Record<string, unknown>;
+  return {
+    ...(typeof record.frameId === "string" ? { frameId: record.frameId } : {}),
+    ...(typeof record.sceneId === "string" ? { sceneId: record.sceneId } : {}),
+  };
 }

--- a/cloud/apps/auth-web/src/lib/audit-labels.ts
+++ b/cloud/apps/auth-web/src/lib/audit-labels.ts
@@ -55,6 +55,7 @@ const eventLabels: Record<string, string> = {
     "Frame access to service API keys changed",
   "frame.session_kicked": "Frame session closed by the cloud",
   "frame.settings_pushed": "Frame settings updated",
+  "frame.telemetry_scope_changed": "Frame log and metric shipping changed",
   "linked_client.revoked": "Linked device revoked",
   "linked_client.scopes_reduced": "Enabled features reduced",
   "linked_client.scopes_updated": "Enabled features updated",

--- a/cloud/apps/auth-web/src/lib/frames.ts
+++ b/cloud/apps/auth-web/src/lib/frames.ts
@@ -815,6 +815,12 @@ export function frameSummary(
           service_settings_enabled: linkedClientScopes(linkedClient).includes(
             frameServiceSettingsScope,
           ),
+          // Same contract: the owner's per-frame telemetry switch
+          // (telemetry/enabled route). Pre-2026-08-03 enrollments report
+          // false here — that is the empty-Logs-panel case, now named.
+          telemetry_enabled: linkedClientScopes(linkedClient).includes(
+            frameTelemetryLogsScope,
+          ),
         }
       : {}),
     status: frame.status,

--- a/cloud/apps/auth-web/src/test/shared-spa/asset-paths.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/asset-paths.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  assetPathKey,
+  normalizeAssetPath,
+  withRenamedAsset,
+  withoutDeletedAsset,
+} from "../../../../../../frontend/src/scenes/frame/panels/Assets/assetPaths";
+
+// The Assets panel's listing comes in two spellings: the backend lists
+// absolute paths under the frame's assets directory, while the cloud hub
+// caches the device's `assets_list` reply, whose paths are relative to that
+// directory (parseAssetEntries in src/lib/frames.ts refuses absolute ones).
+// Deletes and renames used to match rows by the absolute spelling only, so on
+// a cloud frame the deleted row stayed on screen until the next reload.
+describe("assetPathKey", () => {
+  it("collapses every spelling of the same asset to one key", () => {
+    expect(assetPathKey("/srv/assets/photos/a.jpg", "/srv/assets")).toBe(
+      "photos/a.jpg",
+    );
+    expect(assetPathKey("photos/a.jpg", "/srv/assets")).toBe("photos/a.jpg");
+    expect(assetPathKey("./photos/a.jpg", "/srv/assets")).toBe("photos/a.jpg");
+    expect(assetPathKey("/photos/a.jpg", "/srv/assets")).toBe("photos/a.jpg");
+    expect(assetPathKey("photos/a.jpg")).toBe("photos/a.jpg");
+  });
+
+  it("treats the assets directory itself as the root", () => {
+    expect(assetPathKey("/srv/assets", "/srv/assets")).toBe("");
+    expect(assetPathKey("/srv/assets/", "/srv/assets/")).toBe("");
+    expect(assetPathKey(".", "/srv/assets")).toBe("");
+    expect(assetPathKey("", "/srv/assets")).toBe("");
+  });
+
+  it("honours a custom assets directory", () => {
+    expect(assetPathKey("/sdcard/frameos/a.jpg", "/sdcard/frameos")).toBe(
+      "a.jpg",
+    );
+    expect(assetPathKey("a.jpg", "/sdcard/frameos")).toBe("a.jpg");
+  });
+});
+
+describe("withoutDeletedAsset", () => {
+  const cloudListing = [
+    { path: "photos/a.jpg" },
+    { path: "photos/b.jpg" },
+    { path: "photos" },
+    { path: "photos-archive/c.jpg" },
+  ];
+  const backendListing = cloudListing.map((asset) => ({
+    path: normalizeAssetPath(asset.path, "/srv/assets"),
+  }));
+
+  it("drops a relative (cloud) row when the panel deletes by tree path", () => {
+    expect(
+      withoutDeletedAsset(cloudListing, "photos/a.jpg", "/srv/assets"),
+    ).toEqual([
+      { path: "photos/b.jpg" },
+      { path: "photos" },
+      { path: "photos-archive/c.jpg" },
+    ]);
+  });
+
+  it("drops an absolute (backend) row the same way", () => {
+    expect(
+      withoutDeletedAsset(backendListing, "photos/a.jpg", "/srv/assets"),
+    ).toEqual([
+      { path: "/srv/assets/photos/b.jpg" },
+      { path: "/srv/assets/photos" },
+      { path: "/srv/assets/photos-archive/c.jpg" },
+    ]);
+  });
+
+  it("drops a folder with its subtree but not a sibling sharing the prefix", () => {
+    expect(withoutDeletedAsset(cloudListing, "photos", "/srv/assets")).toEqual([
+      { path: "photos-archive/c.jpg" },
+    ]);
+  });
+
+  it("never wipes the listing for the root", () => {
+    expect(withoutDeletedAsset(cloudListing, "", "/srv/assets")).toBe(
+      cloudListing,
+    );
+    expect(
+      withoutDeletedAsset(cloudListing, "/srv/assets", "/srv/assets"),
+    ).toBe(cloudListing);
+  });
+});
+
+describe("withRenamedAsset", () => {
+  it("moves relative rows and keeps them relative", () => {
+    expect(
+      withRenamedAsset(
+        [
+          { path: "photos/a.jpg" },
+          { path: "./photos/b.jpg" },
+          { path: "other/c.jpg" },
+        ],
+        "photos",
+        "pics",
+        "/srv/assets",
+      ),
+    ).toEqual([
+      { path: "pics/a.jpg" },
+      { path: "./pics/b.jpg" },
+      { path: "other/c.jpg" },
+    ]);
+  });
+
+  it("moves absolute rows and keeps them absolute", () => {
+    expect(
+      withRenamedAsset(
+        [{ path: "/srv/assets/photos/a.jpg" }, { path: "/srv/assets/photos" }],
+        "photos",
+        "pics",
+        "/srv/assets",
+      ),
+    ).toEqual([
+      { path: "/srv/assets/pics/a.jpg" },
+      { path: "/srv/assets/pics" },
+    ]);
+  });
+
+  it("renames a single file", () => {
+    expect(
+      withRenamedAsset([{ path: "a.jpg" }], "a.jpg", "b.jpg", "/srv/assets"),
+    ).toEqual([{ path: "b.jpg" }]);
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-deploy-dialog.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-deploy-dialog.test.tsx
@@ -23,7 +23,10 @@ import type { FrameType } from "../../../../../../frontend/src/types";
 
 const fetchMock = vi.fn<typeof fetch>();
 
-function cloudFrame(platform: string, overrides: Partial<FrameType> = {}): FrameType {
+function cloudFrame(
+  platform: string,
+  overrides: Partial<FrameType> = {},
+): FrameType {
   return {
     id: `frame-${platform}` as unknown as FrameType["id"],
     project_id: 1,
@@ -57,7 +60,10 @@ beforeEach(() => {
   // Serial, so the controls under test only exist when it is present.
   Object.defineProperty(navigator, "serial", {
     configurable: true,
-    value: { getPorts: () => Promise.resolve([]), requestPort: () => Promise.reject(new Error("no port")) },
+    value: {
+      getPorts: () => Promise.resolve([]),
+      requestPort: () => Promise.reject(new Error("no port")),
+    },
   });
   testWindow.FRAMEOS_APP_CONFIG = { cloudMode: true };
   testWindow.FRAMEOS_EMBEDDED_NO_BACKEND = true;
@@ -101,20 +107,47 @@ describe("the deploy dialog in cloud mode", () => {
     fireEvent.click(screen.getByRole("button", { name: /Over the air/ }));
 
     // The cloud's deploy: settings push + one checksummed set_scenes.
-    expect(screen.getByRole("button", { name: /Push scenes & settings/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Push scenes & settings/ }),
+    ).toBeTruthy();
     // The firmware nudge (notify_update_available; the device downloads and
     // signature-verifies the image itself). The label is constant — the
     // checkbox next to it is what says whether scenes ride along, and a
     // button that renamed itself made the two disagree.
-    expect(screen.getByRole("button", { name: /Upgrade firmware/ })).toBeTruthy();
-    fireEvent.click(screen.getByRole("checkbox", { name: /Also push scenes & settings/ }));
-    expect(screen.getByRole("button", { name: /Upgrade firmware/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Upgrade firmware/ }),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /Resend scenes & settings/ }),
+    );
+    expect(
+      screen.getByRole("button", { name: /Upgrade firmware/ }),
+    ).toBeTruthy();
     // OTA progress is only visible as ota:cloud log lines, so the view links
     // straight to them.
-    expect(screen.getByRole("button", { name: /Follow along in Logs/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Follow along in Logs/ }),
+    ).toBeTruthy();
+    // Order: firmware (where the "Over the air" button was), then scenes &
+    // settings, then logs — the action the user came for is under the mouse.
+    const firmware = screen.getByRole("button", { name: /Upgrade firmware/ });
+    const scenes = screen.getByRole("button", {
+      name: /Push scenes & settings/,
+    });
+    const logs = screen.getByRole("button", { name: /Follow along in Logs/ });
+    const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+    expect(firmware.compareDocumentPosition(scenes) & FOLLOWING).toBeTruthy();
+    expect(scenes.compareDocumentPosition(logs) & FOLLOWING).toBeTruthy();
+    // The resend tick sits under the upgrade button, not above it.
+    const resend = screen.getByRole("checkbox", {
+      name: /Resend scenes & settings/,
+    });
+    expect(firmware.compareDocumentPosition(resend) & FOLLOWING).toBeTruthy();
     // The USB surfaces stay behind the other path.
     expect(screen.queryByText("Wi-Fi & device status")).toBeNull();
-    expect(screen.queryByRole("button", { name: /Update over USB/ })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Update over USB/ }),
+    ).toBeNull();
   });
 
   it("orders the USB path firmware, scene push, then Wi-Fi repair", () => {
@@ -123,12 +156,19 @@ describe("the deploy dialog in cloud mode", () => {
 
     // 1. The NVS-sparing firmware update, with the same "and the scenes too"
     // tick the over-the-air firmware card offers…
-    expect(screen.getByRole("button", { name: /Update over USB/ })).toBeTruthy();
-    expect(screen.getAllByRole("checkbox", { name: /Also push scenes & settings/ }).length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: /Update over USB/ }),
+    ).toBeTruthy();
+    expect(
+      screen.getAllByRole("checkbox", { name: /Also push scenes & settings/ })
+        .length,
+    ).toBeGreaterThan(0);
     // 2. …the same scene bodies the OTA push sends, over the cable (behind a
     // connect button until a board is attached)…
     expect(screen.getByText("Push scenes & settings")).toBeTruthy();
-    expect(screen.getByText(/Connect the board over USB to push scenes/)).toBeTruthy();
+    expect(
+      screen.getByText(/Connect the board over USB to push scenes/),
+    ).toBeTruthy();
     // 3. …and WebSerial provisioning, the only repair channel for a board
     // whose Wi-Fi credentials are wrong.
     expect(screen.getByText("Wi-Fi & device status")).toBeTruthy();
@@ -136,11 +176,17 @@ describe("the deploy dialog in cloud mode", () => {
     // screen: it needs a claim token bound to this frame, so the cloud bundle
     // registers it (CloudFrameUsbRelink) — absent in this shared-SPA harness,
     // which registers no panels.
-    expect(screen.queryByText(/re-connect it from the "Add\s?frame" panel/i)).toBeNull();
+    expect(
+      screen.queryByText(/re-connect it from the "Add\s?frame" panel/i),
+    ).toBeNull();
   });
 
   it("lands a frame no board has enrolled as straight on the USB view", () => {
-    render(<FrameDeployPlanDrawer frame={cloudFrame("esp32", { status: "pending" })} />);
+    render(
+      <FrameDeployPlanDrawer
+        frame={cloudFrame("esp32", { status: "pending" })}
+      />,
+    );
 
     // Over the air cannot reach a frame with no device behind it (the command
     // queue 409s), so the choice would be a trick question.
@@ -172,21 +218,33 @@ describe("the deploy dialog in cloud mode", () => {
   it("leaves a cloud Pi frame the scene push and the FrameOS update, without the esp32 surfaces", () => {
     render(<FrameDeployPlanDrawer frame={cloudFrame("pi-zero2w")} />);
 
-    expect(screen.getByRole("button", { name: /Push scenes & settings/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Push scenes & settings/ }),
+    ).toBeTruthy();
     // The same notify_update_available nudge the esp32 gets, with Pi wording:
     // the device runs its own signed release upgrade (frameos/upgrade.nim).
     // Constant label; the checkbox owns "and the scenes too".
-    expect(screen.getByRole("button", { name: /Upgrade FrameOS/ })).toBeTruthy();
-    fireEvent.click(screen.getByRole("checkbox", { name: /Also push scenes & settings/ }));
-    expect(screen.getByRole("button", { name: /Upgrade FrameOS/ })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Upgrade FrameOS/ }),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /Resend scenes & settings/ }),
+    );
+    expect(
+      screen.getByRole("button", { name: /Upgrade FrameOS/ }),
+    ).toBeTruthy();
     // USB provisioning and the hardware panel stay esp32-profile surfaces: a
     // cloud Pi has no serial console to provision over and no enrollment
     // hardware report to render.
     expect(screen.queryByRole("button", { name: /Over the air/ })).toBeNull();
     expect(screen.queryByRole("button", { name: /Over USB/ })).toBeNull();
     expect(screen.queryByText("Wi-Fi & device status")).toBeNull();
-    expect(screen.queryByRole("button", { name: /Upgrade firmware/ })).toBeNull();
-    expect(screen.queryByRole("button", { name: /Update over USB/ })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Upgrade firmware/ }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Update over USB/ }),
+    ).toBeNull();
     expect(screen.queryByText("Hardware")).toBeNull();
   });
 

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-sd-image-builder.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-sd-image-builder.test.tsx
@@ -3,7 +3,13 @@
 // The SD image builder inside the workspace's "Add frame" panel. It lives in
 // cloud-frontend/, which has no test runner, so it is tested from auth-web's
 // vitest across the package boundary (see the other shared-spa tests).
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -208,7 +214,12 @@ afterEach(() => {
 describe("SdImageBuilder", () => {
   it("lists boards from the latest release and disables missing ones", async () => {
     mockReleaseAndImage();
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_x")} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_x")}
+      />,
+    );
 
     const available = await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
@@ -229,16 +240,25 @@ describe("SdImageBuilder", () => {
   // so it is the one field the builder never guesses.
   it("selects no board on its own, leaving the download disabled", async () => {
     mockReleaseAndImage();
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_x")} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_x")}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
-    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe("");
+    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe(
+      "",
+    );
     expect(
-      (screen.getByRole("button", {
-        name: /download sd image/i,
-      }) as HTMLButtonElement).disabled,
+      (
+        screen.getByRole("button", {
+          name: /download sd image/i,
+        }) as HTMLButtonElement
+      ).disabled,
     ).toBe(true);
   });
 
@@ -299,14 +319,19 @@ describe("SdImageBuilder", () => {
       name: "Raspberry Pi Zero / Zero W / 1 (32-bit) — image not published yet",
     });
 
-    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe("");
+    expect((screen.getByLabelText("Board") as HTMLSelectElement).value).toBe(
+      "",
+    );
   });
 
   it("reports a failed release lookup instead of silently offering nothing", async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response("{}", { status: 500 }),
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 500 }));
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_x")}
+      />,
     );
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_x")} />);
 
     await screen.findByText(/Could not look up the latest FrameOS release/);
   });
@@ -314,19 +339,21 @@ describe("SdImageBuilder", () => {
   it("refuses WiFi values with double quotes before downloading anything", async () => {
     mockReleaseAndImage();
     const mint = vi.fn(() => Promise.resolve("FRCT_multi"));
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={mint}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
     nameFrame();
-    fireEvent.change(
-      screen.getByPlaceholderText(/WiFi network \(optional/),
-      { target: { value: 'my "network"' } },
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.change(screen.getByPlaceholderText(/WiFi network \(optional/), {
+      target: { value: 'my "network"' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByText(/must not contain double quotes or backslashes/);
     expect(mint).not.toHaveBeenCalled();
@@ -342,7 +369,12 @@ describe("SdImageBuilder", () => {
     mockReleaseAndImage();
     stubSaveFilePicker();
     const mint = vi.fn(() => Promise.resolve("FRCT_multi_use_token"));
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={mint}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
@@ -357,34 +389,37 @@ describe("SdImageBuilder", () => {
     fireEvent.change(screen.getByLabelText("Claim code validity"), {
       target: { value: "7" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
-    expect(mint).toHaveBeenCalledExactlyOnceWith({ multiUse: true, ttlDays: 7 });
+    expect(mint).toHaveBeenCalledExactlyOnceWith({
+      multiUse: true,
+      ttlDays: 7,
+    });
   });
 
   it("builds a personalized image: mints a multi-use token, patches the placeholder, streams to disk", async () => {
     mockReleaseAndImage();
     const saved = stubSaveFilePicker();
     const mint = vi.fn(() => Promise.resolve("FRCT_multi_use_token"));
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={mint}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
     nameFrame();
-    fireEvent.change(
-      screen.getByPlaceholderText(/WiFi network \(optional/),
-      { target: { value: "MyNet" } },
-    );
+    fireEvent.change(screen.getByPlaceholderText(/WiFi network \(optional/), {
+      target: { value: "MyNet" },
+    });
     fireEvent.change(screen.getByPlaceholderText("WiFi password"), {
       target: { value: "hunter2" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
@@ -428,7 +463,12 @@ describe("SdImageBuilder", () => {
   it("requires a root password or an explicit passwordless-root opt-in", async () => {
     mockReleaseAndImage();
     const mint = vi.fn(() => Promise.resolve("FRCT_multi"));
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={mint}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
@@ -439,9 +479,7 @@ describe("SdImageBuilder", () => {
     fireEvent.change(screen.getByPlaceholderText("Frame name"), {
       target: { value: "Kitchen Frame" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByText(/Set a root password for the device, or tick/);
     expect(mint).not.toHaveBeenCalled();
@@ -475,12 +513,13 @@ describe("SdImageBuilder", () => {
     // A typed password makes the passwordless opt-in irrelevant (and
     // disabled, so nameFrame-style ticking is impossible).
     expect(
-      (screen.getByLabelText(/Enable passwordless root login/) as HTMLInputElement)
-        .disabled,
+      (
+        screen.getByLabelText(
+          /Enable passwordless root login/,
+        ) as HTMLInputElement
+      ).disabled,
     ).toBe(true);
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
     const regionText = new TextDecoder().decode(gunzip(savedBytes(saved)));
@@ -501,9 +540,7 @@ describe("SdImageBuilder", () => {
     });
 
     nameFrame();
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
     const regionText = new TextDecoder().decode(gunzip(savedBytes(saved)));
@@ -527,9 +564,7 @@ describe("SdImageBuilder", () => {
     });
 
     nameFrame();
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
     expect(mint).not.toHaveBeenCalled();
@@ -537,9 +572,9 @@ describe("SdImageBuilder", () => {
     expect(regionText).toContain("claim_token=FRCT_existing\n");
     // Success panel explains the expiry semantics: it gates NEW enrollments
     // only, and a fresh image is the re-claim path.
-    expect(
-      screen.getByTestId("sd-image-done").textContent,
-    ).toContain("accepts new frames until");
+    expect(screen.getByTestId("sd-image-done").textContent).toContain(
+      "accepts new frames until",
+    );
   });
 
   it("writes the chosen display driver and its config into the image", async () => {
@@ -561,15 +596,19 @@ describe("SdImageBuilder", () => {
     });
     // Native panel dimensions are prefilled and editable.
     // Portrait-native, straight from the backend device registry.
-    expect((screen.getByLabelText("Display width") as HTMLInputElement).value).toBe("1200");
-    expect((screen.getByLabelText("Display height") as HTMLInputElement).value).toBe("1600");
-    fireEvent.change(screen.getByLabelText("Rotation"), { target: { value: "90" } });
+    expect(
+      (screen.getByLabelText("Display width") as HTMLInputElement).value,
+    ).toBe("1200");
+    expect(
+      (screen.getByLabelText("Display height") as HTMLInputElement).value,
+    ).toBe("1600");
+    fireEvent.change(screen.getByLabelText("Rotation"), {
+      target: { value: "90" },
+    });
     // vcom is an IT8951 knob — no curated panel needs it, so it must not
     // clutter a Waveshare pick.
     expect(screen.queryByLabelText("VCOM (optional)")).toBeNull();
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
     const regionText = new TextDecoder().decode(gunzip(savedBytes(saved)));
@@ -603,9 +642,7 @@ describe("SdImageBuilder", () => {
     fireEvent.change(screen.getByLabelText("VCOM (optional)"), {
       target: { value: "-1.48" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
     const regionText = new TextDecoder().decode(gunzip(savedBytes(saved)));
@@ -616,7 +653,12 @@ describe("SdImageBuilder", () => {
   it("requires the upload URL for http.upload before opening the save dialog", async () => {
     mockReleaseAndImage();
     const mint = vi.fn(() => Promise.resolve("FRCT_multi"));
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={mint}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
@@ -625,12 +667,48 @@ describe("SdImageBuilder", () => {
     fireEvent.change(screen.getByLabelText("Display"), {
       target: { value: "http.upload" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    // No native size for this driver: the form says so and gates the build.
+    screen.getByText(/Width and height are required/);
+    expect(
+      (screen.getByLabelText("Display width") as HTMLInputElement).required,
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
+    await screen.findByText(/Display width is required/);
+
+    fireEvent.change(screen.getByLabelText("Display width"), {
+      target: { value: "800" },
+    });
+    fireEvent.change(screen.getByLabelText("Display height"), {
+      target: { value: "480" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByText(/HTTP upload needs the URL/);
     expect(mint).not.toHaveBeenCalled();
+  });
+
+  it("marks the size optional for HDMI, where the framebuffer autodetects it", async () => {
+    mockReleaseAndImage();
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_multi")}
+      />,
+    );
+    await screen.findByRole("option", {
+      name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
+    });
+
+    fireEvent.change(screen.getByLabelText("Display"), {
+      target: { value: "framebuffer" },
+    });
+    screen.getByText(/optional for HDMI/);
+    expect(
+      (screen.getByLabelText("Display width") as HTMLInputElement).required,
+    ).toBe(false);
+    expect(
+      (screen.getByLabelText("Display height") as HTMLInputElement).required,
+    ).toBe(false);
   });
 
   it("remembers WiFi credentials in localStorage only when asked to", async () => {
@@ -647,26 +725,19 @@ describe("SdImageBuilder", () => {
     });
 
     nameFrame();
-    fireEvent.change(
-      screen.getByPlaceholderText(/WiFi network \(optional/),
-      { target: { value: "MyNet" } },
-    );
+    fireEvent.change(screen.getByPlaceholderText(/WiFi network \(optional/), {
+      target: { value: "MyNet" },
+    });
     fireEvent.change(screen.getByPlaceholderText("WiFi password"), {
       target: { value: "hunter2" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
     // Unchecked by default: nothing is stored.
     expect(localStorage.getItem("frameos-sd-image-wifi")).toBeNull();
 
-    fireEvent.click(
-      screen.getByLabelText(/Remember WiFi credentials/),
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByLabelText(/Remember WiFi credentials/));
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
     expect(localStorage.getItem("frameos-sd-image-wifi")).toBe(
       JSON.stringify({ password: "hunter2", ssid: "MyNet" }),
@@ -692,7 +763,12 @@ describe("SdImageBuilder", () => {
         clicked.push(this);
       });
 
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_m")} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_m")}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
@@ -700,9 +776,7 @@ describe("SdImageBuilder", () => {
     expect(screen.getByText(/assembled in memory/)).toBeDefined();
 
     nameFrame();
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
     await screen.findByTestId("sd-image-done", undefined, { timeout: 5000 });
 
     expect(clicked).toHaveLength(1);
@@ -737,7 +811,12 @@ describe("SdImageBuilder", () => {
       return Promise.resolve(new Response(large.slice()));
     });
     stubFailingSaveFilePicker("The target volume is full.");
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_m")} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_m")}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
@@ -758,15 +837,18 @@ describe("SdImageBuilder", () => {
   it("reports a config that does not fit the placeholder on its own terms", async () => {
     mockReleaseAndImage();
     stubSaveFilePicker();
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_m")} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_m")}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
     nameFrame("x".repeat(5000));
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByText(/does not fit in the 4096-byte placeholder/);
     // Not the "your release is too old" story — nothing is wrong with the
@@ -788,38 +870,40 @@ describe("SdImageBuilder", () => {
     });
     stubSaveFilePicker();
     render(
-      <SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={() => Promise.resolve("FRCT_multi")} />,
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={() => Promise.resolve("FRCT_multi")}
+      />,
     );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
     nameFrame();
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
-    await screen.findByText(
-      /predates in-browser personalization/,
-      undefined,
-      { timeout: 5000 },
-    );
+    await screen.findByText(/predates in-browser personalization/, undefined, {
+      timeout: 5000,
+    });
   });
 
   it("requires a frame name before opening the save dialog", async () => {
     mockReleaseAndImage();
     stubSaveFilePicker();
     const mint = vi.fn(() => Promise.resolve("FRCT_multi"));
-    render(<SdImageBuilder cloudOrigin={window.location.origin} mintClaimToken={mint} />);
+    render(
+      <SdImageBuilder
+        cloudOrigin={window.location.origin}
+        mintClaimToken={mint}
+      />,
+    );
     await screen.findByRole("option", {
       name: "Raspberry Pi Zero 2 W / 3 / 4 (64-bit) (v1.2.3)",
     });
 
     // A board but no name: the name check is the one that must speak up.
     pickBoard();
-    fireEvent.click(
-      screen.getByRole("button", { name: /download sd image/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /download sd image/i }));
 
     await screen.findByText(/Name the frame first/);
     expect(mint).not.toHaveBeenCalled();
@@ -907,9 +991,7 @@ describe("SdImageBuilder", () => {
       });
 
       pickBoard();
-      fireEvent.click(
-        screen.getByLabelText(/Enable passwordless root login/),
-      );
+      fireEvent.click(screen.getByLabelText(/Enable passwordless root login/));
       fireEvent.click(
         screen.getByRole("button", { name: /download sd image/i }),
       );
@@ -966,7 +1048,11 @@ describe("SdImageBuilder", () => {
         <SdImageBuilder
           cloudOrigin={window.location.origin}
           mintClaimToken={() => Promise.resolve("FRCT_bound")}
-          reenrollFrame={{ ...reenrollFrame, device: "not.a.real.driver", width: 800 }}
+          reenrollFrame={{
+            ...reenrollFrame,
+            device: "not.a.real.driver",
+            width: 800,
+          }}
         />,
       );
       await screen.findByRole("option", {
@@ -975,7 +1061,9 @@ describe("SdImageBuilder", () => {
 
       // An unknown value must not silently bake itself into the image while
       // the select renders the "pick later" option.
-      expect((screen.getByLabelText("Display") as HTMLSelectElement).value).toBe("");
+      expect(
+        (screen.getByLabelText("Display") as HTMLSelectElement).value,
+      ).toBe("");
       expect(screen.queryByLabelText("Display width")).toBeNull();
     });
 
@@ -997,9 +1085,7 @@ describe("SdImageBuilder", () => {
       });
 
       pickBoard();
-      fireEvent.click(
-        screen.getByLabelText(/Enable passwordless root login/),
-      );
+      fireEvent.click(screen.getByLabelText(/Enable passwordless root login/));
       fireEvent.click(
         screen.getByRole("button", { name: /download sd image/i }),
       );

--- a/cloud/docs/backups.md
+++ b/cloud/docs/backups.md
@@ -101,7 +101,13 @@ ssh <host> rclone lsl storagebox:frameos-cloud-backups
 ```
 
 `pgbackrest info` is the health check that matters for the live layer: the
-newest backup's WAL "max" keeps advancing as segments archive.
+newest backup's WAL "max" keeps advancing as segments archive. The nightly
+job runs that check for you (status `ok`, newest base backup under
+`PGBACKREST_MAX_AGE_HOURS`, default 36 h, at least one archived WAL segment)
+after shipping its own artifacts, and fails the run — so the same
+healthchecks.io check pages — when the live layer is stuck. Each success ping
+carries `pitr_latest=<type>@<age>h wal_max=<segment>` alongside the box
+capacity.
 
 Storage Box capacity: `rclone about storagebox:` (1 TiB box). The nightly
 job also appends `box_used`/`box_free` to every success ping — the

--- a/cloud/ops/backup/backup.env.example
+++ b/cloud/ops/backup/backup.env.example
@@ -16,6 +16,12 @@ RETENTION_DAYS=30
 # and paste its ping URL here. Without it a silently dead timer stays silent.
 #HEALTHCHECKS_URL=https://hc-ping.com/00000000-0000-0000-0000-000000000000
 
+# The nightly run also checks the pgBackRest stanza (status ok, newest base
+# backup younger than this, WAL actually archived) and fails — i.e. pages on
+# the check above — when the live layer is broken. 0 disables the check.
+#PGBACKREST_STANZA=frameos
+#PGBACKREST_MAX_AGE_HOURS=36
+
 # --- object store (frameos-cloud-object-backup.service) --------------------
 # Where the blob store is copied to, and where it is copied FROM. The source
 # is an rclone remote, not the app's own S3 config; both live in

--- a/cloud/ops/backup/pg-backup.sh
+++ b/cloud/ops/backup/pg-backup.sh
@@ -36,12 +36,18 @@ set -euo pipefail
 #   RETENTION_DAYS    prune remote files older than this (default 30)
 #   HEALTHCHECKS_URL  optional hc-ping.com check URL; start/success/fail pings
 #   LOCAL_DIR         staging dir (default /var/backups/frameos-cloud)
+#   PGBACKREST_STANZA          stanza whose health gates this run (default
+#                              frameos); PGBACKREST_MAX_AGE_HOURS how old the
+#                              newest base backup may be (default 36; 0 skips
+#                              the pgBackRest check entirely)
 
 database_url="${DATABASE_URL:-postgres://frameos_cloud:frameos_cloud@localhost:5432/frameos_cloud}"
 rclone_remote="${RCLONE_REMOTE:-storagebox:frameos-cloud-backups}"
 retention_days="${RETENTION_DAYS:-30}"
 healthchecks_url="${HEALTHCHECKS_URL:-}"
 local_dir="${LOCAL_DIR:-/var/backups/frameos-cloud}"
+pgbackrest_stanza="${PGBACKREST_STANZA:-frameos}"
+pgbackrest_max_age_hours="${PGBACKREST_MAX_AGE_HOURS:-36}"
 keep_local=2
 
 ping() {
@@ -175,6 +181,70 @@ if [ -n "$about_json" ]; then
   fi
 fi
 
-summary="ok db=$(du -h "$db_file" | cut -f1) host=$(du -h "$host_file" | cut -f1) remote=$rclone_remote retention=${retention_days}d${box_summary}"
+# The pgBackRest layer (continuous WAL archiving + daily base backups, the
+# one that actually gives point-in-time recovery) has its own timers and,
+# until this check, no alarm: a broken archive-push or a stuck base backup
+# only showed up to someone running `pgbackrest info` by hand. Fold its
+# health into this run so the single healthchecks.io check covers both
+# layers — a stale or errored stanza fails the run, which pages. Checked
+# LAST so the dump and the host tarball are already shipped when it fires.
+# Skipped, loudly, where pgBackRest is not set up (a rehearsal VM, a dev box)
+# or with PGBACKREST_MAX_AGE_HOURS=0.
+pitr_summary=""
+if ! [[ "$pgbackrest_max_age_hours" =~ ^[0-9]+$ ]]; then
+  echo "PGBACKREST_MAX_AGE_HOURS must be a non-negative integer, got: ${pgbackrest_max_age_hours}" >&2
+  exit 1
+fi
+if [ "$pgbackrest_max_age_hours" -eq 0 ]; then
+  echo "pgBackRest check disabled (PGBACKREST_MAX_AGE_HOURS=0)"
+elif ! command -v pgbackrest >/dev/null 2>&1 || [ ! -e /etc/pgbackrest/pgbackrest.conf ]; then
+  echo "pgBackRest check skipped: not installed/configured on this host"
+  pitr_summary=" pitr=unconfigured"
+else
+  # Runs as postgres: that user owns the repo key and the stanza lock, and
+  # root would leave root-owned files in the spool/lock directories.
+  if ! info_json="$(runuser -u postgres -- pgbackrest --stanza="$pgbackrest_stanza" --output=json info 2>&1)"; then
+    echo "pgbackrest info failed:" >&2
+    echo "$info_json" >&2
+    exit 1
+  fi
+  pitr_summary="$(PGBACKREST_INFO_JSON="$info_json" python3 -c '
+import json, os, sys, time
+stanza_name = sys.argv[1]
+max_age_hours = int(sys.argv[2])
+try:
+    stanzas = json.loads(os.environ["PGBACKREST_INFO_JSON"])
+except ValueError as exc:
+    sys.exit("pgbackrest info did not return JSON: %s" % exc)
+stanza = next((s for s in stanzas if s.get("name") == stanza_name), None)
+if stanza is None:
+    sys.exit("stanza %r missing from pgbackrest info" % stanza_name)
+status = stanza.get("status") or {}
+if status.get("code") != 0:
+    sys.exit("stanza %s status: %s (code %s)" % (stanza_name, status.get("message"), status.get("code")))
+backups = stanza.get("backup") or []
+if not backups:
+    sys.exit("stanza %s has no base backups" % stanza_name)
+latest = max(backups, key=lambda b: (b.get("timestamp") or {}).get("stop") or 0)
+stop = (latest.get("timestamp") or {}).get("stop") or 0
+age_hours = (time.time() - stop) / 3600
+if age_hours > max_age_hours:
+    sys.exit("newest base backup (%s, %s) is %.1f h old, limit %d h — a pgbackrest timer is stuck"
+             % (latest.get("label"), latest.get("type"), age_hours, max_age_hours))
+if latest.get("error"):
+    sys.exit("newest base backup %s is flagged with an error" % latest.get("label"))
+archives = stanza.get("archive") or []
+wal_max = next((a.get("max") for a in reversed(archives) if a.get("max")), None)
+if not wal_max:
+    sys.exit("stanza %s has no archived WAL — archive_command is not reaching the repo" % stanza_name)
+print(" pitr_latest=%s@%.1fh wal_max=%s" % (latest.get("type"), age_hours, wal_max), end="")
+' "$pgbackrest_stanza" "$pgbackrest_max_age_hours")" || {
+    echo "pgBackRest health check failed (reason above) — the dump and host tarball were still shipped." >&2
+    exit 1
+  }
+  echo "pgBackRest ok:${pitr_summary}"
+fi
+
+summary="ok db=$(du -h "$db_file" | cut -f1) host=$(du -h "$host_file" | cut -f1) remote=$rclone_remote retention=${retention_days}d${box_summary}${pitr_summary}"
 echo "Backup complete: $summary"
 ping "" "$summary"

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -249,6 +249,15 @@ pushes, report state. Telemetry is opt-in per scope, exactly as reserved in
 
 Scope changes use the existing `/api/backends/scopes` mechanism (additions
 need owner approval on the provider's device screen; removals are immediate).
+A claim-token enrollment grants all four up front (since 2026-08-03); links
+made before that carry `frame:managed` only and are **never backfilled** —
+adding a scope the owner did not approve is the silent escalation the flow
+refuses. The owner instead flips two per-frame switches in the frame's
+Settings panel (`service-settings/enabled`, `telemetry/enabled` below), which
+grant or remove the scope on the link itself. Scopes are read once per
+WebSocket session, so the telemetry switch also queues a `restart_runtime`
+for an active frame; until the device reconnects, a frame without
+`telemetry:logs` shows an empty Logs panel that names the switch.
 
 ## The management WebSocket
 
@@ -881,6 +890,7 @@ GET  {provider}/api/frames/{id}/commands       # what is still QUEUED for this f
 DELETE {provider}/api/frames/{id}/commands/{command_id}  # cancel one, while it is still undelivered
 GET  {provider}/api/frames/{id}/service-settings          # DEVICE-authed, not session: see "Service settings"
 POST {provider}/api/frames/{id}/service-settings/enabled  # {"enabled": bool} → grants/revokes settings:services, nudges on enable
+POST {provider}/api/frames/{id}/telemetry/enabled         # {"enabled": bool} → grants/revokes telemetry:logs + telemetry:metrics, restart_runtime on change
 WS   {provider}/api/frames/{id}/updates        # browser socket: update_frame / new_log / new_metrics / frame_activity events
 WS   {provider}/api/frames/updates             # browser socket, all the account's frames (fleet view)
 ```

--- a/docs/manual-testing-todo.md
+++ b/docs/manual-testing-todo.md
@@ -43,6 +43,17 @@ flow (changes first-boot behavior for every new user).
   it, watch the frame appear **active with no Confirm step** in the cloud
   workspace (single-use card born active; a multi-use card's first boot is
   active, later cards pending).
+- [ ] **First-boot cloud enrollment on a router that strips DNSSEC (PR #384):**
+  2026-08-20 a Pi 5 card booted, joined WiFi, then every lookup failed with
+  `systemd-resolved: DNSSEC validation failed ... no-signature`; the 30 s
+  network check expired, the setup hotspot took over and the frame never
+  enrolled. Fixes: `DNSSEC=no` drop-in on the image, 90 s check window, and
+  the cloud-chosen display is now applied by `frameos set-display` (the
+  python3 patcher never ran — Buildroot ships no python3; the log said
+  `could not apply display device 'http.upload'`). Re-flash from `main`,
+  boot behind the GL-BE3600, confirm: enrolled within ~1 min, no hotspot,
+  `frame.json` carries the chosen device, postboot log shows
+  `Applied display device`.
 - [ ] **Panel link code (#379):** boot an unclaimed frame in cloud mode with
   no claim code → the panel renders the link code + QR → complete the claim
   from an account, and confirm the code retires once connected.

--- a/frameos/src/frameos.nim
+++ b/frameos/src/frameos.nim
@@ -10,6 +10,7 @@ from ./frameos/frameos import startFrameOS, describeFatalStartupError, fatalStar
 from ./frameos/setup import setupFrameOS, setupFrameOSDrivers, scheduleSetupRebootIfRequired,
   startFrameOSSystemdServices, writeSetupReleasePayload
 from ./frameos/upgrade import runFrameOSUpgrade, parseFrameOSUpgradeOptions
+from ./frameos/display_patch import runSetDisplay
 from ./frameos/version import compiledFrameOSVersion
 
 proc printHelp() =
@@ -24,6 +25,10 @@ proc printHelp() =
   echo "  driver-setup"
   echo "          Run display driver setup for the current frame.json"
   echo "          --reboot-if-required to let setup reboot after changes that require it"
+  echo "  set-display"
+  echo "          Patch the display device (and optional size/rotation/vcom/upload URL) into frame.json"
+  echo "          --device=<key> [--frame-json=PATH] [--width=N] [--height=N] [--rotate=0|90|180|270]"
+  echo "          [--vcom=F] [--upload-url=URL]; run driver-setup afterwards"
   echo "  upgrade Upgrade this installed frame to the latest GitHub release"
   echo "          --dry-run to validate and print the upgrade plan without changing files"
   echo "          --no-reboot to stop after staging when the new release needs a reboot"
@@ -83,6 +88,8 @@ when isMainModule:
           quit(0)
         quit(2)
       quit(0)
+    elif args.len > 0 and args[0] == "set-display":
+      quit(runSetDisplay(if args.len > 1: args[1 .. ^1] else: @[]))
     elif args.len > 0 and args[0] == "upgrade":
       let upgradeArgs = if args.len > 1: args[1 .. ^1] else: @[]
       quit(runFrameOSUpgrade(parseFrameOSUpgradeOptions(upgradeArgs)))

--- a/frameos/src/frameos/display_patch.nim
+++ b/frameos/src/frameos/display_patch.nim
@@ -1,0 +1,104 @@
+## `frameos set-display`: patch the display fields of a frame.json in place.
+##
+## Used by the first-boot script on SD images to apply the display the user
+## picked in the cloud SD builder (`device=` in /boot/frameos-cloud.txt).
+## Buildroot images ship neither python3 nor jq, so the binary has to do the
+## JSON edit itself — it already loads the same file at startup.
+##
+## Only the keys given are touched; everything else in frame.json survives
+## byte-for-byte at the JSON level. Invalid numbers fail before anything is
+## written, so a bad value can never leave a half-patched file behind.
+
+import std/[json, os, strutils]
+
+type
+  DisplayPatch* = object
+    frameJsonPath*: string
+    device*: string
+    width*: string
+    height*: string
+    rotate*: string
+    vcom*: string
+    uploadUrl*: string
+
+const setDisplayUsage* = "FrameOS set-display --device=<key> [--frame-json=PATH] " &
+  "[--width=N] [--height=N] [--rotate=0|90|180|270] [--vcom=F] [--upload-url=URL]"
+
+proc parseSetDisplayArgs*(args: seq[string]): DisplayPatch =
+  result.frameJsonPath = "frame.json"
+  for arg in args:
+    let eq = arg.find('=')
+    if not arg.startsWith("--") or eq < 0:
+      raise newException(ValueError, "FrameOS set-display: unexpected argument '" & arg & "'\n" & setDisplayUsage)
+    let key = arg[2 ..< eq]
+    let value = arg[eq + 1 .. ^1]
+    case key
+    of "frame-json": result.frameJsonPath = value
+    of "device": result.device = value
+    of "width": result.width = value
+    of "height": result.height = value
+    of "rotate": result.rotate = value
+    of "vcom": result.vcom = value
+    of "upload-url": result.uploadUrl = value
+    else:
+      raise newException(ValueError, "FrameOS set-display: unknown option '--" & key & "'\n" & setDisplayUsage)
+  if result.device.len == 0:
+    raise newException(ValueError, "FrameOS set-display: --device is required\n" & setDisplayUsage)
+
+proc parseIntOr(raw, name: string): int =
+  try:
+    result = parseInt(raw.strip())
+  except ValueError:
+    raise newException(ValueError, "FrameOS set-display: invalid " & name & ": " & raw)
+
+proc applyDisplayPatch*(data: JsonNode, patch: DisplayPatch) =
+  ## Mutates `data` (a parsed frame.json). Validates every value first so a
+  ## bad one raises before any key is changed.
+  var width, height, rotate = -1
+  var vcom = 0.0
+  if patch.width.len > 0:
+    width = parseIntOr(patch.width, "width")
+    if width <= 0: raise newException(ValueError, "FrameOS set-display: invalid width: " & patch.width)
+  if patch.height.len > 0:
+    height = parseIntOr(patch.height, "height")
+    if height <= 0: raise newException(ValueError, "FrameOS set-display: invalid height: " & patch.height)
+  if patch.rotate.len > 0:
+    rotate = parseIntOr(patch.rotate, "rotate")
+    if rotate notin [0, 90, 180, 270]:
+      raise newException(ValueError, "FrameOS set-display: invalid rotate: " & patch.rotate)
+  if patch.vcom.len > 0:
+    try:
+      vcom = parseFloat(patch.vcom.strip())
+    except ValueError:
+      raise newException(ValueError, "FrameOS set-display: invalid vcom: " & patch.vcom)
+
+  data["device"] = %patch.device
+  if width > 0: data["width"] = %width
+  if height > 0: data["height"] = %height
+  if rotate >= 0: data["rotate"] = %rotate
+  var config = data{"deviceConfig"}
+  if config == nil or config.kind != JObject:
+    config = newJObject()
+  if patch.vcom.len > 0: config["vcom"] = %vcom
+  # config.nim renames uploadUrl → httpUploadUrl on load; write the canonical
+  # name so the file matches what the runtime logs at bootup.
+  if patch.uploadUrl.len > 0: config["httpUploadUrl"] = %patch.uploadUrl
+  data["deviceConfig"] = config
+
+proc runSetDisplay*(args: seq[string]): int =
+  ## Entry point for the CLI. Returns the process exit code; errors go to
+  ## stderr so the first-boot log shows why a patch was refused.
+  let patch = parseSetDisplayArgs(args)
+  if not fileExists(patch.frameJsonPath):
+    stderr.writeLine("FrameOS set-display: " & patch.frameJsonPath & " not found")
+    return 1
+  let data = parseJson(readFile(patch.frameJsonPath))
+  if data.kind != JObject:
+    stderr.writeLine("FrameOS set-display: " & patch.frameJsonPath & " is not a JSON object")
+    return 1
+  applyDisplayPatch(data, patch)
+  let tmp = patch.frameJsonPath & ".set-display-tmp"
+  writeFile(tmp, data.pretty() & "\n")
+  moveFile(tmp, patch.frameJsonPath)
+  echo "FrameOS set-display: applied device '" & patch.device & "' to " & patch.frameJsonPath
+  return 0

--- a/frameos/src/frameos/tests/test_display_patch.nim
+++ b/frameos/src/frameos/tests/test_display_patch.nim
@@ -1,0 +1,54 @@
+import std/[json, os, unittest]
+import frameos/display_patch
+
+suite "set-display":
+  test "parses args and requires --device":
+    let p = parseSetDisplayArgs(@["--device=http.upload", "--width=800", "--upload-url=https://x/y", "--frame-json=/tmp/f.json"])
+    check p.device == "http.upload"
+    check p.width == "800"
+    check p.uploadUrl == "https://x/y"
+    check p.frameJsonPath == "/tmp/f.json"
+    expect ValueError: discard parseSetDisplayArgs(@["--width=800"])
+    expect ValueError: discard parseSetDisplayArgs(@["--device=x", "--bogus=1"])
+    expect ValueError: discard parseSetDisplayArgs(@["--device=x", "oops"])
+
+  test "patches only the given keys and keeps the rest":
+    var data = %*{"name": "Kitchen", "device": "framebuffer", "width": 100, "height": 50,
+                  "deviceConfig": {"pins": {"cs": 8}}, "rotate": 90}
+    applyDisplayPatch(data, DisplayPatch(device: "waveshare.EPD_10in3", width: "1872", vcom: "-1.48"))
+    check data["device"].getStr == "waveshare.EPD_10in3"
+    check data["width"].getInt == 1872
+    check data["height"].getInt == 50
+    check data["rotate"].getInt == 90
+    check data["name"].getStr == "Kitchen"
+    check data["deviceConfig"]["pins"]["cs"].getInt == 8
+    check data["deviceConfig"]["vcom"].getFloat == -1.48
+
+  test "upload url lands under the canonical httpUploadUrl key":
+    var data = %*{"device": "framebuffer"}
+    applyDisplayPatch(data, DisplayPatch(device: "http.upload", uploadUrl: "https://example.com/up", rotate: "0"))
+    check data["deviceConfig"]["httpUploadUrl"].getStr == "https://example.com/up"
+    check data["rotate"].getInt == 0
+
+  test "rejects bad numbers before touching anything":
+    var data = %*{"device": "framebuffer", "width": 100}
+    expect ValueError: applyDisplayPatch(data, DisplayPatch(device: "x", width: "abc"))
+    expect ValueError: applyDisplayPatch(data, DisplayPatch(device: "x", rotate: "45"))
+    expect ValueError: applyDisplayPatch(data, DisplayPatch(device: "x", height: "0"))
+    expect ValueError: applyDisplayPatch(data, DisplayPatch(device: "x", vcom: "minus"))
+    check data["device"].getStr == "framebuffer"
+    check data["width"].getInt == 100
+
+  test "runSetDisplay rewrites the file atomically":
+    let dir = getTempDir() / "frameos-set-display-test"
+    createDir(dir)
+    let path = dir / "frame.json"
+    writeFile(path, """{"device": "framebuffer", "scenes": [1, 2]}""")
+    check runSetDisplay(@["--device=http.upload", "--frame-json=" & path, "--width=800", "--height=480"]) == 0
+    let data = parseJson(readFile(path))
+    check data["device"].getStr == "http.upload"
+    check data["width"].getInt == 800
+    check data["scenes"].len == 2
+    check not fileExists(path & ".set-display-tmp")
+    check runSetDisplay(@["--device=x", "--frame-json=" & dir / "missing.json"]) == 1
+    removeDir(dir)

--- a/frontend/src/scenes/frame/panels/Assets/assetPaths.ts
+++ b/frontend/src/scenes/frame/panels/Assets/assetPaths.ts
@@ -1,0 +1,105 @@
+export interface AssetPathEntry {
+  path: string
+}
+
+export function normalizeAssetsPath(assetsPath?: string): string {
+  let normalizedPath = (assetsPath || '/srv/assets').replace(/\/+$/, '') || '/srv/assets'
+  while (normalizedPath.startsWith('./')) {
+    normalizedPath = normalizedPath.slice(2)
+  }
+  return normalizedPath || '.'
+}
+
+/**
+ * Paths the backend speaks: absolute under the frame's assets directory
+ * ("/srv/assets/photos/a.jpg"). Anything relative is anchored there.
+ */
+export function normalizeAssetPath(path: string, assetsPath?: string): string {
+  const rawAssetsPath = (assetsPath || '/srv/assets').replace(/\/+$/, '') || '/srv/assets'
+  const normalizedAssetsPath = normalizeAssetsPath(assetsPath)
+  if (!path) {
+    return normalizedAssetsPath
+  }
+  if (
+    path === rawAssetsPath ||
+    path.startsWith(`${rawAssetsPath}/`) ||
+    path === normalizedAssetsPath ||
+    path.startsWith(`${normalizedAssetsPath}/`)
+  ) {
+    return path
+  }
+  if (path.startsWith('/')) {
+    return path
+  }
+  const normalizedPath = path.replace(/^\.\/+/, '').replace(/^\/+/, '')
+  return normalizedPath ? `${normalizedAssetsPath}/${normalizedPath}` : normalizedAssetsPath
+}
+
+/**
+ * One key for every spelling of the same asset. The listing can hold either
+ * absolute backend paths ("/srv/assets/photos/a.jpg") or the relative paths
+ * the cloud hub caches from the device ("photos/a.jpg", "./photos/a.jpg");
+ * both collapse to "photos/a.jpg". The root itself is "".
+ */
+export function assetPathKey(path: string, assetsPath?: string): string {
+  const rawAssetsPath = (assetsPath || '/srv/assets').replace(/\/+$/, '') || '/srv/assets'
+  const normalizedAssetsPath = normalizeAssetsPath(assetsPath)
+  let key = path
+  for (const prefix of [rawAssetsPath, normalizedAssetsPath]) {
+    if (key === prefix) {
+      return ''
+    }
+    if (key.startsWith(`${prefix}/`)) {
+      key = key.slice(prefix.length + 1)
+      break
+    }
+  }
+  key = key
+    .replace(/^(\.\/+)+/, '')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+  return key === '.' ? '' : key
+}
+
+function isUnderKey(key: string, parentKey: string): boolean {
+  return key === parentKey || key.startsWith(`${parentKey}/`)
+}
+
+/** Drop the deleted entry and everything below it, whatever spelling the listing uses. */
+export function withoutDeletedAsset<T extends AssetPathEntry>(assets: T[], path: string, assetsPath?: string): T[] {
+  const deletedKey = assetPathKey(path, assetsPath)
+  if (!deletedKey) {
+    return assets
+  }
+  return assets.filter((asset) => !isUnderKey(assetPathKey(asset.path, assetsPath), deletedKey))
+}
+
+/**
+ * Move the renamed entry (and its subtree) to the new path, keeping each
+ * row's own spelling: absolute rows stay absolute, relative rows stay relative.
+ */
+export function withRenamedAsset<T extends AssetPathEntry>(
+  assets: T[],
+  oldPath: string,
+  newPath: string,
+  assetsPath?: string
+): T[] {
+  const oldKey = assetPathKey(oldPath, assetsPath)
+  const newKey = assetPathKey(newPath, assetsPath)
+  if (!oldKey || !newKey) {
+    return assets
+  }
+  return assets.map((asset) => {
+    const key = assetPathKey(asset.path, assetsPath)
+    if (!isUnderKey(key, oldKey)) {
+      return asset
+    }
+    const movedKey = `${newKey}${key.slice(oldKey.length)}`
+    const movedPath = asset.path.startsWith('/')
+      ? normalizeAssetPath(movedKey, assetsPath)
+      : asset.path.startsWith('./')
+      ? `./${movedKey}`
+      : movedKey
+    return { ...asset, path: movedPath }
+  })
+}

--- a/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
+++ b/frontend/src/scenes/frame/panels/Assets/assetsLogic.ts
@@ -16,6 +16,7 @@ import { uploadFormDataWithProgress } from '../../../../utils/uploadFormDataWith
 import { longRunningTasksModel } from '../../../../models/longRunningTasksModel'
 import { isHiddenOrJunkAssetPath } from '../../../../utils/hiddenFiles'
 import { consumeFontSyncStream, isFontSyncStream } from '../../../../utils/fontSyncStream'
+import { normalizeAssetPath, normalizeAssetsPath, withRenamedAsset, withoutDeletedAsset } from './assetPaths'
 
 export interface AssetsLogicProps {
   frameId: FrameId
@@ -214,35 +215,6 @@ function latestDiskStats(metrics: MetricsType[]): DiskStats | null {
   return null
 }
 
-function normalizeAssetsPath(assetsPath?: string): string {
-  let normalizedPath = (assetsPath || '/srv/assets').replace(/\/+$/, '') || '/srv/assets'
-  while (normalizedPath.startsWith('./')) {
-    normalizedPath = normalizedPath.slice(2)
-  }
-  return normalizedPath || '.'
-}
-
-function normalizeAssetPath(path: string, assetsPath?: string): string {
-  const rawAssetsPath = (assetsPath || '/srv/assets').replace(/\/+$/, '') || '/srv/assets'
-  const normalizedAssetsPath = normalizeAssetsPath(assetsPath)
-  if (!path) {
-    return normalizedAssetsPath
-  }
-  if (
-    path === rawAssetsPath ||
-    path.startsWith(`${rawAssetsPath}/`) ||
-    path === normalizedAssetsPath ||
-    path.startsWith(`${normalizedAssetsPath}/`)
-  ) {
-    return path
-  }
-  if (path.startsWith('/')) {
-    return path
-  }
-  const normalizedPath = path.replace(/^\.\/+/, '').replace(/^\/+/, '')
-  return normalizedPath ? `${normalizedAssetsPath}/${normalizedPath}` : normalizedAssetsPath
-}
-
 async function responseErrorMessage(response: Response, fallback: string): Promise<string> {
   try {
     const text = await response.text()
@@ -287,9 +259,9 @@ export const assetsLogic = kea<assetsLogicType>([
     setStorageMounted: (storageMounted: boolean | null) => ({ storageMounted }),
     syncAssets: true,
     deleteAsset: (path: string) => ({ path }),
-    assetDeleted: (path: string) => ({ path }),
+    assetDeleted: (path: string, assetsPath?: string) => ({ path, assetsPath }),
     renameAsset: (oldPath: string, newPath: string) => ({ oldPath, newPath }),
-    assetRenamed: (oldPath: string, newPath: string) => ({ oldPath, newPath }),
+    assetRenamed: (oldPath: string, newPath: string, assetsPath?: string) => ({ oldPath, newPath, assetsPath }),
     createFolder: (path: string) => ({ path }),
     toggleShowSystemFolders: true,
     toggleShowHiddenFiles: true,
@@ -493,16 +465,11 @@ export const assetsLogic = kea<assetsLogicType>([
       },
       uploadFailure: (state, { path }) =>
         state.map((asset) => (asset.path === path ? { ...asset, size: -2, mtime: -2 } : asset)),
-      assetDeleted: (state, { path }) => state.filter((a) => a.path !== path && !a.path.startsWith(`${path}/`)),
-      assetRenamed: (state, { oldPath, newPath }) => {
-        return state.map((a) =>
-          a.path === oldPath
-            ? { ...a, path: newPath }
-            : a.path.startsWith(`${oldPath}/`)
-            ? { ...a, path: `${newPath}${a.path.slice(oldPath.length)}` }
-            : a
-        )
-      },
+      // The listing's spelling depends on who produced it: the backend lists
+      // absolute paths, the cloud hub caches the device's relative ones. Match
+      // by canonical key so a delete/rename lands on the row either way.
+      assetDeleted: (state, { path, assetsPath }) => withoutDeletedAsset(state, path, assetsPath),
+      assetRenamed: (state, { oldPath, newPath, assetsPath }) => withRenamedAsset(state, oldPath, newPath, assetsPath),
     },
   }),
   selectors({
@@ -744,7 +711,7 @@ export const assetsLogic = kea<assetsLogicType>([
         if (!response.ok) {
           throw new Error('Failed to delete asset')
         }
-        actions.assetDeleted(normalizeAssetPath(path, values.frame.assets_path))
+        actions.assetDeleted(path, values.frame.assets_path)
       } catch (error) {
         console.error(error)
       }
@@ -758,10 +725,7 @@ export const assetsLogic = kea<assetsLogicType>([
         if (!response.ok) {
           throw new Error('Failed to rename asset')
         }
-        actions.assetRenamed(
-          normalizeAssetPath(oldPath, values.frame.assets_path),
-          normalizeAssetPath(newPath, values.frame.assets_path)
-        )
+        actions.assetRenamed(oldPath, newPath, values.frame.assets_path)
       } catch (error) {
         console.error(error)
       }

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -49,6 +49,7 @@ import {
   extendedCloudFrameSettingsMinVersion,
   hardwareCloudFrameSettingsMinVersion,
   setCloudFrameServiceSettingsEnabled,
+  setCloudFrameTelemetryEnabled,
 } from '../../../../utils/cloudFrameApi'
 import { appsLogic } from '../Apps/appsLogic'
 import { frameSettingsLogic } from './frameSettingsLogic'
@@ -419,6 +420,62 @@ function CloudServiceSettingsSection(): JSX.Element {
                 })}
               </div>
             )}
+          </div>
+        </Field>
+      </div>
+    </>
+  )
+}
+
+/**
+ * Cloud-managed frames only: whether the device ships its logs and metrics to
+ * the cloud at all. The owner's per-frame grant of `telemetry:logs` +
+ * `telemetry:metrics`; frames enrolled before 2026-08-03 never received it
+ * and sit with an empty Logs panel that nothing explains — this is the
+ * switch that explains it. Scopes are pinned per connection, so the cloud
+ * restarts the runtime on every change; the panel says so.
+ */
+function CloudTelemetrySection(): JSX.Element | null {
+  const { frameId, frame } = useValues(frameLogic)
+  const { loadFrame } = useActions(framesModel)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Absent = the row we hold came from a broadcast without the link; do not
+  // draw a switch in an unknown position.
+  if (typeof frame?.telemetry_enabled !== 'boolean') {
+    return null
+  }
+  const enabled = frame.telemetry_enabled
+
+  const toggle = async (next: boolean): Promise<void> => {
+    setSaving(true)
+    setError(null)
+    try {
+      await setCloudFrameTelemetryEnabled(frameId, next)
+      loadFrame(frameId)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <H6 id="frame-settings-telemetry" className="mt-2">
+        Logs and metrics
+      </H6>
+      <div className="pl-2 @md:pl-8 space-y-3">
+        <Field name="_noop" label="Ship logs and metrics to the cloud">
+          <div className="w-full space-y-1">
+            <Switch value={enabled} onChange={toggle} disabled={saving} label={enabled ? 'Enabled' : 'Disabled'} />
+            <div className="frameos-muted text-xs">
+              {enabled
+                ? 'The Logs and Metrics panels fill from the device. Changing this restarts FrameOS on the frame.'
+                : 'The Logs and Metrics panels stay empty. Frames set up before August 2026 start out here; enabling restarts FrameOS on the frame.'}
+            </div>
+            {error ? <div className="text-red-300 text-xs">{error}</div> : null}
           </div>
         </Field>
       </div>
@@ -2259,6 +2316,7 @@ export function FrameSettings({
             asking for an API key" is answered here, not in the account-wide
             secrets page. */}
         {hideForCloud ? <CloudServiceSettingsSection /> : null}
+        {hideForCloud ? <CloudTelemetrySection /> : null}
         {!cloudProfile && showFrameInfo ? (
           <>
             <div className="frame-settings-heading-row mt-2 flex items-center justify-between gap-3">

--- a/frontend/src/scenes/frame/panels/Logs/Logs.tsx
+++ b/frontend/src/scenes/frame/panels/Logs/Logs.tsx
@@ -813,7 +813,19 @@ export function Logs({ fullScreen = false, compact = false, className }: LogsPro
                 renderTheme === 'dark' ? 'text-gray-400' : 'text-slate-500'
               )}
             >
-              {searchActive ? 'No matching logs' : 'No logs yet'}
+              {searchActive ? (
+                'No matching logs'
+              ) : frame?.telemetry_enabled === false ? (
+                // A cloud frame whose link was never granted telemetry (every
+                // enrollment before 2026-08-03) ships nothing, silently. Name
+                // the cause and point at the switch instead of "No logs yet".
+                <span className="text-center px-4">
+                  Log shipping is off for this frame — turn on “Ship logs and metrics to the cloud” under Settings →
+                  Logs and metrics.
+                </span>
+              ) : (
+                'No logs yet'
+              )}
             </div>
           ),
         }}

--- a/frontend/src/scenes/frame/panels/Metrics/Metrics.tsx
+++ b/frontend/src/scenes/frame/panels/Metrics/Metrics.tsx
@@ -13,7 +13,8 @@ import { BrushChart } from './BrushChart'
 import { Select } from '../../../../components/Select'
 import { workspaceLogic } from '../../../workspace/workspaceLogic'
 import { metricChartThemes, themeMetricSeries } from './chartTheme'
-import { BoltIcon } from '@heroicons/react/24/outline'
+import { BoltIcon, InformationCircleIcon } from '@heroicons/react/24/outline'
+import { Tooltip } from '../../../../components/Tooltip'
 
 const metricLabels: Record<string, string> = {
   load: 'Load',
@@ -27,6 +28,26 @@ const metricLabels: Record<string, string> = {
   cpuCount: 'CPU count',
   'runtime.sequence': 'Render sequence index (keeps incrementing)',
   'runtime.lastCompletedAgoMs': 'Seconds since last render',
+  wifiRssi: 'WiFi signal (RSSI)',
+}
+
+// Shown behind an (i) next to the card title; the number alone reads as
+// "negative, therefore bad" to anyone who has not met dBm before.
+const metricHelp: Record<string, JSX.Element> = {
+  wifiRssi: (
+    <div className="space-y-1">
+      <div>
+        WiFi signal strength (RSSI) in dBm, as measured by the frame. The values are negative: closer to 0 is stronger.
+      </div>
+      <ul className="list-disc pl-4">
+        <li>−30 to −50: excellent</li>
+        <li>−50 to −67: good, fine for anything a frame does</li>
+        <li>−67 to −75: fair, occasional slow pushes</li>
+        <li>−75 to −85: weak, expect drops and reconnects</li>
+        <li>below −85: unusable — move the frame or the router</li>
+      </ul>
+    </div>
+  ),
 }
 
 const latestDatapointFormatter = new Intl.DateTimeFormat(undefined, {
@@ -83,7 +104,7 @@ export function Metrics({ scrollContainer = true }: MetricsProps = {}) {
   return (
     <div
       className={clsx(
-        'frame-tool-panel relative select-none',
+        'frame-tool-panel relative',
         scrollContainer ? 'h-full overflow-y-auto pr-2' : 'overflow-visible'
       )}
     >
@@ -141,6 +162,15 @@ export function Metrics({ scrollContainer = true }: MetricsProps = {}) {
             <div key={key} className="frame-tool-card mb-3 overflow-hidden rounded-[22px]">
               <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3 text-sm">
                 <strong className="frame-tool-heading">{metricLabels[key] ?? key}</strong>
+                {metricHelp[key] ? (
+                  <Tooltip
+                    title={metricHelp[key]}
+                    className="frame-tool-muted"
+                    titleClassName="w-72 text-xs leading-snug"
+                  >
+                    <InformationCircleIcon className="h-4 w-4" aria-label={`About ${metricLabels[key] ?? key}`} />
+                  </Tooltip>
+                ) : null}
                 {latestMetricSummariesByCategory[key] ? (
                   <span className="frame-tool-muted">{latestMetricSummariesByCategory[key]}</span>
                 ) : null}
@@ -168,7 +198,9 @@ export function Metrics({ scrollContainer = true }: MetricsProps = {}) {
               </div>
               <div
                 className={clsx(
-                  'h-[200px] p-0',
+                  // select-none here only: dragging the brush must not select
+                  // text, but the card titles above stay copyable.
+                  'h-[200px] select-none p-0',
                   theme === 'dark' ? 'bg-[#18181b] text-white' : 'bg-white/70 text-slate-900'
                 )}
               >

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -2542,19 +2542,82 @@ function CloudOtaDeployView({
 
   return (
     <>
+      {/* Order: the action the user came for (firmware) sits where the
+          "Over the air" button was, then scenes & settings, then logs. */}
       <section className="space-y-2">
         <DrawerHeading>
           <span className="inline-flex items-center gap-2">
             <BackToDeployButton onClick={onBack} />
-            <span>Over the air</span>
+            <span>Firmware</span>
           </span>
         </DrawerHeading>
         <div className="frame-tool-card space-y-3 rounded-[22px] p-4">
+          {canUpdateFirmware ? (
+            <>
+              <div className="frame-tool-muted text-sm leading-5">
+                Queues an update notification for the frame (valid for 24 hours). When the frame picks it up, it
+                downloads the latest released image from the cloud, verifies the signature on the device itself,
+                installs it into the spare OTA slot and reboots. Progress shows up in Logs as <code>ota:cloud</code>{' '}
+                lines.
+              </div>
+              {upToDate ? (
+                <div className="frame-tool-muted text-xs leading-4">
+                  The device already runs the latest release ({releaseInfo.release}); asking it to update is a no-op.
+                </div>
+              ) : null}
+              <button
+                type="button"
+                title={
+                  firmwareDisabledReason ??
+                  (alsoPushScenes
+                    ? 'Queue a firmware update and resend this frame’s scenes & settings'
+                    : 'Queue a firmware update notification')
+                }
+                disabled={Boolean(firmwareDisabledReason)}
+                onClick={() => {
+                  if (alsoPushScenes && !scenesInSync) {
+                    // Scenes first: the OTA reboot redelivers a queued push
+                    // when the frame reconnects.
+                    saveAndDeployFrame()
+                  }
+                  updateFrameFirmware(frame.id)
+                }}
+                // Primary while the device is behind the published release —
+                // an available upgrade is the thing to do on this screen.
+                className={clsx(
+                  upToDate ? 'frameos-secondary-button' : 'frameos-primary-action',
+                  'inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40'
+                )}
+              >
+                <CloudArrowDownIcon className="h-4 w-4" />
+                {/* Constant label: the checkbox below says whether scenes ride
+                    along, so a button that renamed itself to "Update
+                    everything" only made the two disagree about what it does. */}
+                Upgrade firmware
+              </button>
+              <Checkbox label="Resend scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
+              {alsoPushScenes && scenesInSync ? (
+                <div className="frame-tool-muted text-xs leading-4">
+                  Scenes &amp; settings are already in sync — nothing extra is sent.
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className="frame-tool-muted text-sm leading-5">
+              {firmwareDisabledReason ?? 'Firmware updates are not available for this frame.'}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <CloudScenesPushCard frame={frame} onPushed={onPushed} />
+
+      <section className="space-y-2">
+        <DrawerHeading>Logs</DrawerHeading>
+        <div className="frame-tool-card space-y-3 rounded-[22px] p-4">
           <div className="frame-tool-muted text-sm leading-5">
-            The frame keeps an outbound connection open to your cloud account — the cloud never connects in to it.
-            Everything you deploy here is saved to the account first, then delivered over that connection: immediately
-            while the frame is online, otherwise queued until it next reconnects. The frame confirms every push, which
-            is what the sync state above reflects.
+            Pushes are saved to your account first and delivered over the frame&apos;s own connection — at once while it
+            is online, otherwise when it next reconnects. The frame confirms each one.
           </div>
           <button
             type="button"
@@ -2566,64 +2629,6 @@ function CloudOtaDeployView({
           </button>
         </div>
       </section>
-
-      <CloudScenesPushCard frame={frame} onPushed={onPushed} />
-
-      {canUpdateFirmware ? (
-        <section className="space-y-2">
-          <DrawerHeading>Firmware</DrawerHeading>
-          <div className="frame-tool-card space-y-3 rounded-[22px] p-4">
-            <div className="frame-tool-muted text-sm leading-5">
-              Queues an update notification for the frame (it stays valid for 24 hours). When the frame picks it up, it
-              downloads the latest released image from the cloud, verifies the signature on the device itself, installs
-              it into the spare OTA slot and reboots. Progress shows up in Logs as <code>ota:cloud</code> lines.
-            </div>
-            {upToDate ? (
-              <div className="frame-tool-muted text-xs leading-4">
-                The device already runs the latest release ({releaseInfo.release}); asking it to update is a no-op.
-              </div>
-            ) : null}
-            <Checkbox label="Also push scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
-            {alsoPushScenes && scenesInSync ? (
-              <div className="frame-tool-muted text-xs leading-4">
-                Scenes &amp; settings are already in sync — nothing extra is sent.
-              </div>
-            ) : null}
-            <button
-              type="button"
-              title={
-                firmwareDisabledReason ??
-                (alsoPushScenes
-                  ? 'Queue a firmware update and push this frame’s scenes & settings'
-                  : 'Queue a firmware update notification')
-              }
-              disabled={Boolean(firmwareDisabledReason)}
-              onClick={() => {
-                if (alsoPushScenes && !scenesInSync) {
-                  // Scenes first: the OTA reboot redelivers a queued push
-                  // when the frame reconnects.
-                  saveAndDeployFrame()
-                }
-                updateFrameFirmware(frame.id)
-              }}
-              // Primary while the device is behind the published release —
-              // an available upgrade is the thing to do on this screen, and a
-              // secondary button next to a primary "push scenes" one read as
-              // the lesser action even when the version row said otherwise.
-              className={clsx(
-                upToDate ? 'frameos-secondary-button' : 'frameos-primary-action',
-                'inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40'
-              )}
-            >
-              <CloudArrowDownIcon className="h-4 w-4" />
-              {/* Constant label: the checkbox above says whether scenes ride
-                  along, so a button that renamed itself to "Update
-                  everything" only made the two disagree about what it does. */}
-              Upgrade firmware
-            </button>
-          </div>
-        </section>
-      ) : null}
     </>
   )
 }
@@ -2990,7 +2995,7 @@ function CloudPiUpdateCard({
             The device already runs the latest release ({releaseInfo.release}); asking it to update is a no-op.
           </div>
         ) : null}
-        <Checkbox label="Also push scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
+        <Checkbox label="Resend scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
         {alsoPushScenes && scenesInSync ? (
           <div className="frame-tool-muted text-xs leading-4">
             Scenes &amp; settings are already in sync — nothing extra is sent.

--- a/frontend/src/scenes/workspace/FrameosShell.tsx
+++ b/frontend/src/scenes/workspace/FrameosShell.tsx
@@ -505,35 +505,38 @@ export function FrameosShell({
             secondarySidebarOpen ? 'border-r border-slate-200/80' : 'max-lg:border-r max-lg:border-slate-200/80'
           )}
         >
-          <a
-            href={homeHref}
-            title={inFrameAdminMode ? 'Frame' : 'Frames home'}
-            onPointerEnter={preloadHome}
-            onFocus={preloadHome}
-            onMouseDown={preloadHome}
-            onClick={(event: MouseEvent<HTMLAnchorElement>) => {
-              if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
-                return
-              }
-              event.preventDefault()
-              if (inFrameAdminMode) {
+          {/* The cloud header already shows the FrameOS Cloud logo; the rail one would duplicate it. */}
+          {!isCloudMode() ? (
+            <a
+              href={homeHref}
+              title={inFrameAdminMode ? 'Frame' : 'Frames home'}
+              onPointerEnter={preloadHome}
+              onFocus={preloadHome}
+              onMouseDown={preloadHome}
+              onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+                if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                  return
+                }
+                event.preventDefault()
+                if (inFrameAdminMode) {
+                  prepareFirstLevelNavigation()
+                  router.actions.push(homeHref)
+                  return
+                }
+                requestNextFramesHomeScrollTop()
                 prepareFirstLevelNavigation()
-                router.actions.push(homeHref)
-                return
-              }
-              requestNextFramesHomeScrollTop()
-              prepareFirstLevelNavigation()
-              if (mode === 'frames') {
-                scrollFramesHomeToTop('smooth', false)
-              } else {
-                router.actions.push(homeHref)
-                scrollFramesHomeToTop()
-              }
-            }}
-            className="workspace-logo-button frameos-icon-button mb-8 flex h-12 w-12 items-center justify-center rounded-xl transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-          >
-            <FrameosLogo variant={theme === 'dark' ? 'white-colors' : 'color'} className="h-10 w-auto" />
-          </a>
+                if (mode === 'frames') {
+                  scrollFramesHomeToTop('smooth', false)
+                } else {
+                  router.actions.push(homeHref)
+                  scrollFramesHomeToTop()
+                }
+              }}
+              className="workspace-logo-button frameos-icon-button mb-8 flex h-12 w-12 items-center justify-center rounded-xl transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            >
+              <FrameosLogo variant={theme === 'dark' ? 'white-colors' : 'color'} className="h-10 w-auto" />
+            </a>
+          ) : null}
           <nav className="flex flex-1 flex-col items-center gap-4">
             {!inFrameAdminMode ? (
               <NavButton

--- a/frontend/src/scenes/workspace/WorkspaceRouteLoading.tsx
+++ b/frontend/src/scenes/workspace/WorkspaceRouteLoading.tsx
@@ -15,6 +15,7 @@ import {
   SunIcon,
 } from '@heroicons/react/24/outline'
 import { FrameosLogo } from '../../components/FrameosLogo'
+import { isCloudMode } from '../../utils/cloudMode'
 import { Spinner } from '../../components/Spinner'
 import { urls } from '../../urls'
 import { preloadSceneComponent, type LoadableSceneKey } from '../scenes'
@@ -227,33 +228,36 @@ export function WorkspaceRouteLoading({ scene }: { scene: string | null }): JSX.
             secondarySidebarOpen ? 'border-r border-slate-200/80' : 'max-lg:border-r max-lg:border-slate-200/80'
           )}
         >
-          <a
-            href={homeHref}
-            title={inFrameAdminMode ? 'Frame' : 'Frames home'}
-            onPointerEnter={preloadHome}
-            onFocus={preloadHome}
-            onMouseDown={preloadHome}
-            onClick={(event: MouseEvent<HTMLAnchorElement>) => {
-              if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
-                return
-              }
-              event.preventDefault()
-              if (inFrameAdminMode) {
-                router.actions.push(homeHref)
-                return
-              }
-              requestNextFramesHomeScrollTop()
-              if (mode === 'frames') {
-                scrollFramesHomeToTop('smooth', false)
-              } else {
-                router.actions.push(homeHref)
-                scrollFramesHomeToTop()
-              }
-            }}
-            className="workspace-logo-button frameos-icon-button mb-8 flex h-12 w-12 items-center justify-center rounded-xl transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-          >
-            <FrameosLogo variant={theme === 'dark' ? 'white-colors' : 'color'} className="h-10 w-auto" />
-          </a>
+          {/* The cloud header already shows the FrameOS Cloud logo; the rail one would duplicate it. */}
+          {!isCloudMode() ? (
+            <a
+              href={homeHref}
+              title={inFrameAdminMode ? 'Frame' : 'Frames home'}
+              onPointerEnter={preloadHome}
+              onFocus={preloadHome}
+              onMouseDown={preloadHome}
+              onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+                if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                  return
+                }
+                event.preventDefault()
+                if (inFrameAdminMode) {
+                  router.actions.push(homeHref)
+                  return
+                }
+                requestNextFramesHomeScrollTop()
+                if (mode === 'frames') {
+                  scrollFramesHomeToTop('smooth', false)
+                } else {
+                  router.actions.push(homeHref)
+                  scrollFramesHomeToTop()
+                }
+              }}
+              className="workspace-logo-button frameos-icon-button mb-8 flex h-12 w-12 items-center justify-center rounded-xl transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            >
+              <FrameosLogo variant={theme === 'dark' ? 'white-colors' : 'color'} className="h-10 w-auto" />
+            </a>
+          ) : null}
           <nav className="flex flex-1 flex-col items-center gap-4">
             {!inFrameAdminMode ? (
               <LoadingNavButton

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -72,6 +72,12 @@ export interface FrameType {
    * owner toggles it per frame; absent means "not reported" (hub broadcasts
    * that do not carry the link), never "off". */
   service_settings_enabled?: boolean
+  /** Cloud-managed frames: whether the frame's link holds `telemetry:logs`
+   * (and `telemetry:metrics`), i.e. whether the device ships logs and metrics
+   * to the cloud at all. Frames enrolled before 2026-08-03 were never granted
+   * it; the owner toggles it per frame. Absent means "not reported", never
+   * "off". */
+  telemetry_enabled?: boolean
   /** The hardware object the device reported at cloud enrollment and on every
    * hub hello (frames.hardware jsonb on the cloud; absent on backend-managed
    * frames). `platform` drives the device-profile capability gating in

--- a/frontend/src/utils/cloudFrameApi.ts
+++ b/frontend/src/utils/cloudFrameApi.ts
@@ -142,6 +142,21 @@ export async function setCloudFrameServiceSettingsEnabled(frameId: FrameId, enab
 }
 
 /**
+ * The owner's per-frame switch for telemetry: whether this frame's link holds
+ * `telemetry:logs` + `telemetry:metrics`, i.e. whether the device ships its
+ * logs and metrics to the cloud. Scopes are pinned per connection, so the
+ * cloud restarts the frame's runtime to apply the change either way.
+ */
+export async function setCloudFrameTelemetryEnabled(frameId: FrameId, enabled: boolean): Promise<void> {
+  const response = await apiFetch(`/api/frames/${frameId}/telemetry/enabled`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  })
+  await assertOk(response, `Failed to ${enabled ? 'enable' : 'disable'} log shipping for this frame`)
+}
+
+/**
  * Push the Schedule panel's edits. Schedule is its own verb (`set_schedule`),
  * not a settings key: POST /api/frames/{id}/schedule persists the full
  * schedule server-side (disabled events included, so the panel round-trips)


### PR DESCRIPTION
First batch of cloud usability polish; more items will land on this branch.

- **Activity feed** (`/account/activity`): new *Frame / scene* column resolved from each audit row's `target` — frame events link to the frame by name, store-scene events show the scene name, events for a since-deleted frame say so. Lookups are account-scoped.
- **Account tabs**: My frames · My scenes · Backends · Backups · Activity · Security.
- **Signup**: removed the "Create a FrameOS Cloud account to link and manage your FrameOS backends" line.

- **Per-frame telemetry switch** (ops loose end): frames enrolled before 2026-08-03 never got `telemetry:logs`/`telemetry:metrics` and silently shipped nothing. New `POST /api/frames/{id}/telemetry/enabled` grants/removes both scopes (explicit owner action, not a backfill), audits the flag, and queues a `restart_runtime` so the hub's per-session scope snapshot refreshes. Frame Settings gets a "Logs and metrics" switch; the Logs panel's empty state points at it.
- **pgBackRest health in the nightly backup** (ops loose end): `pg-backup.sh` now checks the stanza after shipping (status ok, newest base backup < 36 h, WAL archived) and fails the run — so the existing healthchecks.io check pages on a stuck PITR layer. Success pings carry `pitr_latest=… wal_max=…`. `PGBACKREST_MAX_AGE_HOURS=0` disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Nu8A1sgfAuhdJkFX2y4X7
