### PR TITLE
Select options: support { value, label } pairs everywhere

### DIFF
--- a/backend/app/codegen/scene_nim.py
+++ b/backend/app/codegen/scene_nim.py
@@ -8,7 +8,7 @@ import re
 from app.models.frame import Frame
 from app.models.apps import get_local_frame_apps, get_local_app_path, get_scene_app_id
 from app.codegen.drivers_nim import DEFAULT_COMPILATION_MODE
-from app.codegen.utils import sanitize_nim_string, natural_keys, nim_comment
+from app.codegen.utils import sanitize_nim_string, natural_keys, nim_comment, select_field_options
 from app.utils.js_apps import find_js_app_source_key
 from app.utils.scene_execution import scene_is_interpreted
 
@@ -1262,8 +1262,9 @@ class SceneWriter:
                 if field.get("type", "string") == "select":
                     opts = ", ".join(
                         [
-                            f'"{sanitize_nim_string(option)}"'
-                            for option in field.get("options", [])
+                            f'StateFieldOption(value: "{sanitize_nim_string(value)}", '
+                            f'label: "{sanitize_nim_string(label)}")'
+                            for value, label in select_field_options(field.get("options", []))
                         ]
                     )
 

--- a/backend/app/codegen/tests/test_scene_nim.py
+++ b/backend/app/codegen/tests/test_scene_nim.py
@@ -320,6 +320,36 @@ def test_public_state_fields_include_value_and_show_if():
     assert '"counter": %*(5)' in source
 
 
+def test_select_options_accept_strings_and_value_label_pairs():
+    scene = {
+        "id": "scene",
+        "name": "Scene",
+        "nodes": [
+            {"id": "event", "type": "event", "data": {"keyword": "render"}, "position": {"x": 0, "y": 0}},
+        ],
+        "edges": [],
+        "fields": [
+            {
+                "name": "theme",
+                "type": "select",
+                "options": ["dark", {"value": "light", "label": "Light mode"}, {"label": "no value"}],
+                "value": "dark",
+                "access": "public",
+            },
+        ],
+        "settings": {"execution": "compiled", "refreshInterval": 3600, "backgroundColor": "#000000"},
+        "apps": {},
+    }
+    frame = SimpleNamespace(interval=3600, debug=False, scenes=[])
+
+    source = write_scene_nim(frame, scene)
+
+    assert (
+        'options: @[StateFieldOption(value: "dark", label: "dark"), '
+        'StateFieldOption(value: "light", label: "Light mode")]'
+    ) in source
+
+
 def _fusion_scene(consumer_config=None, producer_cache=False, extra_edges=None, extra_nodes=None):
     scene = {
         "id": "scene",

--- a/backend/app/codegen/utils.py
+++ b/backend/app/codegen/utils.py
@@ -12,6 +12,30 @@ def sanitize_nim_string(string: str) -> str:
         .replace('\n', '\\n')
     )
 
+def select_field_options(options) -> list[tuple[str, str]]:
+    """(value, label) pairs for a select field.
+
+    Options are stored as plain strings, or as {"value": .., "label": ..} pairs when the
+    label shown differs from the stored value. Anything unusable is dropped rather than
+    written into the scene as garbage.
+    """
+    pairs: list[tuple[str, str]] = []
+    for option in options or []:
+        if isinstance(option, dict):
+            value = option.get("value")
+            label = option.get("label")
+        else:
+            value = option
+            label = None
+        if isinstance(value, bool) or value is None or isinstance(value, (dict, list)):
+            continue
+        value = str(value)
+        if isinstance(label, bool) or label is None or isinstance(label, (dict, list)):
+            label = value
+        pairs.append((value, str(label)))
+    return pairs
+
+
 def nim_comment(text) -> str:
     # Collapse user text to a single line for use in a generated Nim comment: a
     # raw newline would otherwise close the '# ...' comment and let the rest of

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
@@ -40,6 +40,7 @@ import {
   type PreviewSettingsGroup,
 } from "../lib/preview-settings";
 import type { PreviewLogLine } from "../lib/preview-log";
+import { selectFieldOptions } from "../lib/select-options";
 import { ImageLightbox } from "./ImageLightbox";
 import { PreviewAssetsDialog } from "./PreviewAssetsDialog";
 import { PreviewLog } from "./PreviewLog";
@@ -1440,7 +1441,7 @@ function StateFieldRow({ field, id, value, onChange }: StateFieldRowProps) {
       </div>
     );
   } else if (type === "select" || type === "font") {
-    const options = field.options ?? [];
+    const options = selectFieldOptions(field.options);
     const current = textValue(value);
     control = (
       <select
@@ -1449,12 +1450,12 @@ function StateFieldRow({ field, id, value, onChange }: StateFieldRowProps) {
         onChange={(event) => onChange(event.target.value)}
         value={current}
       >
-        {options.includes(current) ? null : (
+        {options.some((option) => option.value === current) ? null : (
           <option value={current}>{current || "—"}</option>
         )}
         {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
+          <option key={option.value} value={option.value}>
+            {option.label}
           </option>
         ))}
       </select>

--- a/cloud/apps/auth-web/src/lib/ai/prompts.ts
+++ b/cloud/apps/auth-web/src/lib/ai/prompts.ts
@@ -22,6 +22,9 @@ Reference shapes:
   - code: { codeJS: string, codeArgs?: {name,type}[], codeOutputs?: {name,type}[] } — QuickJS snippet.
   - scene: { keyword: string, config: object } — embeds another scene by id.
 - Field: { name, type, label?, description?, required?, value?, options?, access?, persist? }
+- "options" (select fields only): a list of strings — ["dark", "light"] — or of { "value": "dark",
+  "label": "Dark mode" } pairs when the label shown should differ from the stored value. Nothing else;
+  config and state always hold the option's value, never its label.
 - Field types: string, text, float, integer, boolean, color, date, json, node, scene, image, font, select, path.
 
 Rules:

--- a/cloud/apps/auth-web/src/lib/ai/scene-lint.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/scene-lint.test.ts
@@ -178,6 +178,72 @@ describe("lintScenes", () => {
     ]);
   });
 
+  it("accepts both string and {value,label} select options on a scene field", () => {
+    expect(
+      messages([
+        scene({ fields: [{ name: "theme", options: ["dark", "light"], type: "select", value: "dark" }] }),
+      ]),
+    ).toEqual({ errors: [], warnings: [] });
+    expect(
+      messages([
+        scene({
+          fields: [
+            {
+              name: "theme",
+              options: [
+                { label: "Dark", value: "dark" },
+                { label: "Light", value: "light" },
+              ],
+              type: "select",
+              value: "dark",
+            },
+          ],
+        }),
+      ]),
+    ).toEqual({ errors: [], warnings: [] });
+  });
+
+  it("rejects select options that are neither a string nor a value/label pair", () => {
+    const { errors } = messages([
+      scene({
+        fields: [{ name: "theme", options: [{ label: "Dark" }], type: "select", value: "dark" }],
+      }),
+    ]);
+    expect(errors).toEqual([
+      expect.stringContaining('Scene field "theme": each option must be a string'),
+    ]);
+  });
+
+  it("rejects malformed select options on a scene-local app", () => {
+    const { errors } = messages([
+      scene({
+        apps: {
+          myApp: {
+            category: "data",
+            fields: [
+              { name: "theme", options: [{ label: "Dark" }], type: "select", value: "dark" },
+            ],
+            name: "My app",
+            output: [{ name: "out", type: "string" }],
+            sources: { "app.ts": "export function get() { return 'x' }", "config.json": "{}" },
+          },
+        },
+        edges: [
+          { id: "e1", source: "ev", sourceHandle: "next", target: "text", targetHandle: "prev", type: "appNodeEdge" },
+          { id: "e2", source: "my", sourceHandle: "fieldOutput", target: "text", targetHandle: "fieldInput/text", type: "codeNodeEdge" },
+        ],
+        nodes: [
+          { data: { keyword: "render" }, id: "ev", type: "event" },
+          { data: { config: {}, keyword: "render/text" }, id: "text", type: "app" },
+          { data: { config: { theme: "dark" }, keyword: "myApp" }, id: "my", type: "app" },
+        ],
+      }),
+    ]);
+    expect(errors).toEqual([
+      expect.stringContaining('Scene app "myApp" field "theme": each option must be a string'),
+    ]);
+  });
+
   it("accepts scene-local JS apps declared in the scene's apps map", () => {
     const { errors } = messages([
       scene({

--- a/cloud/apps/auth-web/src/lib/ai/scene-lint.ts
+++ b/cloud/apps/auth-web/src/lib/ai/scene-lint.ts
@@ -161,13 +161,56 @@ function fieldOptions(fields: AppField[], name: string): Set<string> | undefined
       continue;
     }
     sawSelect = true;
-    if (Array.isArray(field.options)) {
-      for (const option of field.options) {
-        options.add(String(option));
-      }
+    for (const value of optionValues(field.options)) {
+      options.add(value);
     }
   }
   return sawSelect && options.size > 0 ? options : undefined;
+}
+
+// A select option is either a plain string or a { value, label } pair (both
+// strings). Anything else — a number, a half-filled object — is stored but
+// unrenderable, so it never reaches the editor.
+function optionShapeIssue(options: unknown): string | undefined {
+  if (options === undefined || options === null) {
+    return undefined;
+  }
+  if (!Array.isArray(options)) {
+    return `"options" must be a list; got ${JSON.stringify(options)}`;
+  }
+  const bad = options.find((option) => {
+    if (typeof option === "string") {
+      return false;
+    }
+    const entry = obj(option);
+    return !entry || typeof entry.value !== "string" || typeof entry.label !== "string";
+  });
+  if (bad === undefined) {
+    return undefined;
+  }
+  return (
+    `each option must be a string ("dark") or a { "value": "dark", "label": "Dark" } pair ` +
+    `(both strings); got ${JSON.stringify(bad)}`
+  );
+}
+
+// The values a select field can legitimately store.
+function optionValues(options: unknown): string[] {
+  if (!Array.isArray(options)) {
+    return [];
+  }
+  const values: string[] = [];
+  for (const option of options) {
+    if (typeof option === "string") {
+      values.push(option);
+    } else {
+      const value = obj(option)?.value;
+      if (typeof value === "string") {
+        values.push(value);
+      }
+    }
+  }
+  return values;
 }
 
 function hasDefault(fields: AppField[], name: string): boolean {
@@ -387,6 +430,10 @@ export function lintScene(
     if (type === "select" && !(Array.isArray(field.options) && field.options.length > 0)) {
       push("error", `Scene field "${name}" is a select but has no options.`);
     }
+    const optionIssue = optionShapeIssue(field.options);
+    if (optionIssue) {
+      push("error", `Scene field "${name}": ${optionIssue}.`);
+    }
     if (field.value === undefined || field.value === null) {
       if (["integer", "float", "boolean", "select", "color"].includes(type ?? "")) {
         push("warning", `Scene field "${name}" (${type}) has no default "value"; give it a string default.`);
@@ -406,6 +453,12 @@ export function lintScene(
   // --- scene-local JS apps --------------------------------------------------
   if (sceneApps) {
     for (const [keyword, raw] of Object.entries(sceneApps)) {
+      for (const field of fieldsOf(obj(raw))) {
+        const issue = optionShapeIssue(field.options);
+        if (issue) {
+          push("error", `Scene app "${keyword}" field "${str(field.name) ?? ""}": ${issue}.`);
+        }
+      }
       const sources = obj(obj(raw)?.sources) ?? {};
       for (const [file, content] of Object.entries(sources)) {
         if (typeof content !== "string" || !/\.(ts|js|tsx|jsx)$/.test(file)) {
@@ -544,6 +597,14 @@ export function lintScene(
         continue;
       }
       appByNode.set(id, app);
+      if (app.source === "inline") {
+        for (const field of app.fields) {
+          const issue = optionShapeIssue(field.options);
+          if (issue) {
+            push("error", `App ${keyword} field "${str(field.name) ?? ""}": ${issue}.`, id);
+          }
+        }
+      }
       const config = obj(data.config) ?? {};
       for (const [key, value] of Object.entries(config)) {
         if (!app.fieldNames.has(key)) {

--- a/cloud/apps/auth-web/src/lib/select-options.ts
+++ b/cloud/apps/auth-web/src/lib/select-options.ts
@@ -1,0 +1,45 @@
+/**
+ * A select field's options are either plain strings, or { value, label } pairs when the
+ * stored value and the text shown differ. Scenes are hand-edited, imported and AI-written,
+ * so options also arrive as numbers or half-filled objects; read them through here. A raw
+ * object rendered as a React child takes the whole page down.
+ */
+export type SelectFieldOption = { value: string; label: string };
+
+function optionValue(option: unknown): string | null {
+  if (typeof option === "string") {
+    return option;
+  }
+  if (typeof option === "number" || typeof option === "boolean") {
+    return String(option);
+  }
+  if (option && typeof option === "object" && !Array.isArray(option)) {
+    return optionValue((option as { value?: unknown }).value);
+  }
+  return null;
+}
+
+function optionLabel(option: unknown, value: string): string {
+  if (option && typeof option === "object" && !Array.isArray(option)) {
+    const label = (option as { label?: unknown }).label;
+    if (typeof label === "string" || typeof label === "number" || typeof label === "boolean") {
+      return String(label);
+    }
+  }
+  return value;
+}
+
+/** The options of a select field, ready to render. Unusable entries are dropped. */
+export function selectFieldOptions(options: unknown): SelectFieldOption[] {
+  if (!Array.isArray(options)) {
+    return [];
+  }
+  const result: SelectFieldOption[] = [];
+  for (const option of options) {
+    const value = optionValue(option);
+    if (value !== null) {
+      result.push({ label: optionLabel(option, value), value });
+    }
+  }
+  return result;
+}

--- a/docs/js-apps-and-code-nodes.md
+++ b/docs/js-apps-and-code-nodes.md
@@ -68,6 +68,10 @@ A scene can bundle its own apps in its top-level `apps` map:
 }
 ```
 
+A `select` field lists its choices in `options`, either as plain strings
+(`["dark", "light"]`) or as `{ "value": "dark", "label": "Dark mode" }` pairs
+when the label shown should differ from the value stored in config or state.
+
 App nodes then use `keyword: "myPanel"`. Inside `app.ts` the app sees
 `app.config` (its fields), `app.state`, `app.frame` (`width`, `height`,
 `rotate`, `timeZone`), `context`, and the `frameos` helpers:

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -1628,6 +1628,45 @@ proc parseHook*(s: string, i: var int, v: var NodeId) =
   nodeMappingTable[str] = NodeId(globalNodeCounter)
   v = NodeId(globalNodeCounter)
 
+type RawStateFieldOption = object
+  value: string
+  label: string
+
+proc parseHook*(s: string, i: var int, v: var StateFieldOption) =
+  ## A select option is stored either as "value" (the value doubles as the
+  ## label) or as {"value": .., "label": ..}. Editors have also shipped numbers
+  ## and half-filled objects, and a scene that fails to parse takes the whole
+  ## frame down, so take whatever is there.
+  eatSpace(s, i)
+  if i < s.len and s[i] == '{':
+    var raw: RawStateFieldOption
+    parseHook(s, i, raw)
+    v = StateFieldOption(value: raw.value, label: if raw.label != "": raw.label else: raw.value)
+  elif i < s.len and s[i] == '"':
+    var tmp: string
+    parseHook(s, i, tmp)
+    v = StateFieldOption(value: tmp, label: tmp)
+  elif i < s.len and s[i] == '[':
+    # Nothing usable, but consume it so the rest of the scene still parses.
+    skipValue(s, i)
+    v = StateFieldOption()
+  else:
+    let symbol = parseSymbol(s, i)
+    let value = if symbol == "null": "" else: symbol
+    v = StateFieldOption(value: value, label: value)
+
+proc dumpHook*(s: var string, v: StateFieldOption) =
+  ## Round-trips back to the shape it came in as: a bare string unless it
+  ## carries a label of its own.
+  if v.label == "" or v.label == v.value:
+    dumpHook(s, v.value)
+  else:
+    s.add("{\"value\":")
+    dumpHook(s, v.value)
+    s.add(",\"label\":")
+    dumpHook(s, v.label)
+    s.add('}')
+
 proc parseHook*(s: string, i: var int, v: var SceneId) =
   var tmp: string
   parseHook(s, i, tmp)

--- a/frameos/src/frameos/server/api.nim
+++ b/frameos/src/frameos/server/api.nim
@@ -3,7 +3,7 @@ import jsony
 import pixie
 import chroma
 import times
-import std/[os, strformat, strutils, tables, algorithm]
+import std/[os, strformat, strutils, tables, algorithm, sequtils]
 import locks
 import zippy
 import mummy
@@ -906,15 +906,16 @@ proc renderControlPage*(request: Request) =
     elif fieldType == "select" or fieldType == "boolean" or fieldType == "font":
       fieldsHtml.add(fmt"<select id='{h($key)}' placeholder='{h(placeholder)}'>")
       {.gcsafe.}:
-        let options = if fieldType == "boolean": @[
-          "true", "false"
-        ] elif fieldType == "font":
-          getAvailableFonts(globalFrameConfig.assetsPath)
+        let options = if fieldType == "boolean":
+          @[StateFieldOption(value: "true", label: "true"), StateFieldOption(value: "false", label: "false")]
+        elif fieldType == "font":
+          getAvailableFonts(globalFrameConfig.assetsPath).mapIt(StateFieldOption(value: it, label: it))
         else:
           field.options
       for option in options:
-        let selected = if option == stringValue: " selected" else: ""
-        fieldsHtml.add(fmt"<option value='{h($option)}'{selected}>{h($option)}</option>")
+        let selected = if option.value == stringValue: " selected" else: ""
+        let optionLabel = if option.label != "": option.label else: option.value
+        fieldsHtml.add(fmt"<option value='{h(option.value)}'{selected}>{h(optionLabel)}</option>")
       fieldsHtml.add("</select><br/><br/>")
     elif fieldType == "date":
       fieldsHtml.add(fmt"<input type='date' id='{h($key)}' placeholder='{h(placeholder)}' value='{h(stringValue)}' /><br/><br/>")

--- a/frameos/src/frameos/tests/test_state_field_options.nim
+++ b/frameos/src/frameos/tests/test_state_field_options.nim
@@ -1,0 +1,48 @@
+import std/unittest
+import jsony
+
+import ../interpreter
+import ../types
+
+const sceneJson = """[
+  {
+    "id": "scene-1",
+    "name": "Options",
+    "nodes": [],
+    "edges": [],
+    "apps": {},
+    "fields": [
+      {
+        "name": "theme",
+        "label": "Theme",
+        "type": "select",
+        "value": "dark",
+        "access": "public",
+        "options": ["dark", {"value": "light", "label": "Light mode"}, {"value": "sepia"}, 12, null, ["x"]]
+      }
+    ],
+    "settings": {"execution": "interpreted"}
+  }
+]"""
+
+suite "select field options":
+  test "parses both plain strings and value/label pairs":
+    let scenes = parseInterpretedSceneInputs(sceneJson)
+    check scenes.len == 1
+    let options = scenes[0].fields[0].options
+    check options.len == 6
+    check options[0] == StateFieldOption(value: "dark", label: "dark")
+    check options[1] == StateFieldOption(value: "light", label: "Light mode")
+    # A pair without its own label falls back to the value
+    check options[2] == StateFieldOption(value: "sepia", label: "sepia")
+    # Shapes the editor should never write, but which must not kill the scene
+    check options[3] == StateFieldOption(value: "12", label: "12")
+    check options[4] == StateFieldOption(value: "", label: "")
+    check options[5] == StateFieldOption(value: "", label: "")
+
+  test "dumps back to the shape it came in as":
+    let options = @[
+      StateFieldOption(value: "dark", label: "dark"),
+      StateFieldOption(value: "light", label: "Light mode"),
+    ]
+    check options.toJson() == """["dark",{"value":"light","label":"Light mode"}]"""

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -460,13 +460,20 @@ type
     decodeBoundsNodeId*: NodeId
     decodeBoundsClaimedBy*: NodeId
 
+  # One choice of a "select" state field. Scenes store these either as a plain
+  # string (value doubles as the label) or as {"value": .., "label": ..}; the
+  # parseHook in interpreter.nim accepts both.
+  StateFieldOption* = object
+    value*: string
+    label*: string
+
   # State field definitions. Used in interpreted scenes, and to show the right form to the user
   StateField* = ref object
     name*: string
     label*: string
     fieldType*: string
     value*: JsonNode
-    options*: seq[string]
+    options*: seq[StateFieldOption]
     placeholder*: string
     required*: bool
     secret*: bool

--- a/frameos/wasm/src/index.ts
+++ b/frameos/wasm/src/index.ts
@@ -7,6 +7,7 @@
 export { FrameOSPreview, createFrameOSPreview, type FrameOSPreviewOptions } from './preview'
 export { ditherFrame, panelPalettes, panelPaletteFor, type PanelPaletteKey } from './dither'
 export { mountFrameOSManager, type FrameOSManagerHandle, type FrameOSManagerOptions } from './manager'
+export { selectFieldOptions } from './options'
 export {
   coerceStateFieldValue,
   evaluateShowIf,
@@ -25,6 +26,7 @@ export {
   type SceneEventButton,
   type SceneInfo,
   type SceneNode,
+  type SelectFieldOption,
   type ShowIfCondition,
   type StateField,
 } from './types'

--- a/frameos/wasm/src/manager.ts
+++ b/frameos/wasm/src/manager.ts
@@ -3,6 +3,7 @@
 // pane. Mirrors the device's own /control page (frameos/assets/web/control.html)
 // but runs entirely in the browser against the wasm runtime.
 import { FrameOSPreview, type FrameOSPreviewOptions } from './preview'
+import { selectFieldOptions } from './options'
 import { coerceStateFieldValue, evaluateShowIf, stateFieldShowIfValues } from './showIf'
 import { sceneEventButtons, type FrameOSScene, type StateField } from './types'
 
@@ -218,12 +219,18 @@ export function mountFrameOSManager(container: HTMLElement, options: FrameOSMana
     if (field.type === 'select' || field.type === 'boolean' || field.type === 'font') {
       const select = document.createElement('select')
       select.className = 'frameos-manager__input'
-      const opts = field.type === 'boolean' ? ['true', 'false'] : field.options ?? []
+      const opts =
+        field.type === 'boolean'
+          ? [
+              { label: 'true', value: 'true' },
+              { label: 'false', value: 'false' },
+            ]
+          : selectFieldOptions(field.options)
       for (const opt of opts) {
         const option = document.createElement('option')
-        option.value = opt
-        option.textContent = opt
-        option.selected = String(value ?? '') === opt
+        option.value = opt.value
+        option.textContent = opt.label
+        option.selected = String(value ?? '') === opt.value
         select.appendChild(option)
       }
       select.onchange = () => update(select.value)

--- a/frameos/wasm/src/options.ts
+++ b/frameos/wasm/src/options.ts
@@ -1,0 +1,44 @@
+import type { SelectFieldOption, StateField } from './types'
+
+/**
+ * A select field's options are either plain strings, or `{ value, label }` pairs when the
+ * stored value and the text shown differ. Scenes are hand-edited, imported and AI-written,
+ * so options also arrive as numbers or half-filled objects; read them through here.
+ */
+function optionValue(option: unknown): string | null {
+  if (typeof option === 'string') {
+    return option
+  }
+  if (typeof option === 'number' || typeof option === 'boolean') {
+    return String(option)
+  }
+  if (option && typeof option === 'object' && !Array.isArray(option)) {
+    return optionValue((option as { value?: unknown }).value)
+  }
+  return null
+}
+
+function optionLabel(option: unknown, value: string): string {
+  if (option && typeof option === 'object' && !Array.isArray(option)) {
+    const label = (option as { label?: unknown }).label
+    if (typeof label === 'string' || typeof label === 'number' || typeof label === 'boolean') {
+      return String(label)
+    }
+  }
+  return value
+}
+
+/** The value/label pairs of a select field, ready to render. Unusable entries are dropped. */
+export function selectFieldOptions(options: StateField['options'] | unknown): { value: string; label: string }[] {
+  if (!Array.isArray(options)) {
+    return []
+  }
+  const result: { value: string; label: string }[] = []
+  for (const option of options as SelectFieldOption[]) {
+    const value = optionValue(option)
+    if (value !== null) {
+      result.push({ label: optionLabel(option, value), value })
+    }
+  }
+  return result
+}

--- a/frameos/wasm/src/types.ts
+++ b/frameos/wasm/src/types.ts
@@ -16,13 +16,19 @@ export interface ConfigFieldConditionAnd {
 
 export type ShowIfCondition = ConfigFieldCondition | ConfigFieldConditionAnd
 
+/**
+ * One choice of a 'select' field: a plain string (the value doubles as the label),
+ * or an explicit pair when the stored value and the text shown differ.
+ */
+export type SelectFieldOption = string | { value: string; label: string }
+
 /** A scene state field, as found in a scene JSON's `fields` array. */
 export interface StateField {
   name: string
   label?: string
   type?: string
   value?: unknown
-  options?: string[]
+  options?: SelectFieldOption[]
   placeholder?: string
   required?: boolean
   secret?: boolean

--- a/frontend/schema/config_json.json
+++ b/frontend/schema/config_json.json
@@ -98,7 +98,7 @@
         "options": {
           "description": "List of options for the field, only used if type is 'select'",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/SelectFieldOption"
           },
           "type": "array"
         },
@@ -481,6 +481,27 @@
         }
       },
       "type": "object"
+    },
+    "SelectFieldOption": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": ["value", "label"],
+          "type": "object"
+        }
+      ],
+      "description": "One choice of a 'select' field: a plain string (the value doubles as the label), or an explicit pair when the stored value and the text shown differ."
     }
   }
 }

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -35,7 +35,9 @@ function isOptionGroup(option: SelectOptionEntry): option is OptionGroup {
 function renderOption(option: SelectOption): JSX.Element {
   return (
     <option key={String(option.value)} value={option.value} disabled={option.disabled}>
-      {option.label}
+      {/* A non-string label (scenes have shipped `{ value, label }` option objects) would
+          crash the whole editor as an invalid React child, so never render one raw. */}
+      {typeof option.label === 'string' ? option.label : String(option.label ?? '')}
     </option>
   )
 }

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -30,6 +30,9 @@ import {
   SceneNodeData,
   TemplateType,
   FrameId,
+  AppConfigField,
+  MarkdownField,
+  SceneApp,
 } from '../../types'
 import { forms } from 'kea-forms'
 import equal from 'fast-deep-equal'
@@ -77,6 +80,7 @@ import { normalizeFrameCompilationMode } from '../../utils/frameBuildOptions'
 import { frameHasActivityLog } from '../../decorators/frame'
 import { frameRunsScenesInterpreted, normalizeSceneExecution, sceneExecutionForFrame } from '../../utils/sceneExecution'
 import { normalizeCustomEvent } from '../../utils/frameEvents'
+import { normalizeFieldOptions } from '../../utils/selectOptions'
 import { frameFormSceneErrors } from './frameFormSceneErrors'
 import {
   cloneSplitScreenSceneLayout,
@@ -1766,6 +1770,17 @@ function openSceneControlDrawer(frameId: FrameId, sceneId: string): void {
   router.actions.push(router.values.location.pathname, searchParams, router.values.hashParams)
 }
 
+function normalizeSceneAppFieldOptions(apps: Record<string, SceneApp>): Record<string, SceneApp> {
+  return Object.fromEntries(
+    Object.entries(apps).map(([keyword, app]) => [
+      keyword,
+      app.fields
+        ? { ...app, fields: app.fields.map((field: AppConfigField | MarkdownField) => normalizeFieldOptions(field)) }
+        : app,
+    ])
+  )
+}
+
 export function sanitizeScene(scene: Partial<FrameScene>, frame: Partial<FrameType>): FrameScene {
   const settings = scene.settings ?? {}
   const frameRunsInterpreted = frameRunsScenesInterpreted(frame.mode)
@@ -1797,8 +1812,8 @@ export function sanitizeScene(scene: Partial<FrameScene>, frame: Partial<FrameTy
     name: scene.name || 'Untitled scene',
     nodes: arranged.nodes,
     edges: arranged.edges,
-    apps: normalizeSceneApps(scene.apps),
-    fields: scene.fields ?? [],
+    apps: normalizeSceneAppFieldOptions(normalizeSceneApps(scene.apps)),
+    fields: (scene.fields ?? []).map((field) => normalizeFieldOptions(field)),
     customEvents: (scene.customEvents ?? []).map((event) => normalizeCustomEvent(event)),
     settings: {
       ...settings,

--- a/frontend/src/scenes/frame/panels/Diagram/AppNode.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/AppNode.tsx
@@ -7,6 +7,7 @@ import { RevealDots } from '../../../../components/Reveal'
 import { diagramLogic } from './diagramLogic'
 import { TextInput } from '../../../../components/TextInput'
 import { Select } from '../../../../components/Select'
+import { selectFieldOptions } from '../../../../utils/selectOptions'
 import React, { useState } from 'react'
 import { TextArea } from '../../../../components/TextArea'
 import { frameEditorsLogic } from '../../frameEditorsLogic'
@@ -415,7 +416,7 @@ export function AppNode({ id, isConnectable }: NodeProps<AppNodeData | DispatchN
                                     value={
                                       data.config && field.name in data.config ? data.config[field.name] : field.value
                                     }
-                                    options={(field.options ?? []).map((o) => ({ value: o, label: o }))}
+                                    options={selectFieldOptions(field.options)}
                                     onChange={(value) => updateNodeConfig(id, field.name, value)}
                                   />
                                 ) : field.type === 'scene' ? (

--- a/frontend/src/scenes/frame/panels/Fields/FieldDefinitionForm.tsx
+++ b/frontend/src/scenes/frame/panels/Fields/FieldDefinitionForm.tsx
@@ -1,5 +1,6 @@
 import { Field } from '../../../../components/Field'
 import { Select } from '../../../../components/Select'
+import { selectOptionsFromText, selectOptionsToText } from '../../../../utils/selectOptions'
 import { Switch } from '../../../../components/Switch'
 import { TextArea } from '../../../../components/TextArea'
 import { TextInput } from '../../../../components/TextInput'
@@ -72,12 +73,14 @@ export function FieldDefinitionForm<T extends AppConfigField>({
         <Select options={appConfigFieldTypes.filter((f) => f !== 'node').map((k) => ({ label: k, value: k }))} />
       </Field>
       {field.type === 'select' ? (
-        <Field name="options" label="Options (one per line)">
+        <Field name="options" label='Options (one per line, "value | Label" to show a different label)'>
           <TextArea
-            value={(field.options ?? []).join('\n')}
+            value={selectOptionsToText(field.options)}
             rows={3}
             onChange={(value) =>
-              setFields(fields.map((field, i) => (i === index ? { ...field, options: value.split('\n') } : field)))
+              setFields(
+                fields.map((field, i) => (i === index ? { ...field, options: selectOptionsFromText(value) } : field))
+              )
             }
           />
         </Field>

--- a/frontend/src/scenes/frame/panels/Fields/ShowIfEditor.tsx
+++ b/frontend/src/scenes/frame/panels/Fields/ShowIfEditor.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Button } from '../../../../components/Button'
 import { Select } from '../../../../components/Select'
+import { selectFieldOptions, selectFieldValues } from '../../../../utils/selectOptions'
 import { TextInput } from '../../../../components/TextInput'
 import { TextArea } from '../../../../components/TextArea'
 import type {
@@ -141,7 +142,7 @@ export function ShowIfEditor({ value, onChange, availableFields }: ShowIfEditorP
       return true
     }
     if (conditionField?.type === 'select') {
-      return conditionField.options?.[0]
+      return selectFieldValues(conditionField.options)[0]
     }
     return undefined
   }
@@ -233,7 +234,7 @@ export function ShowIfEditor({ value, onChange, availableFields }: ShowIfEditorP
               ) : conditionField?.type === 'select' && conditionField.options?.length ? (
                 <Select
                   value={conditionValueToString(row.value)}
-                  options={conditionField.options.map((option) => ({ label: option, value: option }))}
+                  options={selectFieldOptions(conditionField.options)}
                   onChange={(text) => updateRow(index, { value: text })}
                   className="min-w-[7rem]"
                 />

--- a/frontend/src/scenes/frame/panels/Scenes/StateFieldEdit.tsx
+++ b/frontend/src/scenes/frame/panels/Scenes/StateFieldEdit.tsx
@@ -2,6 +2,7 @@ import { ColorInput } from '../../../../components/ColorInput'
 import { FontSelect } from '../../../../components/FontSelect'
 import { NumberTextInput } from '../../../../components/NumberTextInput'
 import { Select } from '../../../../components/Select'
+import { selectFieldOptions } from '../../../../utils/selectOptions'
 import { TextArea } from '../../../../components/TextArea'
 import { TextInput } from '../../../../components/TextInput'
 import { PathInput } from '../Assets/PathInput'
@@ -38,7 +39,7 @@ export function StateFieldEdit({
     <Select
       value={stateChanges[field.name] ?? currentState[field.name] ?? value ?? field.value}
       onChange={onChange}
-      options={(field.options ?? []).map((option) => ({ label: option, value: option }))}
+      options={selectFieldOptions(field.options)}
     />
   ) : field.type === 'boolean' ? (
     <Select

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -616,6 +616,12 @@ export interface ConfigFieldConditionAnd {
   and: ConfigFieldCondition[]
 }
 
+/**
+ * One choice of a 'select' field: a plain string (the value doubles as the label),
+ * or an explicit pair when the stored value and the text shown differ.
+ */
+export type SelectFieldOption = string | { value: string; label: string }
+
 export interface AppConfigField {
   /** Unique config field keyword */
   name: string
@@ -624,7 +630,7 @@ export interface AppConfigField {
   /** Type of the field */
   type: AppConfigFieldType
   /** List of options for the field, only used if type is 'select' */
-  options?: string[]
+  options?: SelectFieldOption[]
   /** Whether the path points at a file, a folder or either, only used if type is 'path' */
   pick?: PathFieldPick
   /** Allowed file extensions without the dot (e.g. ["jpg", "png"]), only used if type is 'path' */

--- a/frontend/src/utils/appTypeDeclarations.ts
+++ b/frontend/src/utils/appTypeDeclarations.ts
@@ -1,4 +1,5 @@
 import type { AppConfig, AppConfigField, AppConfigFieldType, MarkdownField } from '../types'
+import { selectFieldValues } from './selectOptions'
 
 const fieldTypeToTsType: Record<AppConfigFieldType, string> = {
   string: 'string',
@@ -30,8 +31,11 @@ function literalString(value: string): string {
 }
 
 function fieldTsType(field: AppConfigField): string {
-  if (field.type === 'select' && Array.isArray(field.options) && field.options.length > 0) {
-    return field.options.map((option) => literalString(String(option))).join(' | ')
+  if (field.type === 'select') {
+    const values = selectFieldValues(field.options)
+    if (values.length > 0) {
+      return values.map(literalString).join(' | ')
+    }
   }
   return fieldTypeToTsType[field.type] ?? 'any'
 }

--- a/frontend/src/utils/selectOptions.ts
+++ b/frontend/src/utils/selectOptions.ts
@@ -1,0 +1,105 @@
+import { Option } from '../components/Select'
+import type { SelectFieldOption } from '../types'
+
+/**
+ * A select field's options are either plain strings, or `{ value, label }` pairs when the
+ * stored value and the text shown differ. Scenes are hand-edited, imported and AI-written,
+ * so options also arrive as numbers or as half-filled objects; read every `field.options`
+ * through here. A raw non-string rendered as a React child takes the whole editor down.
+ */
+function optionValue(option: unknown): string | null {
+  if (typeof option === 'string') {
+    return option
+  }
+  if (typeof option === 'number' || typeof option === 'boolean') {
+    return String(option)
+  }
+  if (option && typeof option === 'object' && !Array.isArray(option)) {
+    return optionValue((option as { value?: unknown }).value)
+  }
+  return null
+}
+
+function optionLabel(option: unknown, value: string): string {
+  if (option && typeof option === 'object' && !Array.isArray(option)) {
+    const label = (option as { label?: unknown }).label
+    if (typeof label === 'string' || typeof label === 'number' || typeof label === 'boolean') {
+      return String(label)
+    }
+  }
+  return value
+}
+
+/** The values of a select field, for storing, comparing and code generation. */
+export function selectFieldValues(options: unknown): string[] {
+  return selectFieldOptions(options).map((option) => option.value)
+}
+
+/** The options of a select field, ready for <Select />. Unusable entries are dropped. */
+export function selectFieldOptions(options: unknown): Option[] {
+  if (!Array.isArray(options)) {
+    return []
+  }
+  const result: Option[] = []
+  for (const option of options) {
+    const value = optionValue(option)
+    if (value !== null) {
+      result.push({ value, label: optionLabel(option, value) })
+    }
+  }
+  return result
+}
+
+/** Canonical storage shape: a plain string unless the option carries its own label. */
+export function normalizeSelectOptions(options: unknown): SelectFieldOption[] {
+  return selectFieldOptions(options).map(({ value, label }) => (label === value ? value : { value, label }))
+}
+
+/**
+ * Options stored in a shape the editor and the frame cannot read (numbers, half-filled
+ * objects) get canonicalized, so the next save writes a scene the device can parse.
+ * Returned untouched when already canonical.
+ */
+export function normalizeFieldOptions<T>(field: T): T {
+  const options = (field as { options?: unknown } | null | undefined)?.options
+  if (options === undefined) {
+    return field
+  }
+  const normalized = normalizeSelectOptions(options)
+  const unchanged =
+    Array.isArray(options) &&
+    options.length === normalized.length &&
+    normalized.every((option, index) =>
+      typeof option === 'string'
+        ? options[index] === option
+        : isSameLabeledOption(options[index], option.value, option.label)
+    )
+  return unchanged ? field : ({ ...field, options: normalized } as T)
+}
+
+function isSameLabeledOption(option: unknown, value: string, label: string): boolean {
+  if (!option || typeof option !== 'object' || Array.isArray(option)) {
+    return false
+  }
+  const entry = option as { value?: unknown; label?: unknown }
+  return entry.value === value && entry.label === label && Object.keys(entry).length === 2
+}
+
+/** The options textarea in the field editor: one option per line, `value | Label` when labeled. */
+export function selectOptionsToText(options: unknown): string {
+  return selectFieldOptions(options)
+    .map(({ value, label }) => (label === value ? value : `${value} | ${label}`))
+    .join('\n')
+}
+
+export function selectOptionsFromText(text: string): SelectFieldOption[] {
+  return text.split('\n').map((line) => {
+    const separator = line.indexOf('|')
+    if (separator === -1) {
+      return line
+    }
+    const value = line.slice(0, separator).trim()
+    const label = line.slice(separator + 1).trim()
+    return label && label !== value ? { value, label } : value
+  })
+}


### PR DESCRIPTION
## The crash

An AI *"add a theme selector"* run on scenes.frameos.net wrote `options: [{value, label}]` into a scene field. Nothing validated the shape, so the object reached React as a child:

```
Uncaught Error: Minified React error #31; ... object with keys {value, label}
```

The page became **"This page couldn't load"** with no way back into the scene. `AppNode.tsx` was doing `(field.options ?? []).map((o) => ({ value: o, label: o }))` — an object `o` became the label.

## The fix

Rather than banning the shape, make it a supported one — labels are worth having:

```ts
export type SelectFieldOption = string | { value: string; label: string }
```

Config and state always store the option's **value**; the label is only ever shown.

### frontend
- `utils/selectOptions.ts` is now the single reader of `field.options`: `selectFieldOptions` (render), `selectFieldValues` (store / compare / TS declarations), `selectOptionsToText`/`FromText`, `normalizeFieldOptions`. Wired into `AppNode`, `StateFieldEdit`, `ShowIfEditor`, `FieldDefinitionForm`, `appTypeDeclarations`.
- The field editor's options textarea takes `value | Label` lines.
- `Select.tsx` coerces a non-string label instead of taking the whole page down — bad data should never white-screen the editor again.
- `sanitizeScene` canonicalizes options on scene fields and scene apps, so an **already-broken scene renders (with its labels) and heals on the next save**.

### frameos (device)
- `StateFieldOption` + jsony parse/dump hooks. A scene that fails to parse takes the whole frame down, so the hook also eats numbers, `null` and arrays rather than raising; the dump hook round-trips to the shape it came in as.
- The on-device control page renders `value`/`label`.

### backend
- `select_field_options()` feeds the compiled-scene codegen, which now emits `StateFieldOption(value: .., label: ..)`.

### cloud
- The AI scene linter accepts both shapes and errors on anything else (bounces back to the model instead of shipping a page-killer); the prompt documents both.
- `SceneLivePreview.tsx` had the identical unsafe `{option}` render — fixed via `lib/select-options.ts` (it can't use the `frameos-wasm` copy until that package is republished).

### frameos-wasm
- `SelectFieldOption` type + `selectFieldOptions`, and its own manager UI fixed.

## Testing

- `nim check` on the full tree clean; new `frameos/src/frameos/tests/test_state_field_options.nim` compiled and run (parses strings, pairs, label-less pairs, numbers, null, arrays; dumps back to the original shape).
- Frontend `tsc` + prettier clean; `frontend/schema/config_json.json` regenerated.
- Cloud: eslint clean, 1121 unit tests pass, scene-lint tests extended for both shapes.
- Backend: 29 codegen tests pass, including a new one covering both option shapes.

Note: the store page only recovers once frontend + cloud are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLi1xan2RFkYB13UJqAhL