### PR TITLE
JPEG cover decodes sample only the crop window

### DIFF
--- a/docs/esp32-memory.md
+++ b/docs/esp32-memory.md
@@ -41,11 +41,13 @@ photo into a clamped decode; dithered 565 costs nothing and removes the
 banding.
 
 Consequence for the 16 MB 13.3": idle free PSRAM drops from ~10.3 MB to
-~6.5 MB, so the streamed cover decode of a 24 MP photo (5.8 MB plan, see
-below) no longer fits the headroom and clamps mildly (~93% sampling
-resolution) until the cover column-window follow-up in todo.md lands
-(2.9 MB plan). That follow-up is what makes RGBX on 16 MB free of
-compromise.
+~6.5 MB. The streamed cover decode of a 24 MP photo planned 5.8 MB against
+that (a mild clamp) until the cover window landed (pixie 28a9cc3, same
+day): the scaled JPEG decoder now samples only the crop, so the same photo
+plans 2.9 MB with a 1.9 MB luma channel and fits the RGBX headroom with
+room to spare. Differential sweep: the whole jpeg suite (orientations
+included) byte-identical; 24 MP-class photos identical except the
+outermost crop-boundary row/column (footprint rounding).
 
 ## The canvas was 2 bytes per pixel everywhere (2026.8.31 – 2026-08-23)
 
@@ -113,10 +115,9 @@ Both leaks had a root cause, fixed in the pixie fork (ab4085b):
   that cannot. Measured on the host: 6 MB block -> untouched; 3 MB block ->
   2172x1448 sampling, 3.07 MB luma, decodes.
 
-Follow-up worth doing: cover-fit should sample only the cropped column
-window. A 3:2 photo on this 3:4 panel would plan 2.9 MB instead of 5.8 MB
-(luma 1.9 MB instead of 3.75 MB), which is the difference between full
-sharpness and a clamp on a heap that has seen a day of churn.
+(The cover column window shipped the same day — pixie 28a9cc3: a 3:2
+photo on this 3:4 panel plans 2.9 MB instead of 5.8 MB, luma 1.9 MB
+instead of 3.75 MB.)
 
 And two things changed on the visibility side:
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,14 +21,10 @@ Two rules that shape most entries:
 
 ## ESP32 memory
 
-- **JPEG cover-fit samples the full row and crops later** (now the gating
-  item for full-quality photos on the 16 MB 13.3" with its RGBX canvas). A 6000x4000
-  photo into the 13.3" 1200x1600 panel plans 5.8 MB with a single 3.75 MB
-  luma buffer; a column window over the cropped region would halve both
-  (docs/esp32-memory.md, 2026-08-23). Touches foldScaledSourceRow, the
-  band row range, EXIF orientation and the fill rects — do it with the
-  jpegsuite fingerprint sweep as the safety net.
-- **Verify on hardware** (docs/esp32-memory.md, 2026-08-23): the 7.3"
+- **Verify on hardware** (docs/esp32-memory.md, 2026-08-23): a 24 MP photo
+  cover-rendered on the 16 MB 13.3" is sharp (no `render:degraded` in the
+  log — the cover window keeps the plan at 2.9 MB inside the RGBX canvas's
+  ~5 MB headroom); the 7.3"
   weather sky renders without bands (RGBX canvas now; boot line
   `canvas: 800x480 rgbx`); the E1004 logs `canvas: 1200x1600 rgb565
   (dithered stores)` and its gradients are band-free; after a text

--- a/frameos/frameos.nimble
+++ b/frameos/frameos.nimble
@@ -16,7 +16,7 @@ bin           = @["frameos"]
 requires "chrono >= 0.3.1"
 requires "checksums >= 0.2.1"
 requires "nim >= 2.2.4"
-requires "https://github.com/FrameOS/pixie#622974d7531eadbdbf43f9c0037d215d2688b312"
+requires "https://github.com/FrameOS/pixie#28a9cc32e013b4d7dd72c830f4a25008cb7259d4"
 requires "mummy >= 0.4.7"
 requires "linuxfb >= 0.1.0"
 requires "QRgen >= 3.1.0"

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "622974d7531eadbdbf43f9c0037d215d2688b312",
+      "vcsRevision": "28a9cc32e013b4d7dd72c830f4a25008cb7259d4",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "e1e98cb1ef3a80f96bf293c88c746a79d9fe4597"
+        "sha1": "b91427ee95d16aea52e98968f998be4b94da00cd"
       }
     }
   },


### PR DESCRIPTION
## Why

For `fitCover`, pixie's scaled JPEG decoder sampled the **whole source** at crop density and discarded everything outside the crop at fill time. A 6000×4000 photo covered onto 1200×1600 planned **5.8 MB** of channel masks with one **3.75 MB** luma allocation (a 2400×1600 grid, half of it thrown away). On the 16 MB 13.3" with its new RGBX canvas (~5 MB decode headroom, #389) that meant a mild permanent clamp — and on a fragmented heap, the 3.75 MB piece was exactly the allocation behind the OOM abort #389 diagnosed.

## What

Pixie fork bump `622974d → 28a9cc3` (branch `jpeg-cover-column-window`): the decoder keeps a **sampled window** — the whole source by default, the crop for cover (same integer math as `scaledFitRects`, so the fill lands on the same rectangle). The band fold maps window-relative coordinates and skips rows the window excludes; the window is un-oriented through `sourceCoords` corner mapping so every EXIF flip/transpose keeps the same rectangle. A full-source window reduces to the old arithmetic exactly.

Same photo now plans **2.9 MB** with a **1.9 MB** luma channel — inside the RGBX headroom with room to spare, so the 16 MB 13.3" renders 24 MP photos at full sharpness.

## Verification

- Differential sweep, whole pixie jpeg suite × {stretch, contain, cover} × 3 target sizes, EXIF orientations f1–f8 included: **byte-identical** to the previous commit.
- Two 24 MP-class generated photos (wide crop + tall crop): interior byte-identical; only the outermost crop-boundary row/column differs (footprint rounding, max 33, mean 0.003/255).
- pixie `test_jpeg`, `test_rgb565` green; frameos `test_decode_degrade`, `test_spilled_image_stream`, `test_repo_scenes_esp32` green; ESP32 firmware builds locally (Nim + IDF).

Hardware item: a 24 MP cover render on the 16 MB 13.3" with no `render:degraded` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PjzFcmRZHCHJvh3sQTdX
