### PR TITLE
SVG radialGradient: pixie bump fe99977 -> 9e4e4f1

### DIFF
--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "fe999770d499ca0bcd9f9a0519a4d8dbc9b26810",
+      "vcsRevision": "9e4e4f1a68047c1cbb3ddcefefa638fa6a019da2",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "b3301852ab42e54a28f6367cbb43227becbb7233"
+        "sha1": "8732fef8170e94f069d15883bf734c3295358360"
       }
     }
   },

--- a/frameos/src/frameos/tests/test_svg_paint_strips.nim
+++ b/frameos/src/frameos/tests/test_svg_paint_strips.nim
@@ -15,14 +15,25 @@ proc buildSvg(width, height: int): string =
   var parts: seq[string] = @[]
   parts.add("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"" & $width &
     "\" height=\"" & $height & "\" viewBox=\"0 0 " & $width & " " & $height & "\">")
-  # pixie ignores <defs>; gradients have to sit at the top level and be in
-  # user space (the same shape the bundled JS apps emit).
+  # Gradients in user space, the shape the bundled JS apps emit; the linear
+  # one at the top level and the radial one in <defs>, both of which pixie
+  # registers.
   parts.add("<linearGradient id=\"bg\" gradientUnits=\"userSpaceOnUse\" " &
     "x1=\"0\" y1=\"0\" x2=\"0\" y2=\"" & $height & "\">" &
     "<stop offset=\"0\" stop-color=\"#12305a\"/><stop offset=\"1\" stop-color=\"#7a1f4b\"/>" &
     "</linearGradient>")
+  parts.add("<defs><radialGradient id=\"glow\" gradientUnits=\"userSpaceOnUse\" " &
+    "cx=\"" & $(width div 3) & "\" cy=\"" & $(height div 3) & "\" r=\"" & $(width div 2) & "\" " &
+    "gradientTransform=\"rotate(25 " & $(width div 3) & " " & $(height div 3) & ") scale(1 0.7)\">" &
+    "<stop offset=\"0\" stop-color=\"#ffe08a\" stop-opacity=\"0.9\"/>" &
+    "<stop offset=\"0.5\" stop-color=\"#ff7a45\" stop-opacity=\"0.5\"/>" &
+    "<stop offset=\"1\" stop-color=\"#ff7a45\" stop-opacity=\"0\"/>" &
+    "</radialGradient></defs>")
   parts.add("<rect x=\"0\" y=\"0\" width=\"" & $width & "\" height=\"" & $height &
     "\" fill=\"url(#bg)\"/>")
+  # A radial glow over the sky, spanning every strip.
+  parts.add("<rect x=\"0\" y=\"0\" width=\"" & $width & "\" height=\"" & $height &
+    "\" fill=\"url(#glow)\"/>")
   # Solid shapes, strokes and transforms spread over the whole canvas so every
   # strip contains geometry that starts outside it.
   for i in 0 ..< 24:


### PR DESCRIPTION
Pins pixie at FrameOS/pixie#5 (`9e4e4f1`), which adds `<radialGradient>` to the SVG renderer — plus `gradientTransform`, `stop-opacity`, gradients inside `<defs>` and percentage lengths — and moves the per-pixel gradient kernels onto a colour table (radial full-canvas fill halves on the host; on the ESP32 it also drops a software `sqrtf` per pixel).

- `frameos/nimble.lock`: vcsRevision + sha1 (computed with the usual ls-tree recipe; the sha1 was verified to reproduce the current pin's value first).
- `test_svg_paint_strips`: a radial glow in `<defs>` with `gradientTransform` and `stop-opacity` over the gradient sky; strips still match the one-pass render bit-exactly (0 differing pixels standalone / into target / root transform). `test_interpreter_svg_paint_strips` (Weather stacked) unchanged, 0 differing.

Docs/prompt/linter text (`docs/js-apps-and-code-nodes.md`, `prompts.ts`, `scene-lint.ts`) currently live uncommitted on `ai-scene-features`; they are updated there, not here.

Merge after FrameOS/pixie#5 (the pin is that PR's head commit either way). Hardware-unverified; the ESP32 timing claim is from the removed work per pixel, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9VpjsaiULMz9s3kTLbHDw