### PR TITLE
Cloud UX: in-sync resend tick, "My scenes" grouping, pulled-scene page

### DIFF
--- a/cloud/apps/auth-web/app/account/scenes/page.tsx
+++ b/cloud/apps/auth-web/app/account/scenes/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { getMyScenesUrl } from "../../../src/lib/env";
 
-// The private scene list moved to the scene store's "My private scenes" tab
+// The private scene list moved to the scene store's "My scenes" tab
 // (app/my-scenes). In production the surface router (src/lib/surfaces.ts)
 // redirects before this page renders; this covers the single-origin dev setup.
 export default function AccountScenesPage() {

--- a/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/download/route.ts
+++ b/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/download/route.ts
@@ -4,9 +4,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { readBlob } from "../../../../../../src/lib/blobs";
 import {
   canAccessPrivateScene,
+  canViewPulledScene,
   shareTokenGrantsAccess,
 } from "../../../../../../src/lib/store-auth";
-import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flow";
+import {
+  jsonError,
+  requireDatabase,
+} from "../../../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../../../src/lib/rate-limit";
 import { storeRoute } from "../../../../../../src/lib/store-cache";
 
@@ -17,7 +21,9 @@ type RouteContext = { params: Promise<{ sceneId: string }> };
 // Download a scene's template zip. Public scenes need no auth (this URL is
 // what repository.json points frameos installs at). Private scenes are
 // downloadable only by their owner's web session. Pulled scenes answer 410
-// everywhere — the moderation kill switch.
+// everywhere — the moderation kill switch — except to the owner's and
+// moderators' own web sessions, who can still open the scene page and get
+// their own zip back from it.
 async function handleGet(request: NextRequest, context: RouteContext) {
   const limited = await rateLimitResponse(request, "store:download", {
     limit: 600,
@@ -53,7 +59,10 @@ async function handleGet(request: NextRequest, context: RouteContext) {
   if (!scene) {
     return jsonError("scene_not_found", 404);
   }
-  if (scene.status === "pulled") {
+  if (
+    scene.status === "pulled" &&
+    !(await canViewPulledScene(scene.accountId))
+  ) {
     return jsonError("scene_pulled", 410);
   }
   if (scene.visibility !== "public") {
@@ -63,7 +72,11 @@ async function handleGet(request: NextRequest, context: RouteContext) {
     );
     if (
       !shared &&
-      !(await canAccessPrivateScene(db, request.headers.get("authorization"), scene.accountId))
+      !(await canAccessPrivateScene(
+        db,
+        request.headers.get("authorization"),
+        scene.accountId,
+      ))
     ) {
       return jsonError("scene_not_found", 404);
     }

--- a/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/image/route.ts
+++ b/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/image/route.ts
@@ -5,9 +5,13 @@ import { publicBlobUrl, readBlob } from "../../../../../../src/lib/blobs";
 import { detectImageContentType } from "../../../../../../src/lib/store";
 import {
   canAccessPrivateScene,
+  canViewPulledScene,
   shareTokenGrantsAccess,
 } from "../../../../../../src/lib/store-auth";
-import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flow";
+import {
+  jsonError,
+  requireDatabase,
+} from "../../../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../../../src/lib/rate-limit";
 import { storeRoute } from "../../../../../../src/lib/store-cache";
 
@@ -79,9 +83,16 @@ async function handleGet(request: NextRequest, context: RouteContext) {
     if (!lead) {
       return jsonError("scene_not_found", 404);
     }
-    preview = { content: lead.content, objectKey: lead.objectKey, tag: lead.id };
+    preview = {
+      content: lead.content,
+      objectKey: lead.objectKey,
+      tag: lead.id,
+    };
   }
-  if (scene.status === "pulled") {
+  if (
+    scene.status === "pulled" &&
+    !(await canViewPulledScene(scene.accountId))
+  ) {
     return jsonError("scene_pulled", 410);
   }
   if (scene.visibility !== "public") {
@@ -91,7 +102,11 @@ async function handleGet(request: NextRequest, context: RouteContext) {
     );
     if (
       !shared &&
-      !(await canAccessPrivateScene(db, request.headers.get("authorization"), scene.accountId))
+      !(await canAccessPrivateScene(
+        db,
+        request.headers.get("authorization"),
+        scene.accountId,
+      ))
     ) {
       return jsonError("scene_not_found", 404);
     }

--- a/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/images/[imageId]/route.ts
+++ b/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/images/[imageId]/route.ts
@@ -5,6 +5,7 @@ import { publicBlobUrl, readBlob } from "../../../../../../../src/lib/blobs";
 import { detectImageContentType } from "../../../../../../../src/lib/store";
 import {
   canAccessPrivateScene,
+  canViewPulledScene,
   shareTokenGrantsAccess,
 } from "../../../../../../../src/lib/store-auth";
 import {
@@ -35,10 +36,7 @@ async function handleGet(request: NextRequest, context: RouteContext) {
   }
 
   const { imageId, sceneId } = await context.params;
-  if (
-    !/^[0-9a-f-]{36}$/i.test(sceneId) ||
-    !/^[0-9a-f-]{36}$/i.test(imageId)
-  ) {
+  if (!/^[0-9a-f-]{36}$/i.test(sceneId) || !/^[0-9a-f-]{36}$/i.test(imageId)) {
     return jsonError("image_not_found", 404);
   }
 
@@ -65,7 +63,7 @@ async function handleGet(request: NextRequest, context: RouteContext) {
   if (!row) {
     return jsonError("image_not_found", 404);
   }
-  if (row.status === "pulled") {
+  if (row.status === "pulled" && !(await canViewPulledScene(row.accountId))) {
     return jsonError("scene_pulled", 410);
   }
   if (row.visibility !== "public") {

--- a/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/scenes.json/route.ts
+++ b/cloud/apps/auth-web/app/api/store/scenes/[sceneId]/scenes.json/route.ts
@@ -5,9 +5,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { readBlob } from "../../../../../../src/lib/blobs";
 import {
   canAccessPrivateScene,
+  canViewPulledScene,
   shareTokenGrantsAccess,
 } from "../../../../../../src/lib/store-auth";
-import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flow";
+import {
+  jsonError,
+  requireDatabase,
+} from "../../../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../../../src/lib/rate-limit";
 import { storeRoute } from "../../../../../../src/lib/store-cache";
 
@@ -18,8 +22,9 @@ type RouteContext = { params: Promise<{ sceneId: string }> };
 // The scenes.json extracted from a scene's template zip — what the
 // in-browser live preview (frameos-wasm) executes. Same access and version
 // rules as the zip download: public scenes are open, private ones owner-only,
-// pulled 410; `?version=N` picks a version (yanked ones included), the
-// default is the newest non-yanked one.
+// pulled 410 for everyone but the owner's and moderators' own sessions;
+// `?version=N` picks a version (yanked ones included), the default is the
+// newest non-yanked one.
 async function handleGet(request: NextRequest, context: RouteContext) {
   const limited = await rateLimitResponse(request, "store:scenes-json", {
     limit: 240,
@@ -54,14 +59,24 @@ async function handleGet(request: NextRequest, context: RouteContext) {
   if (!scene) {
     return jsonError("scene_not_found", 404);
   }
-  if (scene.status === "pulled") {
+  if (
+    scene.status === "pulled" &&
+    !(await canViewPulledScene(scene.accountId))
+  ) {
     return jsonError("scene_pulled", 410);
   }
   const isPublic = scene.visibility === "public";
   if (
     !isPublic &&
-    !shareTokenGrantsAccess(scene.shareToken, request.nextUrl.searchParams.get("share")) &&
-    !(await canAccessPrivateScene(db, request.headers.get("authorization"), scene.accountId))
+    !shareTokenGrantsAccess(
+      scene.shareToken,
+      request.nextUrl.searchParams.get("share"),
+    ) &&
+    !(await canAccessPrivateScene(
+      db,
+      request.headers.get("authorization"),
+      scene.accountId,
+    ))
   ) {
     return jsonError("scene_not_found", 404);
   }

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -54,7 +54,12 @@ body {
   background: var(--bg);
   color: var(--text);
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
     sans-serif;
 }
 
@@ -520,7 +525,8 @@ html.theme-dark .button-primary {
 }
 
 .device-code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     monospace;
   letter-spacing: 0;
 }
@@ -597,7 +603,8 @@ html.theme-dark .button-primary {
 }
 
 .code-input {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     monospace;
   font-size: 18px;
   letter-spacing: 0;
@@ -2367,7 +2374,8 @@ a.stat-tile:hover {
   transform: translateZ(0);
 }
 
-.editor-modal__frame:not(.editor-modal__frame--with-panels) .editor-modal__editor {
+.editor-modal__frame:not(.editor-modal__frame--with-panels)
+  .editor-modal__editor {
   position: absolute;
   inset: 0;
 }
@@ -3255,7 +3263,7 @@ html.theme-dark .ai-panel__render {
   }
 }
 
-/* "Create a scene with AI" on the store front and in My private scenes. */
+/* "Create a scene with AI" on the store front and in My scenes. */
 .ai-create-box {
   display: grid;
   grid-template-columns: minmax(220px, 1fr) minmax(320px, 1fr);
@@ -3285,7 +3293,32 @@ html.theme-dark .ai-panel__render {
   }
 }
 
-/* "My private scenes": filter form on the left, grid/list switch on the right. */
+/* The Public / Private sections of the unfiltered "My scenes" list: a
+   heading with a count, then that group's grid or table. */
+.scene-group {
+  display: grid;
+  gap: 12px;
+}
+
+.scene-group__heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 0;
+  font-size: 16px;
+}
+
+.scene-group__count {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 8px;
+  background: var(--bg-soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+/* "My scenes": filter form on the left, grid/list switch on the right. */
 .my-scenes-toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/cloud/apps/auth-web/app/my-scenes/page.tsx
+++ b/cloud/apps/auth-web/app/my-scenes/page.tsx
@@ -4,7 +4,9 @@ import { redirect } from "next/navigation";
 import { createDb, storeScenes } from "@frameos-cloud/db";
 import { CreateSceneWithAiBox } from "../../src/components/CreateSceneWithAiBox";
 import {
+  MyScenesGroupHeading,
   MyScenesView,
+  groupMyScenes,
   type MyScenesRow,
 } from "../../src/components/MyScenesView";
 import { PublicShell } from "../../src/components/PublicShell";
@@ -21,14 +23,16 @@ import { readSession } from "../../src/lib/session";
 import { accountIsSuperadmin } from "../../src/lib/superadmin";
 import { sceneHasAnyImageSql } from "../../src/lib/store-preview";
 
-export const metadata = { title: "My private scenes" };
+export const metadata = { title: "My scenes" };
 
 export const dynamic = "force-dynamic";
 
-// The "My private scenes" tab of the scene store: every scene the signed-in
+// The "My scenes" tab of the scene store: every scene the signed-in
 // account published (private or public), with filters, zip upload, and the
-// visibility/delete actions. This used to be the /account/scenes page (alias
-// /scenes on the cloud host); both now redirect here.
+// visibility/delete actions. Without a visibility filter the list is split
+// into a Public and a Private section, so the two kinds are never mistaken
+// for each other. This used to be the /account/scenes page (alias /scenes on
+// the cloud host); both now redirect here.
 export default async function MyScenesPage({
   searchParams,
 }: {
@@ -109,10 +113,17 @@ export default async function MyScenesPage({
     id: scene.id,
     name: scene.name,
     slug: scene.slug,
+    status: scene.status,
     tags: scene.tags,
     updatedAt: scene.updatedAt.toISOString(),
     visibility: scene.visibility,
   }));
+  // One table per visibility group when nothing narrows the list to a single
+  // visibility; a filtered list is one flat table without a heading.
+  const grouped = !visibility;
+  const tableGroups = grouped
+    ? groupMyScenes(sceneRows)
+    : [{ key: "all", scenes: sceneRows, title: null }];
 
   return (
     <PublicShell isSuperadmin={isSuperadmin} noCapture signedIn>
@@ -120,7 +131,7 @@ export default async function MyScenesPage({
       <section className="section-block">
         <div className="content-header compact-header">
           <div>
-            <h2>My private scenes</h2>
+            <h2>My scenes</h2>
             <p className="copy">
               Scenes you saved to the FrameOS cloud. Private scenes are visible
               only to you and people with a sharing link; public scenes appear
@@ -134,6 +145,7 @@ export default async function MyScenesPage({
         ) : null}
         {accountId ? <SceneZipUpload /> : null}
         <MyScenesView
+          grouped={grouped}
           filters={
             <form action={myScenesUrl} className="filter-bar" method="get">
               <input
@@ -181,91 +193,103 @@ export default async function MyScenesPage({
           scenes={gridRows}
         >
           {sceneRows.length > 0 ? (
-            <table className="table">
-              <thead>
-                <tr>
-                  <th aria-label="Preview" />
-                  <th>Name</th>
-                  <th>Tags</th>
-                  <th>Visibility</th>
-                  <th>Status</th>
-                  <th>Version</th>
-                  <th>Downloads</th>
-                  <th>Updated</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sceneRows.map((scene) => (
-                  <tr key={scene.id}>
-                    <td className="table-thumb-cell">
-                      <Link href={`/s/${scene.slug}`} tabIndex={-1}>
-                        {scene.hasPreview ? (
-                          <img
-                            alt=""
-                            className="table-thumb"
-                            loading="lazy"
-                            src={`/api/store/scenes/${scene.id}/image`}
-                          />
-                        ) : (
+            tableGroups.map((group) => (
+              <section className="scene-group" key={group.key}>
+                {group.title ? (
+                  <MyScenesGroupHeading
+                    count={group.scenes.length}
+                    title={group.title}
+                  />
+                ) : null}
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th aria-label="Preview" />
+                      <th>Name</th>
+                      <th>Tags</th>
+                      <th>Visibility</th>
+                      <th>Status</th>
+                      <th>Version</th>
+                      <th>Downloads</th>
+                      <th>Updated</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {group.scenes.map((scene) => (
+                      <tr key={scene.id}>
+                        <td className="table-thumb-cell">
+                          <Link href={`/s/${scene.slug}`} tabIndex={-1}>
+                            {scene.hasPreview ? (
+                              <img
+                                alt=""
+                                className="table-thumb"
+                                loading="lazy"
+                                src={`/api/store/scenes/${scene.id}/image`}
+                              />
+                            ) : (
+                              <span
+                                aria-hidden
+                                className="table-thumb table-thumb--empty"
+                              />
+                            )}
+                          </Link>
+                        </td>
+                        <td>
+                          <Link href={`/s/${scene.slug}`}>{scene.name}</Link>
+                        </td>
+                        <td>
+                          {scene.tags.length > 0 ? (
+                            <div className="tag-list">
+                              {scene.tags.map((tag) => (
+                                <span className="tag-pill" key={tag}>
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td>
                           <span
-                            aria-hidden
-                            className="table-thumb table-thumb--empty"
+                            className={
+                              scene.visibility === "public"
+                                ? "pill pill-ok"
+                                : "pill"
+                            }
+                          >
+                            {scene.visibility === "public"
+                              ? "Public"
+                              : "Private"}
+                          </span>
+                        </td>
+                        <td>
+                          {scene.status === "pulled" ? (
+                            <span className="pill pill-warning">Pulled</span>
+                          ) : scene.featuredAt ? (
+                            <span className="pill pill-ok">Featured</span>
+                          ) : (
+                            <span className="pill">Active</span>
+                          )}
+                        </td>
+                        <td>v{scene.latestVersion}</td>
+                        <td>{scene.downloadCount}</td>
+                        <td>{formatDate(scene.updatedAt)}</td>
+                        <td>
+                          <StoreSceneActions
+                            name={scene.name}
+                            sceneId={scene.id}
+                            status={scene.status}
+                            visibility={scene.visibility}
                           />
-                        )}
-                      </Link>
-                    </td>
-                    <td>
-                      <Link href={`/s/${scene.slug}`}>{scene.name}</Link>
-                    </td>
-                    <td>
-                      {scene.tags.length > 0 ? (
-                        <div className="tag-list">
-                          {scene.tags.map((tag) => (
-                            <span className="tag-pill" key={tag}>
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
-                    <td>
-                      <span
-                        className={
-                          scene.visibility === "public"
-                            ? "pill pill-ok"
-                            : "pill"
-                        }
-                      >
-                        {scene.visibility === "public" ? "Public" : "Private"}
-                      </span>
-                    </td>
-                    <td>
-                      {scene.status === "pulled" ? (
-                        <span className="pill pill-warning">Pulled</span>
-                      ) : scene.featuredAt ? (
-                        <span className="pill pill-ok">Featured</span>
-                      ) : (
-                        <span className="pill">Active</span>
-                      )}
-                    </td>
-                    <td>v{scene.latestVersion}</td>
-                    <td>{scene.downloadCount}</td>
-                    <td>{formatDate(scene.updatedAt)}</td>
-                    <td>
-                      <StoreSceneActions
-                        name={scene.name}
-                        sceneId={scene.id}
-                        status={scene.status}
-                        visibility={scene.visibility}
-                      />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
+            ))
           ) : query || visibility || status ? (
             <section className="card">
               <p>No scenes match these filters.</p>

--- a/cloud/apps/auth-web/src/components/CreateSceneWithAiBox.tsx
+++ b/cloud/apps/auth-web/src/components/CreateSceneWithAiBox.tsx
@@ -1,6 +1,6 @@
 import { Sparkles } from "lucide-react";
 
-// A quiet one-line prompt box for the store front and "My private scenes":
+// A quiet one-line prompt box for the store front and "My scenes":
 // describe a scene, land in the new-scene editor with the AI already working
 // on it (/my-scenes/new?prompt=…; that page asks for sign-in first if
 // needed). A plain GET form — no client JavaScript involved.

--- a/cloud/apps/auth-web/src/components/MyScenesView.test.tsx
+++ b/cloud/apps/auth-web/src/components/MyScenesView.test.tsx
@@ -21,6 +21,7 @@ function row(name: string, overrides: Partial<MyScenesRow> = {}): MyScenesRow {
     id: `id-${name}`,
     name,
     slug: name.toLowerCase(),
+    status: "active",
     tags: ["time"],
     updatedAt: "2026-08-01T00:00:00.000Z",
     visibility: "private",
@@ -104,6 +105,46 @@ describe("MyScenesView", () => {
         .getByRole("button", { name: "List view" })
         .getAttribute("aria-pressed"),
     ).toBe("true");
+  });
+
+  it("splits the unfiltered grid into Public and Private sections", () => {
+    render(
+      <MyScenesView
+        grouped
+        scenes={[
+          ...scenes,
+          row("Storm", { status: "pulled", visibility: "public" }),
+        ]}
+      />,
+    );
+
+    const headings = Array.from(
+      document.querySelectorAll(".scene-group__heading"),
+    );
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      "Public scenes2",
+      "Private scenes1",
+    ]);
+    // Public first, then private; a pulled scene stays in its visibility
+    // group but its pill says "Pulled" rather than a visibility that no
+    // longer applies.
+    const cards = screen.getAllByRole("link");
+    expect(cards.map((card) => card.textContent?.slice(0, 5))).toEqual([
+      "Tides",
+      "Storm",
+      "Sunri",
+    ]);
+    expect(screen.getByRole("link", { name: /Storm/ }).textContent).toContain(
+      "Pulled",
+    );
+    expect(
+      screen.getByRole("link", { name: /Storm/ }).textContent,
+    ).not.toContain("Public");
+  });
+
+  it("keeps a flat grid without headings when not grouped", () => {
+    renderView();
+    expect(document.querySelector(".scene-group__heading")).toBeNull();
   });
 
   it("shows the children (empty state) when there are no scenes", () => {

--- a/cloud/apps/auth-web/src/components/MyScenesView.tsx
+++ b/cloud/apps/auth-web/src/components/MyScenesView.tsx
@@ -17,9 +17,52 @@ export type MyScenesRow = {
   name: string;
   slug: string;
   tags: string[];
+  // "active" | "pulled": a pulled scene's card says so instead of its
+  // visibility, which no longer means anything while it is pulled.
+  status: string;
   updatedAt: string;
   visibility: string;
 };
+
+// The visibility groups of the unfiltered list, in display order: what the
+// world sees first, then what only the owner sees. Groups without scenes
+// are skipped.
+export const myScenesGroups = [
+  { key: "public", title: "Public scenes" },
+  { key: "private", title: "Private scenes" },
+] as const;
+
+export type MyScenesGroupKey = (typeof myScenesGroups)[number]["key"];
+
+export function groupMyScenes<T extends { visibility: string }>(scenes: T[]) {
+  return myScenesGroups
+    .map((group) => ({
+      ...group,
+      scenes: scenes.filter((scene) =>
+        group.key === "public"
+          ? scene.visibility === "public"
+          : scene.visibility !== "public",
+      ),
+    }))
+    .filter((group) => group.scenes.length > 0);
+}
+
+// The heading over one visibility group, shared by the grid and the table
+// so both views read the same.
+export function MyScenesGroupHeading({
+  count,
+  title,
+}: {
+  count: number;
+  title: string;
+}) {
+  return (
+    <h3 className="scene-group__heading">
+      {title}
+      <span className="scene-group__count">{count}</span>
+    </h3>
+  );
+}
 
 export const myScenesViewStorageKey = "frameos:my-scenes-view";
 
@@ -40,7 +83,7 @@ function storeView(view: MyScenesViewMode) {
   }
 }
 
-// The grid / list switch on "My private scenes". The grid reuses the store
+// The grid / list switch on "My scenes". The grid reuses the store
 // front's cards; the list is the server-rendered table handed in as
 // `children` (with its owner actions), so it stays exactly as it was. The
 // server always renders the grid; a remembered "list" choice takes over after
@@ -48,12 +91,16 @@ function storeView(view: MyScenesViewMode) {
 export function MyScenesView({
   children,
   filters,
+  grouped = false,
   scenes,
 }: {
   // The table (or the empty-state card when there are no scenes).
   children?: ReactNode | undefined;
   // The server-rendered filter form, laid out left of the toggle.
   filters?: ReactNode | undefined;
+  // Split the grid into Public / Private sections (the unfiltered list);
+  // the page groups the table the same way.
+  grouped?: boolean | undefined;
   scenes: MyScenesRow[];
 }) {
   const [view, setView] = useState<MyScenesViewMode>("grid");
@@ -98,17 +145,35 @@ export function MyScenesView({
         </div>
       </div>
       {view === "grid" && scenes.length > 0 ? (
-        <div className="grid scene-grid">
-          {scenes.map((scene) => (
-            <SceneCard
-              key={scene.id}
-              scene={{ ...scene, updatedAt: new Date(scene.updatedAt) }}
-            />
-          ))}
-        </div>
+        grouped ? (
+          groupMyScenes(scenes).map((group) => (
+            <section className="scene-group" key={group.key}>
+              <MyScenesGroupHeading
+                count={group.scenes.length}
+                title={group.title}
+              />
+              <SceneGrid scenes={group.scenes} />
+            </section>
+          ))
+        ) : (
+          <SceneGrid scenes={scenes} />
+        )
       ) : (
         children
       )}
     </>
+  );
+}
+
+function SceneGrid({ scenes }: { scenes: MyScenesRow[] }) {
+  return (
+    <div className="grid scene-grid">
+      {scenes.map((scene) => (
+        <SceneCard
+          key={scene.id}
+          scene={{ ...scene, updatedAt: new Date(scene.updatedAt) }}
+        />
+      ))}
+    </div>
   );
 }

--- a/cloud/apps/auth-web/src/components/SceneCard.tsx
+++ b/cloud/apps/auth-web/src/components/SceneCard.tsx
@@ -16,6 +16,9 @@ export type SceneCardScene = {
   publisher?: string | null | undefined;
   riskFlags?: string[];
   slug: string;
+  // "active" | "pulled"; a pulled scene shows a "Pulled" pill in place of
+  // its visibility (the owner's listing).
+  status?: string | undefined;
   tags?: string[];
   updatedAt: Date;
   // "private" | "public"; shown as a pill when set (the owner's listing).
@@ -57,7 +60,9 @@ export function SceneCard({ scene }: { scene: SceneCardScene }) {
       {scene.description ? <p className="copy">{scene.description}</p> : null}
       {scene.visibility || category || tags.length > 0 ? (
         <div className="tag-list">
-          {scene.visibility ? (
+          {scene.visibility && scene.status === "pulled" ? (
+            <span className="pill pill-warning">Pulled</span>
+          ) : scene.visibility ? (
             <span
               className={
                 scene.visibility === "public" ? "pill pill-ok" : "pill"

--- a/cloud/apps/auth-web/src/components/SceneInfoPanel.test.tsx
+++ b/cloud/apps/auth-web/src/components/SceneInfoPanel.test.tsx
@@ -152,6 +152,29 @@ describe("SceneInfoPanel", () => {
     expect(screen.getByText(/only visible to you/)).toBeTruthy();
   });
 
+  it("freezes a pulled scene for its owner: the notice, no image controls, only Delete", () => {
+    render(
+      <SceneInfoPanel
+        {...info}
+        isOwner
+        scene={{ ...info.scene, pulledReason: "malware report", status: "pulled" }}
+        signedIn
+      />,
+    );
+    const notice = screen.getByRole("alert");
+    expect(notice.textContent).toContain("Pulled");
+    expect(notice.textContent).toContain("pulled by moderation");
+    expect(notice.textContent).toContain("malware report");
+    // The images still render (the owner's session may read them) but the
+    // server refuses edits on a pulled scene, so no add/remove buttons.
+    expect(document.querySelectorAll(".scene-gallery img")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: /Remove image/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add an image to this scene's page" })).toBeNull();
+    // The way out is deleting the scene; visibility cannot be flipped.
+    expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Make (public|private)/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Report scene" })).toBeNull();
+  });
 
   it("heads the column with the name it is given as a heading, the publisher line under it, then the description, then the images", () => {
     render(<SceneInfoPanel {...info} heading={<span>Clock title</span>} />);

--- a/cloud/apps/auth-web/src/components/SceneInfoPanel.tsx
+++ b/cloud/apps/auth-web/src/components/SceneInfoPanel.tsx
@@ -122,9 +122,11 @@ export function SceneInfoPanel({
           )}
         </div>
       </div>
-      {/* ph-no-capture travels with the gallery too. */}
+      {/* ph-no-capture travels with the gallery too. A pulled scene is
+          frozen server-side (image edits answer scene_pulled), so the owner
+          gets no add/remove controls on it rather than failing ones. */}
       <SceneImageGallery
-        canEdit={isOwner}
+        canEdit={isOwner && isActive}
         hasPreview={scene.hasPreview}
         imageIds={imageIds}
         sceneId={scene.id}
@@ -160,10 +162,24 @@ export function SceneInfoPanel({
       ) : null}
 
       {scene.status === "pulled" ? (
-        <p className="notice-error" role="alert">
-          This scene was pulled by moderation and is hidden from the store
+        <div className="notice notice-error" role="alert">
+          <span className="pill pill-warning">Pulled</span> This scene was pulled by moderation
+          and is hidden from the store
           {scene.pulledReason ? `: ${scene.pulledReason}` : "."}
-        </p>
+          {isOwner || isAdmin
+            ? " Only you and moderators can open this page; the scene cannot be edited, installed or made visible while it is pulled."
+            : ""}
+          {isOwner ? (
+            <div className="notice__actions">
+              <StoreSceneActions
+                name={scene.name}
+                sceneId={scene.id}
+                status={scene.status}
+                visibility={scene.visibility}
+              />
+            </div>
+          ) : null}
+        </div>
       ) : null}
       {isPrivate && isActive ? (
         <div className="notice">

--- a/cloud/apps/auth-web/src/components/StoreTabs.tsx
+++ b/cloud/apps/auth-web/src/components/StoreTabs.tsx
@@ -8,7 +8,7 @@ export function StoreTabs({ active }: { active: "store" | "mine" }) {
   const storeUrl = getStoreUrl();
   const tabs = [
     { href: storeUrl, key: "store", label: "Public scene store" },
-    { href: getMyScenesUrl(), key: "mine", label: "My private scenes" },
+    { href: getMyScenesUrl(), key: "mine", label: "My scenes" },
   ] as const;
   return (
     <nav aria-label="Scene store sections" className="subnav subnav--store">

--- a/cloud/apps/auth-web/src/lib/env.ts
+++ b/cloud/apps/auth-web/src/lib/env.ts
@@ -146,7 +146,7 @@ export function getStoreUrl() {
   return new URL(getStorePath(), getScenesBaseUrl()).toString();
 }
 
-// "My private scenes": the second tab of the scene store, on the scenes host
+// "My scenes": the second tab of the scene store, on the scenes host
 // next to the public store front. It replaced /account/scenes (and its clean
 // alias /scenes on the cloud host), which now redirect here.
 export const myScenesPath = "/my-scenes";

--- a/cloud/apps/auth-web/src/lib/store-auth.ts
+++ b/cloud/apps/auth-web/src/lib/store-auth.ts
@@ -1,11 +1,9 @@
 import { timingSafeEqual } from "node:crypto";
 import type { createDb } from "@frameos-cloud/db";
-import {
-  authenticateLinkedClient,
-  linkedClientHasScope,
-} from "./backend-auth";
+import { authenticateLinkedClient, linkedClientHasScope } from "./backend-auth";
 import { readSession } from "./session";
 import { storePublishScope } from "./store";
+import { accountIsSuperadmin } from "./superadmin";
 
 // A private scene is reachable by its owner two ways: the owner's web session
 // (browsing the store signed in) or a linked client of the owner's account
@@ -22,14 +20,11 @@ export async function canAccessPrivateScene(
     return true;
   }
 
-  const linkedClient = await authenticateLinkedClient(
-    db,
-    authorizationHeader,
-  );
+  const linkedClient = await authenticateLinkedClient(db, authorizationHeader);
   return Boolean(
     linkedClient &&
-      linkedClient.accountId === ownerAccountId &&
-      linkedClientHasScope(linkedClient, storePublishScope),
+    linkedClient.accountId === ownerAccountId &&
+    linkedClientHasScope(linkedClient, storePublishScope),
   );
 }
 
@@ -51,4 +46,21 @@ export function shareTokenGrantsAccess(
   const expected = Buffer.from(sceneShareToken);
   const actual = Buffer.from(provided);
   return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+// A pulled scene is gone for the public, for share-token holders and for
+// linked frames alike — but its owner and moderators still open its page
+// (the store page itself lets them through), so the reads that page is made
+// of (images, scenes.json, the zip) follow the same rule: the owner's or a
+// superadmin's web session, nothing else. Without this the owner sees a
+// page of broken images and a "Could not load the scene (410)".
+export async function canViewPulledScene(ownerAccountId: string) {
+  const session = await readSession();
+  if (!session?.accountId) {
+    return false;
+  }
+  return (
+    session.accountId === ownerAccountId ||
+    (await accountIsSuperadmin(session.accountId))
+  );
 }

--- a/cloud/apps/auth-web/src/lib/surfaces.ts
+++ b/cloud/apps/auth-web/src/lib/surfaces.ts
@@ -18,7 +18,12 @@ const authPagePrefixes = [
 // "/frames" is the cloud frames SPA (app/frames/[[...path]]), an account
 // surface; "/frames-app" holds its static assets and is treated as an
 // asset path below.
-const accountPagePrefixes = ["/account", "/admin", "/device", "/frames"] as const;
+const accountPagePrefixes = [
+  "/account",
+  "/admin",
+  "/device",
+  "/frames",
+] as const;
 const accountSectionRewrites = new Map([
   ["/backends", "/account/installs"],
   ["/backups", "/account/backups"],
@@ -63,7 +68,7 @@ export function isPublicScenePath(pathname: string) {
 }
 
 // Everything the scenes host serves besides its store front: public scene
-// pages plus the signed-in "My private scenes" tab.
+// pages plus the signed-in "My scenes" tab.
 function isScenesHostPath(pathname: string) {
   return isPublicScenePath(pathname) || pathname === myScenesPath;
 }

--- a/cloud/apps/auth-web/src/test/integration/store.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/store.integration.test.ts
@@ -41,7 +41,7 @@ import { createSession, sessionCookieName } from "../../lib/session";
 
 const cookieJar = vi.hoisted(() => new Map<string, string>());
 
-// The "My private scenes" page renders client components (zip upload, row
+// The "My scenes" page renders client components (zip upload, row
 // actions) that read the app router; renderToStaticMarkup has none mounted.
 vi.mock("next/navigation", async (importOriginal) => ({
   ...(await importOriginal<typeof import("next/navigation")>()),
@@ -480,14 +480,14 @@ describe("store publish and distribution", () => {
     expect(forkedPreview?.previewImage).toEqual(sourcePreview?.previewImage);
   });
 
-  it("offers the signed-in owner a 'My private scenes' tab that lists their scenes", async () => {
+  it("offers the signed-in owner a 'My scenes' tab that lists their scenes", async () => {
     const { accessToken } = await linkClient(publishScopes);
     await publish(accessToken);
 
     const signedInMarkup = renderToStaticMarkup(
       await HomePage({ searchParams: Promise.resolve({}) }),
     );
-    expect(signedInMarkup).toContain("My private scenes");
+    expect(signedInMarkup).toContain("My scenes");
     expect(signedInMarkup).toContain("Public scene store");
     // Private scenes are not on the store front itself any more.
     expect(signedInMarkup).not.toContain("Sunrise Clock");
@@ -501,7 +501,7 @@ describe("store publish and distribution", () => {
     const anonymousMarkup = renderToStaticMarkup(
       await HomePage({ searchParams: Promise.resolve({}) }),
     );
-    expect(anonymousMarkup).not.toContain("My private scenes");
+    expect(anonymousMarkup).not.toContain("My scenes");
   });
 
   it("requires the store:publish scope and a structurally valid zip", async () => {
@@ -839,9 +839,7 @@ describe("store publish and distribution", () => {
     expect(metadata.openGraph?.images).toEqual([
       expect.objectContaining({ url: expectedImageUrl }),
     ]);
-    expect(metadata.openGraph?.url).toBe(
-      `${baseUrl}/s/${slug}?share=${share}`,
-    );
+    expect(metadata.openGraph?.url).toBe(`${baseUrl}/s/${slug}?share=${share}`);
     expect(metadata.twitter).toMatchObject({
       card: "summary_large_image",
       images: [expectedImageUrl],
@@ -865,7 +863,9 @@ describe("store publish and distribution", () => {
 
     // Nothing to show yet: the tiles say so and the image route is a 404.
     expect(
-      renderToStaticMarkup(await HomePage({ searchParams: Promise.resolve({}) })),
+      renderToStaticMarkup(
+        await HomePage({ searchParams: Promise.resolve({}) }),
+      ),
     ).toContain("No preview");
     expect(
       renderToStaticMarkup(
@@ -1098,12 +1098,40 @@ describe("store publish and distribution", () => {
     );
     expect(repo.templates).toHaveLength(0);
 
+    // The owner's (here also a moderator's) own session still gets the
+    // scene's reads — the page they can open has to render — while every
+    // other path stays a 410.
+    const ownerDownload = await downloadScene(
+      request(`/api/store/scenes/${sceneId}/download`, "GET"),
+      ctx(sceneId),
+    );
+    expect(ownerDownload.status).toBe(200);
+    const ownerScenesJson = await getScenesJson(
+      request(`/api/store/scenes/${sceneId}/scenes.json`, "GET"),
+      ctx(sceneId),
+    );
+    expect(ownerScenesJson.status).toBe(200);
+
     cookieJar.clear();
     const download = await downloadScene(
       request(`/api/store/scenes/${sceneId}/download`, "GET"),
       ctx(sceneId),
     );
     expect(download.status).toBe(410);
+    const scenesJson = await getScenesJson(
+      request(`/api/store/scenes/${sceneId}/scenes.json`, "GET"),
+      ctx(sceneId),
+    );
+    expect(scenesJson.status).toBe(410);
+    // Nor does the owner's linked frameos backend: frames never install a
+    // pulled scene.
+    const linkedDownload = await downloadScene(
+      request(`/api/store/scenes/${sceneId}/download`, "GET", {
+        headers: { authorization: `Bearer ${accessToken}` },
+      }),
+      ctx(sceneId),
+    );
+    expect(linkedDownload.status).toBe(410);
 
     const republish = await publish(accessToken);
     expect(republish.status).toBe(403);
@@ -1360,8 +1388,12 @@ describe("store publish and distribution", () => {
 
   it("serves a requested scenes.json version, yanked or not, defaulting to the newest live one", async () => {
     const { accessToken } = await linkClient(publishScopes);
-    const scenesV1 = [{ fields: [], id: "scene-1", nodes: [{ data: { keyword: "v1" } }] }];
-    const scenesV2 = [{ fields: [], id: "scene-1", nodes: [{ data: { keyword: "v2" } }] }];
+    const scenesV1 = [
+      { fields: [], id: "scene-1", nodes: [{ data: { keyword: "v1" } }] },
+    ];
+    const scenesV2 = [
+      { fields: [], id: "scene-1", nodes: [{ data: { keyword: "v2" } }] },
+    ];
     const scene = (
       await readJson(
         await publish(accessToken, {

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-deploy-dialog.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-deploy-dialog.test.tsx
@@ -150,6 +150,26 @@ describe("the deploy dialog in cloud mode", () => {
     ).toBeNull();
   });
 
+  it("drops the resend tick when the device already has this exact scene set", () => {
+    // assigned == acked and nothing unsaved: a resend would send nothing, so
+    // the checkbox goes and only the "already in sync" sentence stays. Same
+    // rule on both platforms' cards.
+    const inSync = { assigned_checksum: "abc123", scenes_checksum: "abc123" };
+    for (const platform of ["esp32", "pi-zero2w"] as const) {
+      cleanup();
+      render(<FrameDeployPlanDrawer frame={cloudFrame(platform, inSync)} />);
+      if (platform === "esp32") {
+        fireEvent.click(screen.getByRole("button", { name: /Over the air/ }));
+      }
+      expect(
+        screen.queryByRole("checkbox", { name: /Resend scenes & settings/ }),
+      ).toBeNull();
+      expect(
+        screen.getByText(/already in sync — nothing extra is sent/),
+      ).toBeTruthy();
+    }
+  });
+
   it("orders the USB path firmware, scene push, then Wi-Fi repair", () => {
     render(<FrameDeployPlanDrawer frame={cloudFrame("esp32")} />);
     fireEvent.click(screen.getByRole("button", { name: /Over USB/ }));

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -2574,7 +2574,7 @@ function CloudOtaDeployView({
                 type="button"
                 title={
                   firmwareDisabledReason ??
-                  (alsoPushScenes
+                  (alsoPushScenes && !scenesInSync
                     ? 'Queue a firmware update and resend this frame’s scenes & settings'
                     : 'Queue a firmware update notification')
                 }
@@ -2600,12 +2600,16 @@ function CloudOtaDeployView({
                     everything" only made the two disagree about what it does. */}
                 Upgrade firmware
               </button>
-              <Checkbox label="Resend scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
-              {alsoPushScenes && scenesInSync ? (
+              {/* Nothing to resend when the device already acked everything:
+                  a tick that sends nothing only invites the question of why
+                  it is there, so the sentence stands alone. */}
+              {scenesInSync ? (
                 <div className="frame-tool-muted text-xs leading-4">
                   Scenes &amp; settings are already in sync — nothing extra is sent.
                 </div>
-              ) : null}
+              ) : (
+                <Checkbox label="Resend scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
+              )}
             </>
           ) : (
             <div className="frame-tool-muted text-sm leading-5">
@@ -3000,17 +3004,18 @@ function CloudPiUpdateCard({
             The device already runs the latest release ({releaseInfo.release}); asking it to update is a no-op.
           </div>
         ) : null}
-        <Checkbox label="Resend scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
-        {alsoPushScenes && scenesInSync ? (
+        {scenesInSync ? (
           <div className="frame-tool-muted text-xs leading-4">
             Scenes &amp; settings are already in sync — nothing extra is sent.
           </div>
-        ) : null}
+        ) : (
+          <Checkbox label="Resend scenes & settings" value={alsoPushScenes} onChange={setAlsoPushScenes} />
+        )}
         <button
           type="button"
           title={
             disabledReason ??
-            (alsoPushScenes
+            (alsoPushScenes && !scenesInSync
               ? 'Queue a FrameOS update and push this frame’s scenes & settings'
               : 'Queue a FrameOS update notification')
           }


### PR DESCRIPTION
## Summary

- **Upgrade firmware / FrameOS update**: when scenes & settings are already in sync (assigned checksum acked, nothing unsaved) the "Resend scenes & settings" checkbox is dropped and only the "already in sync — nothing extra is sent" line remains. Both the esp32 and Pi cards.
- **Scene store "My private scenes" → "My scenes"** (it always listed public scenes too). With "All visibilities" selected, the grid and the table are split into **Public scenes** / **Private scenes** sections with counts; a filtered list stays flat. Cards now show a **Pulled** pill instead of the visibility for pulled scenes.
- **Pulled scene page** (e.g. `/s/split-screen`): the owner could open the page but every read on it 410'd — broken images, "Could not load the scene (410)", and image removal failing with `scene_pulled`.
  - The owner's and a superadmin's **web session** now pass the pulled gate on `/image`, `/images/[id]`, `/scenes.json` and `/download` (`canViewPulledScene`). Share tokens, anonymous visitors and linked frames still get 410 — frames never install a pulled scene.
  - The info panel hides the add/remove image controls on a pulled scene (the owner routes deliberately refuse edits — kept as is), shows a **Pulled** pill in the moderation notice, explains that the scene is frozen, and offers the owner **Delete** as the way out.

## Test plan

- [x] `cloud-deploy-dialog.test.tsx`: new case — in-sync frame renders the sentence and no checkbox on both platforms
- [x] `MyScenesView.test.tsx`: grouped grid order + headings/counts, pulled pill, flat when not grouped
- [x] `SceneInfoPanel.test.tsx`: pulled scene for the owner — notice, no image controls, Delete only
- [x] `store.integration.test.ts` (Postgres): owner session downloads/loads scenes.json of a pulled scene (200); anonymous and linked-client stay 410
- [x] cloud `tsc --noEmit`, eslint; frontend `tsc`
- [ ] Hardware/prod: open a pulled scene as its owner on scenes.frameos.net and check the images + editor load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176BTqDLj5w1jh1yAcphfRn