### PR TITLE
Scene store: editor saves keep template.json's title on the listing's name

### DIFF
--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
@@ -14,6 +14,7 @@ import { jsonError, readJsonObject } from "../../../../../../src/lib/device-flow
 import { moderateStoreContent } from "../../../../../../src/lib/moderation";
 import { identityRateLimitResponse } from "../../../../../../src/lib/rate-limit";
 import {
+  extractManifestNameFromZip,
   extractScenesFromZip,
   sceneDisplayName,
 } from "../../../../../../src/lib/scene-title";
@@ -175,10 +176,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
   }
 
+  // The manifest can also have fallen behind the listing the other way round:
+  // editor saves before 2026-08-26 never carried a scene rename into the
+  // template, and the listings that diverged that way were repaired on the
+  // row by hand — leaving template.json (what a download and a frame's
+  // Templates panel show) with the old title. So every save writes the
+  // listing's current name into the manifest, not only a rename. Never the
+  // reverse: the row is what the owner sees and what publishing resolves
+  // names against.
+  const listingName = renameTo ?? scene.name;
+  const manifestName = extractManifestNameFromZip(Buffer.from(latestContent));
   const content = rebuildZipWithScenes(
     Buffer.from(latestContent),
     JSON.stringify(body.scenes, null, 2),
-    renameTo,
+    manifestName === listingName ? undefined : listingName,
   );
   if (!content) {
     return jsonError("invalid_scene_zip", 500);

--- a/cloud/apps/auth-web/src/lib/scene-title.test.ts
+++ b/cloud/apps/auth-web/src/lib/scene-title.test.ts
@@ -1,6 +1,7 @@
 import { strToU8, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import {
+  extractManifestNameFromZip,
   extractScenesFromZip,
   sceneDisplayName,
 } from "./scene-title";
@@ -113,5 +114,23 @@ describe("editor rename reaching the listing title", () => {
     expect(validated.ok && validated.value.manifestName).toBe(
       "Ken Burns Slideshow",
     );
+  });
+});
+
+describe("extractManifestNameFromZip", () => {
+  it("reads the listing title the way publishing does", () => {
+    const zip = makeZip({ description: "d", name: "  Ken Burns slideshow  " }, [
+      { id: "a", name: "Slideshow with motion" },
+    ]);
+    expect(extractManifestNameFromZip(zip)).toBe("Ken Burns slideshow");
+    // The scene title inside is a separate thing.
+    expect(sceneDisplayName(extractScenesFromZip(zip))).toBe(
+      "Slideshow with motion",
+    );
+  });
+
+  it("is undefined for a manifest without a usable name", () => {
+    expect(extractManifestNameFromZip(makeZip({ name: "   " }, []))).toBeUndefined();
+    expect(extractManifestNameFromZip(Buffer.from("not a zip"))).toBeUndefined();
   });
 });

--- a/cloud/apps/auth-web/src/lib/scene-title.ts
+++ b/cloud/apps/auth-web/src/lib/scene-title.ts
@@ -55,3 +55,36 @@ export function sceneDisplayName(scenes: unknown): string | undefined {
   const name = candidate.name.trim().slice(0, maxSceneNameLength);
   return name || undefined;
 }
+
+/**
+ * The listing title the zip's template.json carries (what publishing read
+ * into storeScenes.name). Same shallowest-file rule and the same trim/slice as
+ * validateSceneZip's manifestName; undefined when the zip has no readable
+ * manifest.
+ */
+export function extractManifestNameFromZip(content: Buffer): string | undefined {
+  try {
+    const files = unzipSync(new Uint8Array(content), {
+      filter: (file) => /(^|\/)template\.json$/.test(file.name),
+    });
+    const path = Object.keys(files).sort(
+      (a, b) => a.split("/").length - b.split("/").length || a.localeCompare(b),
+    )[0];
+    const bytes = path ? files[path] : undefined;
+    if (!bytes) {
+      return undefined;
+    }
+    const parsed: unknown = JSON.parse(Buffer.from(bytes).toString("utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const name = (parsed as Record<string, unknown>).name;
+    if (typeof name !== "string") {
+      return undefined;
+    }
+    const trimmed = name.trim().slice(0, maxSceneNameLength);
+    return trimmed || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/cloud/apps/auth-web/src/test/integration/scene-rename.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/scene-rename.integration.test.ts
@@ -1,5 +1,5 @@
 import { strToU8, zipSync } from "fflate";
-import { eq, sql } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 import { NextRequest } from "next/server";
 import {
   createDb,
@@ -9,7 +9,9 @@ import {
 } from "@frameos-cloud/db";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST as editSceneContent } from "../../../app/api/account/scenes/[sceneId]/content/route";
+import { readBlob } from "../../lib/blobs";
 import { resetRateLimitForTests } from "../../lib/rate-limit";
+import { extractManifestNameFromZip } from "../../lib/scene-title";
 import { createSession, sessionCookieName } from "../../lib/session";
 
 // Renaming a scene in the web editor (gear → Rename) used to change only the
@@ -89,12 +91,14 @@ async function seedScene(
   name: string,
   scenes: unknown[],
   slug = name.toLowerCase().replaceAll(" ", "-"),
+  // The title inside the zip's template.json; normally the listing's.
+  manifestName = name,
 ) {
   const [scene] = await db
     .insert(storeScenes)
     .values({ accountId, latestVersion: 1, name, slug, visibility: "public" })
     .returning();
-  const content = templateZip(name, scenes);
+  const content = templateZip(manifestName, scenes);
   await db.insert(storeSceneVersions).values({
     content,
     contentType: "application/zip",
@@ -115,6 +119,17 @@ function saveContent(sceneId: string, scenes: unknown[]) {
     }),
     { params: Promise.resolve({ sceneId }) },
   );
+}
+
+async function latestManifestName(sceneId: string) {
+  const [version] = await db
+    .select()
+    .from(storeSceneVersions)
+    .where(eq(storeSceneVersions.sceneId, sceneId))
+    .orderBy(desc(storeSceneVersions.version))
+    .limit(1);
+  const content = await readBlob(version);
+  return content ? extractManifestNameFromZip(content) : undefined;
 }
 
 async function storedName(sceneId: string) {
@@ -169,6 +184,40 @@ describe("renaming a scene in the editor", () => {
     ]);
     expect(response.status).toBe(200);
     expect((await storedName(sceneId)).name).toBe("Comics pack");
+  });
+
+  it("brings a manifest that fell behind the listing back in line", async () => {
+    const accountId = await signIn();
+    // A listing repaired on the row (the pre-2026-08-26 editor never carried
+    // renames into the zip) still ships a template.json with the old title.
+    const sceneId = await seedScene(
+      accountId,
+      "Slideshow with motion",
+      [{ id: "scene-1", name: "Slideshow with motion", nodes: [] }],
+      "ken-burns-slideshow",
+      "Ken Burns slideshow",
+    );
+
+    const response = await saveContent(sceneId, [
+      { id: "scene-1", name: "Slideshow with motion", nodes: [{ id: "n1" }] },
+    ]);
+    expect(response.status).toBe(200);
+    expect((await storedName(sceneId)).name).toBe("Slideshow with motion");
+    expect(await latestManifestName(sceneId)).toBe("Slideshow with motion");
+  });
+
+  it("keeps a deliberately different listing title in the manifest too", async () => {
+    const accountId = await signIn();
+    const sceneId = await seedScene(accountId, "Comics pack", [
+      { id: "scene-1", name: "Main", nodes: [] },
+    ]);
+
+    const response = await saveContent(sceneId, [
+      { id: "scene-1", name: "Main", nodes: [{ id: "n1" }] },
+    ]);
+    expect(response.status).toBe(200);
+    // The manifest already matched the listing: nothing to rewrite.
+    expect(await latestManifestName(sceneId)).toBe("Comics pack");
   });
 
   it("refuses a rename that collides with another of the account's scenes", async () => {


### PR DESCRIPTION
## Why

https://scenes.frameos.net/s/ken-burns-slideshow showed "Ken Burns slideshow" in the list and "Slideshow with motion" in the scene. Cause: version 3 (an editor save on 2026-08-02) renamed the scene inside `scenes.json`, but the content route at the time never carried a rename into the listing row or the zip's `template.json`. #397 (2026-08-26) added the "listing follows the scene" rule for future saves; the rows that had already diverged were left as they were — and because row and scene now disagree, that rule deliberately never touches them ("a listing titled differently from its scene is left alone").

A prod sweep over all 29 live scenes found exactly two in this state: `ken-burns-slideshow` and `chromium-screenshot` (both edited 2026-07-17 / 2026-08-02, pre-#397). `ken-burns-slideshow` has been repaired on the row (`store_scenes.name` → "Slideshow with motion"); `chromium-screenshot` still needs `name` → "Browser Screenshot".

## What changed

- `extractManifestNameFromZip` (scene-title.ts): reads `template.json`'s name the way `validateSceneZip` does.
- Content route: every editor save writes the listing's current name into the manifest when they differ (rename or not), so a repaired listing's download / Templates-panel title can't lag behind. Never the reverse — the row stays authoritative.
- Tests: unit cases for the helper; integration cases for "manifest fell behind the listing" and "deliberately different listing title stays".

## Verification
- `tsc`, `eslint` clean; `scene-title.test.ts` 9/9; `scene-rename.integration.test.ts` 6/6 against local Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013axgCmeF9rupZ4n5iHd1fi
