### PR TITLE
Browser preview: browser-only asset folder + opt-in real-time rendering

### DIFF
--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -2957,6 +2957,21 @@ a.stat-tile:hover {
   background: var(--bg-soft);
 }
 
+/* A credentials group whose key is saved on the account: one line, with
+   "Use another key" to open the inputs. */
+.preview-settings__group--stored {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.preview-settings__stored {
+  color: var(--muted);
+  font-size: 13px;
+}
+
 /* The preview's "this scene wants to go faster" prompt, and the toggle it
    turns into once answered. */
 .live-preview__fast {

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -2957,6 +2957,189 @@ a.stat-tile:hover {
   background: var(--bg-soft);
 }
 
+/* The preview's "this scene wants to go faster" prompt, and the toggle it
+   turns into once answered. */
+.live-preview__fast {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  border-color: color-mix(in srgb, var(--warning), transparent 55%);
+  color: var(--text);
+}
+
+.live-preview__fast-icon {
+  flex-shrink: 0;
+  color: var(--warning);
+}
+
+.live-preview__fast-copy {
+  flex: 1 1 16em;
+  font-size: 13px;
+}
+
+.live-preview__fast-toggle {
+  font-size: 13px;
+}
+
+/* The browser asset folder dialog (PreviewAssetsDialog). */
+.assets-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.assets-dialog__intro {
+  font-size: 13px;
+}
+
+.assets-dialog__toolbar {
+  align-items: center;
+  gap: 6px;
+}
+
+.assets-dialog__spacer {
+  flex: 1;
+}
+
+.assets-dialog__confirm {
+  font-size: 13px;
+}
+
+.assets-dialog__file-input {
+  display: none;
+}
+
+.assets-dialog__crumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 13px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+.assets-dialog__crumb-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.assets-dialog__crumb {
+  padding: 2px 4px;
+  border: 0;
+  border-radius: 4px;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+}
+
+.assets-dialog__crumb:hover {
+  text-decoration: underline;
+}
+
+.assets-dialog__crumb--current {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.assets-dialog__list {
+  min-height: 8rem;
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+}
+
+.assets-dialog__list--dragging {
+  border-color: var(--accent, #3b82f6);
+  background: color-mix(in srgb, var(--accent, #3b82f6), transparent 90%);
+}
+
+.assets-dialog__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px;
+  border-radius: 6px;
+}
+
+.assets-dialog__row:hover {
+  background: var(--bg-soft);
+}
+
+.assets-dialog__thumb {
+  flex-shrink: 0;
+  width: 64px;
+  height: 48px;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
+.assets-dialog__thumb--blank {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-soft);
+  color: var(--muted);
+}
+
+.assets-dialog__meta {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.assets-dialog__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.assets-dialog__name--folder {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  font-weight: 600;
+}
+
+.assets-dialog__name--folder:hover {
+  text-decoration: underline;
+}
+
+.assets-dialog__details {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.assets-dialog__name-input {
+  flex: 1;
+}
+
+.assets-dialog__empty {
+  margin: 0;
+  padding: 24px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.assets-dialog__footer {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 12px;
+}
+
 /* The new-scene page's display-size picker in the modal bar. */
 .editor-modal__preset {
   display: inline-flex;

--- a/cloud/apps/auth-web/src/components/ImageLightbox.tsx
+++ b/cloud/apps/auth-web/src/components/ImageLightbox.tsx
@@ -5,7 +5,8 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 type ImageLightboxProps = {
-  url: string;
+  /** The image to show; ignored when `liveCanvasRef` is given. */
+  url?: string | undefined;
   alt: string;
   /** The dialog's accessible name. */
   label: string;
@@ -13,6 +14,9 @@ type ImageLightboxProps = {
    * the 1:1 view uses). */
   width?: number | undefined;
   height?: number | undefined;
+  /** Live mode: a <canvas> the owner keeps painting (the preview mirrors
+   * every rendered frame into it), instead of a still image. */
+  liveCanvasRef?: ((canvas: HTMLCanvasElement | null) => void) | undefined;
   onClose: () => void;
 };
 
@@ -21,7 +25,7 @@ type ImageLightboxProps = {
 // beside the image, or Esc. Used by the Preview panel (the rendered frame)
 // and the Info panel's gallery. The overlay lives on <body>: the editor
 // frame's transform would otherwise keep a fixed element inside a column.
-export function ImageLightbox({ url, alt, label, width, height, onClose }: ImageLightboxProps) {
+export function ImageLightbox({ url, alt, label, width, height, liveCanvasRef, onClose }: ImageLightboxProps) {
   const [fit, setFit] = useState(true);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
@@ -46,17 +50,32 @@ export function ImageLightbox({ url, alt, label, width, height, onClose }: Image
         {fit ? "click the image for 1:1" : "click the image to fit"} · Esc to close
       </div>
       <div className={`lightbox__body${fit ? " lightbox__body--fit" : ""}`}>
-        <img
-          alt={alt}
-          className={`lightbox__image${fit ? " lightbox__image--fit" : ""}`}
-          height={height}
-          onClick={(event) => {
-            event.stopPropagation();
-            setFit((current) => !current);
-          }}
-          src={url}
-          width={width}
-        />
+        {liveCanvasRef ? (
+          <canvas
+            aria-label={alt}
+            className={`lightbox__image${fit ? " lightbox__image--fit" : ""}`}
+            height={height}
+            onClick={(event) => {
+              event.stopPropagation();
+              setFit((current) => !current);
+            }}
+            ref={liveCanvasRef}
+            role="img"
+            width={width}
+          />
+        ) : (
+          <img
+            alt={alt}
+            className={`lightbox__image${fit ? " lightbox__image--fit" : ""}`}
+            height={height}
+            onClick={(event) => {
+              event.stopPropagation();
+              setFit((current) => !current);
+            }}
+            src={url}
+            width={width}
+          />
+        )}
       </div>
     </div>,
     document.body,

--- a/cloud/apps/auth-web/src/components/PreviewAssetsDialog.tsx
+++ b/cloud/apps/auth-web/src/components/PreviewAssetsDialog.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+import type { FrameOSPreview, PreviewAssetEntry, PreviewAssetsInfo } from "frameos-wasm";
+import {
+  ChevronRight,
+  File as FileIcon,
+  Folder,
+  FolderPlus,
+  RefreshCw,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type DragEvent } from "react";
+import { createPortal } from "react-dom";
+
+type PreviewAssetsDialogProps = {
+  /** The running preview whose folder is managed; null while it is not
+   * running (the dialog then only explains what the folder is). */
+  preview: FrameOSPreview | null;
+  /** Bumped by the panel whenever the preview reports the folder changed
+   * (a scene saved a file): the listing reloads. */
+  assetsVersion?: number;
+  onClose: () => void;
+};
+
+const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg", ".qoi"];
+
+export function isImageAssetPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return IMAGE_EXTENSIONS.some((extension) => lower.endsWith(extension));
+}
+
+export function formatAssetSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** The folder part of a relative asset path ("" at the root). */
+export function assetParentFolder(path: string): string {
+  const slash = path.lastIndexOf("/");
+  return slash === -1 ? "" : path.slice(0, slash);
+}
+
+export function assetBaseName(path: string): string {
+  const slash = path.lastIndexOf("/");
+  return slash === -1 ? path : path.slice(slash + 1);
+}
+
+/** Entries directly inside `folder`, folders first, then files, by name. */
+export function entriesInFolder(entries: PreviewAssetEntry[], folder: string): PreviewAssetEntry[] {
+  return entries
+    .filter((entry) => assetParentFolder(entry.path) === folder)
+    .sort((a, b) => {
+      if (a.isDir !== b.isDir) {
+        return a.isDir ? -1 : 1;
+      }
+      return assetBaseName(a.path).localeCompare(assetBaseName(b.path), undefined, {
+        sensitivity: "base",
+      });
+    });
+}
+
+function imageMimeType(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".gif")) return "image/gif";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".bmp")) return "image/bmp";
+  if (lower.endsWith(".svg")) return "image/svg+xml";
+  return "image/jpeg";
+}
+
+/** A file's bytes as a data URL (the page's CSP allows data: images, not blob: ones). */
+function bytesToDataUrl(buffer: ArrayBuffer, type: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error("could not read file"));
+    reader.readAsDataURL(new Blob([buffer], { type }));
+  });
+}
+
+// A thumbnail read out of the worker's folder on demand, as a data URL —
+// the store's CSP allows data: images, not blob: ones (see ImageLightbox).
+function AssetThumbnail({ preview, entry }: { preview: FrameOSPreview; entry: PreviewAssetEntry }) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    preview
+      .readAsset(entry.path)
+      .then((buffer) => bytesToDataUrl(buffer, imageMimeType(entry.path)))
+      .then((dataUrl) => {
+        if (!cancelled) {
+          setUrl(dataUrl);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUrl(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [preview, entry.path, entry.mtime, entry.size]);
+  return url ? (
+    <img alt="" className="assets-dialog__thumb" src={url} />
+  ) : (
+    <div className="assets-dialog__thumb assets-dialog__thumb--blank">
+      <FileIcon aria-hidden size={18} />
+    </div>
+  );
+}
+
+// Manage the preview's browser asset folder: the files the running scene
+// sees at /srv/assets. The folder lives in this browser only (the wasm
+// worker's IndexedDB-backed filesystem), never on a frame or in the cloud.
+// Overlay on <body>, like ImageLightbox: the editor frame's transform would
+// otherwise keep a fixed element inside a column.
+export function PreviewAssetsDialog({ preview, assetsVersion = 0, onClose }: PreviewAssetsDialogProps) {
+  const [entries, setEntries] = useState<PreviewAssetEntry[]>([]);
+  const [info, setInfo] = useState<PreviewAssetsInfo | null>(preview?.assetsInfo ?? null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [folder, setFolder] = useState("");
+  const [newFolderName, setNewFolderName] = useState<string | null>(null);
+  const [confirmDeletePath, setConfirmDeletePath] = useState<string | null>(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  const reload = useCallback(async () => {
+    if (!preview) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setEntries(await preview.listAssets());
+      setInfo(preview.assetsInfo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [preview]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload, assetsVersion]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onCloseRef.current();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (folder && !entries.some((entry) => entry.isDir && entry.path === folder)) {
+      setFolder("");
+    }
+  }, [folder, entries]);
+
+  const run = async (task: () => Promise<void>) => {
+    setError(null);
+    try {
+      await task();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+    await reload();
+  };
+
+  const addFiles = (files: FileList | File[] | null) => {
+    if (!preview) {
+      return;
+    }
+    const list = files ? Array.from(files) : [];
+    if (list.length === 0) {
+      return;
+    }
+    void run(async () => {
+      for (const file of list) {
+        await preview.writeAsset(folder ? `${folder}/${file.name}` : file.name, file);
+      }
+    });
+  };
+
+  const submitNewFolder = () => {
+    const name = (newFolderName ?? "").trim().replace(/\//g, "");
+    setNewFolderName(null);
+    if (!preview || !name || name === "." || name === "..") {
+      return;
+    }
+    void run(() => preview.createAssetFolder(folder ? `${folder}/${name}` : name));
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    addFiles(event.dataTransfer?.files ?? null);
+  };
+
+  const visible = entriesInFolder(entries, folder);
+  const totalBytes = entries.reduce((sum, entry) => sum + entry.size, 0);
+  const fileCount = entries.filter((entry) => !entry.isDir).length;
+  const crumbs = folder ? folder.split("/") : [];
+
+  return createPortal(
+    <div
+      aria-label="Browser assets"
+      aria-modal
+      className="dialog"
+      onClick={onClose}
+      role="dialog"
+    >
+      <div
+        className="dialog__panel dialog__panel--wide assets-dialog"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="dialog__head">
+          <h2>Browser assets</h2>
+          <button aria-label="Close" className="dialog__close" onClick={onClose} type="button">
+            <X aria-hidden size={16} />
+          </button>
+        </div>
+        <p className="notice assets-dialog__intro">
+          This is a temporary asset folder that exists <strong>only in this browser</strong> — it is
+          never sent to a frame or to the cloud. The preview runs scenes with it mounted at{" "}
+          <code>/srv/assets</code>, the path a real frame keeps its assets at, so image scenes have
+          something to show and apps that save files have somewhere to put them.{" "}
+          {info?.persistent === false
+            ? "This browser blocks persistent storage, so the folder lives in memory and is gone when the preview restarts."
+            : "It is kept in this browser between previews and shared by every preview you open here."}{" "}
+          A fresh folder starts with a few generated sample photos; add your own images to test
+          slideshows and local-image scenes.
+        </p>
+        {!preview ? (
+          <p className="notice" role="status">
+            Start the preview to manage its folder.
+          </p>
+        ) : null}
+        <div className="button-row assets-dialog__toolbar">
+          <button
+            className="button button--subtle button--small"
+            disabled={!preview}
+            onClick={() => fileInputRef.current?.click()}
+            type="button"
+          >
+            <Upload aria-hidden size={14} />
+            Add files
+          </button>
+          <input
+            aria-label="Add files"
+            className="assets-dialog__file-input"
+            multiple
+            onChange={(event) => {
+              addFiles(event.target.files);
+              event.target.value = "";
+            }}
+            ref={fileInputRef}
+            type="file"
+          />
+          <button
+            className="button button--subtle button--small"
+            disabled={!preview || newFolderName !== null}
+            onClick={() => setNewFolderName("")}
+            type="button"
+          >
+            <FolderPlus aria-hidden size={14} />
+            New folder
+          </button>
+          <button
+            aria-label="Refresh"
+            className="button button--subtle button--small"
+            disabled={!preview || loading}
+            onClick={() => void reload()}
+            title="Reload the folder listing"
+            type="button"
+          >
+            <RefreshCw aria-hidden size={14} />
+          </button>
+          <span className="assets-dialog__spacer" />
+          {confirmReset ? (
+            <>
+              <span className="assets-dialog__confirm">Delete everything and regenerate the samples?</span>
+              <button
+                className="button button-danger button--small"
+                onClick={() => {
+                  setConfirmReset(false);
+                  if (preview) {
+                    void run(() => preview.resetAssets());
+                  }
+                }}
+                type="button"
+              >
+                Reset folder
+              </button>
+              <button
+                className="button button--subtle button--small"
+                onClick={() => setConfirmReset(false)}
+                type="button"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              className="button button--subtle button--small"
+              disabled={!preview}
+              onClick={() => setConfirmReset(true)}
+              title="Delete everything in the folder and regenerate the sample photos"
+              type="button"
+            >
+              Reset to samples
+            </button>
+          )}
+        </div>
+        {error ? (
+          <p className="notice notice-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <div className="assets-dialog__crumbs">
+          <button
+            className={`assets-dialog__crumb${folder ? "" : " assets-dialog__crumb--current"}`}
+            onClick={() => setFolder("")}
+            type="button"
+          >
+            /srv/assets
+          </button>
+          {crumbs.map((crumb, index) => {
+            const path = crumbs.slice(0, index + 1).join("/");
+            const current = index === crumbs.length - 1;
+            return (
+              <span className="assets-dialog__crumb-wrap" key={path}>
+                <ChevronRight aria-hidden size={12} />
+                <button
+                  className={`assets-dialog__crumb${current ? " assets-dialog__crumb--current" : ""}`}
+                  onClick={() => setFolder(path)}
+                  type="button"
+                >
+                  {crumb}
+                </button>
+              </span>
+            );
+          })}
+        </div>
+        <div
+          className={`assets-dialog__list${dragging ? " assets-dialog__list--dragging" : ""}`}
+          onDragLeave={() => setDragging(false)}
+          onDragOver={(event) => {
+            event.preventDefault();
+            setDragging(true);
+          }}
+          onDrop={onDrop}
+        >
+          {newFolderName !== null ? (
+            <div className="assets-dialog__row">
+              <Folder aria-hidden size={18} />
+              <input
+                aria-label="Folder name"
+                autoFocus
+                className="input assets-dialog__name-input"
+                onChange={(event) => setNewFolderName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    submitNewFolder();
+                  } else if (event.key === "Escape") {
+                    setNewFolderName(null);
+                  }
+                }}
+                placeholder="Folder name"
+                value={newFolderName}
+              />
+              <button className="button button-primary button--small" onClick={submitNewFolder} type="button">
+                Create
+              </button>
+              <button
+                className="button button--subtle button--small"
+                onClick={() => setNewFolderName(null)}
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : null}
+          {preview && loading && entries.length === 0 ? (
+            <p className="assets-dialog__empty">Reading the browser folder…</p>
+          ) : visible.length === 0 && newFolderName === null ? (
+            <p className="assets-dialog__empty">
+              {preview ? "This folder is empty. Drop files here, or use “Add files”." : ""}
+            </p>
+          ) : (
+            visible.map((entry) => {
+              const name = assetBaseName(entry.path);
+              const confirming = confirmDeletePath === entry.path;
+              return (
+                <div className="assets-dialog__row" key={entry.path}>
+                  {entry.isDir ? (
+                    <div className="assets-dialog__thumb assets-dialog__thumb--blank">
+                      <Folder aria-hidden size={20} />
+                    </div>
+                  ) : preview && isImageAssetPath(entry.path) ? (
+                    <AssetThumbnail entry={entry} preview={preview} />
+                  ) : (
+                    <div className="assets-dialog__thumb assets-dialog__thumb--blank">
+                      <FileIcon aria-hidden size={18} />
+                    </div>
+                  )}
+                  <div className="assets-dialog__meta">
+                    {entry.isDir ? (
+                      <button
+                        className="assets-dialog__name assets-dialog__name--folder"
+                        onClick={() => setFolder(entry.path)}
+                        type="button"
+                      >
+                        {name}/
+                      </button>
+                    ) : (
+                      <span className="assets-dialog__name" title={entry.path}>
+                        {name}
+                      </span>
+                    )}
+                    <span className="assets-dialog__details">
+                      {entry.isDir ? "Folder" : formatAssetSize(entry.size)}
+                      {entry.mtime ? ` · ${new Date(entry.mtime).toLocaleString()}` : ""}
+                    </span>
+                  </div>
+                  {confirming ? (
+                    <span className="button-row">
+                      <button
+                        className="button button-danger button--small"
+                        onClick={() => {
+                          setConfirmDeletePath(null);
+                          if (preview) {
+                            void run(() => preview.deleteAsset(entry.path));
+                          }
+                        }}
+                        type="button"
+                      >
+                        Delete{entry.isDir ? " folder" : ""}
+                      </button>
+                      <button
+                        className="button button--subtle button--small"
+                        onClick={() => setConfirmDeletePath(null)}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      aria-label={`Delete ${name}`}
+                      className="button button--subtle button--small"
+                      disabled={!preview}
+                      onClick={() => setConfirmDeletePath(entry.path)}
+                      title={entry.isDir ? "Delete this folder and everything in it" : "Delete this file"}
+                      type="button"
+                    >
+                      <Trash2 aria-hidden size={14} />
+                    </button>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+        <div className="assets-dialog__footer">
+          <span>
+            {fileCount} file{fileCount === 1 ? "" : "s"}, {formatAssetSize(totalBytes)}
+            {info?.maxBytes ? ` of ${formatAssetSize(info.maxBytes)}` : ""}
+          </span>
+          <span>Stored in this browser only</span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.test.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.test.tsx
@@ -13,6 +13,9 @@ type PreviewCallbacks = {
   onReady?: (info: unknown) => void;
   onFrame?: (frame: { width: number; height: number; renderMs: number }) => void;
   onState?: (state: Record<string, unknown>) => void;
+  onFastRenderRequest?: (intervalMs: number) => void;
+  onAssetsChanged?: () => void;
+  fastMode?: boolean;
 };
 
 // The wasm runtime is a worker + emscripten bundle — not something jsdom can
@@ -25,8 +28,16 @@ const previews = vi.hoisted(
       destroy: ReturnType<typeof vi.fn>;
       setSceneState: ReturnType<typeof vi.fn>;
       selectScene: ReturnType<typeof vi.fn>;
+      setFastMode: ReturnType<typeof vi.fn>;
+      listAssets: ReturnType<typeof vi.fn>;
+      deleteAsset: ReturnType<typeof vi.fn>;
+      writeAsset: ReturnType<typeof vi.fn>;
     }>,
 );
+// What the fake runtime's browser folder holds; tests replace it.
+const fakeAssets = vi.hoisted(() => ({
+  entries: [] as Array<{ path: string; size: number; mtime: number; isDir: boolean }>,
+}));
 vi.mock("frameos-wasm", async (importOriginal) => ({
   ...(await importOriginal<typeof import("frameos-wasm")>()),
   FrameOSPreview: class {
@@ -40,6 +51,14 @@ vi.mock("frameos-wasm", async (importOriginal) => ({
     setSceneState = vi.fn();
     selectScene = vi.fn();
     attachCanvas = vi.fn();
+    setFastMode = vi.fn();
+    assetsInfo = { mounted: true, persistent: true, root: "/srv/assets", maxBytes: 128 * 1024 * 1024 };
+    listAssets = vi.fn(async () => fakeAssets.entries);
+    readAsset = vi.fn(async () => new ArrayBuffer(4));
+    writeAsset = vi.fn(async () => {});
+    createAssetFolder = vi.fn(async () => {});
+    deleteAsset = vi.fn(async () => {});
+    resetAssets = vi.fn(async () => {});
     constructor(options: PreviewCallbacks & { scenes: unknown[] }) {
       this.options = options;
       previews.push(this);
@@ -86,6 +105,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   previews.length = 0;
+  fakeAssets.entries = [];
   fetchMock.mockClear();
   vi.unstubAllGlobals();
   vi.useRealTimers();
@@ -613,5 +633,105 @@ describe("normalizeHexColor", () => {
     expect(normalizeHexColor("white")).toBeNull();
     expect(normalizeHexColor("#12345")).toBeNull();
     expect(normalizeHexColor("")).toBeNull();
+  });
+});
+
+describe("SceneLivePreviewPanel render pacing", () => {
+  it("asks before letting a fast scene render faster than 1 fps, and keeps the answer across restarts", async () => {
+    render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[clockScene]} />);
+    await waitFor(() => expect(previews).toHaveLength(1));
+    // Throttled by default: no prompt, no toggle.
+    expect(previews[0]!.options.fastMode).toBe(false);
+    expect(screen.queryByText(/wants to render/)).toBeNull();
+    expect(screen.queryByLabelText(/Real-time rendering/)).toBeNull();
+
+    act(() => previews[0]!.options.onFastRenderRequest!(42));
+    expect(screen.getByText(/every 42 ms \(about 24 times a second\)/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run at full speed" }));
+    expect(previews[0]!.setFastMode).toHaveBeenCalledWith(true);
+    // The prompt turns into a toggle.
+    expect(screen.queryByRole("button", { name: "Run at full speed" })).toBeNull();
+    const toggle = screen.getByLabelText(/Real-time rendering/) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+
+    // A restart boots the new runtime unthrottled, and its repeated request
+    // does not bring the prompt back.
+    fireEvent.click(screen.getByRole("button", { name: /Restart/ }));
+    await waitFor(() => expect(previews).toHaveLength(2));
+    expect(previews[1]!.options.fastMode).toBe(true);
+    act(() => previews[1]!.options.onFastRenderRequest!(42));
+    expect(screen.queryByRole("button", { name: "Run at full speed" })).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(previews[1]!.setFastMode).toHaveBeenCalledWith(false);
+    expect((screen.getByLabelText(/Real-time rendering/) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("'Keep 1 fps' dismisses the prompt but leaves the toggle to change one's mind", async () => {
+    render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[clockScene]} />);
+    await waitFor(() => expect(previews).toHaveLength(1));
+    act(() => previews[0]!.options.onFastRenderRequest!(100));
+    fireEvent.click(screen.getByRole("button", { name: "Keep 1 fps" }));
+    expect(previews[0]!.setFastMode).toHaveBeenCalledWith(false);
+    expect(screen.queryByText(/wants to render/)).toBeNull();
+    expect((screen.getByLabelText(/Real-time rendering/) as HTMLInputElement).checked).toBe(false);
+  });
+});
+
+describe("SceneLivePreviewPanel browser assets", () => {
+  it("lists the runtime's browser folder in a dialog, explains where it lives, and deletes on confirmation", async () => {
+    fakeAssets.entries = [
+      { isDir: true, mtime: 0, path: "photos", size: 0 },
+      { isDir: false, mtime: 1_700_000_000_000, path: "photos/beach.jpg", size: 2048 },
+      { isDir: false, mtime: 1_700_000_000_000, path: "sample-sunset.jpg", size: 300 * 1024 },
+    ];
+    Object.assign(URL, { createObjectURL: vi.fn(() => "blob:thumb"), revokeObjectURL: vi.fn() });
+    render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[clockScene]} />);
+    await waitFor(() => expect(previews).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole("button", { name: /Browser assets/ }));
+    const dialog = screen.getByRole("dialog", { name: "Browser assets" });
+    expect(dialog.parentElement).toBe(document.body);
+    expect(dialog.textContent).toContain("only in this browser");
+    expect(dialog.textContent).toContain("/srv/assets");
+    await waitFor(() => expect(previews[0]!.listAssets).toHaveBeenCalled());
+    // Root: the folder and the root file, not the nested one.
+    await waitFor(() => expect(screen.getByText("sample-sunset.jpg")).toBeTruthy());
+    expect(screen.getByText("photos/")).toBeTruthy();
+    expect(screen.queryByText("beach.jpg")).toBeNull();
+    expect(dialog.textContent).toContain("2 files, 302 KB of 128.0 MB");
+
+    // Into the folder, and back via the breadcrumb.
+    fireEvent.click(screen.getByRole("button", { name: "photos/" }));
+    expect(screen.getByText("beach.jpg")).toBeTruthy();
+    expect(screen.queryByText("sample-sunset.jpg")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "/srv/assets" }));
+    expect(screen.getByText("sample-sunset.jpg")).toBeTruthy();
+
+    // Delete asks first, then goes through the runtime.
+    fireEvent.click(screen.getByRole("button", { name: "Delete sample-sunset.jpg" }));
+    expect(previews[0]!.deleteAsset).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(previews[0]!.deleteAsset).toHaveBeenCalledWith("sample-sunset.jpg"));
+    // Reloaded after the change.
+    await waitFor(() => expect(previews[0]!.listAssets).toHaveBeenCalledTimes(2));
+
+    // A scene writing a file while the dialog is open reloads it too.
+    act(() => previews[0]!.options.onAssetsChanged!());
+    await waitFor(() => expect(previews[0]!.listAssets).toHaveBeenCalledTimes(3));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Browser assets" })).toBeNull();
+  });
+
+  it("uploads picked files into the current folder", async () => {
+    render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[clockScene]} />);
+    await waitFor(() => expect(previews).toHaveLength(1));
+    fireEvent.click(screen.getByRole("button", { name: /Browser assets/ }));
+    const input = screen.getByLabelText("Add files") as HTMLInputElement;
+    const file = new File(["jpeg"], "holiday.jpg", { type: "image/jpeg" });
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(previews[0]!.writeAsset).toHaveBeenCalledWith("holiday.jpg", file));
   });
 });

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.test.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AUTO_APPLY_DEBOUNCE_MS,
   EDITOR_RELOAD_DEBOUNCE_MS,
+  measureFps,
   normalizeHexColor,
   NOTICE_HIDE_MS,
   SceneLivePreviewPanel,
@@ -182,9 +183,13 @@ describe("SceneLivePreviewPanel lightbox", () => {
     // On <body>, outside the panel (the editor frame's transform would trap
     // a fixed overlay inside the column).
     expect(dialog.parentElement).toBe(document.body);
-    const image = screen.getByRole("img", { name: "The rendered frame" }) as HTMLImageElement;
-    // A data URL: the page's CSP allows data: images, not blob: ones.
-    expect(image.getAttribute("src")).toBe("data:image/png;base64,QUJD");
+    // Live: a canvas the runtime's frames are mirrored into, not a still.
+    const image = screen.getByRole("img", { name: "The rendered frame" });
+    expect(image.tagName).toBe("CANVAS");
+    const context = HTMLCanvasElement.prototype.getContext("2d") as unknown as { drawImage: ReturnType<typeof vi.fn> };
+    const paintsBefore = context.drawImage.mock.calls.length;
+    act(() => previews[0]!.options.onFrame!({ height: 600, renderMs: 4, width: 800 }));
+    expect(context.drawImage.mock.calls.length).toBeGreaterThan(paintsBefore);
     expect(image.classList.contains("lightbox__image--fit")).toBe(true);
 
     fireEvent.click(image);
@@ -618,6 +623,20 @@ describe("SceneLivePreviewPanel paid scenes", () => {
     expect(link.target).toBe("_blank");
   });
 
+  it("collapses a credentials group whose key is saved on the account, until 'Use another key'", async () => {
+    fetchMock.mockImplementationOnce(async () => Response.json({ openAI: { apiKey: "sk-stored" } }));
+    render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[openAiScene]} />);
+    await screen.findByText("This scene uses keys saved in your account");
+    expect(screen.getByText(/API key from your account/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Apply & reload preview/ })).toBeNull();
+    expect(screen.queryByLabelText("API key")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use another key" }));
+    expect(screen.getByText("This scene uses services that need credentials")).toBeTruthy();
+    expect(screen.getByLabelText("API key")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Apply & reload preview/ })).toBeTruthy();
+  });
+
   it("offers auto apply for a scene without paid services", async () => {
     render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[clockScene]} />);
     await waitFor(() => expect(previews).toHaveLength(1));
@@ -666,6 +685,33 @@ describe("SceneLivePreviewPanel render pacing", () => {
     fireEvent.click(toggle);
     expect(previews[1]!.setFastMode).toHaveBeenCalledWith(false);
     expect((screen.getByLabelText(/Real-time rendering/) as HTMLInputElement).checked).toBe(false);
+    // Off: what the scene asks for, without doubled brackets.
+    expect(screen.getByText(/Real-time rendering \(the scene asks for ~24 fps\)/)).toBeTruthy();
+  });
+
+  it("shows the measured frame rate on the toggle while rendering at full speed", async () => {
+    render(<SceneLivePreviewPanel sceneId="scene-1" scenes={[clockScene]} />);
+    await waitFor(() => expect(previews).toHaveLength(1));
+    act(() => previews[0]!.options.onFastRenderRequest!(42));
+    fireEvent.click(screen.getByRole("button", { name: "Run at full speed" }));
+    const now = vi.spyOn(performance, "now");
+    let clock = 1000;
+    now.mockImplementation(() => clock);
+    for (let i = 0; i < 6; i++) {
+      act(() => previews[0]!.options.onFrame!({ height: 480, renderMs: 4, width: 800 }));
+      clock += 50; // 20 fps
+    }
+    // The figure is published with the batched status update.
+    await waitFor(() => expect(screen.getByText(/Real-time rendering · 20 fps/)).toBeTruthy());
+    now.mockRestore();
+  });
+
+  it("measureFps averages the last arrivals", () => {
+    expect(measureFps([])).toBeNull();
+    expect(measureFps([10])).toBeNull();
+    expect(measureFps([0, 100])).toBe(10);
+    expect(measureFps([0, 50, 100, 150, 200, 250])).toBe(20);
+    expect(measureFps([5, 5])).toBeNull();
   });
 
   it("'Keep 1 fps' dismisses the prompt but leaves the toggle to change one's mind", async () => {

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
@@ -83,10 +83,29 @@ const AUTO_APPLY_STORAGE_KEY = "frameos.preview.autoApply";
 /** "every 42 ms (about 24 times a second)" for the fast-render prompt. */
 export function describeRenderRate(intervalMs: number): string {
   const ms = Math.max(1, Math.round(intervalMs));
-  const perSecond = 1000 / ms;
-  const rate =
-    perSecond >= 10 ? Math.round(perSecond).toString() : perSecond.toFixed(1).replace(/\.0$/, "");
-  return `every ${ms} ms (about ${rate} times a second)`;
+  return `every ${ms} ms (about ${formatFps(1000 / ms)} times a second)`;
+}
+
+/** "24" / "7.5": whole numbers from 10 up, one decimal below. */
+export function formatFps(fps: number): string {
+  return fps >= 10 ? Math.round(fps).toString() : fps.toFixed(1).replace(/\.0$/, "");
+}
+
+/** How many frames are averaged for the live fps figure. */
+export const FPS_WINDOW = 6;
+
+/** Frames per second over the last FPS_WINDOW frame arrival times, or null
+ * with fewer than two of them. */
+export function measureFps(arrivals: readonly number[]): number | null {
+  if (arrivals.length < 2) {
+    return null;
+  }
+  const first = arrivals[0]!;
+  const last = arrivals[arrivals.length - 1]!;
+  if (last <= first) {
+    return null;
+  }
+  return ((arrivals.length - 1) * 1000) / (last - first);
 }
 // Runs a scene in the browser through the frameos-wasm runtime: canvas,
 // showIf-aware state fields, event buttons, and logs — no frame needed. The
@@ -107,9 +126,11 @@ export function SceneLivePreviewPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [savingShot, setSavingShot] = useState(false);
-  // The frame blown up over the page (a click on the canvas): the captured
-  // PNG as a data URL (the CSP's img-src allows data:, not blob:).
-  const [lightbox, setLightbox] = useState<string | null>(null);
+  // The frame blown up over the page (a click on the canvas). Live: the
+  // lightbox shows a canvas the runtime's every frame is mirrored into, so a
+  // slideshow or clock keeps moving at full size.
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const lightboxCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
   // A notice ("Screenshot downloaded.") is transient: it goes away on its
   // own, or sooner with its × button.
@@ -168,6 +189,11 @@ export function SceneLivePreviewPanel({
     intervalMs: number;
     answered: boolean;
   } | null>(null);
+  // The rate the runtime actually renders at (last FPS_WINDOW frames),
+  // shown on the real-time toggle; arrival times live in a ref, the figure
+  // is published with the batched frame status.
+  const frameArrivalsRef = useRef<number[]>([]);
+  const [measuredFps, setMeasuredFps] = useState<number | null>(null);
 
   // The browser asset folder dialog, and the running preview it manages
   // (previewRef is not reactive; this state follows the runtime's life).
@@ -188,6 +214,9 @@ export function SceneLivePreviewPanel({
   const [appliedSettings, setAppliedSettings] = useState<
     Record<string, Record<string, string>>
   >({});
+  // Groups whose keys are saved on the account start collapsed ("using your
+  // account's key"); "Use another key" opens that group's fields.
+  const [credentialsExpanded, setCredentialsExpanded] = useState<Record<string, boolean>>({});
   // Service keys saved in the account's settings (GET /api/settings), used
   // as the base layer so scenes render without retyping them; anything typed
   // above wins per field. null until the (best-effort) fetch settles — the
@@ -321,6 +350,8 @@ export function SceneLivePreviewPanel({
     setSceneInfo(null);
     setRuntimeState({});
     setLogs([]);
+    frameArrivalsRef.current = [];
+    setMeasuredFps(null);
     setStatus("Loading FrameOS runtime…");
     // Overrides for fields the reloaded scenes no longer have are dropped;
     // the rest stay in the form (and, once applied, in the runtime).
@@ -422,9 +453,18 @@ export function SceneLivePreviewPanel({
             return;
           }
           setHasPaintedFrame(true);
+          // Straight through, not batched: the full-size view should move as
+          // soon as the small one does.
+          paintLightbox();
+          const arrivals = frameArrivalsRef.current;
+          arrivals.push(performance.now());
+          if (arrivals.length > FPS_WINDOW) {
+            arrivals.splice(0, arrivals.length - FPS_WINDOW);
+          }
           scheduleFlush("frame", () => {
             if (!cancelled) {
               setStatus(`Rendered ${frame.width}×${frame.height} in ${frame.renderMs} ms`);
+              setMeasuredFps(measureFps(frameArrivalsRef.current));
             }
           });
         },
@@ -613,6 +653,27 @@ export function SceneLivePreviewPanel({
     setAppliedSettings(nested);
   }
 
+  // Mirror the preview canvas into the lightbox canvas (when open), over an
+  // opaque white ground like the screenshots.
+  function paintLightbox() {
+    const source = canvasRef.current;
+    const target = lightboxCanvasRef.current;
+    if (!source || !target) {
+      return;
+    }
+    if (target.width !== source.width || target.height !== source.height) {
+      target.width = source.width;
+      target.height = source.height;
+    }
+    const context = target.getContext("2d");
+    if (!context) {
+      return;
+    }
+    context.fillStyle = "#ffffff";
+    context.fillRect(0, 0, target.width, target.height);
+    context.drawImage(source, 0, 0);
+  }
+
   // The current frame composited over white, or null (with the error set)
   // when there is nothing to capture yet.
   function flattenFrame(): HTMLCanvasElement | null {
@@ -656,18 +717,14 @@ export function SceneLivePreviewPanel({
   }
 
   function closeLightbox() {
-    setLightbox(null);
+    setLightboxOpen(false);
   }
 
   function openLightbox() {
     if (!hasPaintedFrame) {
       return;
     }
-    const flattened = flattenFrame();
-    if (!flattened) {
-      return;
-    }
-    setLightbox(flattened.toDataURL("image/png"));
+    setLightboxOpen(true);
   }
 
   async function downloadScreenshot() {
@@ -722,6 +779,15 @@ export function SceneLivePreviewPanel({
   }
 
   const runtimeScenes = sceneInfo?.scenes ?? [];
+
+  // A settings group whose every field is saved on the account is shown as
+  // "from your account" until "Use another key"; a group with a missing
+  // field, or one typed over, shows its inputs.
+  const credentialsFormShown = (group: PreviewSettingsGroup): boolean =>
+    credentialsExpanded[group.key] === true ||
+    group.fields.some((field) => !storedSettings?.[field.path[0]]?.[field.path[1]]);
+  const anyCredentialsFormShown = requiredSettings.some(credentialsFormShown);
+
   const viewportValid =
     Number.isFinite(viewportForm.width) &&
     Number.isFinite(viewportForm.height) &&
@@ -904,7 +970,10 @@ export function SceneLivePreviewPanel({
             onChange={(event) => answerFastRender(event.target.checked)}
             type="checkbox"
           />
-          Real-time rendering ({describeRenderRate(fastRenderRequest.intervalMs)})
+          Real-time rendering
+          {fastMode && measuredFps !== null
+            ? ` · ${formatFps(measuredFps)} fps`
+            : ` (the scene asks for ~${formatFps(1000 / Math.max(1, fastRenderRequest.intervalMs))} fps)`}
         </label>
       ) : null}
       <div className="live-preview">
@@ -1052,13 +1121,17 @@ export function SceneLivePreviewPanel({
           preview={previewInstance}
         />
       ) : null}
-      {lightbox ? (
+      {lightboxOpen ? (
         <ImageLightbox
           alt="The rendered frame"
           height={viewport.height}
           label="Preview frame"
+          liveCanvasRef={(canvas) => {
+            lightboxCanvasRef.current = canvas;
+            // First paint on mount; every later frame repaints via onFrame.
+            paintLightbox();
+          }}
           onClose={closeLightbox}
-          url={lightbox}
           width={viewport.width}
         />
       ) : null}
@@ -1066,52 +1139,78 @@ export function SceneLivePreviewPanel({
         <div className="card preview-settings">
           <h4 className="preview-settings__title">
             <KeyRound aria-hidden size={16} />
-            This scene uses services that need credentials
+            {anyCredentialsFormShown
+              ? "This scene uses services that need credentials"
+              : "This scene uses keys saved in your account"}
           </h4>
-          <p className="copy preview-settings__hint">
-            Keys saved in your{" "}
-            {settingsUrl ? (
-              <a href={settingsUrl} rel="noreferrer" target="_blank">
-                account settings
-              </a>
+          {anyCredentialsFormShown ? (
+            <p className="copy preview-settings__hint">
+              Keys saved in your{" "}
+              {settingsUrl ? (
+                <a href={settingsUrl} rel="noreferrer" target="_blank">
+                  account settings
+                </a>
+              ) : (
+                "account settings"
+              )}{" "}
+              are applied automatically. Anything typed here stays in this
+              browser tab and is used only by the preview.
+            </p>
+          ) : null}
+          {requiredSettings.map((group) =>
+            credentialsFormShown(group) ? (
+              <div className="preview-settings__group" key={group.key}>
+                <span className="preview-settings__group-title">{group.title}</span>
+                {group.fields.map((field) => {
+                  const formKey = field.path.join(".");
+                  return (
+                    <label className="preview-settings__field" key={formKey}>
+                      <span>{field.label}</span>
+                      <input
+                        autoComplete="off"
+                        className="preview-settings__input"
+                        onChange={(event) =>
+                          setSettingsForm((form) => ({
+                            ...form,
+                            [formKey]: event.target.value,
+                          }))
+                        }
+                        type={field.secret ? "password" : "text"}
+                        value={settingsForm[formKey] ?? ""}
+                      />
+                    </label>
+                  );
+                })}
+              </div>
             ) : (
-              "account settings"
-            )}{" "}
-            are applied automatically. Anything typed here stays in this
-            browser tab and is used only by the preview.
-          </p>
-          {requiredSettings.map((group) => (
-            <div className="preview-settings__group" key={group.key}>
-              <span className="preview-settings__group-title">{group.title}</span>
-              {group.fields.map((field) => {
-                const formKey = field.path.join(".");
-                return (
-                  <label className="preview-settings__field" key={formKey}>
-                    <span>{field.label}</span>
-                    <input
-                      autoComplete="off"
-                      className="preview-settings__input"
-                      onChange={(event) =>
-                        setSettingsForm((form) => ({
-                          ...form,
-                          [formKey]: event.target.value,
-                        }))
-                      }
-                      type={field.secret ? "password" : "text"}
-                      value={settingsForm[formKey] ?? ""}
-                    />
-                  </label>
-                );
-              })}
-            </div>
-          ))}
-          <button
-            className="button button--small"
-            onClick={applySettings}
-            type="button"
-          >
-            Apply &amp; reload preview
-          </button>
+              <div className="preview-settings__group preview-settings__group--stored" key={group.key}>
+                <span className="preview-settings__stored">
+                  <span className="preview-settings__group-title">{group.title}</span>
+                  {" · "}
+                  {joinNames(group.fields.map((field) => field.label))} from your account
+                </span>
+                <button
+                  className="button button--subtle button--small"
+                  onClick={() =>
+                    setCredentialsExpanded((current) => ({ ...current, [group.key]: true }))
+                  }
+                  title={`Type a different ${group.title} key for this preview only`}
+                  type="button"
+                >
+                  Use another key
+                </button>
+              </div>
+            ),
+          )}
+          {anyCredentialsFormShown ? (
+            <button
+              className="button button--small"
+              onClick={applySettings}
+              type="button"
+            >
+              Apply &amp; reload preview
+            </button>
+          ) : null}
         </div>
       ) : null}
       {scenes ? (

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
@@ -13,6 +13,7 @@ import {
 import {
   Camera,
   CircleDollarSign,
+  FolderOpen,
   ImageDown,
   KeyRound,
   Play,
@@ -20,6 +21,7 @@ import {
   RectangleVertical,
   RotateCw,
   X,
+  Zap,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import {
@@ -37,6 +39,7 @@ import {
 } from "../lib/preview-settings";
 import type { PreviewLogLine } from "../lib/preview-log";
 import { ImageLightbox } from "./ImageLightbox";
+import { PreviewAssetsDialog } from "./PreviewAssetsDialog";
 import { PreviewLog } from "./PreviewLog";
 
 type SceneLivePreviewPanelProps = {
@@ -70,8 +73,21 @@ export const NOTICE_HIDE_MS = 4000;
 /** With "Auto apply" on, a burst of typing in the state form becomes one
  * render: this long after the last keystroke. */
 export const AUTO_APPLY_DEBOUNCE_MS = 400;
+/** A scene rendering at full speed reports frames and log lines many times
+ * a second; the panel batches those into one React update per this long.
+ * The first report after a quiet spell goes through at once. */
+export const UI_FLUSH_INTERVAL_MS = 200;
 /** Where "Auto apply" is remembered between editor sessions (this browser). */
 const AUTO_APPLY_STORAGE_KEY = "frameos.preview.autoApply";
+
+/** "every 42 ms (about 24 times a second)" for the fast-render prompt. */
+export function describeRenderRate(intervalMs: number): string {
+  const ms = Math.max(1, Math.round(intervalMs));
+  const perSecond = 1000 / ms;
+  const rate =
+    perSecond >= 10 ? Math.round(perSecond).toString() : perSecond.toFixed(1).replace(/\.0$/, "");
+  return `every ${ms} ms (about ${rate} times a second)`;
+}
 // Runs a scene in the browser through the frameos-wasm runtime: canvas,
 // showIf-aware state fields, event buttons, and logs — no frame needed. The
 // runtime assets are copied into /frameos-wasm by scripts/copy-wasm-assets.mjs.
@@ -142,6 +158,23 @@ export function SceneLivePreviewPanel({
 
   // Bumped by the Restart button; recreates the whole wasm runtime.
   const [restartCount, setRestartCount] = useState(0);
+
+  // Render pacing. The runtime throttles every scene to one render per
+  // second; a scene asking for more (a 24 fps slideshow) gets to ask the
+  // visitor once, and only runs at full speed after "Run at full speed".
+  // The answer survives runtime restarts (editor edits, Restart, Resize).
+  const [fastMode, setFastMode] = useState(false);
+  const [fastRenderRequest, setFastRenderRequest] = useState<{
+    intervalMs: number;
+    answered: boolean;
+  } | null>(null);
+
+  // The browser asset folder dialog, and the running preview it manages
+  // (previewRef is not reactive; this state follows the runtime's life).
+  const [assetsOpen, setAssetsOpen] = useState(false);
+  const [previewInstance, setPreviewInstance] = useState<FrameOSPreview | null>(null);
+  // Bumped when the runtime reports files changed (a scene saved one).
+  const [assetsVersion, setAssetsVersion] = useState(0);
 
   // A screenshot before the runtime's first paint would capture a fully
   // transparent canvas; the button stays disabled until a frame arrives.
@@ -298,14 +331,42 @@ export function SceneLivePreviewPanel({
       Object.fromEntries(Object.entries(values).filter(([key]) => fieldNames.has(key)));
     setEdits(keepKnown);
     appliedStateRef.current = keepKnown(appliedStateRef.current);
+    // Leading-edge throttle: the first line (or frame) after a quiet spell
+    // lands at once, a burst collapses into one trailing update.
+    const flushes: Record<string, { timer: ReturnType<typeof setTimeout> | null; lastAt: number }> = {};
+    const scheduleFlush = (key: string, flush: () => void) => {
+      const entry = (flushes[key] ??= { lastAt: 0, timer: null });
+      if (entry.timer !== null) {
+        return;
+      }
+      const elapsed = Date.now() - entry.lastAt;
+      if (elapsed >= UI_FLUSH_INTERVAL_MS) {
+        entry.lastAt = Date.now();
+        flush();
+        return;
+      }
+      entry.timer = setTimeout(() => {
+        entry.timer = null;
+        entry.lastAt = Date.now();
+        flush();
+      }, UI_FLUSH_INTERVAL_MS - elapsed);
+    };
+    let logQueue: PreviewLogLine[] = [];
     const appendLog = (line: string) => {
       if (cancelled) {
         return;
       }
-      const entry: PreviewLogLine = { id: logIdRef.current++, line, receivedAt: Date.now() };
-      setLogs((previous) => {
-        const next = [...previous, entry];
-        return next.length > maxLogLines ? next.slice(-maxLogLines) : next;
+      logQueue.push({ id: logIdRef.current++, line, receivedAt: Date.now() });
+      scheduleFlush("log", () => {
+        const lines = logQueue;
+        logQueue = [];
+        if (cancelled || lines.length === 0) {
+          return;
+        }
+        setLogs((previous) => {
+          const next = [...previous, ...lines];
+          return next.length > maxLogLines ? next.slice(-maxLogLines) : next;
+        });
       });
     };
     try {
@@ -319,6 +380,22 @@ export function SceneLivePreviewPanel({
         // Fallback only: the runtime fetches URLs client-side first and
         // routes just CORS-blocked hosts through this endpoint.
         proxyUrl: "/api/store/preview-proxy",
+        fastMode,
+        onFastRenderRequest: (intervalMs) => {
+          if (cancelled) {
+            return;
+          }
+          // A restart re-asks; keep the answer already given.
+          setFastRenderRequest((current) => ({
+            intervalMs,
+            answered: current?.answered ?? false,
+          }));
+        },
+        onAssetsChanged: () => {
+          if (!cancelled) {
+            setAssetsVersion((version) => version + 1);
+          }
+        },
         onReady: (info) => {
           if (cancelled || !preview) {
             return;
@@ -345,9 +422,11 @@ export function SceneLivePreviewPanel({
             return;
           }
           setHasPaintedFrame(true);
-          setStatus(
-            `Rendered ${frame.width}×${frame.height} in ${frame.renderMs} ms`,
-          );
+          scheduleFlush("frame", () => {
+            if (!cancelled) {
+              setStatus(`Rendered ${frame.width}×${frame.height} in ${frame.renderMs} ms`);
+            }
+          });
         },
         onState: (state) => {
           if (cancelled) {
@@ -380,17 +459,32 @@ export function SceneLivePreviewPanel({
         },
       });
       previewRef.current = preview;
+      setPreviewInstance(preview);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
     return () => {
       cancelled = true;
+      for (const entry of Object.values(flushes)) {
+        if (entry.timer !== null) {
+          clearTimeout(entry.timer);
+        }
+      }
       preview?.destroy();
       if (previewRef.current === preview) {
         previewRef.current = null;
       }
+      setPreviewInstance((current) => (current === preview ? null : current));
     };
+    // fastMode reaches a running runtime through setFastMode below; only a
+    // fresh runtime reads it from the options, so it is no dependency here.
   }, [scenes, viewport, storedSettings, previewSettings, restartCount, previewGated]);
+
+  function answerFastRender(enabled: boolean) {
+    setFastMode(enabled);
+    setFastRenderRequest((current) => (current ? { ...current, answered: true } : current));
+    previewRef.current?.setFastMode(enabled);
+  }
 
   // The editor switched scenes while the runtime is up: follow it.
   const runtimeReady = sceneInfo !== null;
@@ -672,6 +766,15 @@ export function SceneLivePreviewPanel({
           >
             <ImageDown aria-hidden size={16} />
           </button>
+          <button
+            className="button button--subtle button--small"
+            onClick={() => setAssetsOpen(true)}
+            title="Manage the browser-only asset folder the preview mounts at /srv/assets"
+            type="button"
+          >
+            <FolderOpen aria-hidden size={16} />
+            Browser assets
+          </button>
           {canSaveToGallery && sceneId !== null ? (
             <button
               className="button button--subtle button--small"
@@ -765,6 +868,45 @@ export function SceneLivePreviewPanel({
           </div>
         ) : null}
       </div>
+      {fastRenderRequest && !fastRenderRequest.answered ? (
+        <div className="notice live-preview__fast" role="status">
+          <Zap aria-hidden className="live-preview__fast-icon" size={18} />
+          <span className="live-preview__fast-copy">
+            This scene wants to render {describeRenderRate(fastRenderRequest.intervalMs)}. The
+            preview is holding it to one render per second — let it go at full speed? It keeps your
+            browser busy while the editor is open.
+          </span>
+          <span className="button-row">
+            <button
+              className="button button-primary button--small"
+              onClick={() => answerFastRender(true)}
+              type="button"
+            >
+              Run at full speed
+            </button>
+            <button
+              className="button button--subtle button--small"
+              onClick={() => answerFastRender(false)}
+              type="button"
+            >
+              Keep 1 fps
+            </button>
+          </span>
+        </div>
+      ) : null}
+      {fastRenderRequest?.answered ? (
+        <label
+          className="live-preview-panel__auto-apply live-preview__fast-toggle"
+          title="Let the scene render as often as it asks instead of once per second"
+        >
+          <input
+            checked={fastMode}
+            onChange={(event) => answerFastRender(event.target.checked)}
+            type="checkbox"
+          />
+          Real-time rendering ({describeRenderRate(fastRenderRequest.intervalMs)})
+        </label>
+      ) : null}
       <div className="live-preview">
         {previewGated ? (
           <div className="live-preview__gate" role="status">
@@ -903,6 +1045,13 @@ export function SceneLivePreviewPanel({
           Rotate
         </button>
       </div>
+      {assetsOpen ? (
+        <PreviewAssetsDialog
+          assetsVersion={assetsVersion}
+          onClose={() => setAssetsOpen(false)}
+          preview={previewInstance}
+        />
+      ) : null}
       {lightbox ? (
         <ImageLightbox
           alt="The rendered frame"

--- a/cloud/apps/auth-web/src/test/shared-spa/frameos-wasm-preview.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/frameos-wasm-preview.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FrameOSPreview } from "frameos-wasm";
+
+// The frameos-wasm package's typed wrapper around the preview worker: the
+// init message it sends, the fast-mode switch, and the request/reply
+// plumbing for the browser asset folder ops. The worker itself is an
+// emscripten bundle — stand in with a fake that records messages and lets
+// the test answer them.
+
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  messages: Array<Record<string, unknown>> = [];
+  transfers: Array<Transferable[] | undefined> = [];
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  terminated = false;
+  constructor(
+    readonly url: string | URL,
+    readonly options?: WorkerOptions,
+  ) {
+    FakeWorker.instances.push(this);
+  }
+  postMessage(message: Record<string, unknown>, transfer?: Transferable[]) {
+    this.messages.push(message);
+    this.transfers.push(transfer);
+  }
+  terminate() {
+    this.terminated = true;
+  }
+  /** Deliver a message from the "worker" to the page. */
+  reply(data: Record<string, unknown>) {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+}
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  vi.stubGlobal("Worker", FakeWorker);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function makePreview(extra: Partial<ConstructorParameters<typeof FrameOSPreview>[0]> = {}) {
+  const preview = new FrameOSPreview({
+    height: 480,
+    scenes: [{ id: "scene-1" }],
+    width: 800,
+    workerUrl: "/frameos-wasm/preview-worker.js",
+    ...extra,
+  });
+  return { preview, worker: FakeWorker.instances[0]! };
+}
+
+describe("FrameOSPreview init", () => {
+  it("starts throttled with the browser folder mounted and saving allowed", () => {
+    const { worker } = makePreview();
+    expect(worker.options).toEqual({ type: "module" });
+    expect(worker.messages[0]).toMatchObject({
+      browserAssets: true,
+      fastMode: false,
+      saveAssets: true,
+      type: "init",
+    });
+  });
+
+  it("passes fastMode, saveAssets and browserAssets through", () => {
+    const { worker } = makePreview({
+      browserAssets: false,
+      fastMode: true,
+      saveAssets: { render: false },
+    });
+    expect(worker.messages[0]).toMatchObject({
+      browserAssets: false,
+      fastMode: true,
+      saveAssets: { render: false },
+    });
+  });
+
+  it("reports the folder's backing with ready", () => {
+    const onReady = vi.fn();
+    const { preview, worker } = makePreview({ onReady });
+    const browserAssets = { maxBytes: 1, mounted: true, persistent: false, root: "/srv/assets" };
+    worker.reply({ browserAssets, sceneInfo: { currentSceneId: "scene-1" }, type: "ready" });
+    expect(onReady).toHaveBeenCalledWith({ currentSceneId: "scene-1" }, browserAssets);
+    expect(preview.assetsInfo).toEqual(browserAssets);
+    expect(preview.currentSceneId).toBe("scene-1");
+  });
+});
+
+describe("FrameOSPreview render pacing", () => {
+  it("surfaces the worker's fast-render request and forwards setFastMode", () => {
+    const onFastRenderRequest = vi.fn();
+    const { preview, worker } = makePreview({ onFastRenderRequest });
+    worker.reply({ intervalMs: 42, type: "fastRenderRequest" });
+    expect(onFastRenderRequest).toHaveBeenCalledWith(42);
+
+    preview.setFastMode(true);
+    expect(preview.fastMode).toBe(true);
+    expect(worker.messages.at(-1)).toEqual({ enabled: true, type: "setFastMode" });
+  });
+});
+
+describe("FrameOSPreview browser assets", () => {
+  it("answers each request by id and transfers written bytes", async () => {
+    const onAssetsChanged = vi.fn();
+    const { preview, worker } = makePreview({ onAssetsChanged });
+
+    const listing = preview.listAssets();
+    const listRequest = worker.messages.at(-1)!;
+    expect(listRequest).toMatchObject({ op: "list", type: "assets" });
+    const entries = [{ isDir: false, mtime: 1, path: "a.jpg", size: 3 }];
+    const info = { maxBytes: 9, mounted: true, persistent: true, root: "/srv/assets" };
+    worker.reply({ entries, info, ok: true, requestId: listRequest.requestId, type: "assetsResult" });
+    expect(await listing).toEqual(entries);
+    expect(preview.assetsInfo).toEqual(info);
+
+    const bytes = new Uint8Array([1, 2, 3]);
+    const writing = preview.writeAsset("photos/new.jpg", bytes);
+    const writeRequest = worker.messages.at(-1)!;
+    expect(writeRequest).toMatchObject({ op: "write", path: "photos/new.jpg", type: "assets" });
+    expect(writeRequest.requestId).not.toBe(listRequest.requestId);
+    expect(new Uint8Array(writeRequest.data as ArrayBuffer)).toEqual(bytes);
+    // The buffer is transferred, not copied.
+    expect(worker.transfers.at(-1)).toEqual([writeRequest.data]);
+    worker.reply({ ok: true, requestId: writeRequest.requestId, type: "assetsResult" });
+    await writing;
+
+    // Unrelated ids are ignored; an error reply rejects that request only.
+    worker.reply({ ok: true, requestId: 999, type: "assetsResult" });
+    const deleting = preview.deleteAsset("../etc");
+    const deleteRequest = worker.messages.at(-1)!;
+    worker.reply({ error: "invalid path", ok: false, requestId: deleteRequest.requestId, type: "assetsResult" });
+    await expect(deleting).rejects.toThrow("invalid path");
+
+    worker.reply({ type: "assetsChanged" });
+    expect(onAssetsChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects pending requests when destroyed, and refuses new ones", async () => {
+    const { preview } = makePreview();
+    const pending = preview.resetAssets();
+    preview.destroy();
+    await expect(pending).rejects.toThrow("preview destroyed");
+    await expect(preview.listAssets()).rejects.toThrow("preview is not running");
+  });
+});

--- a/frameos/src/frameos/js_runtime/runtime.nim
+++ b/frameos/src/frameos/js_runtime/runtime.nim
@@ -489,6 +489,12 @@ proc jsChronoParseTs(ctx: ptr JSContext, fmt: JSValue, text: JSValue): JSValue {
   except CatchableError as e:
     raise newException(ValueError, "parseTs failed: " & e.msg)
 
+proc setJsTimeZone*(name: string) =
+  ## The zone `frameos.format` and friends render in. On a device it is
+  ## detected from /etc/localtime; the wasm preview has no such file and
+  ## sets the frame's configured zone here.
+  tzName = name.strip()
+
 proc jsChronoFormat(ctx: ptr JSContext, tsVal: JSValue, fmt: JSValue): JSValue {.nimcall.} =
   let ts = toNimFloat(ctx, tsVal).Timestamp
   let fmtStr = toNimString(ctx, fmt)

--- a/frameos/src/lib/tests/test_tz_slice.nim
+++ b/frameos/src/lib/tests/test_tz_slice.nim
@@ -34,6 +34,16 @@ suite "per-zone tz slices":
     check winter.hour == 1
     check winter.dstName == "CET"
 
+  test "utcOffsetSeconds follows the zone's transitions (what the wasm preview feeds QuickJS's Date)":
+    check loadTimeZoneSlice(brusselsSlice)
+    check utcOffsetSeconds("Europe/Brussels", 1755820800.0) == 7200 # 2025-08-22, CEST
+    check utcOffsetSeconds("Europe/Brussels", 1767225600.0) == 3600 # 2026-01-01, CET
+    check utcOffsetSeconds("UTC", 1755820800.0) == 0
+    check utcOffsetSeconds("Etc/UTC", 1755820800.0) == 0
+    check utcOffsetSeconds("Nowhere/Unknown", 1755820800.0) == 0
+    check loadTimeZoneSlice(stJohnsSlice)
+    check utcOffsetSeconds("America/St_Johns", 1755820800.0) == -9000
+
   test "the POSIX rule for Brussels is the EU rule":
     check loadTimeZoneSlice(brusselsSlice)
     check posixTzRule("Europe/Brussels", 1755820800.0) == "CET-1CEST,M3.5.0,M10.5.0/3"

--- a/frameos/src/lib/tz.nim
+++ b/frameos/src/lib/tz.nim
@@ -199,6 +199,24 @@ proc posixRuleDate(localEpoch: float): string =
     if cal.minute != 0:
       result.add(":" & align($cal.minute, 2, '0'))
 
+proc utcOffsetSeconds*(timeZone: string, epoch: float): int =
+  ## The zone's UTC offset (seconds east, DST folded in) at `epoch` from the
+  ## loaded chrono data; 0 for UTC and for zones that are not loaded. The
+  ## wasm preview routes QuickJS's Date through this so JS clocks follow the
+  ## frame's zone like the Nim side does.
+  let name = canonicalTimeZone(timeZone)
+  if name.len == 0 or name.toLowerAscii() in ["utc", "etc/utc", "uct", "universal", "zulu", "z"]:
+    return 0
+  initTimeZone()
+  let tz = findTimeZone(name)
+  if not tz.valid:
+    return 0
+  result = 0
+  for change in findDstChanges(tz):
+    if change.start > epoch:
+      break
+    result = change.offset.int
+
 proc posixTzRule*(timeZone: string, nowEpoch: float): string =
   ## The POSIX TZ rule matching the loaded chrono data at `nowEpoch`:
   ## "STD-1DST,Mm.w.d,Mm.w.d" when the zone alternates over the coming year,

--- a/frameos/src/wasm/wasm_main.nim
+++ b/frameos/src/wasm/wasm_main.nim
@@ -19,6 +19,7 @@ import frameos/planner
 import frameos/utils/image as frameos_image
 import frameos/utils/memory
 import frameos/js_runtime/runtime as jsRuntime
+import lib/tz
 
 # ------------------------------------------------------------------ JS hooks
 # Implemented in tools/wasm/frameos_library.js and linked by emcc.
@@ -136,6 +137,17 @@ proc runSceneEvent(event: string, payload: JsonNode) =
 
 # ------------------------------------------------------------------- setup
 
+proc frameos_wasm_tz_offset_seconds(epoch: int64): int64 {.exportc, cdecl.} =
+  ## Seconds east of UTC for the frame's configured zone at `epoch`. Called
+  ## from tools/wasm/fos_quickjs_tz.c, which QuickJS's getTimezoneOffset()
+  ## is redirected to, so JS `Date` follows the frame's zone rather than the
+  ## browser's.
+  try:
+    let zone = if frameConfig.isNil: "UTC" else: frameConfig.timeZone
+    utcOffsetSeconds(zone, epoch.float).int64
+  except CatchableError:
+    0
+
 proc frameos_wasm_init(width, height: cint, name: cstring,
     timeZone: cstring, settingsJson: cstring): bool {.exportc, cdecl.} =
   ## Build the minimal FrameConfig + Logger the interpreter and apps expect.
@@ -205,6 +217,12 @@ proc frameos_wasm_init(width, height: cint, name: cstring,
       log: proc(payload: JsonNode) =
         jsLogHook(($payload).cstring)
     )
+    # Load the baked tz data (a device does this from detectSystemTimeZone;
+    # there is no /etc/localtime here) so chrono knows the configured zone.
+    # JS-side time: `frameos.format` (chrono) and `new Date()` (QuickJS via
+    # frameos_wasm_tz_offset_seconds) both follow it.
+    initTimeZone()
+    jsRuntime.setJsTimeZone(frameConfig.timeZone)
     initLock(logger.lock)
     channels.embeddedLogHook = proc(payload: JsonNode) {.gcsafe.} =
       jsLogHook(($payload).cstring)

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -85,15 +85,33 @@ for src in quickjs.c dtoa.c libregexp.c libunicode.c cutils.c; do
         qjs_needs_build=1
     fi
 done
+# JS `Date` must follow the frame's configured time zone, not the browser's:
+# quickjs.c reads local time exactly once, `localtime_r(&ti, &tm);` in
+# getTimezoneOffset(), and that call is redirected to
+# tools/wasm/fos_quickjs_tz.c, which asks the Nim runtime (lib/tz.nim) for
+# the zone's offset. Fail loudly if a QuickJS update moves that line.
+if ! grep -q 'localtime_r(&ti, &tm);' "$QJS_SRC/quickjs.c"; then
+    echo "build_wasm.sh: quickjs.c no longer calls 'localtime_r(&ti, &tm);' in getTimezoneOffset() —" >&2
+    echo "update the localtime_r redirect in tools/wasm/fos_quickjs_tz.c" >&2
+    exit 1
+fi
+QJS_TZ_SHIM="$FRAMEOS_DIR/tools/wasm/fos_quickjs_tz.c"
+if [[ "$qjs_needs_build" == "0" && ( "$QJS_TZ_SHIM" -nt "$QJS_BUILD/libquickjs.a" || "${QJS_TZ_SHIM%.c}.h" -nt "$QJS_BUILD/libquickjs.a" ) ]]; then
+    qjs_needs_build=1
+fi
 if [[ "$qjs_needs_build" == "1" || ! -f "$QJS_BUILD/libquickjs.a" ]]; then
     echo "building QuickJS $QJS_VERSION with emcc"
     for src in quickjs.c dtoa.c libregexp.c libunicode.c cutils.c; do
         emcc -c -O2 \
             -D_GNU_SOURCE \
             -DCONFIG_VERSION="\"$QJS_VERSION\"" \
+            -Dlocaltime_r=fos_quickjs_localtime_r \
+            -include "${QJS_TZ_SHIM%.c}.h" \
             -funsigned-char -fwrapv -fno-strict-aliasing -w \
             "$QJS_SRC/$src" -o "$QJS_BUILD/${src%.c}.o"
     done
+    emcc -c -O2 -w "$QJS_TZ_SHIM" -o "$QJS_BUILD/fos_quickjs_tz.o"
+    rm -f "$QJS_BUILD/libquickjs.a"
     emar rcs "$QJS_BUILD/libquickjs.a" "$QJS_BUILD"/*.o
 fi
 
@@ -103,7 +121,7 @@ FRAMEOS_VERSION="$(python3 tools/frameos_version.py ../versions.json)"
 # _main keeps Nim's generated main() alive: emscripten calls it on module
 # startup and that runs NimMain (all Nim module initializers, e.g. the
 # baked-in font asset tables).
-EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error
+EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error,_frameos_wasm_tz_offset_seconds
 # FS lets the render harness preload a virtual frame's assets into MEMFS;
 # IDBFS (linked below with -lidbfs.js) backs the browser preview's
 # /srv/assets folder with IndexedDB (see tools/wasm/preview-worker.js).

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -104,8 +104,10 @@ FRAMEOS_VERSION="$(python3 tools/frameos_version.py ../versions.json)"
 # startup and that runs NimMain (all Nim module initializers, e.g. the
 # baked-in font asset tables).
 EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error
-# FS lets the render harness preload a virtual frame's assets into MEMFS.
-EXPORTED_RUNTIME_METHODS=cwrap,ccall,UTF8ToString,stringToNewUTF8,lengthBytesUTF8,HEAPU8,FS
+# FS lets the render harness preload a virtual frame's assets into MEMFS;
+# IDBFS (linked below with -lidbfs.js) backs the browser preview's
+# /srv/assets folder with IndexedDB (see tools/wasm/preview-worker.js).
+EXPORTED_RUNTIME_METHODS=cwrap,ccall,UTF8ToString,stringToNewUTF8,lengthBytesUTF8,HEAPU8,FS,IDBFS
 
 mkdir -p "$BUILD_DIR"
 
@@ -148,6 +150,8 @@ nim c \
     --passL:"-sEXPORTED_FUNCTIONS=$EXPORTED_FUNCTIONS" \
     --passL:"-sEXPORTED_RUNTIME_METHODS=$EXPORTED_RUNTIME_METHODS" \
     --passL:"--js-library $FRAMEOS_DIR/tools/wasm/frameos_library.js" \
+    `# IndexedDB-backed filesystem for the preview's browser asset folder.` \
+    --passL:"-lidbfs.js" \
     src/wasm/wasm_main.nim
 
 mkdir -p "$OUT_DIR"

--- a/frameos/tools/wasm/fos_quickjs_tz.c
+++ b/frameos/tools/wasm/fos_quickjs_tz.c
@@ -1,0 +1,20 @@
+#include "fos_quickjs_tz.h"
+
+/* Seconds east of UTC for the frame's configured zone at `epoch`; exported
+ * by src/wasm/wasm_main.nim (frameos_wasm_tz_offset_seconds). */
+extern long long frameos_wasm_tz_offset_seconds(long long epoch);
+
+/* localtime_r for QuickJS: the wall time of *ti in the frame's zone. Only
+ * tm_gmtoff (and the broken-down fields) matter to quickjs.c, which reads
+ * `-tm.tm_gmtoff / 60` in getTimezoneOffset(). DST is already folded into
+ * the offset by the tz data, so tm_isdst stays 0. */
+struct tm *fos_quickjs_localtime_r(const time_t *ti, struct tm *out)
+{
+    if (ti == NULL || out == NULL) return NULL;
+    long long offset = frameos_wasm_tz_offset_seconds((long long)*ti);
+    time_t local = (time_t)(*ti + offset);
+    if (!gmtime_r(&local, out)) return NULL;
+    out->tm_gmtoff = (long)offset;
+    out->tm_isdst = 0;
+    return out;
+}

--- a/frameos/tools/wasm/fos_quickjs_tz.h
+++ b/frameos/tools/wasm/fos_quickjs_tz.h
@@ -1,0 +1,17 @@
+// Force-included into quickjs.c by tools/build_wasm.sh (together with
+// -Dlocaltime_r=fos_quickjs_localtime_r): the one place QuickJS asks libc for
+// local time — getTimezoneOffset() — is redirected to the frame's configured
+// time zone, resolved by the Nim runtime's tz data (lib/tz.nim + chrono).
+//
+// Without this the wasm preview's JS `Date` follows emscripten's localtime_r,
+// i.e. the *browser's* zone, while the Nim side (clock app, chrono formats)
+// uses the frame's zone — a JS clock scene and a Nim clock scene disagreed.
+// Same idea as the ESP32 build's fos_quickjs_tz.c, but via localtime_r since
+// emscripten's struct tm already has tm_gmtoff.
+#ifndef FOS_QUICKJS_TZ_H
+#define FOS_QUICKJS_TZ_H
+#include <time.h>
+
+struct tm *fos_quickjs_localtime_r(const time_t *ti, struct tm *out);
+
+#endif

--- a/frameos/tools/wasm/preview-worker.js
+++ b/frameos/tools/wasm/preview-worker.js
@@ -6,21 +6,56 @@
 // XHR) is allowed and long renders never block the page.
 //
 // Messages in:
-//   {type: 'init', width, height, timeZone, scenesJson, sceneId, settingsJson, proxyUrl}
+//   {type: 'init', width, height, timeZone, scenesJson, sceneId, settingsJson, proxyUrl,
+//    fastMode?, saveAssets?, browserAssets?}
 //   {type: 'render'}                       force a render now
 //   {type: 'event', name, payload}         dispatch a scene event
 //   {type: 'selectScene', sceneId}
+//   {type: 'setFastMode', enabled}         lift (or restore) the 1 fps throttle
+//   {type: 'assets', requestId, op, ...}   browser asset folder ops, see handleAssetsRequest
 // Messages out:
-//   {type: 'ready', sceneInfo}
+//   {type: 'ready', sceneInfo, browserAssets}
 //   {type: 'frame', width, height, buffer, renderMs}   buffer: transferred ArrayBuffer (RGBA)
 //   {type: 'state', state}
 //   {type: 'log', message}
 //   {type: 'sceneEvent', name, payload}
 //   {type: 'error', message}
+//   {type: 'fastRenderRequest', intervalMs}   the scene wants to render faster than the throttle allows
+//   {type: 'assetsChanged'}                   files under /srv/assets changed (a scene wrote, or an op ran)
+//   {type: 'assetsResult', requestId, ok, ...} reply to an 'assets' request
+//
+// Browser asset folder: the runtime's /srv/assets (the same path a real frame
+// keeps its assets at) is an emscripten IDBFS mount — files live in this
+// browser's IndexedDB, never on a frame or a server. Scenes read from it
+// (local images, fonts, ...) and, with saveAssets on, write into it. A fresh
+// folder is seeded with a few generated sample photos so image scenes have
+// something to show. Falls back to a plain in-memory folder (nothing
+// persists) where IndexedDB or the IDBFS export is unavailable.
 
 let Module = null
 let renderTimer = null
 let rendering = false
+
+// Render pacing. Every scene is throttled to at most one render per second:
+// a scene asking for less (a 24 fps slideshow) gets a `fastRenderRequest`
+// notice instead, and only renders that fast once the page opts in with
+// setFastMode. Once per init so the page isn't nagged after declining.
+const THROTTLE_MS = 1000
+const FAST_MIN_MS = 10
+const MAX_DELAY_MS = 15 * 60 * 1000
+let fastMode = false
+let fastRequestSent = false
+
+const ASSETS_ROOT = '/srv/assets'
+// Ceiling for the browser folder; a write past it fails instead of filling
+// the IndexedDB quota with preview downloads.
+const ASSETS_MAX_BYTES = 128 * 1024 * 1024
+let assetsPersistent = false
+let assetsMounted = false
+// Cheap fingerprint of the folder after the last sync, so scene writes
+// (saveAsset in apps) are detected and persisted without syncing IndexedDB
+// on every render.
+let assetsSignature = ''
 
 function post(msg, transfer) {
   self.postMessage(msg, transfer || [])
@@ -38,14 +73,476 @@ function lastError() {
   }
 }
 
-function postState() {
+function log(message) {
+  post({ type: 'log', message })
+}
+
+// The scene's public state after a render/event; only posted when it
+// differs from what the page already has (a fast scene renders many times a
+// second without touching its state).
+let lastPostedState = null
+function postState(force) {
   try {
     const state = call('frameos_wasm_scene_state', 'string', [], [])
+    if (!force && state === lastPostedState) {
+      return
+    }
+    lastPostedState = state
     post({ type: 'state', state: JSON.parse(state) })
   } catch (e) {
     // state is informational; ignore
   }
 }
+
+// ------------------------------------------------------------------ assets
+
+function fsEnsureDir(path) {
+  const FS = Module.FS
+  const parts = path.split('/').filter(Boolean)
+  let current = ''
+  for (const part of parts) {
+    current += '/' + part
+    try {
+      FS.mkdir(current)
+    } catch (e) {
+      // exists
+    }
+  }
+}
+
+// A path from the page (or out of the wasm module) relative to the assets
+// root, or null when it would escape it. Accepts "photos/a.jpg",
+// "/photos/a.jpg" and the absolute "/srv/assets/photos/a.jpg".
+function normalizeAssetPath(path) {
+  let rel = String(path || '')
+  if (rel === ASSETS_ROOT || rel.startsWith(ASSETS_ROOT + '/')) {
+    rel = rel.slice(ASSETS_ROOT.length)
+  }
+  const parts = rel.split('/').filter((part) => part !== '')
+  if (parts.some((part) => part === '.' || part === '..')) {
+    return null
+  }
+  return parts.join('/')
+}
+
+function assetAbsolutePath(rel) {
+  return rel ? ASSETS_ROOT + '/' + rel : ASSETS_ROOT
+}
+
+// Recursive listing of the folder: [{path, size, mtime, isDir}], paths
+// relative to the root, files and folders alike, sorted by path.
+function listAssetEntries() {
+  const FS = Module.FS
+  const entries = []
+  const walk = (dir, relDir) => {
+    let names
+    try {
+      names = FS.readdir(dir)
+    } catch (e) {
+      return
+    }
+    for (const name of names) {
+      if (name === '.' || name === '..') continue
+      const path = dir + '/' + name
+      const rel = relDir ? relDir + '/' + name : name
+      let stat
+      try {
+        stat = FS.stat(path)
+      } catch (e) {
+        continue
+      }
+      const mtime = stat.mtime instanceof Date ? stat.mtime.getTime() : Number(stat.mtime) || 0
+      if (FS.isDir(stat.mode)) {
+        entries.push({ path: rel, size: 0, mtime, isDir: true })
+        walk(path, rel)
+      } else if (FS.isFile(stat.mode)) {
+        entries.push({ path: rel, size: stat.size, mtime, isDir: false })
+      }
+    }
+  }
+  walk(ASSETS_ROOT, '')
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+  return entries
+}
+
+function computeAssetsSignature() {
+  return listAssetEntries()
+    .map((entry) => entry.path + ':' + (entry.isDir ? 'd' : entry.size + ':' + entry.mtime))
+    .join('\n')
+}
+
+function assetsTotalBytes() {
+  let total = 0
+  for (const entry of listAssetEntries()) {
+    total += entry.size
+  }
+  return total
+}
+
+function syncAssets(populate) {
+  return new Promise((resolve, reject) => {
+    if (!assetsPersistent) {
+      resolve()
+      return
+    }
+    Module.FS.syncfs(populate, (err) => (err ? reject(err) : resolve()))
+  })
+}
+
+// Persist the folder to IndexedDB (no-op for the in-memory fallback) and
+// remember its fingerprint so the post-render check stays quiet until
+// something actually changes.
+async function persistAssets() {
+  try {
+    await syncAssets(false)
+  } catch (e) {
+    log('assets: could not persist the browser folder: ' + e)
+  }
+  assetsSignature = computeAssetsSignature()
+}
+
+// After a render: did the scene write into the folder (saveAsset in apps,
+// a downloaded photo, an OpenAI image)? Then persist and tell the page.
+async function persistAssetsIfChanged() {
+  if (!assetsMounted) return
+  let signature
+  try {
+    signature = computeAssetsSignature()
+  } catch (e) {
+    return
+  }
+  if (signature === assetsSignature) return
+  await persistAssets()
+  post({ type: 'assetsChanged' })
+}
+
+function removeAssetTree(absPath) {
+  const FS = Module.FS
+  const stat = FS.stat(absPath)
+  if (FS.isDir(stat.mode)) {
+    for (const name of FS.readdir(absPath)) {
+      if (name === '.' || name === '..') continue
+      removeAssetTree(absPath + '/' + name)
+    }
+    FS.rmdir(absPath)
+  } else {
+    FS.unlink(absPath)
+  }
+}
+
+function clearAssets() {
+  const FS = Module.FS
+  for (const name of FS.readdir(ASSETS_ROOT)) {
+    if (name === '.' || name === '..') continue
+    removeAssetTree(ASSETS_ROOT + '/' + name)
+  }
+}
+
+// --- starter images -------------------------------------------------------
+// A brand-new folder gets a few generated "photos" (1600×1200 JPEGs) so
+// slideshows and local-image scenes render something at once. Drawn with
+// OffscreenCanvas; a browser without it just starts with an empty folder.
+
+function makeRng(seed) {
+  let state = seed >>> 0 || 1
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function paintHills(ctx, width, height, rng, layers, baseY, colors) {
+  for (let layer = 0; layer < layers; layer++) {
+    const amplitude = 40 + layer * 30
+    const yBase = baseY + layer * (height * 0.09)
+    const phase = rng() * Math.PI * 2
+    const freq = 1.5 + rng() * 2
+    ctx.fillStyle = colors[layer % colors.length]
+    ctx.beginPath()
+    ctx.moveTo(0, height)
+    for (let x = 0; x <= width; x += 8) {
+      const t = x / width
+      const y =
+        yBase +
+        Math.sin(t * Math.PI * freq + phase) * amplitude +
+        Math.sin(t * Math.PI * freq * 3.1 + phase * 1.7) * amplitude * 0.3
+      ctx.lineTo(x, y)
+    }
+    ctx.lineTo(width, height)
+    ctx.closePath()
+    ctx.fill()
+  }
+}
+
+function paintStarterImage(ctx, width, height, kind, rng) {
+  if (kind === 'sunset') {
+    const sky = ctx.createLinearGradient(0, 0, 0, height)
+    sky.addColorStop(0, '#2b1a4e')
+    sky.addColorStop(0.45, '#c2453f')
+    sky.addColorStop(0.7, '#f39a4b')
+    sky.addColorStop(1, '#fbd38d')
+    ctx.fillStyle = sky
+    ctx.fillRect(0, 0, width, height)
+    const sunX = width * (0.3 + rng() * 0.4)
+    const sunY = height * 0.58
+    const glow = ctx.createRadialGradient(sunX, sunY, 10, sunX, sunY, height * 0.35)
+    glow.addColorStop(0, 'rgba(255, 240, 200, 0.9)')
+    glow.addColorStop(1, 'rgba(255, 200, 120, 0)')
+    ctx.fillStyle = glow
+    ctx.fillRect(0, 0, width, height)
+    ctx.fillStyle = '#fff3c4'
+    ctx.beginPath()
+    ctx.arc(sunX, sunY, height * 0.07, 0, Math.PI * 2)
+    ctx.fill()
+    paintHills(ctx, width, height, rng, 4, height * 0.6, ['#7a2f4a', '#4e1f3d', '#31142e', '#1c0b1e'])
+  } else if (kind === 'night') {
+    const sky = ctx.createLinearGradient(0, 0, 0, height)
+    sky.addColorStop(0, '#050a1f')
+    sky.addColorStop(0.6, '#0f1f4d')
+    sky.addColorStop(1, '#1c3a6b')
+    ctx.fillStyle = sky
+    ctx.fillRect(0, 0, width, height)
+    const stars = 350 + Math.floor(rng() * 200)
+    for (let i = 0; i < stars; i++) {
+      const x = rng() * width
+      const y = rng() * height * 0.7
+      const r = 0.5 + rng() * 1.8
+      ctx.fillStyle = 'rgba(255,255,255,' + (0.3 + rng() * 0.7).toFixed(2) + ')'
+      ctx.beginPath()
+      ctx.arc(x, y, r, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    const moonX = width * (0.6 + rng() * 0.25)
+    const moonY = height * (0.18 + rng() * 0.15)
+    ctx.fillStyle = '#f4f1de'
+    ctx.beginPath()
+    ctx.arc(moonX, moonY, height * 0.06, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.fillStyle = '#0f1f4d'
+    ctx.beginPath()
+    ctx.arc(moonX + height * 0.025, moonY - height * 0.015, height * 0.05, 0, Math.PI * 2)
+    ctx.fill()
+    paintHills(ctx, width, height, rng, 3, height * 0.68, ['#0b1730', '#070f22', '#03071a'])
+  } else {
+    const sky = ctx.createLinearGradient(0, 0, 0, height * 0.55)
+    sky.addColorStop(0, '#3a8dde')
+    sky.addColorStop(1, '#cfe9ff')
+    ctx.fillStyle = sky
+    ctx.fillRect(0, 0, width, height)
+    const horizon = height * 0.55
+    const sea = ctx.createLinearGradient(0, horizon, 0, height)
+    sea.addColorStop(0, '#1c6fb8')
+    sea.addColorStop(0.7, '#2a9bcf')
+    sea.addColorStop(1, '#5fc8d8')
+    ctx.fillStyle = sea
+    ctx.fillRect(0, horizon, width, height - horizon)
+    ctx.strokeStyle = 'rgba(255,255,255,0.35)'
+    ctx.lineWidth = 2
+    for (let i = 0; i < 26; i++) {
+      const y = horizon + 20 + i * ((height - horizon) / 26)
+      const phase = rng() * Math.PI * 2
+      ctx.beginPath()
+      for (let x = 0; x <= width; x += 10) {
+        const wave = Math.sin(x / (60 + i * 8) + phase) * (2 + i * 0.6)
+        if (x === 0) ctx.moveTo(x, y + wave)
+        else ctx.lineTo(x, y + wave)
+      }
+      ctx.stroke()
+    }
+    const sand = ctx.createLinearGradient(0, height * 0.86, 0, height)
+    sand.addColorStop(0, '#f1dfae')
+    sand.addColorStop(1, '#d8bd7a')
+    ctx.fillStyle = sand
+    ctx.beginPath()
+    ctx.moveTo(0, height)
+    for (let x = 0; x <= width; x += 8) {
+      ctx.lineTo(x, height * 0.88 + Math.sin(x / 140 + 1) * 14)
+    }
+    ctx.lineTo(width, height)
+    ctx.closePath()
+    ctx.fill()
+    const clouds = 4 + Math.floor(rng() * 4)
+    for (let i = 0; i < clouds; i++) {
+      const cx = rng() * width
+      const cy = height * (0.08 + rng() * 0.3)
+      const size = 40 + rng() * 60
+      ctx.fillStyle = 'rgba(255,255,255,0.85)'
+      for (let puff = 0; puff < 5; puff++) {
+        ctx.beginPath()
+        ctx.arc(cx + (puff - 2) * size * 0.7, cy + (puff % 2) * size * 0.25, size * (0.6 + rng() * 0.4), 0, Math.PI * 2)
+        ctx.fill()
+      }
+    }
+  }
+  ctx.font = '600 28px system-ui, sans-serif'
+  ctx.fillStyle = 'rgba(255,255,255,0.75)'
+  ctx.textAlign = 'right'
+  ctx.fillText('FrameOS sample image · ' + kind, width - 32, height - 32)
+}
+
+async function seedStarterAssets() {
+  if (typeof OffscreenCanvas === 'undefined') {
+    log('assets: OffscreenCanvas unavailable; the browser folder starts empty')
+    return
+  }
+  const seed = Math.floor(Math.random() * 0xffffffff)
+  const width = 1600
+  const height = 1200
+  let written = 0
+  for (const kind of ['sunset', 'ocean', 'night']) {
+    try {
+      const canvas = new OffscreenCanvas(width, height)
+      const ctx = canvas.getContext('2d')
+      if (!ctx) continue
+      paintStarterImage(ctx, width, height, kind, makeRng(seed ^ kind.length * 7919))
+      const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.9 })
+      const bytes = new Uint8Array(await blob.arrayBuffer())
+      Module.FS.writeFile(assetAbsolutePath('sample-' + kind + '.jpg'), bytes)
+      written += 1
+    } catch (e) {
+      log('assets: could not generate sample image ' + kind + ': ' + e)
+    }
+  }
+  if (written > 0) {
+    log('assets: generated ' + written + ' sample image(s) in the browser folder')
+  }
+}
+
+// Mount the browser folder at /srv/assets. Called once per worker (after
+// the module is created, before scenes load) so the first render already
+// sees the files.
+async function mountBrowserAssets(enabled) {
+  const FS = Module.FS
+  if (!FS) {
+    log('assets: wasm bundle lacks the FS export; no browser asset folder')
+    return
+  }
+  fsEnsureDir(ASSETS_ROOT)
+  assetsMounted = true
+  if (enabled === false) {
+    return
+  }
+  if (Module.IDBFS && typeof indexedDB !== 'undefined') {
+    try {
+      FS.mount(Module.IDBFS, {}, ASSETS_ROOT)
+      assetsPersistent = true
+      await syncAssets(true)
+    } catch (e) {
+      assetsPersistent = false
+      log('assets: browser storage unavailable (' + e + '); the folder lives in memory for this preview only')
+    }
+  } else {
+    log('assets: persistent browser storage unavailable; the folder lives in memory for this preview only')
+  }
+  const entries = listAssetEntries()
+  if (entries.length === 0) {
+    await seedStarterAssets()
+  }
+  await persistAssets()
+  const files = listAssetEntries().filter((entry) => !entry.isDir).length
+  log(
+    'assets: ' +
+      ASSETS_ROOT +
+      ' is a browser-only folder (' +
+      files +
+      ' file' +
+      (files === 1 ? '' : 's') +
+      (assetsPersistent ? ', kept in this browser between previews)' : ', in memory for this preview only)')
+  )
+}
+
+function browserAssetsInfo() {
+  return { mounted: assetsMounted, persistent: assetsPersistent, root: ASSETS_ROOT, maxBytes: ASSETS_MAX_BYTES }
+}
+
+// Browser folder ops from the page. Every request is answered with an
+// `assetsResult` carrying its requestId; mutations persist first.
+//   {op: 'list'}                       -> {entries}
+//   {op: 'read', path}                 -> {data}   (ArrayBuffer, transferred)
+//   {op: 'write', path, data}          (data: ArrayBuffer/typed array; creates folders)
+//   {op: 'mkdir', path}
+//   {op: 'delete', path}               (files and folders, recursive)
+//   {op: 'reset'}                      wipe the folder and regenerate the samples
+async function handleAssetsRequest(msg) {
+  const requestId = msg.requestId
+  const reply = (payload, transfer) => post({ type: 'assetsResult', requestId, ok: true, ...payload }, transfer)
+  const fail = (error) => post({ type: 'assetsResult', requestId, ok: false, error: String(error) })
+  if (!Module || !assetsMounted) {
+    fail('browser asset folder is not available')
+    return
+  }
+  const FS = Module.FS
+  try {
+    switch (msg.op) {
+      case 'list':
+        reply({ entries: listAssetEntries(), info: browserAssetsInfo() })
+        return
+      case 'read': {
+        const rel = normalizeAssetPath(msg.path)
+        if (!rel) throw new Error('invalid path')
+        const bytes = FS.readFile(assetAbsolutePath(rel))
+        const data = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+        reply({ data }, [data])
+        return
+      }
+      case 'write': {
+        const rel = normalizeAssetPath(msg.path)
+        if (!rel) throw new Error('invalid path')
+        const bytes = msg.data instanceof ArrayBuffer ? new Uint8Array(msg.data) : new Uint8Array(msg.data || [])
+        let existing = 0
+        try {
+          existing = FS.stat(assetAbsolutePath(rel)).size
+        } catch (e) {
+          // new file
+        }
+        if (assetsTotalBytes() - existing + bytes.length > ASSETS_MAX_BYTES) {
+          throw new Error('the browser folder is limited to ' + Math.round(ASSETS_MAX_BYTES / 1024 / 1024) + ' MB')
+        }
+        const slash = rel.lastIndexOf('/')
+        if (slash > 0) fsEnsureDir(assetAbsolutePath(rel.slice(0, slash)))
+        FS.writeFile(assetAbsolutePath(rel), bytes)
+        await persistAssets()
+        post({ type: 'assetsChanged' })
+        reply({})
+        return
+      }
+      case 'mkdir': {
+        const rel = normalizeAssetPath(msg.path)
+        if (!rel) throw new Error('invalid path')
+        fsEnsureDir(assetAbsolutePath(rel))
+        await persistAssets()
+        post({ type: 'assetsChanged' })
+        reply({})
+        return
+      }
+      case 'delete': {
+        const rel = normalizeAssetPath(msg.path)
+        if (!rel) throw new Error('invalid path')
+        removeAssetTree(assetAbsolutePath(rel))
+        await persistAssets()
+        post({ type: 'assetsChanged' })
+        reply({})
+        return
+      }
+      case 'reset':
+        clearAssets()
+        await seedStarterAssets()
+        await persistAssets()
+        post({ type: 'assetsChanged' })
+        reply({})
+        return
+      default:
+        throw new Error('unknown assets op: ' + msg.op)
+    }
+  } catch (e) {
+    fail(e && e.message ? e.message : e)
+  }
+}
+
+// ----------------------------------------------------------------- render
 
 function renderNow() {
   if (!Module || rendering) {
@@ -71,8 +568,18 @@ function renderNow() {
     post({ type: 'error', message: 'render crashed: ' + e })
   } finally {
     rendering = false
+    void persistAssetsIfChanged()
     scheduleNextRender()
   }
+}
+
+// The delay before the next render for a scene that asked for `seconds`:
+// throttled to one render per second unless fast mode is on, never longer
+// than 15 minutes.
+function renderDelayMs(seconds, fast) {
+  const wanted = seconds * 1000
+  const floor = fast ? FAST_MIN_MS : THROTTLE_MS
+  return Math.min(Math.max(wanted, floor), MAX_DELAY_MS)
 }
 
 function scheduleNextRender() {
@@ -94,10 +601,11 @@ function scheduleNextRender() {
   } catch (e) {
     seconds = 300
   }
-  // Keep the preview responsive but sane: at least 1 fps worth of delay,
-  // at most 15 minutes between refreshes.
-  const delayMs = Math.min(Math.max(seconds * 1000, 1000), 15 * 60 * 1000)
-  renderTimer = setTimeout(renderNow, delayMs)
+  if (!fastMode && seconds * 1000 < THROTTLE_MS && !fastRequestSent) {
+    fastRequestSent = true
+    post({ type: 'fastRenderRequest', intervalMs: Math.max(Math.round(seconds * 1000), FAST_MIN_MS) })
+  }
+  renderTimer = setTimeout(renderNow, renderDelayMs(seconds, fastMode))
 }
 
 function renderSoonIfRequested() {
@@ -114,6 +622,8 @@ function renderSoonIfRequested() {
 
 async function init(msg) {
   try {
+    fastMode = Boolean(msg.fastMode)
+    fastRequestSent = false
     const createFrameOS = (await import('./frameos.js')).default
     Module = await createFrameOS({
       locateFile: (path) => new URL(path, import.meta.url).href,
@@ -132,6 +642,8 @@ async function init(msg) {
       Module['frameosProxyUrl'] = msg.proxyUrl
     }
 
+    await mountBrowserAssets(msg.browserAssets)
+
     const ok = call(
       'frameos_wasm_init',
       'boolean',
@@ -147,6 +659,15 @@ async function init(msg) {
     if (!ok) {
       throw new Error('init failed: ' + lastError())
     }
+    // Apps may save into the browser folder (a device's saveAssets setting;
+    // on by default here — it's the visitor's own browser storage). Pass
+    // `saveAssets: false` or a {nodeName: bool} map to mirror a frame.
+    const saveAssets = msg.saveAssets === undefined ? true : msg.saveAssets
+    try {
+      call('frameos_wasm_set_save_assets', 'boolean', ['string'], [JSON.stringify(saveAssets)])
+    } catch (e) {
+      // older bundle without the export
+    }
     const loaded = call('frameos_wasm_load_scenes', 'number', ['string'], [msg.scenesJson])
     if (!loaded) {
       throw new Error('no scenes loaded: ' + lastError())
@@ -154,8 +675,9 @@ async function init(msg) {
     if (msg.sceneId) {
       call('frameos_wasm_select_scene', 'boolean', ['string'], [msg.sceneId])
     }
+    lastPostedState = null
     const sceneInfo = JSON.parse(call('frameos_wasm_scene_info', 'string', [], []))
-    post({ type: 'ready', sceneInfo })
+    post({ type: 'ready', sceneInfo, browserAssets: browserAssetsInfo() })
     renderNow()
   } catch (e) {
     post({ type: 'error', message: String(e && e.message ? e.message : e) })
@@ -189,8 +711,22 @@ self.onmessage = (ev) => {
     case 'selectScene':
       if (Module) {
         call('frameos_wasm_select_scene', 'boolean', ['string'], [msg.sceneId])
+        fastRequestSent = false
         renderNow()
       }
+      break
+    case 'setFastMode':
+      fastMode = Boolean(msg.enabled)
+      if (!fastMode) {
+        // A later fast scene may ask again; this one already got its answer.
+        fastRequestSent = true
+      }
+      if (Module && !rendering) {
+        scheduleNextRender()
+      }
+      break
+    case 'assets':
+      void handleAssetsRequest(msg)
       break
     default:
       break

--- a/frameos/wasm/README.md
+++ b/frameos/wasm/README.md
@@ -52,6 +52,34 @@ preview.selectScene('sceneId')
 preview.destroy()
 ```
 
+### Render pacing
+
+Renders are throttled to one per second. A scene that asks for more (a 24 fps slideshow with
+`refreshInterval: 0.04`) triggers `onFastRenderRequest(intervalMs)` once per runtime start —
+ask the visitor, then `preview.setFastMode(true)` to let the scene run at its own pace
+(`setFastMode(false)` restores the throttle). Pass `fastMode: true` to start unthrottled.
+
+### Browser asset folder
+
+The runtime's `/srv/assets` — where a real frame keeps its assets — is a folder that lives in
+the visitor's browser (IndexedDB, via emscripten's IDBFS). It is shared by every preview on the
+same origin, survives reloads, and never leaves the browser. A fresh folder gets a few generated
+sample photos so image scenes render something at once. Scenes read from it (`data/localImage`,
+fonts, …) and, with `saveAssets` on (the default here), write into it.
+
+```ts
+const entries = await preview.listAssets() // [{path, size, mtime, isDir}]
+await preview.writeAsset('photos/beach.jpg', file) // File/Blob/ArrayBuffer; parents created
+const bytes = await preview.readAsset('photos/beach.jpg')
+await preview.createAssetFolder('photos/2026')
+await preview.deleteAsset('photos') // recursive
+await preview.resetAssets() // wipe + regenerate the samples
+```
+
+`onAssetsChanged` fires when a scene writes into the folder (or an op completes);
+`onReady(sceneInfo, assets)` reports whether the folder is persistent or in-memory.
+Pass `browserAssets: false` for an empty in-memory folder instead.
+
 Helpers for building your own UI are exported too: `evaluateShowIf`, `visiblePublicStateFields`,
 `coerceStateFieldValue`, `sceneEventButtons`, and the `StateField`/`FrameOSScene` types.
 
@@ -61,7 +89,7 @@ Helpers for building your own UI are exported too: `evaluateShowIf`, `visiblePub
   same-origin endpoint that forwards `{method, url, headers, bodyBase64, timeoutMs}` — see
   FrameOS's `/api/frames/{id}/scene_preview_proxy`).
 - Apps that need host processes are not in the wasm build: `data/chromiumScreenshot`,
-  `data/rstpSnapshot`, `data/localImage`.
+  `data/rstpSnapshot`. `data/localImage` reads the browser asset folder (see above).
 - `index.html` in the package root is a standalone demo page:
   `npx serve node_modules/frameos-wasm` and paste a scenes.json.
 

--- a/frameos/wasm/src/index.ts
+++ b/frameos/wasm/src/index.ts
@@ -18,6 +18,8 @@ export {
   type ConfigFieldCondition,
   type ConfigFieldConditionAnd,
   type FrameOSScene,
+  type PreviewAssetEntry,
+  type PreviewAssetsInfo,
   type PreviewFrame,
   type SceneEventButton,
   type SceneInfo,

--- a/frameos/wasm/src/manager.ts
+++ b/frameos/wasm/src/manager.ts
@@ -70,10 +70,10 @@ export function mountFrameOSManager(container: HTMLElement, options: FrameOSMana
   const preview = new FrameOSPreview({
     ...options,
     canvas,
-    onReady: (sceneInfo) => {
+    onReady: (sceneInfo, assets) => {
       status.textContent = ''
       renderControls()
-      options.onReady?.(sceneInfo)
+      options.onReady?.(sceneInfo, assets)
     },
     onFrame: (frame) => {
       status.textContent = `Rendered ${frame.width}×${frame.height} in ${frame.renderMs} ms`

--- a/frameos/wasm/src/preview.ts
+++ b/frameos/wasm/src/preview.ts
@@ -2,7 +2,7 @@
 // The worker loads the emscripten-built scene runtime (frameos.js/frameos.wasm)
 // and drives renders; this class owns the worker lifecycle, paints frames onto
 // a canvas, and exposes events/state as callbacks.
-import type { FrameOSScene, PreviewFrame, SceneInfo } from './types'
+import type { FrameOSScene, PreviewAssetEntry, PreviewAssetsInfo, PreviewFrame, SceneInfo } from './types'
 
 export interface FrameOSPreviewOptions {
   /** URL of the module worker script: `<assets>/preview-worker.js`. The
@@ -27,12 +27,29 @@ export interface FrameOSPreviewOptions {
   proxyUrl?: string
   /** Canvas to paint frames onto; can also be attached later. */
   canvas?: HTMLCanvasElement | null
-  onReady?: (sceneInfo: SceneInfo) => void
+  /** Renders are throttled to one per second unless this is true (see
+   * `onFastRenderRequest` and `setFastMode`). */
+  fastMode?: boolean
+  /** Whether apps may save files into the browser asset folder — a frame's
+   * `saveAssets` setting: a boolean, or `{nodeName: boolean}`. Defaults to
+   * true (it is the visitor's own browser storage). */
+  saveAssets?: boolean | Record<string, boolean>
+  /** Set to false to run with an empty in-memory /srv/assets instead of the
+   * browser's persistent folder. */
+  browserAssets?: boolean
+  onReady?: (sceneInfo: SceneInfo, assets: PreviewAssetsInfo | null) => void
   onFrame?: (frame: PreviewFrame) => void
   onState?: (state: Record<string, unknown>) => void
   onLog?: (message: string) => void
   onSceneEvent?: (name: string, payload: Record<string, unknown>) => void
   onError?: (message: string) => void
+  /** The scene asked to render every `intervalMs` — faster than the 1 fps
+   * throttle. Fires once per runtime start; call `setFastMode(true)` to let
+   * the scene run at its own pace. */
+  onFastRenderRequest?: (intervalMs: number) => void
+  /** Files in the browser asset folder changed: the scene saved something,
+   * or an asset op completed. */
+  onAssetsChanged?: () => void
 }
 
 interface PendingFrame {
@@ -41,24 +58,36 @@ interface PendingFrame {
   buffer: ArrayBuffer
 }
 
+interface PendingAssetRequest {
+  resolve: (result: Record<string, any>) => void
+  reject: (error: Error) => void
+}
+
 export class FrameOSPreview {
   readonly options: FrameOSPreviewOptions
   private worker: Worker | null = null
   private canvas: HTMLCanvasElement | null = null
   private pendingFrame: PendingFrame | null = null
   private destroyed = false
+  private assetRequests = new Map<number, PendingAssetRequest>()
+  private nextAssetRequestId = 1
 
   /** Latest scene info from the runtime (set once `ready` fires). */
   sceneInfo: SceneInfo | null = null
+  /** How the runtime's /srv/assets is backed (set once `ready` fires). */
+  assetsInfo: PreviewAssetsInfo | null = null
   /** Latest public state of the current scene. */
   state: Record<string, unknown> = {}
   /** The scene currently selected in the runtime. */
   currentSceneId: string | null = null
+  /** Whether renders may run faster than once per second. */
+  fastMode: boolean
 
   constructor(options: FrameOSPreviewOptions) {
     this.options = options
     this.canvas = options.canvas ?? null
     this.currentSceneId = options.sceneId ?? null
+    this.fastMode = Boolean(options.fastMode)
 
     this.worker = new Worker(options.workerUrl, { type: 'module' })
     this.worker.onerror = (event: ErrorEvent) => {
@@ -75,6 +104,9 @@ export class FrameOSPreview {
       settingsJson: JSON.stringify(options.settings ?? {}),
       proxyUrl: options.proxyUrl || '',
       sceneId: options.sceneId || '',
+      fastMode: this.fastMode,
+      saveAssets: options.saveAssets === undefined ? true : options.saveAssets,
+      browserAssets: options.browserAssets === undefined ? true : options.browserAssets,
     })
   }
 
@@ -85,10 +117,11 @@ export class FrameOSPreview {
     switch (msg.type) {
       case 'ready':
         this.sceneInfo = msg.sceneInfo ?? null
+        this.assetsInfo = msg.browserAssets ?? null
         if (this.sceneInfo?.currentSceneId) {
           this.currentSceneId = this.sceneInfo.currentSceneId
         }
-        this.options.onReady?.(msg.sceneInfo)
+        this.options.onReady?.(msg.sceneInfo, this.assetsInfo)
         break
       case 'frame':
         this.pendingFrame = { width: msg.width, height: msg.height, buffer: msg.buffer }
@@ -108,6 +141,25 @@ export class FrameOSPreview {
       case 'error':
         this.options.onError?.(String(msg.message ?? 'Unknown FrameOS preview error'))
         break
+      case 'fastRenderRequest':
+        this.options.onFastRenderRequest?.(Number(msg.intervalMs) || 0)
+        break
+      case 'assetsChanged':
+        this.options.onAssetsChanged?.()
+        break
+      case 'assetsResult': {
+        const pending = this.assetRequests.get(msg.requestId)
+        if (!pending) {
+          break
+        }
+        this.assetRequests.delete(msg.requestId)
+        if (msg.ok) {
+          pending.resolve(msg)
+        } else {
+          pending.reject(new Error(String(msg.error ?? 'asset request failed')))
+        }
+        break
+      }
     }
   }
 
@@ -157,6 +209,68 @@ export class FrameOSPreview {
     this.worker?.postMessage({ type: 'selectScene', sceneId })
   }
 
+  /** Let the scene render as often as it asks (true), or throttle it back
+   * to one render per second (false). */
+  setFastMode(enabled: boolean): void {
+    this.fastMode = enabled
+    this.worker?.postMessage({ type: 'setFastMode', enabled })
+  }
+
+  private assetRequest(op: string, params: Record<string, unknown> = {}, transfer: Transferable[] = []): Promise<Record<string, any>> {
+    return new Promise((resolve, reject) => {
+      if (!this.worker || this.destroyed) {
+        reject(new Error('preview is not running'))
+        return
+      }
+      const requestId = this.nextAssetRequestId++
+      this.assetRequests.set(requestId, { resolve, reject })
+      this.worker.postMessage({ type: 'assets', requestId, op, ...params }, transfer)
+    })
+  }
+
+  /** Every file and folder in the browser asset folder (/srv/assets). */
+  async listAssets(): Promise<PreviewAssetEntry[]> {
+    const result = await this.assetRequest('list')
+    if (result.info) {
+      this.assetsInfo = result.info
+    }
+    return (result.entries ?? []) as PreviewAssetEntry[]
+  }
+
+  /** The bytes of one file in the browser asset folder. */
+  async readAsset(path: string): Promise<ArrayBuffer> {
+    const result = await this.assetRequest('read', { path })
+    return result.data as ArrayBuffer
+  }
+
+  /** Write (create or replace) a file; missing parent folders are created. */
+  async writeAsset(path: string, data: ArrayBuffer | Uint8Array | Blob): Promise<void> {
+    let buffer: ArrayBuffer
+    if (data instanceof Blob) {
+      buffer = await data.arrayBuffer()
+    } else if (data instanceof ArrayBuffer) {
+      buffer = data
+    } else {
+      buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer
+    }
+    await this.assetRequest('write', { path, data: buffer }, [buffer])
+  }
+
+  /** Create a folder (and its parents). */
+  async createAssetFolder(path: string): Promise<void> {
+    await this.assetRequest('mkdir', { path })
+  }
+
+  /** Delete a file, or a folder with everything in it. */
+  async deleteAsset(path: string): Promise<void> {
+    await this.assetRequest('delete', { path })
+  }
+
+  /** Empty the folder and regenerate the sample images. */
+  async resetAssets(): Promise<void> {
+    await this.assetRequest('reset')
+  }
+
   /** Terminate the worker; the instance cannot be reused afterwards. */
   destroy(): void {
     this.destroyed = true
@@ -164,6 +278,10 @@ export class FrameOSPreview {
     this.worker = null
     this.pendingFrame = null
     this.canvas = null
+    for (const pending of this.assetRequests.values()) {
+      pending.reject(new Error('preview destroyed'))
+    }
+    this.assetRequests.clear()
   }
 }
 

--- a/frameos/wasm/src/types.ts
+++ b/frameos/wasm/src/types.ts
@@ -65,6 +65,30 @@ export interface PreviewFrame {
   renderMs: number
 }
 
+/** One entry of the browser asset folder (the runtime's /srv/assets). */
+export interface PreviewAssetEntry {
+  /** Path relative to the folder root, e.g. `photos/beach.jpg`. */
+  path: string
+  /** Bytes; 0 for folders. */
+  size: number
+  /** Last modification, ms since the epoch. */
+  mtime: number
+  isDir: boolean
+}
+
+/** How the runtime's /srv/assets is backed, sent with the worker's `ready` message. */
+export interface PreviewAssetsInfo {
+  /** False when the wasm bundle has no filesystem export at all. */
+  mounted: boolean
+  /** True when the folder is kept in this browser's IndexedDB between
+   * previews; false when it lives in memory for this worker only. */
+  persistent: boolean
+  /** The folder's absolute path inside the runtime (`/srv/assets`). */
+  root: string
+  /** Size ceiling for the folder in bytes. */
+  maxBytes: number
+}
+
 /** An interactive scene event (custom `event` node) usable as a button. */
 export interface SceneEventButton {
   keyword: string

--- a/frontend/src/components/BatteryIndicator.tsx
+++ b/frontend/src/components/BatteryIndicator.tsx
@@ -1,0 +1,98 @@
+import clsx from 'clsx'
+
+export type BatteryTone = 'full' | 'ok' | 'low' | 'critical'
+
+/** Colour band for a charge level: green down to 50, amber to 20, red below. */
+export function batteryTone(percent: number): BatteryTone {
+  if (percent >= 80) {
+    return 'full'
+  }
+  if (percent >= 50) {
+    return 'ok'
+  }
+  if (percent >= 20) {
+    return 'low'
+  }
+  return 'critical'
+}
+
+export function clampBatteryPercent(value: unknown): number | null {
+  const percent = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(percent)) {
+    return null
+  }
+  return Math.max(0, Math.min(100, Math.round(percent)))
+}
+
+const toneText: Record<BatteryTone, string> = {
+  full: 'text-emerald-500',
+  ok: 'text-emerald-500',
+  low: 'text-amber-500',
+  critical: 'text-red-500',
+}
+
+const toneBar: Record<BatteryTone, string> = {
+  full: 'bg-emerald-500',
+  ok: 'bg-emerald-500',
+  low: 'bg-amber-500',
+  critical: 'bg-red-500',
+}
+
+export function batteryTitle(percent: number): string {
+  const tone = batteryTone(percent)
+  return `Battery ${percent}%${tone === 'critical' ? ' — charge soon' : tone === 'low' ? ' — getting low' : ''}`
+}
+
+/**
+ * A battery glyph filled to `percent`, coloured by charge band, with the
+ * percentage next to it and (optionally) a thin progress bar underneath.
+ */
+export function BatteryIndicator({
+  percent,
+  size = 'md',
+  showLabel = true,
+  withBar = false,
+  className,
+  title,
+}: {
+  percent: number
+  size?: 'sm' | 'md'
+  showLabel?: boolean
+  withBar?: boolean
+  className?: string
+  title?: string
+}): JSX.Element {
+  const level = Math.max(0, Math.min(100, Math.round(percent)))
+  const tone = batteryTone(level)
+  // Glyph geometry (viewBox 24×12): body 20×10 at (0.5,1), cap 2×4 at the right.
+  const fillWidth = (17 * level) / 100
+  const iconClassName = size === 'sm' ? 'h-2.5 w-5' : 'h-3 w-6'
+
+  return (
+    <span
+      className={clsx('inline-flex flex-col gap-0.5', className)}
+      title={title ?? batteryTitle(level)}
+      data-testid="battery-indicator"
+      data-battery-percent={level}
+      data-battery-tone={tone}
+    >
+      <span className={clsx('inline-flex items-center gap-1 leading-none', toneText[tone])}>
+        <svg viewBox="0 0 24 12" className={clsx('shrink-0', iconClassName)} aria-hidden>
+          <rect x="0.5" y="1" width="20" height="10" rx="2" fill="none" stroke="currentColor" strokeWidth="1.5" />
+          <rect x="21.5" y="4" width="2" height="4" rx="0.5" fill="currentColor" />
+          <rect x="2" y="2.5" width={fillWidth} height="7" rx="1" fill="currentColor" />
+        </svg>
+        {showLabel ? (
+          <span className={clsx('font-semibold tabular-nums', size === 'sm' ? 'text-[10px]' : 'text-[11px]')}>
+            {level}%
+          </span>
+        ) : null}
+      </span>
+      {withBar ? (
+        <span className="block h-1 w-full overflow-hidden rounded-full bg-slate-500/20">
+          <span className={clsx('block h-full rounded-full', toneBar[tone])} style={{ width: `${level}%` }} />
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/frontend/src/scenes/frame/panels/Metrics/HeaderMetrics.tsx
+++ b/frontend/src/scenes/frame/panels/Metrics/HeaderMetrics.tsx
@@ -13,6 +13,7 @@ import { metricChartThemes, themeMetricSeries, type MetricChartTheme } from './c
 import { urls } from '../../../../urls'
 import { frameMetricsPreviewLogic } from '../../../workspace/frameMetricsPreviewLogic'
 import type { FrameId } from '../../../../types'
+import { BatteryIndicator, batteryTitle } from '../../../../components/BatteryIndicator'
 
 const chartHeight = 28
 const chartMargin = { top: 3, right: 1, bottom: 3, left: 1 }
@@ -20,6 +21,7 @@ const metricLabels: Record<string, string> = {
   load: 'Load',
   memoryUsage: 'Mem',
   diskUsage: 'Disk',
+  batteryPercent: 'Battery',
 }
 const compactMetricLabels: Record<string, string> = {
   load: 'L',
@@ -108,9 +110,8 @@ function HeaderMetricChart({
 
 export function HeaderMetrics({ frameId }: { frameId: FrameId }) {
   const { theme } = useValues(workspaceLogic)
-  const { headerMetricsByCategory, previewMetricsTimeRange, latestMetricSummariesByCategory } = useValues(
-    frameMetricsPreviewLogic({ frameId })
-  )
+  const { headerMetricsByCategory, previewMetricsTimeRange, latestMetricSummariesByCategory, latestBatteryPercent } =
+    useValues(frameMetricsPreviewLogic({ frameId }))
   const metricEntries = Object.entries(headerMetricsByCategory).filter(([, series]) => series.length > 0)
   const chartTheme = metricChartThemes[theme]
 
@@ -130,39 +131,50 @@ export function HeaderMetrics({ frameId }: { frameId: FrameId }) {
               ? 'border-white/10 bg-white/[0.06] shadow-black/10 hover:bg-white/[0.09]'
               : 'border-slate-200/70 bg-white/70 shadow-slate-950/5 hover:bg-white/90'
           )}
-          title={`${metricLabels[key] ?? key}${
-            latestMetricSummariesByCategory[key] ? ` ${latestMetricSummariesByCategory[key]}` : ''
-          }`}
+          title={
+            key === 'batteryPercent' && latestBatteryPercent !== null
+              ? batteryTitle(latestBatteryPercent)
+              : `${metricLabels[key] ?? key}${
+                  latestMetricSummariesByCategory[key] ? ` ${latestMetricSummariesByCategory[key]}` : ''
+                }`
+          }
         >
-          <span
-            className={clsx(
-              'flex min-w-0 items-baseline gap-1 whitespace-nowrap leading-none',
-              theme === 'dark' ? 'text-gray-300' : 'text-slate-700'
-            )}
-          >
-            <span className="shrink-0 text-[10px] font-semibold uppercase">
-              <span className="@4xl:hidden">{compactMetricLabels[key] ?? metricLabels[key] ?? key}</span>
-              <span className="hidden @4xl:inline">{metricLabels[key] ?? key}</span>
-            </span>
-            {latestMetricSummariesByCategory[key] ? (
+          {key === 'batteryPercent' && latestBatteryPercent !== null ? (
+            // A battery glyph with the charge and a bar, instead of label + sparkline.
+            <BatteryIndicator percent={latestBatteryPercent} withBar className="min-w-[3.25rem]" />
+          ) : (
+            <>
               <span
                 className={clsx(
-                  'min-w-0 truncate text-[11px] font-medium',
-                  theme === 'dark' ? 'text-gray-400' : 'text-slate-500'
+                  'flex min-w-0 items-baseline gap-1 whitespace-nowrap leading-none',
+                  theme === 'dark' ? 'text-gray-300' : 'text-slate-700'
                 )}
               >
-                {latestMetricSummariesByCategory[key]}
+                <span className="shrink-0 text-[10px] font-semibold uppercase">
+                  <span className="@4xl:hidden">{compactMetricLabels[key] ?? metricLabels[key] ?? key}</span>
+                  <span className="hidden @4xl:inline">{metricLabels[key] ?? key}</span>
+                </span>
+                {latestMetricSummariesByCategory[key] ? (
+                  <span
+                    className={clsx(
+                      'min-w-0 truncate text-[11px] font-medium',
+                      theme === 'dark' ? 'text-gray-400' : 'text-slate-500'
+                    )}
+                  >
+                    {latestMetricSummariesByCategory[key]}
+                  </span>
+                ) : null}
               </span>
-            ) : null}
-          </span>
-          {key !== 'diskUsage' ? (
-            <HeaderMetricChart
-              series={themeMetricSeries(series, chartTheme)}
-              timeRange={previewMetricsTimeRange}
-              chartTheme={chartTheme}
-              className="hidden @5xl:block @5xl:w-20 @7xl:w-[104px]"
-            />
-          ) : null}
+              {key !== 'diskUsage' ? (
+                <HeaderMetricChart
+                  series={themeMetricSeries(series, chartTheme)}
+                  timeRange={previewMetricsTimeRange}
+                  chartTheme={chartTheme}
+                  className="hidden @5xl:block @5xl:w-20 @7xl:w-[104px]"
+                />
+              ) : null}
+            </>
+          )}
         </A>
       ))}
     </div>

--- a/frontend/src/scenes/frame/panels/Metrics/metricsLogic.ts
+++ b/frontend/src/scenes/frame/panels/Metrics/metricsLogic.ts
@@ -855,15 +855,28 @@ export function metricsByCategoryFromMetrics(metrics: MetricsType[]): Record<str
   return metricsByCategory
 }
 
+/** The newest finite battery charge (%) in the metrics, or null. */
+export function latestBatteryPercentFromMetrics(metrics: MetricsType[]): number | null {
+  for (let i = metrics.length - 1; i >= 0; i--) {
+    const percent = Number(metrics[i].metrics?.batteryPercent)
+    if (Number.isFinite(percent)) {
+      return Math.max(0, Math.min(100, Math.round(percent)))
+    }
+  }
+  return null
+}
+
 export function latestMetricSummariesByCategoryFromMetrics(metrics: MetricsType[]): Record<string, string> {
   const loadSummary = getLatestLoadSummary(metrics)
   const memoryUsageSummary = getLatestUsageSummary(metrics, 'memoryUsage')
   const diskUsageSummary = getLatestUsageSummary(metrics, 'diskUsage')
+  const batteryPercent = latestBatteryPercentFromMetrics(metrics)
   const runtimeDimensionsSummary = getLatestRuntimeDimensionsSummary(metrics)
   return {
     ...(loadSummary ? { load: loadSummary } : {}),
     ...(memoryUsageSummary ? { memoryUsage: memoryUsageSummary } : {}),
     ...(diskUsageSummary ? { diskUsage: diskUsageSummary } : {}),
+    ...(batteryPercent !== null ? { batteryPercent: `${batteryPercent}%` } : {}),
     ...(runtimeDimensionsSummary ? { runtimeDimensions: runtimeDimensionsSummary } : {}),
   }
 }

--- a/frontend/src/scenes/frame/panels/Scenes/BrowserAssetsModal.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/BrowserAssetsModal.tsx
@@ -1,0 +1,439 @@
+import { useActions, useValues } from 'kea'
+import clsx from 'clsx'
+import { useEffect, useRef, useState, type DragEvent } from 'react'
+import {
+  ArrowPathIcon,
+  ArrowUpTrayIcon,
+  ChevronRightIcon,
+  DocumentIcon,
+  FolderIcon,
+  FolderPlusIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline'
+
+import { Button } from '../../../../components/Button'
+import { Modal } from '../../../../components/Modal'
+import { Spinner } from '../../../../components/Spinner'
+import { TextInput } from '../../../../components/TextInput'
+import { livePreviewLogic, readPreviewAsset, type PreviewAssetEntry } from './livePreviewLogic'
+import type { FrameId } from '../../../../types'
+
+const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg', '.qoi']
+
+export function isImageAssetPath(path: string): boolean {
+  const lower = path.toLowerCase()
+  return IMAGE_EXTENSIONS.some((extension) => lower.endsWith(extension))
+}
+
+export function formatAssetSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/** The folder part of a relative asset path ('' at the root). */
+export function assetParentFolder(path: string): string {
+  const slash = path.lastIndexOf('/')
+  return slash === -1 ? '' : path.slice(0, slash)
+}
+
+export function assetBaseName(path: string): string {
+  const slash = path.lastIndexOf('/')
+  return slash === -1 ? path : path.slice(slash + 1)
+}
+
+/** Entries directly inside `folder`, folders first, then files, by name. */
+export function entriesInFolder(entries: PreviewAssetEntry[], folder: string): PreviewAssetEntry[] {
+  return entries
+    .filter((entry) => assetParentFolder(entry.path) === folder)
+    .sort((a, b) => {
+      if (a.isDir !== b.isDir) {
+        return a.isDir ? -1 : 1
+      }
+      return assetBaseName(a.path).localeCompare(assetBaseName(b.path), undefined, { sensitivity: 'base' })
+    })
+}
+
+/** MIME type for a thumbnail blob, by extension. */
+function imageMimeType(path: string): string {
+  const lower = path.toLowerCase()
+  if (lower.endsWith('.png')) {
+    return 'image/png'
+  }
+  if (lower.endsWith('.gif')) {
+    return 'image/gif'
+  }
+  if (lower.endsWith('.webp')) {
+    return 'image/webp'
+  }
+  if (lower.endsWith('.bmp')) {
+    return 'image/bmp'
+  }
+  if (lower.endsWith('.svg')) {
+    return 'image/svg+xml'
+  }
+  return 'image/jpeg'
+}
+
+// A thumbnail read out of the worker's folder on demand; the blob URL is
+// revoked when the row goes away (or the file changes).
+function AssetThumbnail({ frameId, entry }: { frameId: FrameId; entry: PreviewAssetEntry }): JSX.Element {
+  const [url, setUrl] = useState<string | null>(null)
+  useEffect(() => {
+    let objectUrl: string | null = null
+    let cancelled = false
+    readPreviewAsset(frameId, entry.path)
+      .then((buffer) => {
+        if (cancelled) {
+          return
+        }
+        objectUrl = URL.createObjectURL(new Blob([buffer], { type: imageMimeType(entry.path) }))
+        setUrl(objectUrl)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUrl(null)
+        }
+      })
+    return () => {
+      cancelled = true
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [frameId, entry.path, entry.mtime, entry.size])
+  return url ? (
+    <img src={url} alt="" className="h-12 w-16 shrink-0 rounded-md object-cover" />
+  ) : (
+    <div className="flex h-12 w-16 shrink-0 items-center justify-center rounded-md bg-slate-500/10">
+      <DocumentIcon className="h-5 w-5 opacity-50" />
+    </div>
+  )
+}
+
+/**
+ * Manage the browser preview's asset folder: the files the running scene
+ * sees at /srv/assets. The folder lives in this browser only (the worker's
+ * IndexedDB-backed filesystem), never on a frame or a server.
+ */
+export function BrowserAssetsModal({ frameId }: { frameId: FrameId }): JSX.Element | null {
+  const { previewAssetsOpen, previewAssets, previewAssetsInfo, previewAssetsLoading, previewAssetsError } = useValues(
+    livePreviewLogic({ frameId })
+  )
+  const {
+    closePreviewAssets,
+    loadPreviewAssets,
+    uploadPreviewAssets,
+    createPreviewAssetFolder,
+    deletePreviewAsset,
+    resetPreviewAssets,
+  } = useActions(livePreviewLogic({ frameId }))
+
+  const [folder, setFolder] = useState('')
+  const [newFolderName, setNewFolderName] = useState<string | null>(null)
+  const [confirmDeletePath, setConfirmDeletePath] = useState<string | null>(null)
+  const [confirmReset, setConfirmReset] = useState(false)
+  const [dragging, setDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Back to the root whenever the dialog opens; a folder deleted from under
+  // us also falls back to the root.
+  useEffect(() => {
+    if (previewAssetsOpen) {
+      setFolder('')
+      setNewFolderName(null)
+      setConfirmDeletePath(null)
+      setConfirmReset(false)
+    }
+  }, [previewAssetsOpen])
+  useEffect(() => {
+    if (folder && !previewAssets.some((entry) => entry.isDir && entry.path === folder)) {
+      setFolder('')
+    }
+  }, [folder, previewAssets])
+
+  if (!previewAssetsOpen) {
+    return null
+  }
+
+  const entries = entriesInFolder(previewAssets, folder)
+  const totalBytes = previewAssets.reduce((sum, entry) => sum + entry.size, 0)
+  const fileCount = previewAssets.filter((entry) => !entry.isDir).length
+  const crumbs = folder ? folder.split('/') : []
+
+  const addFiles = (files: FileList | File[] | null): void => {
+    const list = files ? Array.from(files) : []
+    if (list.length > 0) {
+      uploadPreviewAssets(folder, list)
+    }
+  }
+  const submitNewFolder = (): void => {
+    const name = (newFolderName ?? '').trim().replace(/\//g, '')
+    if (name && name !== '.' && name !== '..') {
+      createPreviewAssetFolder(folder ? `${folder}/${name}` : name)
+    }
+    setNewFolderName(null)
+  }
+  const onDrop = (event: DragEvent<HTMLDivElement>): void => {
+    event.preventDefault()
+    setDragging(false)
+    addFiles(event.dataTransfer?.files ?? null)
+  }
+
+  return (
+    <Modal open onClose={closePreviewAssets} title="Browser assets" panelClassName="max-w-[720px]" align="top">
+      <div className="space-y-4 p-5">
+        <div className="rounded-lg border border-blue-400/40 bg-blue-500/10 p-3 text-sm">
+          <p>
+            This is a temporary asset folder that exists <strong>only in this browser</strong> — it is never sent to a
+            frame or to the cloud. The preview runs scenes with it mounted at <code>/srv/assets</code>, the path a real
+            frame keeps its assets at, so image scenes have something to show and apps that save files have somewhere to
+            put them.{' '}
+            {previewAssetsInfo?.persistent === false
+              ? 'This browser blocks persistent storage, so the folder lives in memory and is gone when the preview closes.'
+              : 'It is kept in this browser between previews and shared by every preview you open here.'}
+          </p>
+          <p className="mt-1 opacity-80">
+            A fresh folder starts with a few generated sample photos. Add your own images to test slideshows and
+            local-image scenes; put the same files on the frame itself for the real thing.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="small"
+            color="secondary"
+            className="flex items-center gap-1"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <ArrowUpTrayIcon className="h-4 w-4" />
+            Add files
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            data-testid="browser-assets-file-input"
+            onChange={(event) => {
+              addFiles(event.target.files)
+              event.target.value = ''
+            }}
+          />
+          <Button
+            size="small"
+            color="secondary"
+            className="flex items-center gap-1"
+            onClick={() => setNewFolderName('')}
+            disabled={newFolderName !== null}
+          >
+            <FolderPlusIcon className="h-4 w-4" />
+            New folder
+          </Button>
+          <Button
+            size="small"
+            color="secondary"
+            className="flex items-center gap-1"
+            onClick={loadPreviewAssets}
+            disabled={previewAssetsLoading}
+            title="Reload the folder listing"
+          >
+            <ArrowPathIcon className={clsx('h-4 w-4', previewAssetsLoading && 'animate-spin')} />
+            Refresh
+          </Button>
+          <div className="ml-auto flex items-center gap-2">
+            {confirmReset ? (
+              <>
+                <span className="text-sm">Delete everything and regenerate the samples?</span>
+                <Button
+                  size="small"
+                  color="red"
+                  onClick={() => {
+                    setConfirmReset(false)
+                    resetPreviewAssets()
+                  }}
+                >
+                  Reset folder
+                </Button>
+                <Button size="small" color="secondary" onClick={() => setConfirmReset(false)}>
+                  Cancel
+                </Button>
+              </>
+            ) : (
+              <Button
+                size="small"
+                color="secondary"
+                onClick={() => setConfirmReset(true)}
+                title="Delete everything in the folder and regenerate the sample photos"
+              >
+                Reset to samples
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {previewAssetsError ? (
+          <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+            {previewAssetsError}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-1 text-sm">
+          <button
+            type="button"
+            className={clsx('rounded px-1 hover:underline', !folder && 'font-semibold')}
+            onClick={() => setFolder('')}
+          >
+            /srv/assets
+          </button>
+          {crumbs.map((crumb, index) => {
+            const path = crumbs.slice(0, index + 1).join('/')
+            return (
+              <span key={path} className="flex items-center gap-1">
+                <ChevronRightIcon className="h-3 w-3 opacity-60" />
+                <button
+                  type="button"
+                  className={clsx('rounded px-1 hover:underline', index === crumbs.length - 1 && 'font-semibold')}
+                  onClick={() => setFolder(path)}
+                >
+                  {crumb}
+                </button>
+              </span>
+            )
+          })}
+        </div>
+
+        <div
+          className={clsx(
+            'max-h-[50vh] min-h-[8rem] overflow-y-auto rounded-lg border p-1',
+            dragging ? 'border-blue-400 bg-blue-500/10' : 'border-white/10'
+          )}
+          onDragOver={(event) => {
+            event.preventDefault()
+            setDragging(true)
+          }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={onDrop}
+          data-testid="browser-assets-list"
+        >
+          {newFolderName !== null ? (
+            <div className="flex items-center gap-2 p-2">
+              <FolderIcon className="h-5 w-5 shrink-0 opacity-70" />
+              <TextInput
+                autoFocus
+                value={newFolderName}
+                onChange={(value) => setNewFolderName(value)}
+                placeholder="Folder name"
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    submitNewFolder()
+                  } else if (event.key === 'Escape') {
+                    setNewFolderName(null)
+                  }
+                }}
+              />
+              <Button size="small" color="primary" onClick={submitNewFolder}>
+                Create
+              </Button>
+              <Button size="small" color="secondary" onClick={() => setNewFolderName(null)}>
+                Cancel
+              </Button>
+            </div>
+          ) : null}
+          {previewAssetsLoading && previewAssets.length === 0 ? (
+            <div className="flex items-center justify-center gap-2 p-6 text-sm">
+              <Spinner />
+              Reading the browser folder…
+            </div>
+          ) : entries.length === 0 && newFolderName === null ? (
+            <div className="p-6 text-center text-sm opacity-70">
+              This folder is empty. Drop files here, or use “Add files”.
+            </div>
+          ) : (
+            entries.map((entry) => {
+              const name = assetBaseName(entry.path)
+              const confirming = confirmDeletePath === entry.path
+              return (
+                <div
+                  key={entry.path}
+                  className="flex items-center gap-3 rounded-md p-2 hover:bg-slate-500/10"
+                  data-testid="browser-asset-row"
+                >
+                  {entry.isDir ? (
+                    <div className="flex h-12 w-16 shrink-0 items-center justify-center rounded-md bg-slate-500/10">
+                      <FolderIcon className="h-6 w-6 opacity-70" />
+                    </div>
+                  ) : isImageAssetPath(entry.path) ? (
+                    <AssetThumbnail frameId={frameId} entry={entry} />
+                  ) : (
+                    <div className="flex h-12 w-16 shrink-0 items-center justify-center rounded-md bg-slate-500/10">
+                      <DocumentIcon className="h-5 w-5 opacity-50" />
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    {entry.isDir ? (
+                      <button
+                        type="button"
+                        className="block max-w-full truncate text-left font-medium hover:underline"
+                        onClick={() => setFolder(entry.path)}
+                      >
+                        {name}/
+                      </button>
+                    ) : (
+                      <div className="truncate font-medium" title={entry.path}>
+                        {name}
+                      </div>
+                    )}
+                    <div className="text-xs opacity-60">
+                      {entry.isDir ? 'Folder' : formatAssetSize(entry.size)}
+                      {entry.mtime ? ` · ${new Date(entry.mtime).toLocaleString()}` : ''}
+                    </div>
+                  </div>
+                  {confirming ? (
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Button
+                        size="tiny"
+                        color="red"
+                        onClick={() => {
+                          setConfirmDeletePath(null)
+                          deletePreviewAsset(entry.path)
+                        }}
+                      >
+                        Delete{entry.isDir ? ' folder' : ''}
+                      </Button>
+                      <Button size="tiny" color="secondary" onClick={() => setConfirmDeletePath(null)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      size="tiny"
+                      color="secondary"
+                      className="!px-2 shrink-0"
+                      title={entry.isDir ? 'Delete this folder and everything in it' : 'Delete this file'}
+                      onClick={() => setConfirmDeletePath(entry.path)}
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              )
+            })
+          )}
+        </div>
+
+        <div className="flex items-center justify-between text-xs opacity-70">
+          <span>
+            {fileCount} file{fileCount === 1 ? '' : 's'}, {formatAssetSize(totalBytes)}
+            {previewAssetsInfo?.maxBytes ? ` of ${formatAssetSize(previewAssetsInfo.maxBytes)}` : ''}
+          </span>
+          <span>Stored in this browser only</span>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
@@ -96,9 +96,12 @@ export function renderLogLine(line: string): JSX.Element | string {
 /** "every 42 ms (about 24 times a second)" for the fast-render prompt. */
 export function describeRenderRate(intervalMs: number): string {
   const ms = Math.max(1, Math.round(intervalMs))
-  const perSecond = 1000 / ms
-  const rate = perSecond >= 10 ? Math.round(perSecond).toString() : perSecond.toFixed(1).replace(/\.0$/, '')
-  return `every ${ms} ms (about ${rate} times a second)`
+  return `every ${ms} ms (about ${formatFps(1000 / ms)} times a second)`
+}
+
+/** "24" / "7.5": whole numbers from 10 up, one decimal below. */
+export function formatFps(fps: number): string {
+  return fps >= 10 ? Math.round(fps).toString() : fps.toFixed(1).replace(/\.0$/, '')
 }
 
 // One runtime log line. Memoized with a stable key: a scene rendering at
@@ -170,6 +173,7 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
     renderCount,
     fastMode,
     fastRenderRequest,
+    measuredFps,
   } = useValues(livePreviewLogic({ frameId }))
   const {
     closeLivePreview,
@@ -401,7 +405,13 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
               <Checkbox
                 value={fastMode}
                 onChange={(checked) => setFastMode(checked)}
-                label={`Real-time rendering (${describeRenderRate(fastRenderRequest.intervalMs)})`}
+                label={
+                  fastMode && measuredFps !== null
+                    ? `Real-time rendering · ${formatFps(measuredFps)} fps`
+                    : `Real-time rendering (the scene asks for ~${formatFps(
+                        1000 / Math.max(1, fastRenderRequest.intervalMs)
+                      )} fps)`
+                }
                 title="Let the scene render as often as it asks instead of once per second"
               />
             ) : null}

--- a/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/LivePreviewModal.tsx
@@ -1,7 +1,15 @@
 import { useActions, useValues } from 'kea'
 import clsx from 'clsx'
-import { useEffect, useRef, useState } from 'react'
-import { CheckIcon, CursorArrowRaysIcon, EyeIcon, FolderPlusIcon, PencilSquareIcon } from '@heroicons/react/24/outline'
+import { memo, useEffect, useRef, useState } from 'react'
+import {
+  BoltIcon,
+  CheckIcon,
+  CursorArrowRaysIcon,
+  EyeIcon,
+  FolderOpenIcon,
+  FolderPlusIcon,
+  PencilSquareIcon,
+} from '@heroicons/react/24/outline'
 
 import { Button } from '../../../../components/Button'
 import { Checkbox } from '../../../../components/Checkbox'
@@ -12,7 +20,8 @@ import { insertBreaks } from '../../../../utils/insertBreaks'
 import { visiblePublicStateFields } from '../../../../utils/showIf'
 import { frameLogic } from '../../frameLogic'
 import { templatesLogic } from '../Templates/templatesLogic'
-import { livePreviewLogic } from './livePreviewLogic'
+import { BrowserAssetsModal } from './BrowserAssetsModal'
+import { livePreviewLogic, type LivePreviewLogLine } from './livePreviewLogic'
 import { scenesLogic } from './scenesLogic'
 import { StateFieldEdit } from './StateFieldEdit'
 import type { FrameId } from '../../../../types'
@@ -84,6 +93,28 @@ export function renderLogLine(line: string): JSX.Element | string {
   return line
 }
 
+/** "every 42 ms (about 24 times a second)" for the fast-render prompt. */
+export function describeRenderRate(intervalMs: number): string {
+  const ms = Math.max(1, Math.round(intervalMs))
+  const perSecond = 1000 / ms
+  const rate = perSecond >= 10 ? Math.round(perSecond).toString() : perSecond.toFixed(1).replace(/\.0$/, '')
+  return `every ${ms} ms (about ${rate} times a second)`
+}
+
+// One runtime log line. Memoized with a stable key: a scene rendering at
+// full speed appends lines many times a second, and only the new rows
+// should cost anything.
+const LogRow = memo(function LogRow({ log }: { log: LivePreviewLogLine }): JSX.Element {
+  return (
+    <div className="flex gap-3">
+      <div className="shrink-0 whitespace-nowrap text-slate-500">{formatTimestamp(log.timestamp)}</div>
+      <div className={clsx('min-w-0 flex-1 break-words', logLineColor(log.line))} style={{ wordBreak: 'break-word' }}>
+        {renderLogLine(log.line)}
+      </div>
+    </div>
+  )
+})
+
 // The preview can be hosted from several components (scene card, diagram
 // toolbar, template row) that may be mounted at the same time. Only ONE of
 // them may render the dialog: two identical stacked dialogs close each other,
@@ -137,10 +168,18 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
     wasmUnsupportedApps,
     lastRenderMs,
     renderCount,
+    fastMode,
+    fastRenderRequest,
   } = useValues(livePreviewLogic({ frameId }))
-  const { closeLivePreview, registerCanvas, dispatchPreviewEvent, forcePreviewRender } = useActions(
-    livePreviewLogic({ frameId })
-  )
+  const {
+    closeLivePreview,
+    registerCanvas,
+    dispatchPreviewEvent,
+    forcePreviewRender,
+    setFastMode,
+    dismissFastRenderRequest,
+    openPreviewAssets,
+  } = useActions(livePreviewLogic({ frameId }))
   const { scenes: frameScenes, previewingSceneId } = useValues(scenesLogic({ frameId }))
   const { previewScene } = useActions(scenesLogic({ frameId }))
   const { applyTemplate } = useActions(frameLogic({ frameId }))
@@ -324,10 +363,48 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
             </div>
           ) : null}
 
+          {fastRenderRequest && !fastRenderRequest.answered ? (
+            <div
+              className="flex shrink-0 flex-wrap items-center gap-2 rounded-lg border border-amber-400/40 bg-amber-500/10 p-3 text-sm"
+              data-testid="fast-render-request"
+            >
+              <BoltIcon className="h-5 w-5 shrink-0 text-amber-600" />
+              <span className="min-w-0 flex-1">
+                This scene wants to render {describeRenderRate(fastRenderRequest.intervalMs)}. The preview is holding it
+                to one render per second — let it go at full speed? It will keep your browser busy while this dialog is
+                open.
+              </span>
+              <Button size="small" color="primary" onClick={() => setFastMode(true)}>
+                Run at full speed
+              </Button>
+              <Button size="small" color="secondary" onClick={dismissFastRenderRequest}>
+                Keep 1 fps
+              </Button>
+            </div>
+          ) : null}
+
           <div className="flex shrink-0 flex-wrap items-center gap-2">
             <Button size="small" color="secondary" onClick={forcePreviewRender}>
               Re-render
             </Button>
+            <Button
+              size="small"
+              color="secondary"
+              className="flex items-center gap-1"
+              onClick={openPreviewAssets}
+              title="Manage the browser-only asset folder the preview mounts at /srv/assets"
+            >
+              <FolderOpenIcon className="h-4 w-4" />
+              Browser assets
+            </Button>
+            {fastRenderRequest?.answered ? (
+              <Checkbox
+                value={fastMode}
+                onChange={(checked) => setFastMode(checked)}
+                label={`Real-time rendering (${describeRenderRate(fastRenderRequest.intervalMs)})`}
+                title="Let the scene render as often as it asks instead of once per second"
+              />
+            ) : null}
             {sceneEventButtons.map((event) => (
               <Button
                 key={`${event.keyword}:${event.label ?? ''}`}
@@ -428,17 +505,7 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
               className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-white/10 bg-slate-900 p-2 font-mono text-sm leading-5"
             >
               {previewLogs.length > 0 ? (
-                previewLogs.map((log, index) => (
-                  <div key={index} className="flex gap-3">
-                    <div className="shrink-0 whitespace-nowrap text-slate-500">{formatTimestamp(log.timestamp)}</div>
-                    <div
-                      className={clsx('min-w-0 flex-1 break-words', logLineColor(log.line))}
-                      style={{ wordBreak: 'break-word' }}
-                    >
-                      {renderLogLine(log.line)}
-                    </div>
-                  </div>
-                ))
+                previewLogs.map((log) => <LogRow key={log.id} log={log} />)
               ) : (
                 <div className="flex h-full items-center justify-center text-slate-500">No logs yet</div>
               )}
@@ -447,11 +514,14 @@ export function LivePreviewModal({ frameId }: { frameId: FrameId }): JSX.Element
 
           <div className="frameos-muted shrink-0 text-xs">
             Runs the scene with the FrameOS interpreter compiled to WebAssembly, in your browser. Apps that fetch
-            external URLs are routed through a same-origin proxy to get around browser CORS restrictions, so images
-            and data load — the device itself fetches them directly. Device-only apps (screenshots, camera snapshots)
-            are unavailable.
+            external URLs are routed through a same-origin proxy to get around browser CORS restrictions, so images and
+            data load — the device itself fetches them directly. <code>/srv/assets</code> is a folder that lives only in
+            this browser (“Browser assets” above), not the frame's real assets. Device-only apps (screenshots, camera
+            snapshots) are unavailable.
           </div>
         </div>
+
+        <BrowserAssetsModal frameId={frameId} />
 
         {editStateValues ? (
           <Modal

--- a/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
@@ -34,6 +34,8 @@ export interface LivePreviewSceneEvent {
 }
 
 export interface LivePreviewLogLine {
+  /** Stable per line, so the log list can skip re-rendering old rows. */
+  id: number
   timestamp: string
   line: string
 }
@@ -45,14 +47,102 @@ export interface LivePreviewSourceTemplate {
 }
 
 const MAX_LOG_LINES = 200
+// A scene rendering at full speed reports frames, state and log lines many
+// times a second; the page batches them so React work stays bounded. The
+// first item after a quiet spell goes through at once (leading edge).
+const UI_FLUSH_INTERVAL_MS = 200
+let nextLogLineId = 1
 
 // Apps that can't work in the browser preview: excluded from the wasm build
-// (see frameos/src/apps/apps.nim — child processes, external binaries) or
-// dependent on the frame's local filesystem.
+// (see frameos/src/apps/apps.nim — child processes, external binaries).
+// data/localImage works: it reads the browser asset folder (see
+// BrowserAssetsModal) mounted at the frame's /srv/assets path.
 const WASM_UNAVAILABLE_APPS: Record<string, string> = {
   'data/chromiumScreenshot': 'requires Playwright/Chromium',
   'data/rstpSnapshot': 'requires FFmpeg',
-  'data/localImage': "reads images from the frame's local storage",
+}
+
+/** One entry of the browser asset folder (the worker's /srv/assets). */
+export interface PreviewAssetEntry {
+  /** Relative to the folder root, e.g. `photos/beach.jpg`. */
+  path: string
+  size: number
+  mtime: number
+  isDir: boolean
+}
+
+/** How the worker backs /srv/assets (from its `ready` / `list` replies). */
+export interface PreviewAssetsInfo {
+  mounted: boolean
+  /** Kept in IndexedDB between previews, or in memory for this worker only. */
+  persistent: boolean
+  root: string
+  maxBytes: number
+}
+
+/** The scene asked to render every `intervalMs` — faster than the 1 fps throttle. */
+export interface FastRenderRequest {
+  intervalMs: number
+  /** The user accepted or declined; the banner is gone, the toggle stays. */
+  answered: boolean
+}
+
+/**
+ * Bytes of one file in the running preview's browser asset folder, for
+ * thumbnails. Rejects when no preview runs for the frame.
+ */
+export function readPreviewAsset(frameId: FrameId, path: string): Promise<ArrayBuffer> {
+  const logic = livePreviewLogic.findMounted({ frameId })
+  const request = logic?.cache.assetRequest as PreviewAssetRequest | undefined
+  if (!request) {
+    return Promise.reject(new Error('preview is not running'))
+  }
+  return request('read', { path }).then((result) => result.data as ArrayBuffer)
+}
+
+type PreviewAssetRequest = (
+  op: string,
+  params?: Record<string, unknown>,
+  transfer?: Transferable[]
+) => Promise<Record<string, any>>
+
+/**
+ * Request/reply plumbing for the worker's browser asset folder ops: every
+ * request carries an id, the worker answers with an `assetsResult` for it.
+ */
+function createAssetRequester(worker: Worker): {
+  request: PreviewAssetRequest
+  resolve: (msg: Record<string, any>) => void
+  rejectAll: () => void
+} {
+  const pending = new Map<number, { resolve: (msg: Record<string, any>) => void; reject: (error: Error) => void }>()
+  let nextId = 1
+  return {
+    request: (op, params = {}, transfer = []) =>
+      new Promise((resolve, reject) => {
+        const requestId = nextId++
+        pending.set(requestId, { resolve, reject })
+        worker.postMessage({ type: 'assets', requestId, op, ...params }, transfer)
+      }),
+    resolve: (msg) => {
+      const entry = pending.get(msg.requestId)
+      if (!entry) {
+        return
+      }
+      pending.delete(msg.requestId)
+      if (msg.ok) {
+        entry.resolve(msg)
+      } else {
+        entry.reject(new Error(String(msg.error ?? 'asset request failed')))
+      }
+    },
+    rejectAll: () => {
+      for (const entry of pending.values()) {
+        entry.reject(new Error('preview stopped'))
+      }
+      pending.clear()
+    },
+  }
 }
 
 export interface WasmUnsupportedApp {
@@ -88,12 +178,19 @@ export interface livePreviewLogicValues {
   frame: FrameType // frameLogic
   frameForm: Partial<FrameType> // frameLogic
   scenes: FrameScene[] // scenesLogic
+  fastMode: boolean
+  fastRenderRequest: FastRenderRequest | null
   gpioButtons: GPIOButton[]
   lastRenderMs: number | null
   livePreviewScene: FrameScene | null
   livePreviewSceneId: string | null
   livePreviewScenes: FrameScene[] | null
   livePreviewSourceTemplate: LivePreviewSourceTemplate | null
+  previewAssets: PreviewAssetEntry[]
+  previewAssetsError: string | null
+  previewAssetsInfo: PreviewAssetsInfo | null
+  previewAssetsLoading: boolean
+  previewAssetsOpen: boolean
   previewDimensions: {
     height: number
     width: number
@@ -114,7 +211,22 @@ export interface livePreviewLogicActions {
     message: string
     timestamp: string
   }
+  appendPreviewLogs: (lines: LivePreviewLogLine[]) => {
+    lines: LivePreviewLogLine[]
+  }
   closeLivePreview: () => {
+    value: true
+  }
+  closePreviewAssets: () => {
+    value: true
+  }
+  createPreviewAssetFolder: (path: string) => {
+    path: string
+  }
+  deletePreviewAsset: (path: string) => {
+    path: string
+  }
+  dismissFastRenderRequest: () => {
     value: true
   }
   dispatchPreviewEvent: (
@@ -124,7 +236,13 @@ export interface livePreviewLogicActions {
     name: string
     payload: Record<string, any>
   }
+  fastRenderRequested: (intervalMs: number) => {
+    intervalMs: number
+  }
   forcePreviewRender: () => {
+    value: true
+  }
+  loadPreviewAssets: () => {
     value: true
   }
   openLivePreview: (
@@ -138,14 +256,32 @@ export interface livePreviewLogicActions {
     sourceTemplate: LivePreviewSourceTemplate | null
     state: Record<string, any> | null
   }
+  openPreviewAssets: () => {
+    value: true
+  }
+  previewAssetsChanged: () => {
+    value: true
+  }
+  previewAssetsFailed: (error: string) => {
+    error: string
+  }
+  previewAssetsLoaded: (
+    entries: PreviewAssetEntry[],
+    info: PreviewAssetsInfo | null
+  ) => {
+    entries: PreviewAssetEntry[]
+    info: PreviewAssetsInfo | null
+  }
   previewErrored: (message: string) => {
     message: string
   }
   previewFrame: (
     width: number,
     height: number,
-    renderMs: number
+    renderMs: number,
+    count?: number
   ) => {
+    count: number
     height: number
     renderMs: number
     width: number
@@ -156,11 +292,27 @@ export interface livePreviewLogicActions {
   registerCanvas: (canvas: HTMLCanvasElement | null) => {
     canvas: HTMLCanvasElement | null
   }
+  resetFastRender: () => {
+    value: true
+  }
+  resetPreviewAssets: () => {
+    value: true
+  }
+  setFastMode: (enabled: boolean) => {
+    enabled: boolean
+  }
   setPreviewSettings: (settings: Record<string, Record<string, any>>) => {
     settings: Record<string, Record<string, any>>
   }
   setPreviewState: (state: Record<string, any>) => {
     state: Record<string, any>
+  }
+  uploadPreviewAssets: (
+    folder: string,
+    files: File[]
+  ) => {
+    files: File[]
+    folder: string
   }
 }
 
@@ -216,13 +368,36 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
     closeLivePreview: true,
     registerCanvas: (canvas: HTMLCanvasElement | null) => ({ canvas }),
     previewReady: true,
-    previewFrame: (width: number, height: number, renderMs: number) => ({ width, height, renderMs }),
+    // `count` frames arrived since the last report (the page coalesces).
+    previewFrame: (width: number, height: number, renderMs: number, count: number = 1) => ({
+      width,
+      height,
+      renderMs,
+      count,
+    }),
     previewErrored: (message: string) => ({ message }),
     appendPreviewLog: (message: string) => ({ message, timestamp: new Date().toISOString() }),
+    appendPreviewLogs: (lines: LivePreviewLogLine[]) => ({ lines }),
     setPreviewState: (state: Record<string, any>) => ({ state }),
     dispatchPreviewEvent: (name: string, payload: Record<string, any>) => ({ name, payload }),
     forcePreviewRender: true,
     setPreviewSettings: (settings: Record<string, Record<string, any>>) => ({ settings }),
+    // Render pacing: the worker throttles to 1 fps and asks before going faster.
+    fastRenderRequested: (intervalMs: number) => ({ intervalMs }),
+    dismissFastRenderRequest: true,
+    setFastMode: (enabled: boolean) => ({ enabled }),
+    resetFastRender: true,
+    // The browser asset folder (the worker's /srv/assets, kept in IndexedDB).
+    openPreviewAssets: true,
+    closePreviewAssets: true,
+    loadPreviewAssets: true,
+    previewAssetsLoaded: (entries: PreviewAssetEntry[], info: PreviewAssetsInfo | null) => ({ entries, info }),
+    previewAssetsFailed: (error: string) => ({ error }),
+    previewAssetsChanged: true,
+    uploadPreviewAssets: (folder: string, files: File[]) => ({ folder, files }),
+    createPreviewAssetFolder: (path: string) => ({ path }),
+    deletePreviewAsset: (path: string) => ({ path }),
+    resetPreviewAssets: true,
   }),
   reducers({
     livePreviewSceneId: [
@@ -253,8 +428,9 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
         openLivePreview: () => [],
         appendPreviewLog: (state, { message, timestamp }) => [
           ...state.slice(-(MAX_LOG_LINES - 1)),
-          { timestamp, line: message },
+          { id: nextLogLineId++, timestamp, line: message },
         ],
+        appendPreviewLogs: (state, { lines }) => [...state, ...lines].slice(-MAX_LOG_LINES),
       },
     ],
     // Scenes passed explicitly to openLivePreview (e.g. template previews);
@@ -290,7 +466,7 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       0,
       {
         openLivePreview: () => 0,
-        previewFrame: (state) => state + 1,
+        previewFrame: (state, { count }) => state + count,
       },
     ],
     // User-entered app settings (API keys etc.) merged over the backend's
@@ -300,6 +476,64 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       {} as Record<string, Record<string, any>>,
       {
         setPreviewSettings: (_, { settings }) => settings,
+      },
+    ],
+    // Whether the worker may render faster than once a second. Survives
+    // restarts of the same scene (state edits, new keys); a different scene
+    // starts throttled again.
+    fastMode: [
+      false,
+      {
+        setFastMode: (_, { enabled }) => enabled,
+        resetFastRender: () => false,
+        closeLivePreview: () => false,
+      },
+    ],
+    fastRenderRequest: [
+      null as FastRenderRequest | null,
+      {
+        fastRenderRequested: (state, { intervalMs }) => ({ intervalMs, answered: state?.answered ?? false }),
+        dismissFastRenderRequest: (state) => (state ? { ...state, answered: true } : state),
+        setFastMode: (state) => (state ? { ...state, answered: true } : state),
+        resetFastRender: () => null,
+        closeLivePreview: () => null,
+      },
+    ],
+    previewAssetsOpen: [
+      false,
+      {
+        openPreviewAssets: () => true,
+        closePreviewAssets: () => false,
+        closeLivePreview: () => false,
+      },
+    ],
+    previewAssets: [
+      [] as PreviewAssetEntry[],
+      {
+        previewAssetsLoaded: (_, { entries }) => entries,
+      },
+    ],
+    previewAssetsInfo: [
+      null as PreviewAssetsInfo | null,
+      {
+        previewAssetsLoaded: (state, { info }) => info ?? state,
+        openLivePreview: () => null,
+      },
+    ],
+    previewAssetsLoading: [
+      false,
+      {
+        loadPreviewAssets: () => true,
+        previewAssetsLoaded: () => false,
+        previewAssetsFailed: () => false,
+      },
+    ],
+    previewAssetsError: [
+      null as string | null,
+      {
+        loadPreviewAssets: () => null,
+        previewAssetsFailed: (_, { error }) => error,
+        openPreviewAssets: () => null,
       },
     ],
   }),
@@ -394,6 +628,16 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       cache.worker?.terminate()
       cache.worker = null
       cache.pendingFrame = null
+      cache.assetRequester?.rejectAll()
+      cache.assetRequester = null
+      cache.assetRequest = null
+      clearUiFlushes(cache)
+      // A different scene starts throttled again; a restart of the same one
+      // (state edits, new keys) keeps the user's fast-mode answer.
+      if (cache.lastOpenedSceneId !== sceneId) {
+        actions.resetFastRender()
+      }
+      cache.lastOpenedSceneId = sceneId
 
       // An explicit `scenes` list lets callers preview scenes that aren't installed
       // on the frame yet (e.g. templates in the "add scene" panel); otherwise fall
@@ -487,6 +731,9 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
         return
       }
       cache.worker = worker
+      const assetRequester = createAssetRequester(worker)
+      cache.assetRequester = assetRequester
+      cache.assetRequest = assetRequester.request
       worker.onerror = (event) => {
         actions.previewErrored(
           event.message ||
@@ -501,22 +748,42 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
             actions.previewReady()
             break
           case 'frame': {
+            // Paint at once; report to the store in batches (see UI_FLUSH_INTERVAL_MS).
             cache.pendingFrame = msg
             drawFrame(cache)
-            actions.previewFrame(msg.width, msg.height, msg.renderMs)
+            const stats = cache.frameStats ?? { width: 0, height: 0, renderMs: 0, count: 0 }
+            cache.frameStats = { width: msg.width, height: msg.height, renderMs: msg.renderMs, count: stats.count + 1 }
+            scheduleUiFlush(cache, 'frame', () => {
+              const flushed = cache.frameStats
+              cache.frameStats = null
+              if (flushed) {
+                actions.previewFrame(flushed.width, flushed.height, flushed.renderMs, flushed.count)
+              }
+            })
             break
           }
           case 'state':
             actions.setPreviewState(msg.state ?? {})
             break
           case 'log':
-            actions.appendPreviewLog(String(msg.message ?? ''))
+            queuePreviewLog(cache, String(msg.message ?? ''), (lines) => actions.appendPreviewLogs(lines))
             break
           case 'sceneEvent':
-            actions.appendPreviewLog(`event: ${msg.name} ${JSON.stringify(msg.payload ?? {})}`)
+            queuePreviewLog(cache, `event: ${msg.name} ${JSON.stringify(msg.payload ?? {})}`, (lines) =>
+              actions.appendPreviewLogs(lines)
+            )
             break
           case 'error':
             actions.previewErrored(String(msg.message ?? 'Unknown live preview error'))
+            break
+          case 'fastRenderRequest':
+            actions.fastRenderRequested(Number(msg.intervalMs) || 0)
+            break
+          case 'assetsChanged':
+            actions.previewAssetsChanged()
+            break
+          case 'assetsResult':
+            assetRequester.resolve(msg)
             break
           default:
             break
@@ -537,6 +804,10 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
         settingsJson,
         proxyUrl,
         sceneId,
+        fastMode: values.fastMode,
+        // Apps may save into the browser folder; it is the user's own
+        // browser storage, so the frame's saveAssets setting doesn't apply.
+        saveAssets: true,
       })
     },
     closeLivePreview: () => {
@@ -544,7 +815,93 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       cache.worker = null
       cache.pendingFrame = null
       cache.canvas = null
+      clearUiFlushes(cache)
+      cache.assetRequester?.rejectAll()
+      cache.assetRequester = null
+      cache.assetRequest = null
+      cache.lastOpenedSceneId = null
       setLivePreviewHash(null)
+    },
+    setFastMode: ({ enabled }) => {
+      cache.worker?.postMessage({ type: 'setFastMode', enabled })
+    },
+    openPreviewAssets: () => {
+      actions.loadPreviewAssets()
+    },
+    previewAssetsChanged: () => {
+      if (values.previewAssetsOpen) {
+        actions.loadPreviewAssets()
+      }
+    },
+    // No breakpoint: reloads overlap (an upload's reload racing the worker's
+    // assetsChanged), every listing is complete, and the last one wins.
+    loadPreviewAssets: async () => {
+      const request = cache.assetRequest as PreviewAssetRequest | null
+      if (!request) {
+        actions.previewAssetsFailed('The preview is not running — start it to manage its browser assets.')
+        return
+      }
+      try {
+        const result = await request('list')
+        actions.previewAssetsLoaded((result.entries ?? []) as PreviewAssetEntry[], result.info ?? null)
+      } catch (error) {
+        actions.previewAssetsFailed(error instanceof Error ? error.message : String(error))
+      }
+    },
+    uploadPreviewAssets: async ({ folder, files }) => {
+      const request = cache.assetRequest as PreviewAssetRequest | null
+      if (!request) {
+        return
+      }
+      for (const file of files) {
+        const path = folder ? `${folder}/${file.name}` : file.name
+        try {
+          const data = await file.arrayBuffer()
+          await request('write', { path, data }, [data])
+        } catch (error) {
+          actions.previewAssetsFailed(
+            `Could not add ${file.name}: ${error instanceof Error ? error.message : String(error)}`
+          )
+          return
+        }
+      }
+      actions.loadPreviewAssets()
+    },
+    createPreviewAssetFolder: async ({ path }) => {
+      const request = cache.assetRequest as PreviewAssetRequest | null
+      if (!request) {
+        return
+      }
+      try {
+        await request('mkdir', { path })
+        actions.loadPreviewAssets()
+      } catch (error) {
+        actions.previewAssetsFailed(error instanceof Error ? error.message : String(error))
+      }
+    },
+    deletePreviewAsset: async ({ path }) => {
+      const request = cache.assetRequest as PreviewAssetRequest | null
+      if (!request) {
+        return
+      }
+      try {
+        await request('delete', { path })
+        actions.loadPreviewAssets()
+      } catch (error) {
+        actions.previewAssetsFailed(error instanceof Error ? error.message : String(error))
+      }
+    },
+    resetPreviewAssets: async () => {
+      const request = cache.assetRequest as PreviewAssetRequest | null
+      if (!request) {
+        return
+      }
+      try {
+        await request('reset')
+        actions.loadPreviewAssets()
+      } catch (error) {
+        actions.previewAssetsFailed(error instanceof Error ? error.message : String(error))
+      }
     },
     registerCanvas: ({ canvas }) => {
       cache.canvas = canvas
@@ -582,8 +939,67 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
   beforeUnmount(({ cache }) => {
     cache.worker?.terminate()
     cache.worker = null
+    clearUiFlushes(cache)
+    cache.assetRequester?.rejectAll()
+    cache.assetRequester = null
+    cache.assetRequest = null
   }),
 ])
+
+/**
+ * Leading-edge throttle per key: the first call after a quiet spell runs
+ * now, further calls within UI_FLUSH_INTERVAL_MS collapse into one trailing
+ * run. Timers live in the logic's cache so a restart can drop them.
+ */
+function scheduleUiFlush(cache: Record<string, any>, key: string, flush: () => void): void {
+  const flushes: Record<string, { timer: ReturnType<typeof setTimeout> | null; lastAt: number }> = (cache.uiFlushes ??=
+    {})
+  const entry = (flushes[key] ??= { timer: null, lastAt: 0 })
+  if (entry.timer !== null) {
+    return
+  }
+  const elapsed = Date.now() - entry.lastAt
+  if (elapsed >= UI_FLUSH_INTERVAL_MS) {
+    entry.lastAt = Date.now()
+    flush()
+    return
+  }
+  entry.timer = setTimeout(() => {
+    entry.timer = null
+    entry.lastAt = Date.now()
+    flush()
+  }, UI_FLUSH_INTERVAL_MS - elapsed)
+}
+
+function clearUiFlushes(cache: Record<string, any>): void {
+  for (const entry of Object.values(
+    (cache.uiFlushes ?? {}) as Record<string, { timer: ReturnType<typeof setTimeout> | null }>
+  )) {
+    if (entry.timer !== null) {
+      clearTimeout(entry.timer)
+      entry.timer = null
+    }
+  }
+  cache.uiFlushes = {}
+  cache.frameStats = null
+  cache.logQueue = []
+}
+
+function queuePreviewLog(
+  cache: Record<string, any>,
+  line: string,
+  append: (lines: LivePreviewLogLine[]) => void
+): void {
+  const queue: LivePreviewLogLine[] = (cache.logQueue ??= [])
+  queue.push({ id: nextLogLineId++, timestamp: new Date().toISOString(), line })
+  scheduleUiFlush(cache, 'log', () => {
+    const lines = cache.logQueue ?? []
+    cache.logQueue = []
+    if (lines.length > 0) {
+      append(lines)
+    }
+  })
+}
 
 /** Paint the latest worker frame onto the registered canvas. */
 function drawFrame(cache: Record<string, any>): void {

--- a/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/livePreviewLogic.tsx
@@ -52,6 +52,21 @@ const MAX_LOG_LINES = 200
 // first item after a quiet spell goes through at once (leading edge).
 const UI_FLUSH_INTERVAL_MS = 200
 let nextLogLineId = 1
+/** How many frame arrivals the live fps figure averages over. */
+export const FPS_WINDOW = 6
+
+/** Frames per second over `arrivals` (ms timestamps), or null below two frames. */
+export function measureFps(arrivals: readonly number[]): number | null {
+  if (arrivals.length < 2) {
+    return null
+  }
+  const first = arrivals[0]
+  const last = arrivals[arrivals.length - 1]
+  if (last <= first) {
+    return null
+  }
+  return ((arrivals.length - 1) * 1000) / (last - first)
+}
 
 // Apps that can't work in the browser preview: excluded from the wasm build
 // (see frameos/src/apps/apps.nim — child processes, external binaries).
@@ -186,6 +201,7 @@ export interface livePreviewLogicValues {
   livePreviewSceneId: string | null
   livePreviewScenes: FrameScene[] | null
   livePreviewSourceTemplate: LivePreviewSourceTemplate | null
+  measuredFps: number | null
   previewAssets: PreviewAssetEntry[]
   previewAssetsError: string | null
   previewAssetsInfo: PreviewAssetsInfo | null
@@ -279,9 +295,11 @@ export interface livePreviewLogicActions {
     width: number,
     height: number,
     renderMs: number,
-    count?: number
+    count?: number,
+    fps?: number | null
   ) => {
     count: number
+    fps: number | null
     height: number
     renderMs: number
     width: number
@@ -368,12 +386,14 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
     closeLivePreview: true,
     registerCanvas: (canvas: HTMLCanvasElement | null) => ({ canvas }),
     previewReady: true,
-    // `count` frames arrived since the last report (the page coalesces).
-    previewFrame: (width: number, height: number, renderMs: number, count: number = 1) => ({
+    // `count` frames arrived since the last report (the page coalesces);
+    // `fps` is the measured rate over the last few frames.
+    previewFrame: (width: number, height: number, renderMs: number, count: number = 1, fps: number | null = null) => ({
       width,
       height,
       renderMs,
       count,
+      fps,
     }),
     previewErrored: (message: string) => ({ message }),
     appendPreviewLog: (message: string) => ({ message, timestamp: new Date().toISOString() }),
@@ -467,6 +487,14 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
       {
         openLivePreview: () => 0,
         previewFrame: (state, { count }) => state + count,
+      },
+    ],
+    // Frames per second over the last FPS_WINDOW frames, for the real-time toggle.
+    measuredFps: [
+      null as number | null,
+      {
+        openLivePreview: () => null,
+        previewFrame: (_, { fps }) => fps,
       },
     ],
     // User-entered app settings (API keys etc.) merged over the backend's
@@ -753,11 +781,22 @@ export const livePreviewLogic = kea<livePreviewLogicType>([
             drawFrame(cache)
             const stats = cache.frameStats ?? { width: 0, height: 0, renderMs: 0, count: 0 }
             cache.frameStats = { width: msg.width, height: msg.height, renderMs: msg.renderMs, count: stats.count + 1 }
+            const arrivals: number[] = (cache.frameArrivals ??= [])
+            arrivals.push(performance.now())
+            if (arrivals.length > FPS_WINDOW) {
+              arrivals.splice(0, arrivals.length - FPS_WINDOW)
+            }
             scheduleUiFlush(cache, 'frame', () => {
               const flushed = cache.frameStats
               cache.frameStats = null
               if (flushed) {
-                actions.previewFrame(flushed.width, flushed.height, flushed.renderMs, flushed.count)
+                actions.previewFrame(
+                  flushed.width,
+                  flushed.height,
+                  flushed.renderMs,
+                  flushed.count,
+                  measureFps(cache.frameArrivals ?? [])
+                )
               }
             })
             break
@@ -982,6 +1021,7 @@ function clearUiFlushes(cache: Record<string, any>): void {
   }
   cache.uiFlushes = {}
   cache.frameStats = null
+  cache.frameArrivals = []
   cache.logQueue = []
 }
 

--- a/frontend/src/scenes/workspace/FrameBatteryIndicator.tsx
+++ b/frontend/src/scenes/workspace/FrameBatteryIndicator.tsx
@@ -1,0 +1,51 @@
+import { useValues } from 'kea'
+
+import { BatteryIndicator, clampBatteryPercent } from '../../components/BatteryIndicator'
+import type { FrameType } from '../../types'
+import { frameMetricsPreviewLogic } from './frameMetricsPreviewLogic'
+
+/** The newest battery reading the cloud attached to the frame itself, if any. */
+export function frameLastBatteryPercent(frame: FrameType): number | null {
+  return clampBatteryPercent(frame.last_metrics?.batteryPercent)
+}
+
+/**
+ * Battery charge of the selected frame, from its recent metrics (the same
+ * logic the header chips and alert indicator mount) with the cloud's
+ * `last_metrics` as fallback. Nothing for frames without a battery pin.
+ */
+export function FrameBatteryIndicator({
+  frame,
+  size = 'md',
+  className,
+}: {
+  frame: FrameType
+  size?: 'sm' | 'md'
+  className?: string
+}): JSX.Element | null {
+  const { latestBatteryPercent } = useValues(frameMetricsPreviewLogic({ frameId: frame.id }))
+  const percent = latestBatteryPercent ?? frameLastBatteryPercent(frame)
+  if (percent === null) {
+    return null
+  }
+  return <BatteryIndicator percent={percent} size={size} className={className} />
+}
+
+/**
+ * Battery charge for a frame row in a list, read from `last_metrics` only —
+ * no metrics fetch per row. Cloud frames carry it; backend frames show
+ * theirs in the header chips once selected.
+ */
+export function FrameSidebarBattery({
+  frame,
+  className,
+}: {
+  frame: FrameType
+  className?: string
+}): JSX.Element | null {
+  const percent = frameLastBatteryPercent(frame)
+  if (percent === null) {
+    return null
+  }
+  return <BatteryIndicator percent={percent} size="sm" className={className} />
+}

--- a/frontend/src/scenes/workspace/FrameWorkspace.tsx
+++ b/frontend/src/scenes/workspace/FrameWorkspace.tsx
@@ -17,6 +17,7 @@ import { FrameImageOverlayControls } from './FrameImageOverlayControls'
 import { FrameSceneSidebarCard } from './FrameSceneSidebarCard'
 import { FrameSidebarPreview } from './FrameSidebarPreview'
 import { FrameMetricAlertIndicator } from './FrameMetricAlertIndicator'
+import { FrameBatteryIndicator } from './FrameBatteryIndicator'
 import { FrameActionsMenu } from './FrameActionsMenu'
 import { sceneWorkspaceLogic } from './sceneWorkspaceLogic'
 import {
@@ -352,6 +353,7 @@ function FrameSelector({
           </select>
           <FrameMetricAlertIndicator frame={frame} containerClassName="absolute right-7 top-1/2 -translate-y-1/2" />
         </div>
+        <FrameBatteryIndicator frame={frame} className="shrink-0" />
         <FrameActionsMenu
           frame={frame}
           className="frameos-form-control flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white !px-0 !py-0 text-slate-700 shadow-none transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"

--- a/frontend/src/scenes/workspace/FramesHome.tsx
+++ b/frontend/src/scenes/workspace/FramesHome.tsx
@@ -22,6 +22,7 @@ import { PlayIcon } from '@heroicons/react/24/solid'
 import { framesModel } from '../../models/framesModel'
 import { DropdownMenu } from '../../components/DropdownMenu'
 import { FrameConnectionDot } from '../../components/FrameConnectionDot'
+import { FrameSidebarBattery } from './FrameBatteryIndicator'
 import { FrameImage } from '../../components/FrameImage'
 import { Modal } from '../../components/Modal'
 import { Spinner } from '../../components/Spinner'
@@ -298,6 +299,7 @@ function FrameTreeRow({
             <span className="block truncate text-xs text-slate-400">{sidebarFrameActivityDescription(frame)}</span>
           </button>
           <FrameMetricAlertIndicator frame={frame} />
+          <FrameSidebarBattery frame={frame} />
           <SidebarStatusDots frame={frame} inactive={inactive} />
         </div>
       </div>

--- a/frontend/src/scenes/workspace/frameMetricsPreviewLogic.ts
+++ b/frontend/src/scenes/workspace/frameMetricsPreviewLogic.ts
@@ -17,6 +17,7 @@ import type { MetricsType, FrameId } from '../../types'
 import { apiFetch } from '../../utils/apiFetch'
 import {
   filterMetricsByCategoryAndTimeRange,
+  latestBatteryPercentFromMetrics,
   latestMetricSummariesByCategoryFromMetrics,
   metricsByCategoryFromMetrics,
   metricTimestamp,
@@ -37,6 +38,7 @@ export interface FrameMetricsPreviewLogicProps {
 export interface frameMetricsPreviewLogicValues {
   currentTime: number
   headerMetricsByCategory: Record<string, MetricSeries[]>
+  latestBatteryPercent: number | null
   latestMetricSummariesByCategory: Record<string, string>
   metricsByCategory: Record<string, MetricSeries[]>
   previewMetricsTimeRange: TimeRange | null
@@ -79,6 +81,7 @@ export interface frameMetricsPreviewLogicMeta {
       previewMetricsTimeRange: TimeRange | null
     ) => Record<string, MetricSeries[]>
     latestMetricSummariesByCategory: (sortedRecentMetrics: MetricsType[]) => Record<string, string>
+    latestBatteryPercent: (sortedRecentMetrics: MetricsType[]) => number | null
   }
 }
 
@@ -166,7 +169,7 @@ export const frameMetricsPreviewLogic = kea<frameMetricsPreviewLogicType>([
       ) =>
         filterMetricsByCategoryAndTimeRange(
           metricsByCategory,
-          ['load', 'memoryUsage', 'diskUsage'],
+          ['load', 'memoryUsage', 'diskUsage', 'batteryPercent'],
           previewMetricsTimeRange
         ),
     ],
@@ -174,6 +177,13 @@ export const frameMetricsPreviewLogic = kea<frameMetricsPreviewLogicType>([
       (s) => [s.sortedRecentMetrics],
       (metrics: frameMetricsPreviewLogicValues['sortedRecentMetrics']): Record<string, string> =>
         latestMetricSummariesByCategoryFromMetrics(metrics),
+    ],
+    // Frames with a battery pin (ESP32 boards) report a charge estimate;
+    // shown as a battery glyph in the header chips and the workspace sidebar.
+    latestBatteryPercent: [
+      (s) => [s.sortedRecentMetrics],
+      (metrics: frameMetricsPreviewLogicValues['sortedRecentMetrics']): number | null =>
+        latestBatteryPercentFromMetrics(metrics),
     ],
   }),
   afterMount(({ actions, cache }) => {


### PR DESCRIPTION
## What

**Browser asset folder for the wasm preview.** The preview worker now mounts `/srv/assets` (the path a real frame keeps its assets at) as an emscripten IDBFS folder backed by the visitor's IndexedDB — it lives only in that browser, persists between previews, and is shared by every preview on the origin. A fresh folder is seeded with three generated 1600×1200 sample photos (sunset / ocean / night), so `data/localImage` scenes (Ken Burns, SD card image, …) finally render in the browser, on the cloud too. `saveAssets` is on by default in the preview, so apps that save files write into the same folder (persisted after the render, and the page is told via `assetsChanged`). Falls back to an in-memory folder where IndexedDB is unavailable.

- Worker: `assets` request/reply ops (`list`, `read`, `write`, `mkdir`, `delete`, `reset`), path sanitising, a 128 MB ceiling.
- `frameos-wasm`: `listAssets/readAsset/writeAsset/createAssetFolder/deleteAsset/resetAssets`, `onAssetsChanged`, `onReady(sceneInfo, assets)`, `browserAssets`/`saveAssets` options; README documents it.
- Frontend `LivePreviewModal`: **Browser assets** button → `BrowserAssetsModal` (breadcrumb navigation, thumbnails, add files / drag-drop, new folder, delete with inline confirm, reset to samples, "stored in this browser only" copy). `data/localImage` is no longer listed as unavailable in the preview.
- Cloud store editor panel: same button + `PreviewAssetsDialog` (data-URL thumbnails, the CSP blocks `blob:`).

**Opt-in real-time rendering.** Renders stay throttled to one per second. A scene that asks for more (Ken Burns at 0.0416 s) triggers a `fastRenderRequest` once per runtime start; both hosts show "This scene wants to render every 42 ms (about 24 times a second) … let it go at full speed?" with **Run at full speed** / **Keep 1 fps**. Once answered the prompt turns into a *Real-time rendering* toggle that shows the **measured fps** (average of the last 6 frames), and the answer survives restarts of the same scene.

To keep a 24 fps scene from pegging the main thread, page-side updates are coalesced: frame stats and log lines flush at most every 200 ms (leading edge), the worker posts scene state only when it changed, and the frontend's log rows are memoized with stable ids.

**JS time in the frame's zone.** The wasm QuickJS took its offset from emscripten's `localtime_r` — the *browser's* zone — while the Nim side (clock app, chrono) used the frame's configured zone, so JS clock scenes (word clock) were off. `quickjs.c` is now compiled with `localtime_r` redirected to `tools/wasm/fos_quickjs_tz.c`, which asks the Nim runtime (`lib/tz.utcOffsetSeconds`, chrono data) for the zone's offset; the wasm init also loads the baked tz data and points the chrono JS proxies (`frameos.format`) at the same zone. A build guard fails if a QuickJS update moves that call.

**Store preview panel.** Credentials groups whose keys are saved on the account collapse to "OpenAI · API key from your account" with **Use another key**; the lightbox is now a live canvas mirrored on every frame (slideshows/clocks keep moving at full size).

**Battery indicators.** Frames reporting `batteryPercent` get a battery glyph (charge %, colour band green/amber/red, progress bar) in the header metric chips next to L/M/D, next to the workspace frame selector (visible under Settings), and in sidebar rows from the cloud's `last_metrics`.

## Build

`build_wasm.sh` links `-lidbfs.js`, exports `IDBFS`, compiles QuickJS with the tz shim and exports `_frameos_wasm_tz_offset_seconds`; the bundle still loads under Node (backend `embedded_wasm_render.mjs` harness).

## Tests / verification

- vitest: `FrameOSPreview` init/pacing/asset plumbing with a fake Worker; store panel prompt → toggle → fps, credentials collapse, live lightbox, dialog listing/navigation/delete/upload. Nim: `test_tz_slice` covers `utcOffsetSeconds` (Brussels summer/winter, UTC, unknown, St. John's).
- Verified in Chrome against the dev stack: frontend modal on a 1920×1080 Ken Burns scene (~15 fps at full speed, page responsive, fps label live), persisted folder across tabs, upload/folder/delete; cloud `/s/ken-burns-slideshow` at full speed with 0–2 ms event-loop lag, live lightbox; `/s/word-clock` now shows local time (02:33 CEST, was UTC); `new Date()` probed under Node for Europe/Brussels (+0200), America/St_Johns (−0230), UTC; battery chip + sidebar indicator rendered for an ESP32 frame with fresh metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7w4DyRdXnxzovRp41Grz9
