### PR TITLE
ESP32: stop the heap leak that turned every render blurry

### DIFF
--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -39,6 +39,7 @@ from app.tasks.embedded_firmware import (
     embedded_provisioning_plan,
     embedded_required_sdkconfig_for_frame,
     embedded_render_psram_bytes,
+    embedded_render_canvas_bytes_per_pixel,
     embedded_render_mode_for_frame,
     embedded_sdkconfig_defaults_for_frame,
     embedded_sd_card_assets_for_frame,
@@ -211,9 +212,10 @@ def test_embedded_firmware_layout_tracks_flash_and_ram():
     assert layout['ram']['width'] == 1200
     assert layout['ram']['height'] == 1600
     assert layout['ram']['pixelFormat'] == FOS_PIXEL_4BPP_SPECTRA6
-    # The canvas is 16-bit RGB (2 B/px); the old key name stays for the UI.
-    assert layout['ram']['canvasBytesPerPixel'] == 2
-    assert layout['ram']['canvasBufferBytes'] == 1200 * 1600 * 2
+    # 1200x1600 on a 16 MB module: a full RGBX canvas (7.3 MB) takes under
+    # half the PSRAM, so the canvas is 4 B/px; the old key name stays for the UI.
+    assert layout['ram']['canvasBytesPerPixel'] == 4
+    assert layout['ram']['canvasBufferBytes'] == 1200 * 1600 * 4
     assert layout['ram']['rgbaBufferBytes'] == layout['ram']['canvasBufferBytes']
     assert layout['ram']['packedBufferBytes'] == 960_000
     assert layout['ram']['renderWorkingBytes'] > layout['ram']['canvasBufferBytes']
@@ -557,14 +559,28 @@ def test_embedded_panel_formats_and_buffer_sizes():
     assert embedded_buffer_size(1200, 1600, FOS_PIXEL_4BPP_SPECTRA6) == 600 * 1600
 
 
+def test_embedded_render_canvas_bytes_per_pixel():
+    mb = 1024 * 1024
+    # RGBX whenever a full canvas is at most half the module's PSRAM.
+    assert embedded_render_canvas_bytes_per_pixel(800, 480, 8 * mb) == 4      # 1.5 MB of 8
+    assert embedded_render_canvas_bytes_per_pixel(1200, 1600, 16 * mb) == 4   # 7.3 MB of 16
+    assert embedded_render_canvas_bytes_per_pixel(1200, 1600, 8 * mb) == 2    # 7.3 MB of 8
+    assert embedded_render_canvas_bytes_per_pixel(0, 0, 8 * mb) == 0
+
+
 def test_embedded_render_psram_estimate():
-    # 800x480 at 2 B/px (768KB) + default packed 1bpp + ~1.5MB reserve is ~2.4MB.
+    mb = 1024 * 1024
+    # 800x480 on 8 MB: RGBX canvas (1.5 MB) + default packed 1bpp + ~1.5MB reserve is ~3.1MB.
     need = embedded_render_psram_bytes(800, 480)
-    assert 2_300_000 < need < 2_500_000
-    # 1200x1600 Spectra 6: 3.84MB canvas + 960KB packed + 1.5MB reserve, under 8MB.
-    need = embedded_render_psram_bytes(1200, 1600, FOS_PIXEL_4BPP_SPECTRA6)
+    assert 3_000_000 < need < 3_200_000
+    # 1200x1600 Spectra 6 on 8 MB: 3.84MB 565 canvas + 960KB packed + 1.5MB reserve, under 8MB.
+    need = embedded_render_psram_bytes(1200, 1600, FOS_PIXEL_4BPP_SPECTRA6, 8 * mb)
     assert 6_300_000 < need < 6_400_000
-    assert need < 8 * 1024 * 1024
+    assert need < 8 * mb
+    # The same panel on 16 MB gets the RGBX canvas: 7.68MB + 960KB + 1.5MB, under 16MB.
+    need = embedded_render_psram_bytes(1200, 1600, FOS_PIXEL_4BPP_SPECTRA6, 16 * mb)
+    assert 10_100_000 < need < 10_300_000
+    assert need < 16 * mb
 
 
 def test_panel_fits_default_8mb_module():

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -112,7 +112,7 @@ EMBEDDED_PLATFORMS: dict[str, dict[str, Any]] = {
 EMBEDDED_PLATFORM_ALIASES = EMBEDDED_PLATFORMS[SUPPORTED_EMBEDDED_PLATFORM]["aliases"]
 EMBEDDED_PROJECT_DIR = REPO_ROOT / "embedded" / "esp32"
 # Bump when the firmware project changes so existing "ready" images rebuild on next request
-EMBEDDED_FIRMWARE_VERSION = 48  # 16-bit render canvas reserved at boot, streamed packers, E1004 (T133A01) preset
+EMBEDDED_FIRMWARE_VERSION = 49  # RGBX canvas where it fits, dithered 565 stores, contiguous decode budget, OOM-leak restart
 EMBEDDED_DEFAULT_PANEL = "EPD_7in5_V2"
 EMBEDDED_DEFAULT_MAX_HTTP_RESPONSE_BYTES = 4 * 1024 * 1024
 EMBEDDED_PIN_KEYS = ("rst", "dc", "cs", "cs2", "busy", "sck", "mosi", "pwr")
@@ -573,13 +573,17 @@ EMBEDDED_RELEASE_FIRMWARE: dict[str, dict[str, str]] = {
     "esp32-c3": {"asset": "esp32-c3-generic", "flashSize": "4MB"},
 }
 # Memory guardrail (M4): the on-device renderer composites into a pixie canvas
-# (16-bit RGB 5/6/5, 2 B/px — frameos/src/embedded/embedded_runtime.nim
-# `renderCanvas`), packs it to the selected panel format, and needs headroom
-# for the Nim heap + QuickJS. Keep both constants in sync with
-# FOS_RENDER_CANVAS_BYTES_PER_PIXEL / FOS_RENDER_PSRAM_RESERVE in
-# components/frameos_display (the firmware's boot-time fit check) and
-# EmbeddedReserveBytes in frameos/src/frameos/utils/memory.nim.
-EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL = 2
+# (frameos/src/embedded/embedded_runtime.nim `renderCanvas`), packs it to the
+# selected panel format, and needs headroom for the Nim heap + QuickJS. The
+# canvas is RGBX (4 B/px) when a full canvas takes at most half the module's
+# PSRAM, else 16-bit RGB 5/6/5 (2 B/px) — the 800x480 boards and a 1200x1600
+# panel on a 16 MB module render in full colour, 1200x1600 on 8 MB is the one
+# that needs 565. Keep the rule and the reserve in sync with
+# fos_render_canvas_bytes_per_pixel / FOS_RENDER_PSRAM_RESERVE in
+# components/frameos_display (the firmware's boot-time fit check),
+# sceneCanvasFormat in embedded_runtime.nim, and EmbeddedReserveBytes in
+# frameos/src/frameos/utils/memory.nim.
+EMBEDDED_RENDER_CANVAS_RGBX_MAX_PSRAM_SHARE = 2
 EMBEDDED_RENDER_PSRAM_RESERVE_BYTES = 1536 * 1024
 EMBEDDED_QUICKJS_HEAP_LIMIT_BYTES = 4 * 1024 * 1024
 EMBEDDED_PREVIEW_SNAPSHOT_RESERVE_BYTES = 1024 * 1024
@@ -1198,9 +1202,23 @@ def embedded_buffer_size(width: int, height: int, pixel_format: int) -> int:
     raise ValueError(f"Unsupported embedded pixel format: {pixel_format}")
 
 
-def embedded_render_psram_bytes(width: int, height: int, pixel_format: int = FOS_PIXEL_1BPP) -> int:
-    """PSRAM the on-device renderer needs for a width×height panel."""
-    canvas = width * height * EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL
+def embedded_render_canvas_bytes_per_pixel(width: int, height: int, psram_bytes: int) -> int:
+    """Bytes per pixel of the scene canvas on a module with ``psram_bytes`` of PSRAM:
+    4 (RGBX) when a full canvas takes at most half of it, else 2 (RGB 5/6/5)."""
+    if width <= 0 or height <= 0:
+        return 0
+    rgbx = width * height * 4
+    if psram_bytes > 0 and rgbx * EMBEDDED_RENDER_CANVAS_RGBX_MAX_PSRAM_SHARE <= psram_bytes:
+        return 4
+    return 2
+
+
+def embedded_render_psram_bytes(
+    width: int, height: int, pixel_format: int = FOS_PIXEL_1BPP, psram_bytes: int = 8 * 1024 * 1024
+) -> int:
+    """PSRAM the on-device renderer needs for a width×height panel on a module with
+    ``psram_bytes`` of PSRAM (the canvas format depends on it)."""
+    canvas = width * height * embedded_render_canvas_bytes_per_pixel(width, height, psram_bytes)
     packed = embedded_buffer_size(width, height, pixel_format)
     return canvas + packed + EMBEDDED_RENDER_PSRAM_RESERVE_BYTES
 
@@ -1318,9 +1336,9 @@ def embedded_firmware_layout_for_frame(frame: Frame, firmware: dict[str, Any] | 
     dims = device_dimensions(frame.device) or (0, 0)
     width, height = dims
     pixel_format = embedded_pixel_format_for_panel(panel)
-    canvas_bytes = (
-        width * height * EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL if width > 0 and height > 0 else 0
-    )
+    psram_bytes = embedded_module_psram_bytes(frame)
+    canvas_bytes_per_pixel = embedded_render_canvas_bytes_per_pixel(width, height, psram_bytes)
+    canvas_bytes = width * height * canvas_bytes_per_pixel
     packed_bytes = embedded_buffer_size(width, height, pixel_format) if width > 0 and height > 0 else 0
     render_mode = embedded_render_mode_for_frame(frame)
     render_working_bytes = (
@@ -1329,7 +1347,6 @@ def embedded_firmware_layout_for_frame(frame: Frame, firmware: dict[str, Any] | 
         else 0
     )
     preview_bmp_bytes = _embedded_bmp_preview_bytes(width, height, pixel_format)
-    psram_bytes = embedded_module_psram_bytes(frame)
     return {
         "flash": {
             "flashSize": flash_profile["flashSize"],
@@ -1350,10 +1367,10 @@ def embedded_firmware_layout_for_frame(frame: Frame, firmware: dict[str, Any] | 
             "pixelFormat": pixel_format,
             "pixelFormatName": _pixel_format_name(pixel_format),
             "renderMode": "local" if render_mode == EMBEDDED_RENDER_LOCAL else "remote",
-            # Historical key name: the canvas is 16-bit RGB now, not RGBA.
+            # Historical key name: the canvas is RGBX or 16-bit RGB, never RGBA.
             "rgbaBufferBytes": canvas_bytes,
             "canvasBufferBytes": canvas_bytes,
-            "canvasBytesPerPixel": EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL,
+            "canvasBytesPerPixel": canvas_bytes_per_pixel,
             "packedBufferBytes": packed_bytes,
             "renderReserveBytes": EMBEDDED_RENDER_PSRAM_RESERVE_BYTES,
             "renderWorkingBytes": render_working_bytes,
@@ -1387,8 +1404,8 @@ def check_embedded_panel_fits_memory(frame: Frame) -> None:
     if not dims:
         return
     width, height = dims
-    need = embedded_render_psram_bytes(width, height, embedded_pixel_format_for_panel(panel))
     have = embedded_module_psram_bytes(frame)
+    need = embedded_render_psram_bytes(width, height, embedded_pixel_format_for_panel(panel), have)
     if need > have:
         raise ValueError(
             f"Panel {panel} ({width}x{height}) needs ~{need / (1024 * 1024):.1f} MB PSRAM to "

--- a/cloud/apps/auth-web/app/api/store/account/repository.json/route.ts
+++ b/cloud/apps/auth-web/app/api/store/account/repository.json/route.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 import { accounts, storeScenes } from "@frameos-cloud/db";
 import { NextRequest, NextResponse } from "next/server";
 import {

--- a/cloud/apps/auth-web/app/publishers/[accountId]/page.tsx
+++ b/cloud/apps/auth-web/app/publishers/[accountId]/page.tsx
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { accounts, createDb, storeScenes } from "@frameos-cloud/db";
 import { PublicShell } from "../../../src/components/PublicShell";

--- a/cloud/apps/auth-web/app/s/[slug]/page.tsx
+++ b/cloud/apps/auth-web/app/s/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { Download } from "lucide-react";
 import { headers } from "next/headers";
 import Link from "next/link";

--- a/docs/esp32-memory.md
+++ b/docs/esp32-memory.md
@@ -25,7 +25,29 @@ Measured 2026-08-14 on v2026.8.19 with `-d:memProbe`:
 The first render after a boot — the one that also pays the scene parse and
 the app transpiles — no longer touches the emergency reserve.
 
-## The canvas is 2 bytes per pixel (2026.8.31)
+## The canvas is RGBX where it fits, 565 where it must (2026-08-23)
+
+One rule in three places — `fos_render_canvas_bytes_per_pixel`
+(components/frameos_display), `sceneCanvasFormat` (embedded_runtime.nim),
+`embedded_render_canvas_bytes_per_pixel` (backend embedded_firmware.py):
+**4 B/px when width×height×4 ≤ PSRAM/2, else 2 B/px.** 800×480 on 8 MB →
+RGBX (1.5 MB); 1200×1600 on 16 MB → RGBX (7.3 MB); 1200×1600 on 8 MB → 565.
+A 565 canvas sets pixie's `ditherStores`, which is what fixes the gradient
+banding the 2026.8.31 move caused (see embedded/esp32/README.md, "The
+render canvas"). RGB888 (3 B/px) for the 8 MB 13.3" was considered and
+rejected: 5.5 MiB canvas + 0.9 packed + 1.5 reserve leaves ~1.8 MB of
+headroom for decodes, fonts, QuickJS and TLS, which turns every large
+photo into a clamped decode; dithered 565 costs nothing and removes the
+banding.
+
+Consequence for the 16 MB 13.3": idle free PSRAM drops from ~10.3 MB to
+~6.5 MB, so the streamed cover decode of a 24 MP photo (5.8 MB plan, see
+below) no longer fits the headroom and clamps mildly (~93% sampling
+resolution) until the cover column-window follow-up in todo.md lands
+(2.9 MB plan). That follow-up is what makes RGBX on 16 MB free of
+compromise.
+
+## The canvas was 2 bytes per pixel everywhere (2026.8.31 – 2026-08-23)
 
 The scene canvas became a 16-bit RGB 5/6/5 pixie image (`embedded/esp32/README.md`,
 "The render canvas is 16-bit"). The budget arithmetic that moved with it, in

--- a/docs/esp32-memory.md
+++ b/docs/esp32-memory.md
@@ -58,6 +58,28 @@ pathological decodes — which the budget/degrade ladder already absorbs —
 while weakening the OOM-containment backstop that keeps a failed
 allocation from rebooting the device. Decision 2026-08-14: keep 1 MB.
 
+## Leaks are permanent, and they look like blur (2026-08-23)
+
+A longjmp OOM abort skips every Nim destructor, so whatever the aborted
+call held is gone until reboot. Case from a 16 MB 13.3" board on 2026.8.34:
+idle free PSRAM was 10.3 MB after boot; a scene switch cost 1.6 MB (open
+question, no abort logged); one `render-cycle-failed` at 01:08Z took it to
+4.3 MB with a 1.9 MB largest block. Every render afterwards "succeeded" —
+`decodeIntoTargetWithDegrade` dropped each 24 MP photo to a half/quarter
+decode and stretched it — so the abort streak reset on every render and
+the frame showed soft images for a day with nothing in the log.
+
+Two things changed:
+
+- `render:degraded` (utils/image.nim) is logged each time the ladder drops a
+  rung, with the rung, the decode size and the headroom it was planned
+  against. A frame whose photos got soft now says why in the cloud log.
+- `memory:oomAbort` (frameos_nim_glue.c) is logged on every abort, with
+  free/largest PSRAM and the post-first-render baseline. When one abort
+  leaves less than `FOS_NIM_OOM_LEAK_RESTART_PERCENT` (50%) of that
+  baseline free, the frame restarts immediately instead of rendering
+  degraded until someone power-cycles it. The old streak rules stay.
+
 ## Boot and render costs
 
 Same bench frame, for context when weighing "do less at boot" ideas:

--- a/docs/esp32-memory.md
+++ b/docs/esp32-memory.md
@@ -69,7 +69,34 @@ question, no abort logged); one `render-cycle-failed` at 01:08Z took it to
 decode and stretched it — so the abort streak reset on every render and
 the frame showed soft images for a day with nothing in the log.
 
-Two things changed:
+Both leaks had a root cause, fixed in the pixie fork (ab4085b):
+
+- **The 1.6 MB "scene switch leak" was the typeface.** The first text the
+  boot ever drew (the error frame) parsed Ubuntu-Regular into the global
+  typeface cache, and a parsed font kept the raw GPOS kerning matrix
+  (class1 x class2 ValueRecords, per lookup) next to the derived tables the
+  lookup actually reads — 1.6 MB of a 2 MB parsed font on a 64-bit host.
+  The parser now drops that scratch: 2039 KB -> 910 KB retained, kerning
+  and rendered pixels identical.
+- **The abort was a contiguity miss.** The streamed-JPEG plan for a
+  6000x4000 cover-fit into 1200x1600 is 5.8 MB, and its luma channel is
+  ONE 3.75 MB allocation (cover samples the full 2400-wide row and crops
+  later). The budget check asked only whether 5.8 MB fit the 7.1 MB
+  headroom; the largest free block had fragmented below 3.75 MB, the
+  malloc failed, and the longjmp abort leaked everything the render held.
+  pixie now carries a second, contiguous budget
+  (`setDecodeContiguousBudgetBytes`, fed from the largest free PSRAM block
+  by `refreshDecodeContiguousBudget`): the SOF plan clamps its sampling
+  resolution so the largest channel fits, and refuses catchably when even
+  that cannot. Measured on the host: 6 MB block -> untouched; 3 MB block ->
+  2172x1448 sampling, 3.07 MB luma, decodes.
+
+Follow-up worth doing: cover-fit should sample only the cropped column
+window. A 3:2 photo on this 3:4 panel would plan 2.9 MB instead of 5.8 MB
+(luma 1.9 MB instead of 3.75 MB), which is the difference between full
+sharpness and a clamp on a heap that has seen a day of churn.
+
+And two things changed on the visibility side:
 
 - `render:degraded` (utils/image.nim) is logged each time the ladder drops a
   rung, with the rung, the decode size and the headroom it was planned

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,6 +19,21 @@ Two rules that shape most entries:
 
 ---
 
+## ESP32 memory
+
+- **Scene switch leaks ~1.6 MB of PSRAM** (13.3" 16 MB board, 2026.8.34, log
+  2026-08-22T22:04Z): switching "SD card image" → "Unsplash image" (which
+  rendered its missing-API-key error frame) dropped idle free PSRAM from
+  10.3 MB to 8.7 MB and the largest block from 7.4 MB to 6–7 MB; switching
+  back did not recover it. No OOM abort was logged. Find what the old
+  scene's teardown keeps (cached image? QuickJS runtime? error-frame
+  intermediates?) — with the SD scene's 24 MP photos the headroom is thin
+  enough that this leak is what made the next abort possible.
+- **Verify on hardware**: `memory:oomAbort` + leak-percent restart and the
+  `render:degraded` event (docs/esp32-memory.md, 2026-08-23). Cheapest
+  repro: assign a scene that fetches an oversized image with the budget
+  forced low, watch the cloud log for both events.
+
 ## Pre-release manual test sweep
 
 `docs/manual-testing-todo.md` collects every unticked manual checkbox and

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,18 +21,16 @@ Two rules that shape most entries:
 
 ## ESP32 memory
 
-- **Scene switch leaks ~1.6 MB of PSRAM** (13.3" 16 MB board, 2026.8.34, log
-  2026-08-22T22:04Z): switching "SD card image" → "Unsplash image" (which
-  rendered its missing-API-key error frame) dropped idle free PSRAM from
-  10.3 MB to 8.7 MB and the largest block from 7.4 MB to 6–7 MB; switching
-  back did not recover it. No OOM abort was logged. Find what the old
-  scene's teardown keeps (cached image? QuickJS runtime? error-frame
-  intermediates?) — with the SD scene's 24 MP photos the headroom is thin
-  enough that this leak is what made the next abort possible.
-- **Verify on hardware**: `memory:oomAbort` + leak-percent restart and the
-  `render:degraded` event (docs/esp32-memory.md, 2026-08-23). Cheapest
-  repro: assign a scene that fetches an oversized image with the budget
-  forced low, watch the cloud log for both events.
+- **JPEG cover-fit samples the full row and crops later.** A 6000x4000
+  photo into the 13.3" 1200x1600 panel plans 5.8 MB with a single 3.75 MB
+  luma buffer; a column window over the cropped region would halve both
+  (docs/esp32-memory.md, 2026-08-23). Touches foldScaledSourceRow, the
+  band row range, EXIF orientation and the fill rects — do it with the
+  jpegsuite fingerprint sweep as the safety net.
+- **Verify on hardware** (docs/esp32-memory.md, 2026-08-23): after a text
+  render idle PSRAM should drop ~0.5 MB, not 1.6 MB; `render:degraded` and
+  `memory:oomAbort` appear in the cloud log when provoked (force the budget
+  low with an oversized photo); the leak-percent restart fires.
 
 ## Pre-release manual test sweep
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,13 +21,17 @@ Two rules that shape most entries:
 
 ## ESP32 memory
 
-- **JPEG cover-fit samples the full row and crops later.** A 6000x4000
+- **JPEG cover-fit samples the full row and crops later** (now the gating
+  item for full-quality photos on the 16 MB 13.3" with its RGBX canvas). A 6000x4000
   photo into the 13.3" 1200x1600 panel plans 5.8 MB with a single 3.75 MB
   luma buffer; a column window over the cropped region would halve both
   (docs/esp32-memory.md, 2026-08-23). Touches foldScaledSourceRow, the
   band row range, EXIF orientation and the fill rects — do it with the
   jpegsuite fingerprint sweep as the safety net.
-- **Verify on hardware** (docs/esp32-memory.md, 2026-08-23): after a text
+- **Verify on hardware** (docs/esp32-memory.md, 2026-08-23): the 7.3"
+  weather sky renders without bands (RGBX canvas now; boot line
+  `canvas: 800x480 rgbx`); the E1004 logs `canvas: 1200x1600 rgb565
+  (dithered stores)` and its gradients are band-free; after a text
   render idle PSRAM should drop ~0.5 MB, not 1.6 MB; `render:degraded` and
   `memory:oomAbort` appear in the cloud log when provoked (force the budget
   low with an oversized photo); the leak-percent restart fires.

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -389,18 +389,22 @@ failed optimization.
 
 ## The render canvas is 16-bit (2026.8.31)
 
-The scene canvas the Nim renderer composites into is a pixie `pfRgb565`
-image — packed RGB 5/6/5, 2 bytes per pixel — not RGBA. Every panel this
-firmware drives is a dithered e-paper, and the dither keeps its own
-full-precision error rows beside the canvas (`forEachPaletteDithered` /
-`forEachGrayDithered` in `frameos/src/frameos/utils/dither.nim`), so the
-5/6-bit colour the canvas holds is a precision the output cannot show: a
-6-colour Floyd–Steinberg field has per-pixel error dozens of times the 565
-step. What it buys is the **13.3" 1200×1600 panel on an 8 MB module** — the
-RGBA canvas was 7.3 MiB and did not fit, the 565 one is 3.7 MiB and does
+The canvas format is decided per board (`fos_render_canvas_bytes_per_pixel`
+in `components/frameos_display`): **RGBX when a full canvas takes at most
+half the module's PSRAM, else 16-bit RGB 5/6/5.** The 800×480 boards (1.5 MB
+of 8 MB) and a 1200×1600 panel on a 16 MB module (7.3 MB) render in full
+colour; **1200×1600 on an 8 MB module is the one that needs 565** — RGBA is
+7.3 MiB and does not fit, 565 is 3.7 MiB and does
 (`fos_display_render_psram_bytes`: canvas + packed + 1.5 MiB reserve =
-6.1 MiB). Every other board gains 0.4–0.7 MiB of headroom, and half the
-PSRAM traffic per render.
+6.1 MiB). 565 is not free of cost even though the dither keeps its error
+rows at full precision (`forEachPaletteDithered` / `forEachGrayDithered` in
+`frameos/src/frameos/utils/dither.nim`): rounding every stored pixel to 5/6
+bits turns a smooth gradient into plateaus — a 480-row sky keeps 11 blue
+levels of 90 — and the diffusion pass prints the plateau edges as bands
+(seen on the 7.3" weather scene, 2026-08-23). So a 565 canvas stores with
+pixie's per-pixel dither (`Image.ditherStores`, hashed rounding offsets,
+idempotent for exact colours), which brings the gradient back at no memory
+cost: 88 row-mean levels against RGBX's 90 on the same sky.
 
 The canvas is also **one block for the device's uptime**: `main.c` calls
 `frameos_nim_reserve_canvas(fos_display_canvas_bytes())` right after the
@@ -409,8 +413,8 @@ before Wi-Fi and TLS fragment the heap, and `embedded_runtime.nim`'s
 `renderCanvas()` wraps it with `newImage565Over` and reuses it every render.
 Nothing aliases the canvas across renders (the value pipeline never caches
 the live canvas), so reuse is safe, and the per-render allocate/collect
-churn is gone. `-d:frameosCanvasRgbx` in `FRAMEOS_EXTRA_NIM_FLAGS` keeps the
-old RGBA canvas for A/B measurement. The Pi runtime and the wasm preview are
+churn is gone. `-d:frameosCanvasRgbx` / `-d:frameosCanvas565` in
+`FRAMEOS_EXTRA_NIM_FLAGS` force a format for A/B measurement. The Pi runtime and the wasm preview are
 untouched and keep full RGBA.
 
 Two allocation facts worth knowing before profiling anything here:

--- a/embedded/esp32/components/frameos_display/frameos_display.c
+++ b/embedded/esp32/components/frameos_display/frameos_display.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 
@@ -161,11 +162,28 @@ fos_pixel_format_t fos_display_panel_format(size_t index)
  * (frameos/src/frameos/utils/memory.nim). */
 #define FOS_RENDER_PSRAM_RESERVE (1536u * 1024u)
 
+size_t fos_render_canvas_bytes_per_pixel(int width, int height, size_t psram_total_bytes)
+{
+    if (width <= 0 || height <= 0) return 0;
+    size_t rgbx = (size_t)width * (size_t)height * 4u;
+    if (psram_total_bytes > 0 && rgbx * FOS_RENDER_CANVAS_RGBX_MAX_PSRAM_SHARE <= psram_total_bytes) {
+        return 4;
+    }
+    return 2;
+}
+
+size_t fos_display_canvas_bytes_per_pixel(void)
+{
+    if (!s_panel) return 0;
+    return fos_render_canvas_bytes_per_pixel(fos_display_width(), fos_display_height(),
+                                             heap_caps_get_total_size(MALLOC_CAP_SPIRAM));
+}
+
 size_t fos_display_canvas_bytes(void)
 {
     if (!s_panel) return 0;
     return (size_t)fos_display_width() * (size_t)fos_display_height() *
-           (size_t)FOS_RENDER_CANVAS_BYTES_PER_PIXEL;
+           fos_display_canvas_bytes_per_pixel();
 }
 
 size_t fos_display_render_psram_bytes(void)

--- a/embedded/esp32/components/frameos_display/include/frameos_display.h
+++ b/embedded/esp32/components/frameos_display/include/frameos_display.h
@@ -47,14 +47,24 @@ const char *fos_display_panel_name(size_t index);
 int fos_display_panel_width(size_t index);
 int fos_display_panel_height(size_t index);
 fos_pixel_format_t fos_display_panel_format(size_t index);
-/* Bytes per pixel of the scene canvas the Nim renderer composites into.
- * 2: pixie's 16-bit RGB 5/6/5 surface (frameos/src/embedded/embedded_runtime.nim,
- * `renderCanvas`). Every panel here is a dithered e-paper and the dither keeps
- * its own full-precision error rows, so the canvas's 5/6-bit colour is
- * below what the output can show — and it is what fits a 1200x1600 canvas
- * in an 8 MB module (3.7 MiB instead of 7.3 MiB). Mirrored by
- * EMBEDDED_RENDER_CANVAS_BYTES_PER_PIXEL in backend embedded_firmware.py. */
-#define FOS_RENDER_CANVAS_BYTES_PER_PIXEL 2u
+/* Bytes per pixel of the scene canvas the Nim renderer composites into
+ * (frameos/src/embedded/embedded_runtime.nim, `renderCanvas`), decided per
+ * board: 4 (pixie's RGBX) when a full canvas takes at most half the
+ * module's PSRAM, else 2 (pixie's 16-bit RGB 5/6/5 surface). Both the
+ * 800x480 boards (1.5 MB of 8 MB) and a 1200x1600 panel on a 16 MB module
+ * (7.3 MB) get RGBX; 1200x1600 on an 8 MB module gets 565, which is what
+ * makes it fit at all (3.7 MB). Rendering into 565 costs colour: the
+ * dither keeps its error rows at full precision, but the 5/6-bit rounding
+ * of every stored pixel turns a smooth gradient into plateaus the
+ * diffusion then prints as visible bands — so 565 canvases store with a
+ * per-pixel dither (pixie `ditherStores`) and RGBX is used wherever it
+ * fits. The same rule lives in `embedded_render_canvas_bytes_per_pixel` in
+ * backend embedded_firmware.py and `sceneCanvasFormat` in
+ * embedded_runtime.nim; keep the three in step. */
+#define FOS_RENDER_CANVAS_RGBX_MAX_PSRAM_SHARE 2u
+size_t fos_render_canvas_bytes_per_pixel(int width, int height, size_t psram_total_bytes);
+/* The above for the selected panel and this module's PSRAM. */
+size_t fos_display_canvas_bytes_per_pixel(void);
 /* Bytes of the scene canvas for the selected panel (0 when headless). */
 size_t fos_display_canvas_bytes(void);
 /* PSRAM the on-device renderer needs for this panel: the scene canvas

--- a/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
+++ b/embedded/esp32/components/frameos_nim/frameos_nim_glue.c
@@ -324,22 +324,64 @@ void fos_nim_fatal_oom(size_t size)
  * than one clean restart. */
 #define FOS_NIM_OOM_ABORT_RESTART_STREAK 4
 
+/* The streak rules above only fire when renders keep failing. A single abort
+ * that leaks a big chunk but leaves enough for the decode budget's degrade
+ * ladder is worse in practice: every render from then on "succeeds" at half
+ * or quarter resolution, the streak resets each time, and the frame shows
+ * soft images forever. Seen on a 16 MB 13.3" board: one abort took free
+ * PSRAM from 8.6 MB to 4.3 MB (largest block 6 MB -> 1.9 MB) and every
+ * photo after it rendered blurry for a day. Leaked memory never comes back,
+ * so when one abort has eaten more than this share of what a healthy boot
+ * had free, restart right away instead of rendering degraded until the next
+ * power cycle. The baseline is taken after the first successful render, the
+ * steady state the frame actually lives in. */
+#define FOS_NIM_OOM_LEAK_RESTART_PERCENT 50
+
 static int s_frame_width = 0;
 static int s_frame_height = 0;
 static unsigned s_nim_oom_abort_streak = 0;
+static size_t s_psram_free_baseline = 0;
+
+static void nim_note_healthy_render(void)
+{
+    s_nim_oom_abort_streak = 0;
+    if (s_psram_free_baseline == 0) {
+        s_psram_free_baseline = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        ESP_LOGI("fos_nim", "PSRAM baseline after first render: %u bytes free",
+                 (unsigned)s_psram_free_baseline);
+    }
+}
 
 static void nim_oom_abort_note(const char *what)
 {
     s_nim_oom_abort_streak++;
     size_t canvas_bytes = (size_t)s_frame_width * (size_t)s_frame_height * 4u;
     size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    size_t free_psram = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     bool canvas_impossible = canvas_bytes > 0 && largest < canvas_bytes;
-    ESP_LOGE("fos_nim", "%s aborted: out of memory (abort streak %u, largest PSRAM block %u, canvas needs %u)",
-             what, s_nim_oom_abort_streak, (unsigned)largest, (unsigned)canvas_bytes);
-    if ((s_nim_oom_abort_streak >= 2 && canvas_impossible) ||
-        s_nim_oom_abort_streak >= FOS_NIM_OOM_ABORT_RESTART_STREAK) {
+    bool leaked_too_much = s_psram_free_baseline > 0 &&
+        free_psram < s_psram_free_baseline / 100u * FOS_NIM_OOM_LEAK_RESTART_PERCENT;
+    ESP_LOGE("fos_nim", "%s aborted: out of memory (abort streak %u, PSRAM free %u largest block %u, baseline %u, canvas needs %u)",
+             what, s_nim_oom_abort_streak, (unsigned)free_psram, (unsigned)largest,
+             (unsigned)s_psram_free_baseline, (unsigned)canvas_bytes);
+    bool restart = (s_nim_oom_abort_streak >= 2 && canvas_impossible) ||
+                   s_nim_oom_abort_streak >= FOS_NIM_OOM_ABORT_RESTART_STREAK ||
+                   leaked_too_much;
+    /* The serial line above never reaches the cloud; this one does, so the
+     * "render-cycle-failed" it precedes has a cause next to it. */
+    char line[360];
+    snprintf(line, sizeof(line),
+             "{\"event\":\"memory:oomAbort\",\"source\":\"esp32\","
+             "\"where\":\"%s\",\"streak\":%u,\"freePsram\":%u,"
+             "\"largestPsramBlock\":%u,\"baselinePsram\":%u,"
+             "\"status\":\"%s\"}",
+             what, s_nim_oom_abort_streak, (unsigned)free_psram, (unsigned)largest,
+             (unsigned)s_psram_free_baseline, restart ? "restarting" : "leaked");
+    frameos_nim_log_hook(line);
+    if (restart) {
         ESP_LOGE("fos_nim", "OOM aborts have leaked the Nim heap beyond recovery; restarting");
-        vTaskDelay(pdMS_TO_TICKS(250)); /* let the log lines drain */
+        frameos_nim_flush_logs();
+        vTaskDelay(pdMS_TO_TICKS(1500)); /* let the log lines drain, cloud included */
         esp_restart();
     }
 }
@@ -426,7 +468,7 @@ int frameos_nim_render(uint8_t *buf, size_t len, int pixel_format)
     if (setjmp(s_nim_oom_jmp) == 0) {
         s_nim_oom_jmp_armed = true;
         result = fos_nim_render_impl(buf, len, pixel_format);
-        if (result == 0) s_nim_oom_abort_streak = 0;
+        if (result == 0) nim_note_healthy_render();
     } else {
         nim_oom_abort_note("render");
         result = -1;
@@ -445,7 +487,7 @@ int frameos_nim_render_alloc(uint8_t **buf, size_t *len, int pixel_format)
     if (setjmp(s_nim_oom_jmp) == 0) {
         s_nim_oom_jmp_armed = true;
         result = fos_nim_render_alloc_impl(buf, len, pixel_format);
-        if (result == 0) s_nim_oom_abort_streak = 0;
+        if (result == 0) nim_note_healthy_render();
     } else {
         nim_oom_abort_note("render");
         if (s_pending_render_buffer != NULL) {

--- a/frameos/frameos.nimble
+++ b/frameos/frameos.nimble
@@ -16,7 +16,7 @@ bin           = @["frameos"]
 requires "chrono >= 0.3.1"
 requires "checksums >= 0.2.1"
 requires "nim >= 2.2.4"
-requires "https://github.com/FrameOS/pixie#ab4085b57bb852b717ff8d5dfc4126a7d05d0161"
+requires "https://github.com/FrameOS/pixie#622974d7531eadbdbf43f9c0037d215d2688b312"
 requires "mummy >= 0.4.7"
 requires "linuxfb >= 0.1.0"
 requires "QRgen >= 3.1.0"

--- a/frameos/frameos.nimble
+++ b/frameos/frameos.nimble
@@ -16,7 +16,7 @@ bin           = @["frameos"]
 requires "chrono >= 0.3.1"
 requires "checksums >= 0.2.1"
 requires "nim >= 2.2.4"
-requires "https://github.com/FrameOS/pixie#64ce3c9d50170ba5c1e879b414710650a2811423"
+requires "https://github.com/FrameOS/pixie#ab4085b57bb852b717ff8d5dfc4126a7d05d0161"
 requires "mummy >= 0.4.7"
 requires "linuxfb >= 0.1.0"
 requires "QRgen >= 3.1.0"

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "64ce3c9d50170ba5c1e879b414710650a2811423",
+      "vcsRevision": "ab4085b57bb852b717ff8d5dfc4126a7d05d0161",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "cbe7b87a3e146d49033d260a0ee8dba7a08b22b5"
+        "sha1": "69c8ebae30d66798dd521846568a82c81691e9b9"
       }
     }
   },

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "ab4085b57bb852b717ff8d5dfc4126a7d05d0161",
+      "vcsRevision": "622974d7531eadbdbf43f9c0037d215d2688b312",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "69c8ebae30d66798dd521846568a82c81691e9b9"
+        "sha1": "e1e98cb1ef3a80f96bf293c88c746a79d9fe4597"
       }
     }
   },

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -503,16 +503,21 @@ proc fos_nim_set_fusion_impl(enabled: cint) {.exportc, cdecl.} =
 #
 # One scene canvas for the device's uptime, not one per render.
 #
-# Two decisions live here. The format: a 16-bit RGB 5/6/5 pixie image, half
-# the bytes of RGBA. Every panel the ESP32 firmware drives is a dithered
-# e-paper, and the dither (`forEachPaletteDithered`, `forEachGrayDithered`)
-# keeps its error state in its own rows at full precision, so the 5/6-bit
-# colour the canvas holds is a precision the output cannot show: a 6-colour
-# Floyd–Steinberg field has per-pixel error dozens of times the 565 step. It
-# is what makes 1200x1600 fit an 8 MB module — RGBA is 7.3 MiB and does not,
-# 565 is 3.7 MiB and does. `-d:frameosCanvasRgbx` keeps the old RGBA canvas
-# for A/B measurement; the Pi runtime and the wasm preview are untouched
-# either way and keep full RGBA.
+# Two decisions live here. The format, decided per board by the firmware
+# (`fos_render_canvas_bytes_per_pixel`, components/frameos_display): RGBX
+# when a full canvas takes at most half the module's PSRAM, else pixie's
+# 16-bit RGB 5/6/5 surface. The 800x480 boards and a 1200x1600 panel on a
+# 16 MB module render in full colour; 1200x1600 on an 8 MB module is the
+# one that needs 565 — RGBA is 7.3 MiB and does not fit, 565 is 3.7 MiB and
+# does. A 565 canvas costs colour even though the dither keeps its error
+# rows at full precision: rounding every stored pixel to 5/6 bits turns a
+# smooth gradient into plateaus (a 480-row sky keeps 11 blue levels of 90),
+# and the diffusion pass prints the plateau edges as bands — seen on the
+# 7.3" weather scene. So a 565 canvas stores with pixie's per-pixel dither
+# (`ditherStores`), which brings the gradient back at no memory cost, and
+# RGBX is used wherever it fits. `-d:frameosCanvasRgbx` / `-d:frameosCanvas565`
+# force a format for A/B measurement; the Pi runtime and the wasm preview are
+# untouched either way and keep full RGBA.
 #
 # The lifetime: the memory comes from one PSRAM block the firmware claims at
 # boot (`frameos_nim_reserve_canvas`, before Wi-Fi and TLS have carved the
@@ -524,12 +529,15 @@ proc fos_nim_set_fusion_impl(enabled: cint) {.exportc, cdecl.} =
 # cache never stores the live canvas), so reusing it is safe.
 
 proc canvasBuffer(len: csize_t): pointer {.importc: "frameos_nim_canvas_buffer", cdecl.}
+proc canvasBytesPerPixel(): csize_t {.importc: "fos_display_canvas_bytes_per_pixel", cdecl.}
 
 var sceneCanvas: Image
 
 proc sceneCanvasFormat*(): PixelFormat =
   when defined(frameosCanvasRgbx): pfRgbx
-  else: pfRgb565
+  elif defined(frameosCanvas565): pfRgb565
+  else:
+    if canvasBytesPerPixel() == 4: pfRgbx else: pfRgb565
 
 proc sceneCanvasWidth*(): int =
   if frameConfig.isNil: 0
@@ -564,6 +572,9 @@ proc renderCanvas*(): Image =
     sceneCanvas =
       if format == pfRgb565: newImage565(width, height)
       else: newImage(width, height)
+  if format == pfRgb565:
+    sceneCanvas.ditherStores = true
+  log(&"canvas: {width}x{height} " & (if format == pfRgb565: "rgb565 (dithered stores)" else: "rgbx"))
   sceneCanvas
 
 proc sceneRefreshSeconds*(): float =

--- a/frameos/src/frameos/utils/image.nim
+++ b/frameos/src/frameos/utils/image.nim
@@ -14,6 +14,7 @@ import std/xmltree
 import std/strtabs
 
 import frameos/spool
+import frameos/channels
 import frameos/utils/http_client
 import frameos/utils/memory
 import frameos/utils/font
@@ -583,6 +584,20 @@ proc decodeIntoTargetWithDegrade*(target: Image, fit: ScaledDecodeFit,
         # decode, so the upscale is a pure stretch.
         target.scaleAndDrawImage(temp, "stretch")
         refreshDecodeBudgetInto()
+        # A degraded render is silent on the panel — it only looks soft — so
+        # say so in the log: a frame that "used to be sharp" is otherwise
+        # undiagnosable from the cloud (seen on a 13.3" whose heap had been
+        # leaked by an OOM abort: every render quietly fell to this rung).
+        log(%*{
+          "event": "render:degraded",
+          "divisor": divisor,
+          "width": temp.width,
+          "height": temp.height,
+          "targetWidth": target.width,
+          "targetHeight": target.height,
+          "headroomBytes": availableRenderHeadroomBytes(),
+          "reason": refusalMsg,
+        })
         return target
       except PixieError as retryRefusal:
         if not retryRefusal.msg.contains("memory budget"):

--- a/frameos/src/frameos/utils/memory.nim
+++ b/frameos/src/frameos/utils/memory.nim
@@ -122,6 +122,19 @@ proc availableRenderHeadroomBytes*(): int =
     # Development hosts: plenty of memory, keep decodes bounded anyway.
     1024 * 1024 * 1024
 
+proc refreshDecodeContiguousBudget() =
+  ## The headroom budget answers whether a decode's buffers can coexist;
+  ## this one bounds the largest SINGLE buffer by the largest free block.
+  ## Both are needed: the 13.3E6 passed a 5.8MB streamed-JPEG plan with
+  ## 8.6MB free, then died allocating its 3.75MB luma channel in a heap
+  ## whose largest block had fragmented below that (2026-08-23). With the
+  ## limit set, pixie clamps the sampling resolution to what fits instead.
+  ## Hosts report "plenty" and effectively leave it unlimited.
+  when defined(frameosEmbedded):
+    setDecodeContiguousBudgetBytes(max(0, fos_psram_largest_free_block().int))
+  else:
+    setDecodeContiguousBudgetBytes(0)
+
 proc refreshDecodeBudget*() =
   ## Updates pixie's per-decode budget from live memory. Decode
   ## intermediates may take roughly half of what is available, leaving the
@@ -136,6 +149,7 @@ proc refreshDecodeBudget*() =
   let available = availableRenderHeadroomBytes()
   if available > 0:
     setDecodeBudgetBytes(available div 2)
+  refreshDecodeContiguousBudget()
 
 proc refreshDecodeBudgetInto*() =
   ## refreshDecodeBudget for decodes that stream into an existing target
@@ -147,6 +161,7 @@ proc refreshDecodeBudgetInto*() =
   let available = availableRenderHeadroomBytes()
   if available > 0:
     setDecodeBudgetBytes(available)
+  refreshDecodeContiguousBudget()
 
 proc ensureRenderAllocation*(bytes: int64, what: string) =
   ## Raises a catchable error when an allocation plan clearly exceeds the


### PR DESCRIPTION
## Why

Cloud frame 529463b4 (13.3" Spectra-6, 16 MB PSRAM, 2026.8.34) rendered every photo soft for a day. The full log told the story in two steps on one boot:

1. **22:04Z, scene switch → 1.6 MB gone for good.** First text render of the boot (an error frame) parsed the default font into the global typeface cache. A parsed pixie typeface kept the raw GPOS kerning matrix (class1 × class2 ValueRecords per lookup) next to the derived tables the lookup reads: 1.6 MB of a 2 MB parsed Ubuntu-Regular.
2. **01:08Z, `render-cycle-failed` → 4.3 MB gone for good.** The streamed-JPEG plan for a 6000×4000 cover-fit into 1200×1600 is 5.8 MB with ONE 3.75 MB luma allocation. The budget only checked the 5.8 MB against headroom (7.1 MB); the largest free block had fragmented below 3.75 MB, malloc failed, and the longjmp OOM abort leaked everything the render held.

From then on every render "succeeded" via `decodeIntoTargetWithDegrade`'s ½/¼ rung, which reset the abort streak each time — so no restart, and nothing in the log.

## What

**Root causes — pixie fork bump `64ce3c9 → ab4085b`** (branch `gpos-and-contiguous-budget`, based on `rgb565-surface`):
- `opentype.nim` drops the GPOS parse scratch once the kerning tables are built: 2039 KB → 910 KB retained for Ubuntu-Regular; kerning values + rendered masters identical.
- `decodebudget.nim` gains a contiguous budget (`setDecodeContiguousBudgetBytes`, 0 = unlimited). The JPEG SOF plan clamps its sampling resolution so the largest single channel fits it, and refuses catchably ("memory budget" in the message → degrade ladder) when even that cannot. Host check: 6 MB block → untouched; 3 MB block → 2172×1448 sampling, 3.07 MB luma, decodes.
- `utils/memory.nim` feeds the largest free PSRAM block into it from both budget refreshes.

**Visibility + containment:**
- `render:degraded` event whenever the degrade ladder drops a rung (divisor, decode size, headroom, refusal).
- `memory:oomAbort` event on every abort, with free/largest PSRAM and the post-first-render baseline.
- A single abort that leaves < 50 % of that baseline free restarts the frame immediately (`FOS_NIM_OOM_LEAK_RESTART_PERCENT`) instead of rendering soft until a power cycle.

Docs: `docs/esp32-memory.md` has the case with numbers; `docs/todo.md` has the follow-up (cover-fit should sample only the cropped column window — halves the plan for 3:2 photos on this 3:4 panel) and the hardware checklist.


## Also: the 565 banding (7.3" weather scene)

Reproduced on the host: a 480-row sky gradient stored into a 565 canvas keeps **11 blue levels** (RGBX: 90); Floyd–Steinberg over those plateaus prints the plateau edges as lines. Two fixes:

- **Canvas format per board**, one rule in firmware / Nim / backend: RGBX when a full canvas is ≤ half the module's PSRAM, else 565. 7.3"/8 MB → RGBX (1.5 MB); 13.3"/16 MB → RGBX (7.3 MB); 13.3"/8 MB (E1004) → 565.
- **Dithered 565 stores** (pixie fork `622974d`, `Image.ditherStores`, opt-in): hashed per-pixel rounding offsets, idempotent for exact colours. 88 row-mean levels vs RGBX's 90, mean row error 0.25/255, zero drift on re-store. This is what fixes the E1004 at zero memory cost — RGB888 there would leave ~1.8 MB of headroom and turn every large photo into a clamped decode.

Firmware version 49. Built locally with IDF (Nim + C); the 565 oracle test stays bit-exact, new `test_rgb565_dither`.

Note for the 16 MB 13.3": RGBX drops idle PSRAM to ~6.5 MB, so 24 MP cover decodes clamp mildly (~93 %) until the cover column-window follow-up lands.

## Test plan

- [x] pixie `test_fonts` (masters identical to master), `test_svg_text`, `test_jpeg`
- [x] frameos `test_decode_degrade`, `test_spilled_image_stream`, `test_repo_scenes_esp32` (13 scenes) on the bumped fork
- [x] glue change compiled against stubbed ESP headers
- [ ] Hardware: 7.3" sky without bands (boot line `canvas: 800x480 rgbx`); E1004 logs `canvas: 1200x1600 rgb565 (dithered stores)` and is band-free; after a text render idle PSRAM drops ~0.5 MB (was 1.6); provoke a low budget and see `render:degraded`; provoke an abort and see `memory:oomAbort` + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PjzFcmRZHCHJvh3sQTdX
