### PR TITLE
ESP32 deep sleep: battery-guard hysteresis, power/settings visibility, streamed image_get, sleep-aware cloud TTLs

### DIFF
--- a/backend/app/tasks/tests/test_esp32_power.py
+++ b/backend/app/tasks/tests/test_esp32_power.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Runs embedded/esp32/main/tests/test_fos_power.c.
+#
+# Same arrangement as test_esp32_wake.py next door: host tests that nothing
+# invokes are host tests that do not exist.
+#
+# fos_power.c is the pass-start power decision of a deep-sleeping frame —
+# whether a cell is present, whether it is critical, whether the pass ends in
+# esp_deep_sleep — with the hysteresis that keeps one bad ADC burst from
+# switching deep sleep off for nine hours. Pure arithmetic; the ADC read and
+# the RTC-memory state live in fos_client.c.
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ESP32_DIR = REPO_ROOT / "embedded" / "esp32"
+MAIN_DIR = ESP32_DIR / "main"
+POWER_SOURCE = MAIN_DIR / "fos_power.c"
+POWER_TEST_SOURCE = MAIN_DIR / "tests" / "test_fos_power.c"
+
+
+def test_sources_exist():
+    assert POWER_SOURCE.is_file(), f"missing {POWER_SOURCE}"
+    assert POWER_TEST_SOURCE.is_file(), f"missing {POWER_TEST_SOURCE}"
+
+
+def test_power_helper_is_pure():
+    """The point of the split: fos_power.c must stay buildable without the IDF."""
+    source = POWER_SOURCE.read_text()
+    assert "#include" in source
+    assert "esp_" not in source, "fos_power.c must not pull in IDF headers or calls"
+    assert "freertos" not in source
+
+
+@pytest.mark.skipif(shutil.which("cc") is None, reason="no C compiler on PATH")
+def test_fos_power_host_tests_pass(tmp_path: Path):
+    binary = tmp_path / "test_fos_power"
+    compile_result = subprocess.run(
+        [
+            "cc",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-O2",
+            "-I",
+            str(MAIN_DIR),
+            str(POWER_SOURCE),
+            str(POWER_TEST_SOURCE),
+            "-o",
+            str(binary),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "power host tests do not compile:\n" + compile_result.stderr
+    )
+
+    run_result = subprocess.run(
+        [str(binary)], capture_output=True, text=True, timeout=180
+    )
+    assert run_result.returncode == 0, (
+        "power host tests failed:\n" + run_result.stdout[-4000:]
+    )
+
+    # Assert the count too: a binary that asserted nothing would also exit 0.
+    summary = re.search(r"(\d+) checks, (\d+) failures", run_result.stdout)
+    assert summary is not None, (
+        "could not find the check summary in the output:\n" + run_result.stdout[-4000:]
+    )
+    assert int(summary.group(1)) >= 25
+    assert int(summary.group(2)) == 0

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/asset/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/asset/route.ts
@@ -2,10 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { readBlob } from "../../../../../src/lib/blobs";
 import { jsonError, requireDatabase } from "../../../../../src/lib/device-flow";
 import {
+  assetFetchCommandTtlMs,
   cachedAssetFile,
   queueAssetGetIfIdle,
   recentFailedAssetGet,
 } from "../../../../../src/lib/frame-asset-cache";
+import { commandTtlForFrame } from "../../../../../src/lib/frame-sleep";
 import {
   frameForAccount,
   maxAssetPathChars,
@@ -135,7 +137,14 @@ export async function GET(
   const needsFetch =
     !cached || now - cached.updatedAt.getTime() > cacheStaleAfterMs;
   if (needsFetch && frame.status === "active") {
-    await queueAssetGetIfIdle(db, session.accountId, frame.id, path, thumb);
+    await queueAssetGetIfIdle(
+      db,
+      session.accountId,
+      frame.id,
+      path,
+      thumb,
+      commandTtlForFrame(frame, assetFetchCommandTtlMs, now),
+    );
   }
   if (cached) {
     // Stale-while-revalidate: the refresh (if any) was queued above and the

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/image/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/image/route.ts
@@ -1,10 +1,11 @@
-import { and, eq, gt, inArray, isNull, or } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 import { frameAssetFiles, frameCommands } from "@frameos-cloud/db";
 import { NextRequest, NextResponse } from "next/server";
 import { readBlob } from "../../../../../src/lib/blobs";
 import { jsonError, requireDatabase } from "../../../../../src/lib/device-flow";
+import { queueImageGetIfIdle } from "../../../../../src/lib/frame-asset-cache";
+import { commandTtlForFrame, frameIsAsleep } from "../../../../../src/lib/frame-sleep";
 import {
-  enqueueFrameCommand,
   frameForAccount,
   frameImageAssetPath,
   markFramePreviewWatched,
@@ -14,6 +15,8 @@ import { readSession } from "../../../../../src/lib/session";
 
 export const runtime = "nodejs";
 
+// For an awake frame; a sleeping frame's fetch stretches to its next wake
+// (commandTtlForFrame) so the device finds it on the pass that can answer it.
 const fetchCommandTtlMs = 2 * 60 * 1000;
 // The preview panel wants "the current image" — anything older than a
 // render interval is history. A passive load (?t=-1, a tile filling in)
@@ -41,25 +44,6 @@ async function cachedImage(db: Db, frameId: string) {
         eq(frameAssetFiles.frameId, frameId),
         eq(frameAssetFiles.path, frameImageAssetPath),
         eq(frameAssetFiles.thumb, false),
-      ),
-    )
-    .limit(1);
-  return row;
-}
-
-async function outstandingImageGet(db: Db, frameId: string) {
-  const [row] = await db
-    .select({ id: frameCommands.id })
-    .from(frameCommands)
-    .where(
-      and(
-        eq(frameCommands.frameId, frameId),
-        eq(frameCommands.type, "image_get"),
-        inArray(frameCommands.status, ["pending", "sent"]),
-        or(
-          isNull(frameCommands.expiresAt),
-          gt(frameCommands.expiresAt, new Date()),
-        ),
       ),
     )
     .limit(1);
@@ -124,19 +108,17 @@ export async function GET(
   const wantsFresh = tParam !== null && tParam !== "-1";
   const needsFetch =
     !cached || now - cached.updatedAt.getTime() > imageStaleAfterMs;
-  if (
-    needsFetch &&
-    frame.status === "active" &&
-    !(await outstandingImageGet(db, frame.id))
-  ) {
-    await enqueueFrameCommand(db, {
-      createdByAccountId: session.accountId,
-      frameId: frame.id,
-      ttlMs: fetchCommandTtlMs,
-      type: "image_get",
-    });
+  if (needsFetch && frame.status === "active") {
+    await queueImageGetIfIdle(
+      db,
+      session.accountId,
+      frame.id,
+      commandTtlForFrame(frame, fetchCommandTtlMs, now),
+    );
   }
-  const canWaitForFresh = frame.status === "active";
+  // A frame that announced a sleep answers on its next wake, minutes away:
+  // the fetch is queued for it, but nobody should long-poll for it now.
+  const canWaitForFresh = frame.status === "active" && !frameIsAsleep(frame, now);
   if (cached && !(wantsFresh && needsFetch && canWaitForFresh)) {
     return await imageResponse(cached);
   }

--- a/cloud/apps/auth-web/app/api/frames/[frameId]/scene_images/[sceneId]/route.ts
+++ b/cloud/apps/auth-web/app/api/frames/[frameId]/scene_images/[sceneId]/route.ts
@@ -3,11 +3,13 @@ import { readBlob } from "../../../../../../src/lib/blobs";
 import { csrfResponse } from "../../../../../../src/lib/csrf";
 import { jsonError, requireDatabase } from "../../../../../../src/lib/device-flow";
 import {
+  assetFetchCommandTtlMs,
   cachedAssetFile,
   queueAssetGetIfIdle,
   recentFailedAssetGet,
   sceneSnapshotAssetPath,
 } from "../../../../../../src/lib/frame-asset-cache";
+import { commandTtlForFrame } from "../../../../../../src/lib/frame-sleep";
 import {
   frameForAccount,
   markFramePreviewWatched,
@@ -131,6 +133,7 @@ export async function GET(
       frame.id,
       snapshotPath,
       thumb,
+      commandTtlForFrame(frame, assetFetchCommandTtlMs),
     );
   }
   const cachedContent = await readBlob(cached);

--- a/cloud/apps/auth-web/src/lib/frame-asset-cache.ts
+++ b/cloud/apps/auth-web/src/lib/frame-asset-cache.ts
@@ -14,6 +14,10 @@ import {
   type FramesDatabase,
 } from "./frames";
 
+// For an AWAKE frame. A sleeping frame's fetch has to outlive its sleep:
+// callers pass commandTtlForFrame(frame, assetFetchCommandTtlMs) instead
+// (frame-sleep.ts) — a 2-minute TTL on a 15-minute sleeper expired every
+// single time, which is how a frame's image stayed stale for days.
 export const assetFetchCommandTtlMs = 2 * 60 * 1000;
 
 /**
@@ -129,6 +133,7 @@ export async function queueAssetGetIfIdle(
   frameId: string,
   path: string,
   thumb: boolean,
+  ttlMs: number = assetFetchCommandTtlMs,
 ) {
   if (await outstandingAssetGet(db, frameId, path, thumb)) {
     return;
@@ -137,9 +142,53 @@ export async function queueAssetGetIfIdle(
     createdByAccountId: accountId,
     frameId,
     payload: { path, ...(thumb ? { thumb: true } : {}) },
-    ttlMs: assetFetchCommandTtlMs,
+    ttlMs,
     type: "asset_get",
   });
+}
+
+/** A live (pending or sent, unexpired) image_get for this frame. */
+export async function outstandingImageGet(db: FramesDatabase, frameId: string) {
+  const [row] = await db
+    .select({ id: frameCommands.id })
+    .from(frameCommands)
+    .where(
+      and(
+        eq(frameCommands.frameId, frameId),
+        eq(frameCommands.type, "image_get"),
+        inArray(frameCommands.status, ["pending", "sent"]),
+        or(
+          isNull(frameCommands.expiresAt),
+          gt(frameCommands.expiresAt, new Date()),
+        ),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+/**
+ * Queue an image_get (the frame's current rendered image, cached under
+ * frameImageAssetPath) unless one is already in flight. The route behind the
+ * preview panel and the hub's `render` handler (for devices whose image is
+ * their framebuffer, not a snapshot file) both go through here.
+ */
+export async function queueImageGetIfIdle(
+  db: Parameters<typeof enqueueFrameCommand>[0],
+  accountId: string,
+  frameId: string,
+  ttlMs: number = assetFetchCommandTtlMs,
+) {
+  if (await outstandingImageGet(db, frameId)) {
+    return false;
+  }
+  await enqueueFrameCommand(db, {
+    createdByAccountId: accountId,
+    frameId,
+    ttlMs,
+    type: "image_get",
+  });
+  return true;
 }
 
 /**

--- a/cloud/apps/auth-web/src/lib/frame-sleep.test.ts
+++ b/cloud/apps/auth-web/src/lib/frame-sleep.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  commandTtlForFrame,
+  frameIsAsleep,
+  maxSleepWaitMs,
+  previewWatchGraceMs,
+} from "./frame-sleep";
+
+const now = Date.parse("2026-08-28T13:00:00Z");
+const twoMinutes = 2 * 60 * 1000;
+
+describe("commandTtlForFrame", () => {
+  it("is the base TTL for an awake frame", () => {
+    expect(commandTtlForFrame({ nextWakeAt: null }, twoMinutes, now)).toBe(twoMinutes);
+  });
+
+  it("is the base TTL when the forecast is already past", () => {
+    const frame = { nextWakeAt: new Date(now - 1000) };
+    expect(commandTtlForFrame(frame, twoMinutes, now)).toBe(twoMinutes);
+  });
+
+  it("reaches past the announced wake by the base TTL", () => {
+    // A 15-minute weather frame: the command must survive the whole sleep.
+    const frame = { nextWakeAt: new Date(now + 14 * 60 * 1000) };
+    expect(commandTtlForFrame(frame, twoMinutes, now)).toBe(14 * 60 * 1000 + twoMinutes);
+  });
+
+  it("caps a broken forecast at the firmware's longest sleep", () => {
+    const frame = { nextWakeAt: new Date(now + 365 * 86_400 * 1000) };
+    expect(commandTtlForFrame(frame, twoMinutes, now)).toBe(maxSleepWaitMs + twoMinutes);
+  });
+});
+
+describe("frameIsAsleep", () => {
+  it("reads the forecast", () => {
+    expect(frameIsAsleep({ nextWakeAt: null }, now)).toBe(false);
+    expect(frameIsAsleep({ nextWakeAt: new Date(now - 1) }, now)).toBe(false);
+    expect(frameIsAsleep({ nextWakeAt: new Date(now + 1) }, now)).toBe(true);
+  });
+});
+
+describe("previewWatchGraceMs", () => {
+  it("is zero without an announced sleep", () => {
+    expect(previewWatchGraceMs(undefined)).toBe(0);
+    expect(previewWatchGraceMs(0)).toBe(0);
+    expect(previewWatchGraceMs(Number.NaN)).toBe(0);
+  });
+
+  it("stretches the watch window by one sleep", () => {
+    expect(previewWatchGraceMs(838)).toBe(838_000);
+    expect(previewWatchGraceMs(838.4)).toBe(838_000);
+  });
+
+  it("is bounded", () => {
+    expect(previewWatchGraceMs(10 ** 9)).toBe(maxSleepWaitMs);
+  });
+});

--- a/cloud/apps/auth-web/src/lib/frame-sleep.ts
+++ b/cloud/apps/auth-web/src/lib/frame-sleep.ts
@@ -1,0 +1,51 @@
+// Sleep-aware command timing for deep-sleeping frames (docs/cloud-frames.md,
+// "sleep"). Pure on purpose — the hub and the routes both import it, and the
+// unit tests run it without a database.
+
+// The firmware caps one sleep at 7 days; anything past that (plus an hour of
+// clock skew) on a frame row is a broken forecast and is not waited for.
+export const maxSleepWaitMs = (7 * 86_400 + 3_600) * 1000;
+
+/**
+ * How long a "fetch me something now" command (image_get, asset_get) should
+ * stay valid for this frame. A frame that is asleep cannot see the command
+ * until it wakes: a 2-minute TTL on a frame that sleeps 15 minutes expires
+ * every time — the E1004 whose image never updated for days. So the TTL
+ * reaches past the announced wake (`next_wake_at` from the device's `sleep`
+ * message) by the base TTL, and is the base TTL alone for an awake frame or
+ * one with no forecast.
+ */
+export function commandTtlForFrame(
+  frame: { nextWakeAt: Date | null },
+  baseTtlMs: number,
+  now = Date.now(),
+): number {
+  const wakeAt = frame.nextWakeAt?.getTime();
+  if (wakeAt === undefined || !Number.isFinite(wakeAt) || wakeAt <= now) {
+    return baseTtlMs;
+  }
+  return Math.min(wakeAt - now, maxSleepWaitMs) + baseTtlMs;
+}
+
+/** Is the frame's own forecast saying it is asleep right now? */
+export function frameIsAsleep(
+  frame: { nextWakeAt: Date | null },
+  now = Date.now(),
+): boolean {
+  const wakeAt = frame.nextWakeAt?.getTime();
+  return wakeAt !== undefined && Number.isFinite(wakeAt) && wakeAt > now;
+}
+
+/**
+ * The preview-watch grace for a frame that deep sleeps between renders: a
+ * person who opened the frame's page while it slept is still "looking" when
+ * it wakes and renders one sleep later, so the three-minute watch window
+ * stretches by the length of the last announced sleep (bounded like the
+ * TTL). Zero for frames that never announced a sleep.
+ */
+export function previewWatchGraceMs(lastSleepSeconds: number | undefined): number {
+  if (lastSleepSeconds === undefined || !Number.isFinite(lastSleepSeconds) || lastSleepSeconds <= 0) {
+    return 0;
+  }
+  return Math.min(Math.round(lastSleepSeconds) * 1000, maxSleepWaitMs);
+}

--- a/cloud/apps/auth-web/src/lib/frames.ts
+++ b/cloud/apps/auth-web/src/lib/frames.ts
@@ -1614,13 +1614,18 @@ export async function markFramePreviewWatched(
   }
 }
 
+// `graceMs` stretches the window for a frame that was asleep: a deep-sleep
+// frame renders once per sleep, so "looked at it within the last sleep" is
+// what makes its next render worth fetching (previewWatchGraceMs in
+// frame-sleep.ts; the hub remembers each frame's last announced sleep).
 export function framePreviewIsWatched(
   frame: { previewWatchedAt: Date | null },
   now = Date.now(),
+  graceMs = 0,
 ): boolean {
   return (
     frame.previewWatchedAt !== null &&
-    now - frame.previewWatchedAt.getTime() <= previewWatchWindowMs
+    now - frame.previewWatchedAt.getTime() <= previewWatchWindowMs + graceMs
   );
 }
 

--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -53,8 +53,10 @@ import {
   cachedAssetFile,
   assetFetchCommandTtlMs,
   outstandingAssetGet,
+  queueImageGetIfIdle,
   sceneSnapshotAssetPath,
 } from "../../auth-web/src/lib/frame-asset-cache";
+import { previewWatchGraceMs } from "../../auth-web/src/lib/frame-sleep";
 import {
   allowsPrivateNetworkOrigins,
   getAllowedBrowserOrigins,
@@ -180,6 +182,13 @@ const logBatchRateLimit = { limit: 120, windowMs: 60_000 };
 // (SCENE_IMAGE_MAX_AGE_SECONDS); this is the ceiling that holds even if a
 // firmware forgets to, so a chatty frame cannot turn a preview into a stream.
 const renderPreviewRateLimit = { limit: 4, windowMs: 60_000 };
+// Each frame's last announced sleep (seconds), so a `render` from a
+// deep-sleep frame counts a page opened while it slept as "still looking":
+// it renders once per sleep, and the three-minute watch window alone never
+// spans one. In-process only — lost on restart, which just costs a preview
+// that refreshes on the next page load.
+const lastSleepSeconds = new Map<string, number>();
+const maxLastSleepEntries = 10_000;
 
 // Unauthenticated upgrade attempts are cheap for the client and cost the hub a
 // database select each, so they are limited per client IP through the shared
@@ -989,6 +998,10 @@ export async function startFrameHub(
         ? msg.reason.slice(0, 32)
         : null;
     session.sleeping = true;
+    if (lastSleepSeconds.size >= maxLastSleepEntries) {
+      lastSleepSeconds.clear();
+    }
+    lastSleepSeconds.set(session.frame.id, wakeInSeconds);
     await db
       .update(frames)
       .set({
@@ -1017,6 +1030,11 @@ export async function startFrameHub(
   // keeps a copy of what the device already drew for itself, while someone is
   // looking, and otherwise leaves the frame alone. It never renders scenes
   // itself and never asks a device to screenshot on demand.
+  //
+  // `image: "image_get"` (ESP32 firmware 2026.8.43+): the device keeps no
+  // snapshot files — its image IS the framebuffer — so the fetch is an
+  // image_get into the current-image slot rather than an asset_get of a
+  // per-scene PNG.
   async function handleRender(
     session: DeviceSession,
     msg: Record<string, unknown>,
@@ -1028,6 +1046,7 @@ export async function startFrameHub(
     if (!activeScene) {
       return;
     }
+    const imageViaGet = msg.image === "image_get";
     // Re-read: `session.frame` is the row as it was at connect, and viewers
     // come and go over the life of a socket.
     const [frame] = await db
@@ -1038,7 +1057,14 @@ export async function startFrameHub(
       .from(frames)
       .where(eq(frames.id, session.frame.id))
       .limit(1);
-    if (!frame || !framePreviewIsWatched(frame)) {
+    if (
+      !frame ||
+      !framePreviewIsWatched(
+        frame,
+        Date.now(),
+        previewWatchGraceMs(lastSleepSeconds.get(session.frame.id)),
+      )
+    ) {
       return;
     }
     // Cheap frequency cap on top of the device's own (it writes a snapshot at
@@ -1050,6 +1076,17 @@ export async function startFrameHub(
         renderPreviewRateLimit,
       ).allowed
     ) {
+      return;
+    }
+    if (imageViaGet) {
+      // The device is awake and connected this instant (it just announced),
+      // and holds its deep sleep for the stream, so the base TTL is right.
+      await queueImageGetIfIdle(
+        db,
+        frame.accountId,
+        session.frame.id,
+        assetFetchCommandTtlMs,
+      );
       return;
     }
     const path = sceneSnapshotAssetPath(activeScene);

--- a/docs/cloud-frames.md
+++ b/docs/cloud-frames.md
@@ -444,7 +444,7 @@ lines), nothing retained across disconnects, and error acks are ignored.
 | `scene_ack` | `{"checksum", "active_scene"}` | after a successful `set_scenes`, drives provider-side sync state. When the acked checksum matches the provider's current assigned set, the provider also promotes its per-scene deploy ledger (`assigned_scene_state` → `deployed_scene_state` on the frame row) so the workspace can name WHICH scene is still pending on later edits |
 | `assets` | `{"id", "assets": […], "truncated"?}` | reply to `assets_list`; the provider caches the latest listing per frame (the reference provider rejects listings over **256 KiB** of JSON rather than truncating them) |
 | `asset_chunk` | `{"id", "seq", "data", "done", …}` | reply stream to `asset_get`; the provider reassembles in order, bounds the total at its per-file cap, and discards the partial file on a chunk carrying `"error"` or on disconnect |
-| `render` | `{"active_scene": "…"}` | "I have written a fresh snapshot of this scene." Announcement only, never bytes — see Previews below. A provider that does not want it can ignore it entirely |
+| `render` | `{"active_scene": "…", "image"?: "image_get"}` | "I have written a fresh snapshot of this scene." Announcement only, never bytes — see Previews below. A provider that does not want it can ignore it entirely. `image: "image_get"` (ESP32 firmware **2026.8.43**+) says the device keeps no snapshot files — its image is its framebuffer — so a provider that wants the picture fetches it with `image_get` (into its current-image slot) rather than `asset_get` of a per-scene PNG |
 
 A provider must tolerate unknown frame→provider types (forward compatibility).
 
@@ -475,11 +475,24 @@ three-minute window). A frame nobody is looking at costs one small JSON
 message per snapshot write and nothing else — no polling, no scraping, and no
 standing stream of images out of a home.
 
-The fetch itself is the ordinary `asset_get` verb, so a provider that ignores
-`render` entirely still gets previews the moment a tile asks for one; it just
-gets them a render late. Devices must not send `render` more than once per
-snapshot write, and providers should cap the resulting fetches per frame
-regardless (the reference hub allows four a minute).
+The fetch itself is the ordinary `asset_get` verb (or `image_get` when the
+announcement says so), so a provider that ignores `render` entirely still
+gets previews the moment a tile asks for one; it just gets them a render
+late. Devices must not send `render` more than once per snapshot write, and
+providers should cap the resulting fetches per frame regardless (the
+reference hub allows four a minute).
+
+Two things make this work for a frame that deep sleeps between renders. A
+fetch queued while the frame is asleep must outlive the sleep: the reference
+provider stretches the `image_get` / `asset_get` TTL past the frame's
+announced `next_wake_at` (a two-minute TTL on a fifteen-minute sleeper
+expired every time). And "someone is looking" has to span one sleep: the
+frame renders exactly once per wake, so the reference hub adds the frame's
+last announced `wake_in_seconds` to its three-minute watch window when that
+frame's `render` arrives. On the device side, an `image_get` that lands at
+`hello` — before the wake's render exists — waits for that render (up to
+150 s) instead of answering `no_image`, and the deep sleep holds (up to 45 s)
+while the stream is still going out.
 
 A provider acks `log_batch` and `metrics` with `ok: false` and `rate_limited`
 when the frame exceeds its ingestion budget, or `payload_too_large` when a

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -295,7 +295,13 @@ bytes with the device key. Implemented verbs: `get_state`, `render`,
 `set_scenes` (stored through the same interpreted-scene path as
 `usb_api upload-scenes`; `scene_ack` is sent only after the render task has
 actually hot-loaded the payload), `set_settings` (the `interval`/`name`
-subset), `image_get`, and the full asset verb set — `assets_list`,
+subset), `image_get` (the packed framebuffer as BMP, built a row at a time
+straight off the boot-time framebuffer reservation — since 2026.8.43 the
+preview snapshot borrows that buffer instead of copying it, and the stream
+allocates one 24 KiB chunk, so an 8 MB board with a 960 KB panel can finally
+serve one; an `image_get` that arrives before the wake's render waits for it,
+and the deep sleep holds while the stream goes out), and the full asset verb
+set — `assets_list`,
 `asset_get`, `asset_put`, `asset_mkdir`, `asset_delete`, `asset_rename` —
 against the mounted SD card (shared implementation in `main/fos_assets.c`,
 also behind the local HTTP asset API and the `usb_api` asset commands).
@@ -408,6 +414,31 @@ per 900 s, with the radio listening the whole time. Three things changed:
   wake, at the end of its pass (after the render and the panel refresh, so
   `renderLastMs` is this wake's); that one sample is now delivered every
   cycle instead of winning a race with the sleep.
+
+The pass-start power decision (2026.8.43, `fos_power.c`, host-tested by
+`main/tests/test_fos_power.c`) reads the cell twice a moment apart and keeps
+the higher burst, then weighs it against the last believed reading kept in
+RTC memory: a cell that was there a pass ago survives one implausible
+reading (two consecutive sub-2.5 V reads mean "no cell"), "critical" takes
+two consecutive passes below 3.2 V, and a critical cell always deep sleeps
+under `deep_sleep_on_battery` — it is a battery by definition. Before this,
+one 16-sample ADC burst reading "0 %" on a 3.9 V cell both parked the frame
+in the six-hour critical sleep and, because a sub-2.5 V reading also meant
+"no cell", switched deep sleep OFF, so the frame sat awake with the radio on
+for nine hours (E1004, 2026-08-27). Every pass now logs a `power` line —
+`deepSleep` (`battery` / `always` / `critical` / `off`), `onBattery`,
+`wakeCheckSeconds`, the millivolts read and, when they differ, the
+millivolts believed (`suspect: true`) — so "deep sleep silently off" and
+"the owner switched it off" are told apart in the cloud log; a settings
+push or poll that changes anything logs `settings:cloud` / `settings:sync`
+`applied` with the keys and values that changed.
+
+A pass that ends in an awake hold (a verb arrived, `keep_awake`) no longer
+renders again when the hold ends: the next panel refresh's due time is kept
+for every wait, so the follow-up pass checks in and sleeps until it. And
+the SNTP sync flag is also set from the sync callback: a pool that answered
+after the boot-time wait used to leave the whole boot "unsynced" — hub-stamped
+logs, no wake-check schedule — for as long as the frame stayed up.
 
 The sleep also **holds for a running OTA** (up to 15 min): the
 `notify_update_available` verb only keeps the frame awake 15 s while the

--- a/embedded/esp32/main/CMakeLists.txt
+++ b/embedded/esp32/main/CMakeLists.txt
@@ -4,6 +4,7 @@ idf_component_register(
         "fos_board.c"
         "fos_buttons.c"
         "fos_wake.c"
+        "fos_power.c"
         "fos_config.c"
         "fos_framebuffer.c"
         "fos_wifi.c"

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -30,6 +30,7 @@
 #include "fos_framebuffer.h"
 #include "fos_mem.h"
 #include "fos_ota.h"
+#include "fos_power.h"
 #include "fos_scenes.h"
 #include "fos_schedule.h"
 #include "fos_settings.h"
@@ -44,17 +45,18 @@ static const char *TAG = "fos_client";
 #define START_RENDER_LOOP_BIT BIT1
 #define CLIENT_TASK_STACK_BYTES 40960
 
-/* Below this charge we stop rendering and sleep long to protect the cell. */
-#define FOS_BATTERY_CRITICAL_PCT 3
+/* Below FOS_POWER_CRITICAL_MV (fos_power.h) for two passes running we stop
+ * rendering and sleep this long to protect the cell. */
 #define FOS_BATTERY_CRITICAL_SLEEP_SEC (6 * 3600)
+/* The two ADC bursts behind one pass-start reading are this far apart; a
+ * Wi-Fi TX burst that sagged the first one has moved on by the second. */
+#define FOS_BATTERY_RESAMPLE_GAP_MS 60
 
-/* A cell reading at least this many mV counts as "running on battery" for
- * deep_sleep_on_battery. It is the best power-source signal we have: no
- * supported board wires VBUS to a readable pin (the PhotoPainter's AXP2101
- * could tell, but nothing reads its status registers yet). A plugged-in,
- * charging frame passes this too — acceptable, deep sleeping while charging
- * costs nothing. */
-#define FOS_BATTERY_PRESENT_MV 2500
+/* How long a deep sleep waits for the cloud task to finish streaming the
+ * frame's image (an `image_get` the provider queued on this pass's `render`
+ * announcement, or one that waited out the sleep in the command queue). The
+ * 960 KB E1004 BMP takes a few seconds; the cap is for a stalled socket. */
+#define FOS_ASSET_SLEEP_HOLD_MAX_SEC 45
 
 /* How long to hold the boot open for the provider's management socket before
  * a deep sleep, so queued commands can land (each arriving verb arms the
@@ -84,6 +86,10 @@ static const char *TAG = "fos_client";
  * RTC domain keeps both this variable and the system clock through deep
  * sleep. 0 = unknown, render on the next pass. */
 RTC_DATA_ATTR static time_t s_next_render_due;
+/* The pass-start power decision's memory (fos_power.h): the last believed
+ * cell reading and the confirmation streaks that keep one bad ADC burst
+ * from switching deep sleep off or parking the frame for six hours. */
+RTC_DATA_ATTR static fos_power_state_t s_power_state;
 
 /* FrameOS embedded bitmap wire format ("FOSB"):
  * magic[4] ver(u8) format(u8) width(u16le) height(u16le) reserved(u16le),
@@ -109,8 +115,17 @@ static EventGroupHandle_t s_events;
 static SemaphoreHandle_t s_snapshot_lock;
 static portMUX_TYPE s_keep_awake_lock = portMUX_INITIALIZER_UNLOCKED;
 static uint32_t s_render_count = 0;
+/* Passes that reached render_once this boot, failed or not: what
+ * fos_client_render_pending() means by "the wake's render is still owed". */
+static uint32_t s_render_attempts = 0;
 static int64_t s_last_render_ms = 0;
 static uint8_t *s_last_frame = NULL;
+/* True when s_last_frame IS the boot-time framebuffer reservation (borrowed,
+ * never freed here) rather than a copy this file owns. The reservation holds
+ * the last packed render until someone borrows it again, so a preview costs
+ * no PSRAM at all — the 8 MB E1004 could never afford the 960 KB copy and
+ * shipped "hash only" snapshots, i.e. no image, on every render. */
+static bool s_last_frame_borrowed = false;
 static size_t s_last_frame_len = 0;
 static int s_last_frame_width = 0;
 static int s_last_frame_height = 0;
@@ -199,7 +214,7 @@ static void log_metrics_sample(void)
         used += (size_t)snprintf(json + used, sizeof(json) - used,
                                  ",\"batteryPercent\":%d,\"batteryMillivolts\":%d,\"onBattery\":%s",
                                  battery_pct, battery_mv,
-                                 battery_mv >= FOS_BATTERY_PRESENT_MV ? "true" : "false");
+                                 battery_mv >= FOS_POWER_PRESENT_MV ? "true" : "false");
     }
     if (used < sizeof(json) - 2) {
         snprintf(json + used, sizeof(json) - used, "}");
@@ -546,15 +561,53 @@ static void log_render_event(const char *event, const char *scene_id,
     }
 }
 
+/* Drop a borrowed snapshot before its buffer is lent out again (the next
+ * render, a console display_test, the status screen): whoever borrows the
+ * reservation is about to overwrite it. Runs on the borrower's task from
+ * fos_framebuffer_acquire; a preview stream holding the lock finishes first
+ * (bounded — a stalled socket must not stall the panel). */
+static void snapshot_before_lend(void)
+{
+    if (!s_snapshot_lock) return;
+    if (xSemaphoreTake(s_snapshot_lock, pdMS_TO_TICKS(30000)) != pdTRUE) {
+        ESP_LOGW(TAG, "preview snapshot still streaming after 30 s; rendering over it");
+        return;
+    }
+    if (s_last_frame_borrowed) {
+        s_last_frame = NULL;
+        s_last_frame_len = 0;
+        s_last_frame_borrowed = false;
+    }
+    xSemaphoreGive(s_snapshot_lock);
+}
+
 static void store_snapshot(const uint8_t *buf, size_t len, int width, int height,
                            fos_pixel_format_t format, uint32_t render_count,
                            int64_t render_ms)
 {
     if (!buf || len == 0 || width <= 0 || height <= 0 || !s_snapshot_lock) return;
+    if (fos_framebuffer_is_reserved(buf)) {
+        /* The packed bytes stay put in the reservation until the next
+         * borrower; point at them instead of copying. */
+        xSemaphoreTake(s_snapshot_lock, portMAX_DELAY);
+        uint8_t *old = s_last_frame_borrowed ? NULL : s_last_frame;
+        s_last_frame = (uint8_t *)buf;
+        s_last_frame_borrowed = true;
+        s_last_frame_len = len;
+        s_last_frame_width = width;
+        s_last_frame_height = height;
+        s_last_frame_format = format;
+        s_last_frame_render_count = render_count;
+        s_last_frame_render_ms = render_ms;
+        xSemaphoreGive(s_snapshot_lock);
+        free(old);
+        return;
+    }
     if (!should_keep_packed_snapshot(len)) {
         xSemaphoreTake(s_snapshot_lock, portMAX_DELAY);
-        uint8_t *old = s_last_frame;
+        uint8_t *old = s_last_frame_borrowed ? NULL : s_last_frame;
         s_last_frame = NULL;
+        s_last_frame_borrowed = false;
         s_last_frame_len = 0;
         s_last_frame_width = width;
         s_last_frame_height = height;
@@ -578,8 +631,9 @@ static void store_snapshot(const uint8_t *buf, size_t len, int width, int height
     memcpy(copy, buf, len);
 
     xSemaphoreTake(s_snapshot_lock, portMAX_DELAY);
-    uint8_t *old = s_last_frame;
+    uint8_t *old = s_last_frame_borrowed ? NULL : s_last_frame;
     s_last_frame = copy;
+    s_last_frame_borrowed = false;
     s_last_frame_len = len;
     s_last_frame_width = width;
     s_last_frame_height = height;
@@ -630,6 +684,37 @@ esp_err_t fos_client_snapshot_copy(uint8_t *out, size_t out_len, int *width, int
     if (render_ms) *render_ms = s_last_frame_render_ms;
     xSemaphoreGive(s_snapshot_lock);
     return ESP_OK;
+}
+
+bool fos_client_snapshot_acquire(uint32_t timeout_ms, const uint8_t **buf, int *width,
+                                 int *height, fos_pixel_format_t *format, size_t *len)
+{
+    if (!buf || !s_snapshot_lock) return false;
+    if (xSemaphoreTake(s_snapshot_lock, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) return false;
+    if (!s_last_frame || s_last_frame_len == 0) {
+        xSemaphoreGive(s_snapshot_lock);
+        return false;
+    }
+    *buf = s_last_frame;
+    if (width) *width = s_last_frame_width;
+    if (height) *height = s_last_frame_height;
+    if (format) *format = s_last_frame_format;
+    if (len) *len = s_last_frame_len;
+    return true; /* lock held until fos_client_snapshot_release */
+}
+
+void fos_client_snapshot_release(void)
+{
+    if (s_snapshot_lock) xSemaphoreGive(s_snapshot_lock);
+}
+
+bool fos_client_render_pending(void)
+{
+    /* The first pass of a boot has not run its render yet (a deep-sleep wake
+     * renders before it does anything else), or the loop was told to render
+     * now. A render that failed counts as run: nothing is coming. */
+    if (s_render_attempts == 0 && !s_render_paused_for_memory) return true;
+    return s_events && (xEventGroupGetBits(s_events) & RENDER_NOW_BIT) != 0;
 }
 
 /* ------------------------------------------------------------ remote mode */
@@ -875,6 +960,7 @@ static esp_err_t render_once(void)
         }
     }
     int64_t total_ms = (esp_timer_get_time() - start) / 1000;
+    s_render_attempts++;
     current_scene_details(scene_id, sizeof(scene_id), scene_name, sizeof(scene_name));
     log_render_event(err == ESP_OK ? "render:done" : "render:error", scene_id,
                      scene_name, err == ESP_OK ? "ok" : "error", "complete",
@@ -882,6 +968,11 @@ static esp_err_t render_once(void)
                      err == ESP_OK ? s_render_count : render_attempt, total_ms,
                      width, height, format, buf_len, err);
     frameos_nim_flush_logs();
+    if (err == ESP_OK && !skipped_refresh) {
+        /* "I drew something new" — the provider decides whether anyone is
+         * looking and fetches the image with image_get if so. */
+        fos_cloud_announce_render(scene_id);
+    }
     /* Returns the reservation to the pool, or frees a one-off allocation —
      * including the Nim renderer's buffer on the local-render path. */
     fos_framebuffer_release(buf);
@@ -1094,6 +1185,12 @@ static void client_task(void *arg)
                      wake_cause_name());
         }
         frameos_nim_log_hook(line);
+        /* The RTC due date is only meaningful across a deep sleep: after an
+         * OTA, an OOM restart or a power cycle the panel may show anything,
+         * so the first pass renders whatever the old bookkeeping said. */
+        if (esp_reset_reason() != ESP_RST_DEEPSLEEP) {
+            s_next_render_due = 0;
+        }
     }
     while (true) {
         int64_t cycle_start = esp_timer_get_time();
@@ -1129,21 +1226,73 @@ static void client_task(void *arg)
 
         /* Battery guardrail: when the cell is nearly empty, skip the (costly)
          * render + panel refresh and sleep long so a low battery can't keep
-         * cycling the display down to a damaging voltage. */
-        int battery_pct = -1, battery_mv = 0; /* one sample decides the whole pass */
-        if (fos_battery_present()) fos_battery_read(&battery_mv, &battery_pct);
-        bool battery_critical = battery_pct >= 0 && battery_pct <= FOS_BATTERY_CRITICAL_PCT;
-        bool on_battery = battery_mv >= FOS_BATTERY_PRESENT_MV;
-        bool deep_sleep_now =
-            config->deep_sleep || (config->deep_sleep_on_battery && on_battery);
+         * cycling the display down to a damaging voltage. Two bursts a
+         * moment apart, the higher one wins (a radio burst can only sag a
+         * reading, never inflate it); fos_power_decide then weighs it
+         * against the state carried in RTC memory — see fos_power.h for the
+         * log this replays. */
+        int battery_pct = -1, battery_mv = 0;
+        if (fos_battery_present()) {
+            fos_battery_read(&battery_mv, &battery_pct);
+            vTaskDelay(pdMS_TO_TICKS(FOS_BATTERY_RESAMPLE_GAP_MS));
+            int again_mv = 0, again_pct = -1;
+            fos_battery_read(&again_mv, &again_pct);
+            if (again_mv > battery_mv) {
+                battery_mv = again_mv;
+                battery_pct = again_pct;
+            }
+        }
+        fos_power_input_t power_in = {
+            .mv = battery_mv,
+            .deep_sleep = config->deep_sleep,
+            .deep_sleep_on_battery = config->deep_sleep_on_battery,
+        };
+        fos_power_decision_t power;
+        fos_power_decide(&power_in, &s_power_state, &power);
+        bool battery_critical = power.critical;
+        bool deep_sleep_now = power.deep_sleep;
+        /* Say what this pass decided and from what: the one line that tells
+         * "deep sleep silently off" from "the owner switched it off". Only
+         * where it can say something — a stay-connected frame without a
+         * cell would just repeat "off" every interval. */
+        if (config->deep_sleep || config->deep_sleep_on_battery || power.suspect ||
+            power.critical) {
+            char line[256];
+            size_t used = (size_t)snprintf(
+                line, sizeof(line),
+                "{\"event\":\"power\",\"source\":\"esp32\",\"deepSleep\":\"%s\","
+                "\"onBattery\":%s,\"wakeCheckSeconds\":%lu",
+                !deep_sleep_now ? "off" : config->deep_sleep ? "always"
+                                  : battery_critical ? "critical" : "battery",
+                power.on_battery ? "true" : "false",
+                (unsigned long)config->wake_check_sec);
+            if (fos_battery_present() && used < sizeof(line) - 96) {
+                used += (size_t)snprintf(line + used, sizeof(line) - used,
+                                         ",\"batteryMillivolts\":%d,\"batteryPercent\":%d",
+                                         battery_mv, battery_pct);
+                if (power.mv_used != battery_mv) {
+                    used += (size_t)snprintf(line + used, sizeof(line) - used,
+                                             ",\"believedMillivolts\":%d", power.mv_used);
+                }
+            }
+            if (power.suspect && used < sizeof(line) - 24) {
+                used += (size_t)snprintf(line + used, sizeof(line) - used, ",\"suspect\":true");
+            }
+            if (used < sizeof(line) - 2) {
+                snprintf(line + used, sizeof(line) - used, "}");
+                frameos_nim_log_hook(line);
+            }
+        }
         /* A wake-check pass: this deep-sleeping frame woke early (or is held
          * awake) only to check the control plane for commands — the panel's
          * scheduled render is not due yet, so skip the costly refresh. An
          * explicit render signal always wins. */
         time_t wall_now = time(NULL);
         bool clock_ok = fos_wifi_time_synced() && wall_now > 1000000000;
-        bool checkin_pass = deep_sleep_now && config->wake_check_sec > 0 &&
-                            !force_render && clock_ok &&
+        /* Not gated on wake_check_seconds: a keep-awake hold (a verb that
+         * arrived as the pass ended) also lands here with the due date still
+         * ahead, and used to render the same scene a second time. */
+        bool checkin_pass = deep_sleep_now && !force_render && clock_ok &&
                             s_next_render_due > wall_now + 2 &&
                             /* a due date past the longest allowed interval is
                              * garbage (clock jump, stale RTC) — render */
@@ -1227,7 +1376,26 @@ static void client_task(void *arg)
         }
         ESP_LOGI(TAG, "next render in %lu s (interval %lu s)",
                  (unsigned long)sleep_s, (unsigned long)interval);
+        /* The next panel refresh is due at the end of this wait — whether the
+         * wait is a deep sleep (the RTC keeps it) or an awake hold cut short
+         * by a keep-awake, whose follow-up pass must then check in, not
+         * render again. */
+        s_next_render_due = clock_ok ? time(NULL) + (time_t)sleep_s : 0;
         uint32_t keep_awake_s = keep_awake_remaining_seconds();
+        if (deep_sleep_now && fos_display_present() && fos_cloud_asset_jobs_pending()) {
+            /* An image_get is queued or streaming (the provider fetches the
+             * frame's image on this pass's `render` announcement while
+             * someone is looking). A few seconds now beats an image that is
+             * never delivered. */
+            int64_t hold_end = esp_timer_get_time() +
+                               (int64_t)FOS_ASSET_SLEEP_HOLD_MAX_SEC * 1000000LL;
+            frameos_nim_log_hook("{\"event\":\"sleep:held\",\"source\":\"esp32\","
+                                 "\"reason\":\"image\"}");
+            while (fos_cloud_asset_jobs_pending() && esp_timer_get_time() < hold_end) {
+                vTaskDelay(pdMS_TO_TICKS(250));
+            }
+            keep_awake_s = keep_awake_remaining_seconds();
+        }
         if (deep_sleep_now && fos_display_present() && fos_ota_busy()) {
             /* See FOS_OTA_SLEEP_HOLD_MAX_SEC. Success reboots from inside the
              * OTA task; failure clears busy and we fall through to sleep. */
@@ -1272,7 +1440,6 @@ static void client_task(void *arg)
             if (config->wake_check_sec >= 60 && chunk > config->wake_check_sec) {
                 chunk = config->wake_check_sec;
             }
-            s_next_render_due = clock_ok ? time(NULL) + (time_t)sleep_s : 0;
             bool wake_check = chunk < sleep_s;
             ESP_LOGI(TAG, "deep sleeping for %lu s%s%s", (unsigned long)chunk,
                      config->wake_schedule ? " (wake-on-schedule)" : "",
@@ -1358,6 +1525,7 @@ void fos_client_start(void)
     if (s_events) return;
     s_events = xEventGroupCreate();
     s_snapshot_lock = xSemaphoreCreateMutex();
+    fos_framebuffer_set_lend_hook(snapshot_before_lend);
     if (!s_events || !s_snapshot_lock) {
         ESP_LOGE(TAG, "render task init failed: event group or snapshot lock unavailable");
         if (s_events) {

--- a/embedded/esp32/main/fos_client.h
+++ b/embedded/esp32/main/fos_client.h
@@ -52,3 +52,15 @@ bool fos_client_snapshot_info(int *width, int *height, fos_pixel_format_t *forma
 esp_err_t fos_client_snapshot_copy(uint8_t *out, size_t out_len, int *width, int *height,
                                    fos_pixel_format_t *format, uint32_t *render_count,
                                    int64_t *render_ms);
+/* Borrow the packed snapshot in place for a streaming reader (the cloud
+ * image_get, the HTTP preview): on true the snapshot lock is HELD until
+ * fos_client_snapshot_release(), and a render that needs the buffer waits
+ * for it (bounded) — keep the hold to the seconds it takes to stream. False
+ * when there is no snapshot or the lock stayed busy for timeout_ms. */
+bool fos_client_snapshot_acquire(uint32_t timeout_ms, const uint8_t **buf, int *width,
+                                 int *height, fos_pixel_format_t *format, size_t *len);
+void fos_client_snapshot_release(void);
+/* True while a render is still owed: this boot's first pass has not finished,
+ * or a render signal is queued. An image_get arriving now waits for it
+ * instead of answering "no image" seconds before there is one. */
+bool fos_client_render_pending(void);

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -1416,6 +1416,21 @@ bool fos_cloud_announce_sleep(uint32_t wake_in_seconds, int64_t next_render_at,
     return true;
 }
 
+bool fos_cloud_announce_render(const char *scene_id)
+{
+    if (!s_ws_client || !s_ws_ready) return false;
+    cJSON *msg = cJSON_CreateObject();
+    if (!msg) return false;
+    cJSON_AddStringToObject(msg, "type", "render");
+    cJSON_AddStringToObject(msg, "active_scene", scene_id ? scene_id : "");
+    /* No snapshot files on this profile: the image is the framebuffer,
+     * fetched with image_get. */
+    cJSON_AddStringToObject(msg, "image", "image_get");
+    ws_send_json(msg);
+    cJSON_Delete(msg);
+    return true;
+}
+
 static void ws_reboot_task(void *arg)
 {
     (void)arg;
@@ -1507,7 +1522,14 @@ typedef struct {
     size_t data_len;
     long long offset;                   /* asset_put_chunk: where the bytes land */
     bool complete;                      /* asset_put_chunk: last chunk, commit to `path` */
+    int64_t deadline_us;                /* image_get: how long to wait for a render */
 } asset_job_t;
+
+/* An image_get that arrives before this boot's first render has finished
+ * (a deep-sleep wake takes ~60 s to render; the provider's queued command
+ * lands at hello) waits for the render instead of answering no_image. */
+#define FOS_CLOUD_IMAGE_WAIT_MAX_US (150LL * 1000000LL)
+static volatile bool s_asset_job_running = false;
 
 /* asset_put_chunk: the assembled file's ceiling on the card. Chunks arrive
  * one WS frame each (so each is bounded by FOS_CLOUD_WS_MAX_MSG anyway); the
@@ -1623,73 +1645,128 @@ static void asset_job_run_get(const asset_job_t *job)
     fclose(file);
 }
 
-/* Stream one in-memory payload as asset_chunk frames (image_get). */
-static void asset_stream_buffer(const char *id, const uint8_t *data, size_t total,
-                                const char *content_type)
+/* image_get as asset_chunk frames straight off the packed snapshot: the BMP
+ * is built a row at a time into one chunk buffer (FOS_CLOUD_ASSET_CHUNK_BYTES)
+ * and sent as each fills. Nothing image-sized is allocated — the 8 MB E1004
+ * could never spare the 960 KB copy plus the 960 KB BMP the old path
+ * needed, and answered every image_get with no_image. */
+typedef struct {
+    const char *id;
+    uint8_t *raw;
+    size_t raw_len;
+    char *b64;
+    size_t b64_cap;
+    size_t total;
+    size_t sent;
+    int seq;
+    bool failed;
+} image_stream_t;
+
+static bool image_stream_flush(image_stream_t *st, bool done)
 {
-    size_t b64_cap = ((FOS_CLOUD_ASSET_CHUNK_BYTES + 2) / 3) * 4 + 8;
-    char *b64 = fos_big_malloc(b64_cap);
-    if (!b64) {
-        asset_chunk_send_error(id, "no_memory");
-        return;
+    if (st->failed) return false;
+    if (st->raw_len == 0 && !done) return true;
+    size_t b64_len = 0;
+    if (mbedtls_base64_encode((unsigned char *)st->b64, st->b64_cap, &b64_len,
+                              st->raw, st->raw_len) != 0) {
+        st->failed = true;
+        return false;
     }
-    size_t offset = 0;
-    int seq = 0;
-    do {
-        size_t chunk = total - offset;
-        if (chunk > FOS_CLOUD_ASSET_CHUNK_BYTES) chunk = FOS_CLOUD_ASSET_CHUNK_BYTES;
-        size_t b64_len = 0;
-        if (mbedtls_base64_encode((unsigned char *)b64, b64_cap, &b64_len,
-                                  data + offset, chunk) != 0) {
-            asset_chunk_send_error(id, "no_memory");
-            break;
-        }
-        b64[b64_len] = '\0';
-        offset += chunk;
-        bool done = offset >= total;
-        cJSON *msg = cJSON_CreateObject();
-        if (!msg) {
-            asset_chunk_send_error(id, "no_memory");
-            break;
-        }
-        if (id[0]) cJSON_AddStringToObject(msg, "id", id);
-        cJSON_AddStringToObject(msg, "type", "asset_chunk");
-        cJSON_AddNumberToObject(msg, "seq", seq);
-        cJSON_AddStringToObject(msg, "data", b64);
-        cJSON_AddBoolToObject(msg, "done", done);
-        if (seq == 0) {
-            cJSON_AddNumberToObject(msg, "size", (double)total);
-            cJSON_AddNumberToObject(msg, "mtime", (double)(esp_timer_get_time() / 1000000));
-            cJSON_AddStringToObject(msg, "content_type", content_type);
-        }
-        if (!s_ws_client || !s_ws_ready) {
-            cJSON_Delete(msg);
-            break;
-        }
-        ws_send_json(msg);
+    st->b64[b64_len] = '\0';
+    cJSON *msg = cJSON_CreateObject();
+    if (!msg) {
+        st->failed = true;
+        return false;
+    }
+    if (st->id[0]) cJSON_AddStringToObject(msg, "id", st->id);
+    cJSON_AddStringToObject(msg, "type", "asset_chunk");
+    cJSON_AddNumberToObject(msg, "seq", st->seq);
+    cJSON_AddStringToObject(msg, "data", st->b64);
+    cJSON_AddBoolToObject(msg, "done", done);
+    if (st->seq == 0) {
+        cJSON_AddNumberToObject(msg, "size", (double)st->total);
+        cJSON_AddNumberToObject(msg, "mtime", (double)(esp_timer_get_time() / 1000000));
+        cJSON_AddStringToObject(msg, "content_type", "image/bmp");
+    }
+    if (!s_ws_client || !s_ws_ready) {
         cJSON_Delete(msg);
-        seq++;
-        if (done) break;
-    } while (true);
-    free(b64);
+        st->failed = true;
+        return false;
+    }
+    ws_send_json(msg);
+    cJSON_Delete(msg);
+    st->seq++;
+    st->sent += st->raw_len;
+    st->raw_len = 0;
+    return true;
 }
 
-/* image_get: the current render, packed to BMP by the same path the USB
- * `usb_api image` command uses. Runs on the cloud task; the pack allocates
- * from PSRAM and is freed before the next job. */
-static void asset_job_run_image(const asset_job_t *job)
+static void image_stream_begin(void *ctx, size_t total)
 {
-    uint8_t *bmp = NULL;
-    size_t bmp_len = 0;
-    char scene_id[128] = "";
-    if (fos_http_preview_bmp_alloc(&bmp, &bmp_len, scene_id, sizeof(scene_id)) != ESP_OK ||
-        !bmp || bmp_len == 0) {
-        free(bmp);
-        asset_chunk_send_error(job->id, "no_image");
-        return;
+    ((image_stream_t *)ctx)->total = total;
+}
+
+static bool image_stream_write(void *ctx, const uint8_t *data, size_t len)
+{
+    image_stream_t *st = (image_stream_t *)ctx;
+    while (len > 0) {
+        size_t room = FOS_CLOUD_ASSET_CHUNK_BYTES - st->raw_len;
+        size_t take = len < room ? len : room;
+        memcpy(st->raw + st->raw_len, data, take);
+        st->raw_len += take;
+        data += take;
+        len -= take;
+        if (st->raw_len == FOS_CLOUD_ASSET_CHUNK_BYTES) {
+            bool done = st->sent + st->raw_len >= st->total;
+            if (!image_stream_flush(st, done)) return false;
+        }
     }
-    asset_stream_buffer(job->id, bmp, bmp_len, "image/bmp");
-    free(bmp);
+    return true;
+}
+
+/* Returns false when the job was deferred (re-queued by the caller). */
+static bool asset_job_run_image(const asset_job_t *job)
+{
+    int width = 0, height = 0;
+    fos_pixel_format_t format = FOS_PIXEL_1BPP;
+    size_t packed_len = 0;
+    if (!fos_client_snapshot_info(&width, &height, &format, &packed_len, NULL, NULL)) {
+        if (fos_client_render_pending() && esp_timer_get_time() < job->deadline_us) {
+            return false; /* the render this boot is about to produce it */
+        }
+        asset_chunk_send_error(job->id, "no_image");
+        return true;
+    }
+    image_stream_t st = {.id = job->id, .raw = NULL, .raw_len = 0, .b64 = NULL,
+                         .b64_cap = ((FOS_CLOUD_ASSET_CHUNK_BYTES + 2) / 3) * 4 + 8,
+                         .total = 0, .sent = 0, .seq = 0, .failed = false};
+    st.raw = fos_big_malloc(FOS_CLOUD_ASSET_CHUNK_BYTES);
+    st.b64 = fos_big_malloc(st.b64_cap);
+    if (!st.raw || !st.b64) {
+        free(st.raw);
+        free(st.b64);
+        asset_chunk_send_error(job->id, "no_memory");
+        return true;
+    }
+    static const fos_preview_sink_t sink = {
+        .begin = image_stream_begin,
+        .write = image_stream_write,
+    };
+    /* A render packing into the buffer holds the lock for ~10 s on the
+     * E1004; wait it out rather than answer no_image. */
+    esp_err_t err = fos_http_preview_bmp_stream(&sink, &st, 30000, NULL, 0);
+    if (err == ESP_OK && !st.failed) {
+        /* The tail: whatever the last full chunk left behind. */
+        if (st.sent < st.total) image_stream_flush(&st, true);
+    } else if (st.seq == 0) {
+        /* Nothing on the wire yet: an ordinary error frame. Mid-stream the
+         * provider discards the partial when the stream just stops. */
+        asset_chunk_send_error(job->id, err == ESP_ERR_NOT_FOUND ? "no_image"
+                                        : err == ESP_ERR_TIMEOUT ? "busy" : "failed");
+    }
+    free(st.raw);
+    free(st.b64);
+    return true;
 }
 
 /* Write verbs ack from the job (the ack carries the result), so the SPI
@@ -1789,9 +1866,21 @@ static bool ws_process_asset_jobs(void)
     while (s_ws_client && s_ws_ready &&
            xQueueReceive(s_asset_jobs, &job, 0) == pdTRUE) {
         const char *err = NULL;
+        s_asset_job_running = true;
         switch (job.kind) {
             case ASSET_JOB_LIST: asset_job_run_list(&job); break;
-            case ASSET_JOB_IMAGE: asset_job_run_image(&job); break;
+            case ASSET_JOB_IMAGE:
+                if (!asset_job_run_image(&job)) {
+                    /* Deferred until the render lands: back of the queue,
+                     * looked at again on the next 1 s tick (not now — with
+                     * one job queued that would spin). */
+                    s_asset_job_running = false;
+                    if (xQueueSendToBack(s_asset_jobs, &job, 0) != pdTRUE) {
+                        asset_chunk_send_error(job.id, "busy");
+                    }
+                    return worked;
+                }
+                break;
             case ASSET_JOB_GET: asset_job_run_get(&job); break;
             case ASSET_JOB_PUT:
                 asset_job_run_put(&job);
@@ -1813,9 +1902,16 @@ static bool ws_process_asset_jobs(void)
         }
         free(job.data);
         job.data = NULL;
+        s_asset_job_running = false;
         worked = true;
     }
     return worked;
+}
+
+bool fos_cloud_asset_jobs_pending(void)
+{
+    if (s_asset_job_running) return true;
+    return s_asset_jobs && uxQueueMessagesWaiting(s_asset_jobs) > 0;
 }
 
 /* Free the payloads of any jobs abandoned by a dropped session. The provider
@@ -1838,7 +1934,8 @@ static void ws_flush_asset_jobs(void)
 static void ws_handle_asset_verb(asset_job_kind_t kind, const cJSON *root, const cJSON *id)
 {
     asset_job_t job = { .kind = (uint8_t)kind, .id = "", .path = "", .dst = "",
-                        .data = NULL, .data_len = 0, .offset = 0, .complete = false };
+                        .data = NULL, .data_len = 0, .offset = 0, .complete = false,
+                        .deadline_us = esp_timer_get_time() + FOS_CLOUD_IMAGE_WAIT_MAX_US };
     bool ack_now = true; /* read verbs: bare ack, then reply frames */
     if (cJSON_IsString(id) && id->valuestring &&
         strlen(id->valuestring) < sizeof(job.id)) {
@@ -2178,6 +2275,15 @@ static void ws_handle_set_settings(const cJSON *root, const cJSON *id)
         }
     }
     fos_config_t *config = fos_config();
+    /* Snapshot to diff against once persisted: the `settings:cloud` line
+     * below is the device-side confirmation of what the push changed. One
+     * lazily allocated copy, reused (this handler runs on the WS task only):
+     * not the stack — the config carries token buffers — and not a per-call
+     * malloc that every validation `return` above would have to free. NULL
+     * just loses the detail. */
+    static fos_config_t *before = NULL;
+    if (!before) before = fos_big_malloc(sizeof(*before));
+    if (before) memcpy(before, config, sizeof(*before));
     const cJSON *interval = cJSON_GetObjectItem(settings, "interval");
     if (interval != NULL) {
         if (!cJSON_IsNumber(interval) || interval->valuedouble < 1 ||
@@ -2391,6 +2497,16 @@ static void ws_handle_set_settings(const cJSON *root, const cJSON *id)
     if (fos_config_save() != ESP_OK) {
         ws_ack(id, false, "persist_failed");
         return;
+    }
+    {
+        char changes[320] = "";
+        fos_settings_describe_changes(before, config, changes, sizeof(changes));
+        char line[400];
+        snprintf(line, sizeof(line),
+                 "{\"event\":\"settings:cloud\",\"source\":\"esp32\","
+                 "\"status\":\"applied\",\"changed\":\"%s\"}",
+                 changes);
+        frameos_nim_log_hook(line);
     }
     ws_ack(id, true, NULL);
     if (restart_for_init && !battery_changed && !rotate_changed) {

--- a/embedded/esp32/main/fos_cloud.h
+++ b/embedded/esp32/main/fos_cloud.h
@@ -64,6 +64,17 @@ bool fos_cloud_ws_connected(void);
  * before esp_deep_sleep. False when there is no live session. */
 bool fos_cloud_announce_sleep(uint32_t wake_in_seconds, int64_t next_render_at,
                               const char *reason, bool wake_check);
+/* Tell the provider the panel just got a fresh render of `scene_id` (the
+ * `render` message, docs/cloud-frames.md "Previews"). The provider decides
+ * whether anyone is looking and, if so, queues an `image_get` — this
+ * profile keeps no snapshot files, so the message says the image is to be
+ * fetched with image_get rather than asset_get. False without a session. */
+bool fos_cloud_announce_render(const char *scene_id);
+/* An asset job (an image_get streaming the frame's image, a card read or
+ * write) is queued or running on the cloud task. A deep sleep waits for
+ * these — bounded — so an image the provider asked for on this very pass is
+ * delivered before the CPU halts. */
+bool fos_cloud_asset_jobs_pending(void);
 /* Wait (up to timeout_ms) for every log line queued for the live session,
  * and the newest metrics sample, to be handed to the socket — the cloud task
  * batches both on a 1 s tick, so a caller about to halt the CPU has to give

--- a/embedded/esp32/main/fos_framebuffer.c
+++ b/embedded/esp32/main/fos_framebuffer.c
@@ -32,6 +32,7 @@ bool fos_framebuffer_should_reserve(size_t len, size_t psram_total, size_t inter
 static uint8_t *s_reserved;
 static size_t s_reserved_len;
 static SemaphoreHandle_t s_lock;
+static void (*s_lend_hook)(void);
 
 void fos_framebuffer_reserve(size_t len)
 {
@@ -90,6 +91,7 @@ uint8_t *fos_framebuffer_acquire(size_t len)
      * the twenty seconds an e-paper refresh takes. */
     if (s_reserved && len == s_reserved_len && s_lock &&
         xSemaphoreTake(s_lock, 0) == pdTRUE) {
+        if (s_lend_hook) s_lend_hook();
         return s_reserved;
     }
     uint8_t *buf = fos_big_malloc(len);
@@ -110,6 +112,16 @@ void fos_framebuffer_release(uint8_t *buf)
 size_t fos_framebuffer_reserved_bytes(void)
 {
     return s_reserved ? s_reserved_len : 0;
+}
+
+bool fos_framebuffer_is_reserved(const uint8_t *buf)
+{
+    return buf != NULL && buf == s_reserved;
+}
+
+void fos_framebuffer_set_lend_hook(void (*hook)(void))
+{
+    s_lend_hook = hook;
 }
 
 #endif /* ESP_PLATFORM */

--- a/embedded/esp32/main/fos_framebuffer.h
+++ b/embedded/esp32/main/fos_framebuffer.h
@@ -42,6 +42,14 @@ void fos_framebuffer_release(uint8_t *buf);
 /* Bytes held by the boot-time reservation, 0 when there is none. Reported in
  * the status JSON so "why did this render fail" is answerable from a log. */
 size_t fos_framebuffer_reserved_bytes(void);
+/* Is `buf` the reservation itself? Its bytes outlive a release: the last
+ * packed render stays readable in place until the next acquire, which is
+ * what lets the preview snapshot borrow it instead of copying 960 KB. */
+bool fos_framebuffer_is_reserved(const uint8_t *buf);
+/* Called on the acquiring task right before the reservation is lent out —
+ * the moment its previous contents stop being valid. fos_client.c uses it
+ * to drop a borrowed snapshot (after any in-flight preview stream). */
+void fos_framebuffer_set_lend_hook(void (*hook)(void));
 
 /* Reservation policy, split out so the host tests can pin it: always on
  * PSRAM boards; on PSRAM-less boards only when the buffer fits and enough

--- a/embedded/esp32/main/fos_http.c
+++ b/embedded/esp32/main/fos_http.c
@@ -978,29 +978,51 @@ static uint8_t preview_palette_index(const uint8_t *buf, int width, int height,
     }
 }
 
-esp_err_t fos_http_preview_bmp_alloc(uint8_t **out, size_t *out_len, char *scene_id, size_t scene_id_len)
+/* One BMP row (bottom-up order) of the snapshot, in scene orientation. */
+static void preview_bmp_row(const uint8_t *packed, int width, int height,
+                            fos_pixel_format_t format, int rotate, int out_width,
+                            int out_height, int y, uint16_t bit_count,
+                            uint8_t *row, size_t row_stride)
 {
-    if (out) *out = NULL;
-    if (out_len) *out_len = 0;
-    if (!out || !out_len) return ESP_ERR_INVALID_ARG;
+    memset(row, 0, row_stride);
+    for (int x = 0; x < out_width; x++) {
+        /* Scene (x,y) → the panel position the packer put it at (the
+         * same mapping embedded_main.panelCoords applies). */
+        int px = x, py = y;
+        switch (rotate) {
+            case 90: px = out_height - 1 - y; py = x; break;
+            case 180: px = out_width - 1 - x; py = out_height - 1 - y; break;
+            case 270: px = y; py = out_width - 1 - x; break;
+            default: break;
+        }
+        uint8_t index = preview_palette_index(packed, width, height, format, px, py);
+        if (bit_count == 1) {
+            if (index & 1u) row[(size_t)x >> 3] |= 0x80 >> (x & 7);
+        } else if (x & 1) {
+            row[(size_t)x >> 1] |= index & 0x0F;
+        } else {
+            row[(size_t)x >> 1] |= (index & 0x0F) << 4;
+        }
+    }
+}
 
+esp_err_t fos_http_preview_bmp_stream(const fos_preview_sink_t *sink, void *ctx,
+                                      uint32_t lock_timeout_ms,
+                                      char *scene_id, size_t scene_id_len)
+{
+    if (!sink || !sink->write) return ESP_ERR_INVALID_ARG;
     int width = 0, height = 0;
     fos_pixel_format_t format = FOS_PIXEL_1BPP;
     size_t packed_len = 0;
-    if (!fos_client_snapshot_info(&width, &height, &format, &packed_len, NULL, NULL)) {
+    const uint8_t *packed = NULL;
+    /* Is there anything at all? Cheap, and it tells NOT_FOUND from TIMEOUT. */
+    if (!fos_client_snapshot_info(&width, &height, &format, &packed_len, NULL, NULL) ||
+        width <= 0 || height <= 0 || packed_len == 0) {
         return ESP_ERR_NOT_FOUND;
     }
-    if (width <= 0 || height <= 0 || packed_len == 0) {
-        return ESP_ERR_NOT_FOUND;
-    }
-
-    uint8_t *packed = fos_big_malloc(packed_len);
-    if (!packed) packed = malloc(packed_len);
-    if (!packed) return ESP_ERR_NO_MEM;
-    esp_err_t err = fos_client_snapshot_copy(packed, packed_len, &width, &height, &format, NULL, NULL);
-    if (err != ESP_OK) {
-        free(packed);
-        return ESP_ERR_NOT_FOUND;
+    if (!fos_client_snapshot_acquire(lock_timeout_ms, &packed, &width, &height, &format,
+                                     &packed_len)) {
+        return ESP_ERR_TIMEOUT;
     }
 
     /* The packed snapshot is in PANEL orientation (the packers rotate while
@@ -1017,31 +1039,26 @@ esp_err_t fos_http_preview_bmp_alloc(uint8_t **out, size_t *out_len, char *scene
     size_t pixel_bytes = row_stride * (size_t)out_height;
     size_t palette_bytes = palette_entries * 4u;
     if (pixel_bytes > UINT32_MAX - 54u - palette_bytes) {
-        free(packed);
+        fos_client_snapshot_release();
         return ESP_ERR_INVALID_SIZE;
     }
     size_t bmp_len = 54u + palette_bytes + pixel_bytes;
-    uint8_t *bmp = fos_big_malloc(bmp_len);
-    if (!bmp) bmp = malloc(bmp_len);
-    if (!bmp) {
-        free(packed);
-        return ESP_ERR_NO_MEM;
-    }
-    memset(bmp, 0, bmp_len);
 
-    bmp[0] = 'B'; bmp[1] = 'M';
-    put_u32le(&bmp[2], (uint32_t)bmp_len);
-    put_u32le(&bmp[10], (uint32_t)(54u + palette_bytes));
-    put_u32le(&bmp[14], 40);
-    put_u32le(&bmp[18], (uint32_t)out_width);
-    put_u32le(&bmp[22], (uint32_t)out_height);
-    put_u16le(&bmp[26], 1);
-    put_u16le(&bmp[28], bit_count);
-    put_u32le(&bmp[34], (uint32_t)pixel_bytes);
-    put_u32le(&bmp[46], (uint32_t)palette_entries);
-    put_u32le(&bmp[50], (uint32_t)palette_entries);
+    uint8_t header[54u + 16u * 4u];
+    memset(header, 0, sizeof(header));
+    header[0] = 'B'; header[1] = 'M';
+    put_u32le(&header[2], (uint32_t)bmp_len);
+    put_u32le(&header[10], (uint32_t)(54u + palette_bytes));
+    put_u32le(&header[14], 40);
+    put_u32le(&header[18], (uint32_t)out_width);
+    put_u32le(&header[22], (uint32_t)out_height);
+    put_u16le(&header[26], 1);
+    put_u16le(&header[28], bit_count);
+    put_u32le(&header[34], (uint32_t)pixel_bytes);
+    put_u32le(&header[46], (uint32_t)palette_entries);
+    put_u32le(&header[50], (uint32_t)palette_entries);
 
-    uint8_t *palette = bmp + 54u;
+    uint8_t *palette = header + 54u;
     memset(palette, 255, palette_bytes);
     size_t colors = 0;
     const uint8_t *rgb = preview_palette(format, &colors);
@@ -1056,68 +1073,122 @@ esp_err_t fos_http_preview_bmp_alloc(uint8_t **out, size_t *out_len, char *scene
     if (scene_id && scene_id_len > 0) {
         current_scene_id(scene_id, scene_id_len);
     }
-    uint8_t *pixels = bmp + 54u + palette_bytes;
-    size_t row_index = 0;
-    for (int y = out_height - 1; y >= 0; y--) {
-        uint8_t *row = pixels + row_index * row_stride;
-        memset(row, 0, row_stride);
-        for (int x = 0; x < out_width; x++) {
-            /* Scene (x,y) → the panel position the packer put it at (the
-             * same mapping embedded_main.panelCoords applies). */
-            int px = x, py = y;
-            switch (rotate) {
-                case 90: px = out_height - 1 - y; py = x; break;
-                case 180: px = out_width - 1 - x; py = out_height - 1 - y; break;
-                case 270: px = y; py = out_width - 1 - x; break;
-                default: break;
-            }
-            uint8_t index = preview_palette_index(packed, width, height, format, px, py);
-            if (bit_count == 1) {
-                if (index & 1u) row[(size_t)x >> 3] |= 0x80 >> (x & 7);
-            } else if (x & 1) {
-                row[(size_t)x >> 1] |= index & 0x0F;
-            } else {
-                row[(size_t)x >> 1] |= (index & 0x0F) << 4;
-            }
-        }
-        row_index++;
-    }
 
-    free(packed);
-    *out = bmp;
-    *out_len = bmp_len;
+    uint8_t *row = malloc(row_stride);
+    if (!row) {
+        fos_client_snapshot_release();
+        return ESP_ERR_NO_MEM;
+    }
+    if (sink->begin) sink->begin(ctx, bmp_len);
+    bool ok = sink->write(ctx, header, 54u + palette_bytes);
+    for (int y = out_height - 1; ok && y >= 0; y--) {
+        preview_bmp_row(packed, width, height, format, rotate, out_width, out_height, y,
+                        bit_count, row, row_stride);
+        ok = sink->write(ctx, row, row_stride);
+    }
+    free(row);
+    fos_client_snapshot_release();
+    return ok ? ESP_OK : ESP_FAIL;
+}
+
+/* The whole BMP in one heap buffer, for callers that need it contiguous (the
+ * USB `usb_api image` reply). Built by the streaming path: the framebuffer
+ * itself is never copied. */
+typedef struct {
+    uint8_t *buf;
+    size_t cap;
+    size_t used;
+    bool failed;
+} preview_collect_t;
+
+static void preview_collect_begin(void *ctx, size_t total)
+{
+    preview_collect_t *c = (preview_collect_t *)ctx;
+    c->buf = fos_big_malloc(total);
+    if (!c->buf) c->buf = malloc(total);
+    c->cap = c->buf ? total : 0;
+    c->used = 0;
+    c->failed = c->buf == NULL;
+}
+
+static bool preview_collect_write(void *ctx, const uint8_t *data, size_t len)
+{
+    preview_collect_t *c = (preview_collect_t *)ctx;
+    if (!c->buf || c->used + len > c->cap) {
+        c->failed = true;
+        return false;
+    }
+    memcpy(c->buf + c->used, data, len);
+    c->used += len;
+    return true;
+}
+
+esp_err_t fos_http_preview_bmp_alloc(uint8_t **out, size_t *out_len, char *scene_id, size_t scene_id_len)
+{
+    if (out) *out = NULL;
+    if (out_len) *out_len = 0;
+    if (!out || !out_len) return ESP_ERR_INVALID_ARG;
+    preview_collect_t collect = {0};
+    static const fos_preview_sink_t sink = {
+        .begin = preview_collect_begin,
+        .write = preview_collect_write,
+    };
+    esp_err_t err = fos_http_preview_bmp_stream(&sink, &collect, 10000, scene_id, scene_id_len);
+    if (err == ESP_FAIL && collect.failed && !collect.buf) err = ESP_ERR_NO_MEM;
+    if (err != ESP_OK) {
+        free(collect.buf);
+        return err;
+    }
+    *out = collect.buf;
+    *out_len = collect.used;
     return ESP_OK;
+}
+
+/* httpd chunked send as a preview sink. */
+static bool preview_httpd_write(void *ctx, const uint8_t *data, size_t len)
+{
+    httpd_req_t *req = (httpd_req_t *)ctx;
+    return httpd_resp_send_chunk(req, (const char *)data, (ssize_t)len) == ESP_OK;
 }
 
 static esp_err_t preview_bmp_handler(httpd_req_t *req)
 {
     REQUIRE_PROTECTED_ACCESS();
 
-    uint8_t *bmp = NULL;
-    size_t bmp_len = 0;
     char scene_id[128];
     scene_id[0] = '\0';
-    esp_err_t err = fos_http_preview_bmp_alloc(&bmp, &bmp_len, scene_id, sizeof(scene_id));
-    if (err == ESP_ERR_NOT_FOUND) {
+    int width = 0, height = 0;
+    fos_pixel_format_t format = FOS_PIXEL_1BPP;
+    size_t packed_len = 0;
+    if (!fos_client_snapshot_info(&width, &height, &format, &packed_len, NULL, NULL)) {
         const char *reason = strcmp(fos_client_snapshot_mode(), "hash-only") == 0
             ? "panel image is rendered, but preview snapshot was not retained"
             : "no preview rendered yet";
         return httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, reason);
     }
-    if (err == ESP_ERR_INVALID_SIZE) {
-        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "preview too large");
-    }
-    if (err != ESP_OK) {
-        return httpd_resp_send_500(req);
-    }
+    /* Headers go out before the first chunk, so the scene id has to be read
+     * up front; the stream re-reads it under the lock (same value). */
+    current_scene_id(scene_id, sizeof(scene_id));
     httpd_resp_set_type(req, "image/bmp");
     httpd_resp_set_hdr(req, "Cache-Control", "no-store");
     if (scene_id[0]) {
         httpd_resp_set_hdr(req, "X-Scene-Id", scene_id);
     }
-    err = httpd_resp_send(req, (const char *)bmp, bmp_len);
-    free(bmp);
-    return err;
+    static const fos_preview_sink_t sink = { .begin = NULL, .write = preview_httpd_write };
+    esp_err_t err = fos_http_preview_bmp_stream(&sink, req, 10000, NULL, 0);
+    if (err == ESP_ERR_NOT_FOUND) {
+        return httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "no preview rendered yet");
+    }
+    if (err == ESP_ERR_TIMEOUT) {
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "preview busy (rendering)");
+    }
+    if (err == ESP_ERR_INVALID_SIZE) {
+        return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "preview too large");
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+    return httpd_resp_send_chunk(req, NULL, 0);
 }
 
 static esp_err_t setup_post_handler(httpd_req_t *req)

--- a/embedded/esp32/main/fos_http.h
+++ b/embedded/esp32/main/fos_http.h
@@ -39,3 +39,19 @@ typedef struct {
 
 void fos_http_collect_storage_info(fos_storage_info_t *info);
 esp_err_t fos_http_preview_bmp_alloc(uint8_t **out, size_t *out_len, char *scene_id, size_t scene_id_len);
+
+/* The same BMP, streamed: `begin` is called once with the total byte count,
+ * then `write` with the header, the palette and each pixel row (bottom-up,
+ * BMP order) until the image is complete. A `write` returning false aborts
+ * the stream (ESP_FAIL). Reads the packed snapshot in place under its lock
+ * — no copy of the framebuffer, no whole-image buffer — which is what lets
+ * an 8 MB board with a 960 KB panel serve a preview at all. ESP_ERR_NOT_FOUND
+ * when nothing is rendered; ESP_ERR_TIMEOUT when the snapshot stayed locked
+ * (a render packing into it) for `lock_timeout_ms`. */
+typedef struct {
+    void (*begin)(void *ctx, size_t total);
+    bool (*write)(void *ctx, const uint8_t *data, size_t len);
+} fos_preview_sink_t;
+esp_err_t fos_http_preview_bmp_stream(const fos_preview_sink_t *sink, void *ctx,
+                                      uint32_t lock_timeout_ms,
+                                      char *scene_id, size_t scene_id_len);

--- a/embedded/esp32/main/fos_power.c
+++ b/embedded/esp32/main/fos_power.c
@@ -1,0 +1,77 @@
+#include "fos_power.h"
+
+#include <string.h>
+
+static uint8_t bump(uint8_t streak)
+{
+    return streak < 255 ? (uint8_t)(streak + 1) : streak;
+}
+
+void fos_power_decide(const fos_power_input_t *in, fos_power_state_t *state,
+                      fos_power_decision_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    int mv = in->mv > 0 ? in->mv : 0;
+    bool seen_cell = state->last_good_mv >= FOS_POWER_PRESENT_MV;
+
+    if (mv >= FOS_POWER_PRESENT_MV) {
+        state->low_streak = 0;
+        bool implausible = seen_cell &&
+                           mv < state->last_good_mv - FOS_POWER_GLITCH_DROP_MV;
+        if (implausible) {
+            /* Believe the drop only once it repeats: a single burst that
+             * reads 0.6 V low is the ADC, not the cell. Until then the
+             * decision runs on the last believed value. */
+            state->drop_streak = bump(state->drop_streak);
+            if (state->drop_streak >= FOS_POWER_CONFIRM_PASSES) {
+                state->drop_streak = 0;
+                state->last_good_mv = mv;
+            } else {
+                out->suspect = true;
+            }
+        } else {
+            state->drop_streak = 0;
+            state->last_good_mv = mv;
+        }
+        out->mv_used = state->last_good_mv;
+        out->on_battery = true;
+    } else {
+        /* Below the presence threshold (or no reading at all). A cell that
+         * was there a pass ago does not vanish for one burst; it is gone
+         * once the reading repeats. */
+        state->low_streak = bump(state->low_streak);
+        state->drop_streak = 0;
+        if (seen_cell && state->low_streak < FOS_POWER_CONFIRM_PASSES) {
+            out->on_battery = true;
+            out->suspect = true;
+            out->mv_used = state->last_good_mv;
+        } else {
+            out->on_battery = false;
+            out->mv_used = mv;
+            if (state->low_streak >= FOS_POWER_CONFIRM_PASSES) {
+                state->last_good_mv = 0; /* start over when a cell returns */
+            }
+        }
+    }
+
+    /* Critical: the believed value, two passes running. A suspect pass never
+     * counts toward it (its own reading was just disbelieved), and a pass
+     * without a cell cannot be critical. */
+    bool critical_now = out->on_battery && !out->suspect &&
+                        out->mv_used > 0 && out->mv_used <= FOS_POWER_CRITICAL_MV;
+    if (critical_now) {
+        state->critical_streak = bump(state->critical_streak);
+    } else {
+        state->critical_streak = 0;
+    }
+    out->critical = state->critical_streak >= FOS_POWER_CONFIRM_PASSES;
+    if (critical_now && !out->critical) {
+        out->suspect = true; /* first critical read: render, but say so */
+    }
+
+    /* A critical cell is a battery by definition, so deep_sleep_on_battery
+     * sleeps on it even when the presence test above was lost — the whole
+     * point of the critical branch is to stop spending the cell. */
+    out->deep_sleep = in->deep_sleep ||
+                      (in->deep_sleep_on_battery && (out->on_battery || out->critical));
+}

--- a/embedded/esp32/main/fos_power.h
+++ b/embedded/esp32/main/fos_power.h
@@ -1,0 +1,74 @@
+/*
+ * The pass-start power decision: does this pass deep sleep, and is the cell
+ * critical? Pure arithmetic on purpose — no IDF, no ADC — so
+ * main/tests/test_fos_power.c can argue with it on a laptop. fos_client.c
+ * feeds it the pass's battery reading plus the state it keeps in RTC memory
+ * across deep sleeps, and writes the updated state back.
+ *
+ * Why a decision needs state at all: the battery read is one 16-sample ADC
+ * burst, and a single burst has been seen reporting 0 % on a cell that read
+ * 3932 mV seventy seconds later (E1004, 2026-08-27). Before this module that
+ * one reading did two things at once — it parked the frame in the six-hour
+ * "critical" sleep, and, because a sub-2.5 V reading also means "no cell",
+ * it switched deep sleep OFF for the pass, so the "protect the cell" branch
+ * sat awake with the radio on for nine hours. Now:
+ *
+ *  - a cell that has been seen stays "present" through one implausible
+ *    reading (two consecutive sub-threshold reads clear it);
+ *  - "critical" needs two consecutive passes of critical readings;
+ *  - a critical cell IS a battery, so deep_sleep_on_battery sleeps on it
+ *    whatever the presence test said.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* A cell reading at least this many mV counts as "running on battery" for
+ * deep_sleep_on_battery. It is the best power-source signal we have: no
+ * supported board wires VBUS to a readable pin (the PhotoPainter's AXP2101
+ * could tell, but nothing reads its status registers yet). A plugged-in,
+ * charging frame passes this too — acceptable, deep sleeping while charging
+ * costs nothing. */
+#define FOS_POWER_PRESENT_MV 2500
+/* Below this the cell is nearly empty (about 3 % on fos_battery.c's
+ * discharge curve): skip the render + panel refresh and sleep long, so a low
+ * battery cannot keep cycling the display down to a damaging voltage. */
+#define FOS_POWER_CRITICAL_MV 3200
+/* A reading this far below the last believed one, inside one pass interval,
+ * is a sensor glitch until it repeats: a resting Li-ion cell does not lose
+ * 0.6 V between two wakes. */
+#define FOS_POWER_GLITCH_DROP_MV 600
+/* Consecutive passes a doubtful reading has to repeat before it is believed:
+ * for "no cell", for "critical", and for a large drop. */
+#define FOS_POWER_CONFIRM_PASSES 2
+
+/* What survives between passes (RTC memory on the device: zeroed on a
+ * power-on reset, kept through deep sleep). All zero = never read a cell. */
+typedef struct {
+    int last_good_mv;         /* last believed reading, 0 = none yet */
+    uint8_t low_streak;       /* consecutive passes reading below PRESENT */
+    uint8_t critical_streak;  /* consecutive passes reading below CRITICAL */
+    uint8_t drop_streak;      /* consecutive passes with an implausible drop */
+} fos_power_state_t;
+
+typedef struct {
+    int mv;                       /* this pass's reading; 0 = no reading */
+    bool deep_sleep;              /* config: always deep sleep */
+    bool deep_sleep_on_battery;   /* config: deep sleep while a cell is present */
+} fos_power_input_t;
+
+typedef struct {
+    int mv_used;        /* the millivolts the decision believed */
+    bool on_battery;    /* a cell is present (deep_sleep_on_battery's test) */
+    bool critical;      /* skip the render, sleep FOS_BATTERY_CRITICAL_SLEEP_SEC */
+    bool deep_sleep;    /* this pass ends in esp_deep_sleep */
+    bool suspect;       /* the reading was overridden or is awaiting confirmation */
+} fos_power_decision_t;
+
+/* Decide the pass from the reading and the carried state; `state` is
+ * updated in place for the next pass. `in` may carry mv == 0 for a frame
+ * without battery sensing: then on_battery and critical are false, and only
+ * `deep_sleep` (the always-on flag) can sleep. */
+void fos_power_decide(const fos_power_input_t *in, fos_power_state_t *state,
+                      fos_power_decision_t *out);

--- a/embedded/esp32/main/fos_settings.c
+++ b/embedded/esp32/main/fos_settings.c
@@ -321,6 +321,18 @@ static void log_settings_event(const char *status, const char *detail)
     frameos_nim_log_hook(line);
 }
 
+/* `applied` with what changed: the owner toggling deep sleep in the cloud
+ * used to leave no trace on the device beyond a bare "applied". */
+static void log_settings_applied(const char *detail, const char *changed)
+{
+    char line[512];
+    snprintf(line, sizeof(line),
+             "{\"event\":\"settings:sync\",\"source\":\"esp32\","
+             "\"status\":\"applied\",\"detail\":\"%s\",\"changed\":\"%s\"}",
+             detail ? detail : "", changed ? changed : "");
+    frameos_nim_log_hook(line);
+}
+
 /* Read at most `limit` bytes of the response body. Returns a NUL-terminated
  * malloc'd buffer (caller frees) or NULL. */
 static char *read_body(esp_http_client_handle_t client, int64_t content_length,
@@ -493,11 +505,93 @@ static bool apply_frame_settings(const cJSON *frame)
 static void log_settings_exit(const char *why)
 {
     /* Once per boot per reason would be ideal; once per pass is acceptable
-     * noise for a sync that should never silently die again. */
+     * noise for a sync that should never silently die again. NULL = the sync
+     * is going ahead: re-arm the guard, log nothing (this used to log a
+     * `skipped` with an empty detail two seconds before every `fetched`). */
     static const char *s_last_why = NULL;
     if (why == s_last_why) return;
     s_last_why = why;
-    log_settings_event("skipped", why);
+    if (why) log_settings_event("skipped", why);
+}
+
+/* Append "key=value" to a comma-separated list. */
+static void change_append(char *out, size_t out_len, const char *key, const char *value)
+{
+    size_t used = strlen(out);
+    if (used >= out_len) return;
+    snprintf(out + used, out_len - used, "%s%s=%s", used ? "," : "", key, value);
+}
+
+static void change_append_int(char *out, size_t out_len, const char *key, long value)
+{
+    char buf[24];
+    snprintf(buf, sizeof(buf), "%ld", value);
+    change_append(out, out_len, key, buf);
+}
+
+void fos_settings_describe_changes(const fos_config_t *before, const fos_config_t *after,
+                                   char *out, size_t out_len)
+{
+    if (!out || out_len == 0) return;
+    out[0] = '\0';
+    if (!before || !after) return;
+    if (before->interval_sec != after->interval_sec) {
+        change_append_int(out, out_len, "interval", (long)after->interval_sec);
+    }
+    if (strcmp(before->hostname, after->hostname) != 0) {
+        change_append(out, out_len, "name", after->hostname);
+    }
+    if (before->render_mode != after->render_mode) {
+        change_append(out, out_len, "render_mode",
+                      after->render_mode == FOS_RENDER_REMOTE ? "remote" : "local");
+    }
+    if (before->rotate != after->rotate) {
+        change_append_int(out, out_len, "rotate", (long)after->rotate);
+    }
+    if (strcmp(before->scaling_mode, after->scaling_mode) != 0) {
+        change_append(out, out_len, "scaling_mode", after->scaling_mode);
+    }
+    if (strcmp(before->time_zone, after->time_zone) != 0) {
+        change_append(out, out_len, "timezone", after->time_zone);
+    }
+    if (before->deep_sleep != after->deep_sleep) {
+        change_append(out, out_len, "deep_sleep", after->deep_sleep ? "true" : "false");
+    }
+    if (before->deep_sleep_on_battery != after->deep_sleep_on_battery) {
+        change_append(out, out_len, "deep_sleep_on_battery",
+                      after->deep_sleep_on_battery ? "true" : "false");
+    }
+    if (before->wake_schedule != after->wake_schedule) {
+        change_append(out, out_len, "wake_schedule", after->wake_schedule ? "true" : "false");
+    }
+    if (before->wake_check_sec != after->wake_check_sec) {
+        change_append_int(out, out_len, "wake_check_seconds", (long)after->wake_check_sec);
+    }
+    if (before->battery_pin != after->battery_pin) {
+        change_append_int(out, out_len, "battery_pin", (long)after->battery_pin);
+    }
+    if (before->battery_divider != after->battery_divider) {
+        char buf[24];
+        snprintf(buf, sizeof(buf), "%.2f", (double)after->battery_divider);
+        change_append(out, out_len, "battery_divider", buf);
+    }
+    if (before->battery_enable_pin != after->battery_enable_pin) {
+        change_append_int(out, out_len, "battery_enable_pin", (long)after->battery_enable_pin);
+    }
+    if (before->debug_logging != after->debug_logging) {
+        change_append(out, out_len, "debug", after->debug_logging ? "true" : "false");
+    }
+    if (before->max_http_response_bytes != after->max_http_response_bytes) {
+        change_append_int(out, out_len, "max_http_response_bytes",
+                          (long)after->max_http_response_bytes);
+    }
+    char buttons_before[FOS_GPIO_BUTTONS_SPEC_LEN];
+    char buttons_after[FOS_GPIO_BUTTONS_SPEC_LEN];
+    fos_config_format_gpio_buttons(before, buttons_before, sizeof(buttons_before));
+    fos_config_format_gpio_buttons(after, buttons_after, sizeof(buttons_after));
+    if (strcmp(buttons_before, buttons_after) != 0) {
+        change_append_int(out, out_len, "gpio_buttons", (long)after->gpio_button_count);
+    }
 }
 
 /* Pick the payload source and fill in its URL + Authorization value.
@@ -681,6 +775,10 @@ esp_err_t fos_settings_sync(bool force)
      * carries neither (the provider pushes them as set_settings/set_schedule
      * verbs), so these lookups simply miss on a cloud payload. */
     const cJSON *frame = cJSON_GetObjectItem(root, "frame");
+    /* A copy to diff against for the `applied` line; heap, not stack — the
+     * config carries the token buffers. NULL just loses the detail. */
+    fos_config_t *before = cJSON_IsObject(frame) ? malloc(sizeof(*before)) : NULL;
+    if (before) memcpy(before, config, sizeof(*before));
     bool changed = cJSON_IsObject(frame) ? apply_frame_settings(frame) : false;
     const cJSON *offset = cJSON_IsObject(frame)
                               ? cJSON_GetObjectItem(frame, "utcOffsetMinutes")
@@ -702,14 +800,18 @@ esp_err_t fos_settings_sync(bool force)
 
     if (changed) {
         if (fos_config_save() != ESP_OK) {
+            free(before);
             log_settings_event("error", "persist-failed");
             return ESP_FAIL;
         }
-        log_settings_event("applied", s_restart_after_apply ? "restarting" : "");
+        char changes[320] = "";
+        fos_settings_describe_changes(before, config, changes, sizeof(changes));
+        log_settings_applied(s_restart_after_apply ? "restarting" : "", changes);
         ESP_LOGI(TAG, "settings applied from backend (interval=%lu render_mode=%d rotate=%u scaling=%s)",
                  (unsigned long)config->interval_sec, (int)config->render_mode,
                  (unsigned)config->rotate, config->scaling_mode);
     }
+    free(before);
     if (response_etag[0]) {
         strlcpy(s_etag, response_etag, sizeof(s_etag));
     }

--- a/embedded/esp32/main/fos_settings.h
+++ b/embedded/esp32/main/fos_settings.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "esp_err.h"
+#include "fos_config.h"
 
 /* Pull declarative settings and apply them without a rebuild. Runs on the
  * render task, next to the scenes sync, ETag'd against one of two sources:
@@ -17,6 +19,12 @@
  * Both feed frameos_nim_apply_service_settings, which replaces the groups the
  * payload carries and deletes the ones it does not. */
 esp_err_t fos_settings_sync(bool force);
+/* Which declarative settings differ between two config snapshots, as the
+ * wire's snake_case keys with their new values ("deep_sleep_on_battery=false,
+ * interval=900"), for the log line that confirms what a settings push or
+ * poll actually changed on the device. Empty string when nothing did. */
+void fos_settings_describe_changes(const fos_config_t *before, const fos_config_t *after,
+                                   char *out, size_t out_len);
 void fos_settings_request_sync(void);
 
 /* A cloud session reached `ready`. Pass whether its scopes list contained

--- a/embedded/esp32/main/fos_wifi.c
+++ b/embedded/esp32/main/fos_wifi.c
@@ -1,6 +1,7 @@
 #include "fos_wifi.h"
 
 #include <string.h>
+#include <sys/time.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
@@ -342,9 +343,20 @@ int fos_wifi_rssi(void)
     return 0;
 }
 
+/* SNTP keeps polling in the background after the boot-time wait; a pool
+ * that answered late used to leave s_time_synced false for the whole boot —
+ * hub-stamped logs, no wake-check schedule, no wall-clock alignment — even
+ * though the clock had long been set (12 h of it on an awake E1004). */
+static void on_sntp_synced(struct timeval *tv)
+{
+    (void)tv;
+    s_time_synced = true;
+}
+
 esp_err_t fos_wifi_sync_time(uint32_t timeout_ms)
 {
     esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+    config.sync_cb = on_sntp_synced;
     esp_err_t err = esp_netif_sntp_init(&config);
     if (err != ESP_OK) return err;
     /* Back from deep sleep with the RTC still counting: the clock is the

--- a/embedded/esp32/main/tests/test_fos_power.c
+++ b/embedded/esp32/main/tests/test_fos_power.c
@@ -1,0 +1,166 @@
+/*
+ * Host tests for the pass-start power decision (fos_power.c). No IDF, no
+ * mocks: the file is pure arithmetic on purpose, so a laptop compiler can
+ * check it.
+ *
+ * Build and run (from embedded/esp32/):
+ *
+ *   cc -std=c11 -Wall -Wextra -Werror -O2 -Imain \
+ *      main/fos_power.c main/tests/test_fos_power.c \
+ *      -o /tmp/test_fos_power && /tmp/test_fos_power
+ *
+ * (backend/app/tasks/tests/test_esp32_power.py does exactly that in CI.)
+ *
+ * The cases replay a real log: a reTerminal E1004 on battery whose
+ * pass-start ADC burst read "0 %" seconds before its post-render sample
+ * read 3932 mV, and which then sat awake for nine hours because that one
+ * reading both parked it in the critical sleep and told it there was no
+ * cell to sleep on.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "fos_power.h"
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond, ...)                                                       \
+    do {                                                                       \
+        g_checks++;                                                            \
+        if (!(cond)) {                                                         \
+            g_failures++;                                                      \
+            printf("FAIL %s:%d: ", __func__, __LINE__);                        \
+            printf(__VA_ARGS__);                                               \
+            printf("\n");                                                      \
+        }                                                                      \
+    } while (0)
+
+static fos_power_decision_t decide(fos_power_state_t *state, int mv, bool on_battery_flag)
+{
+    fos_power_input_t in = {.mv = mv, .deep_sleep = false,
+                            .deep_sleep_on_battery = on_battery_flag};
+    fos_power_decision_t out;
+    fos_power_decide(&in, state, &out);
+    return out;
+}
+
+static void test_healthy_cell_sleeps_every_pass(void)
+{
+    fos_power_state_t state;
+    memset(&state, 0, sizeof(state));
+    const int readings[] = {4164, 4150, 4070, 4052, 4036};
+    for (size_t i = 0; i < sizeof(readings) / sizeof(readings[0]); i++) {
+        fos_power_decision_t d = decide(&state, readings[i], true);
+        CHECK(d.on_battery, "pass %zu: %d mV is a cell", i, readings[i]);
+        CHECK(d.deep_sleep, "pass %zu: deep_sleep_on_battery sleeps", i);
+        CHECK(!d.critical && !d.suspect, "pass %zu: nothing odd about %d mV", i, readings[i]);
+        CHECK(d.mv_used == readings[i], "pass %zu: believed as read", i);
+    }
+    CHECK(state.last_good_mv == 4036, "state carries the last believed reading");
+}
+
+static void test_one_glitch_does_not_switch_deep_sleep_off(void)
+{
+    /* The 2026-08-27 log: 4036 mV a pass ago, one burst reads far too low. */
+    fos_power_state_t state;
+    memset(&state, 0, sizeof(state));
+    decide(&state, 4036, true);
+    fos_power_decision_t d = decide(&state, 1900, true);
+    CHECK(d.on_battery, "a cell seen a pass ago is still there through one bad burst");
+    CHECK(d.deep_sleep, "...so the pass still deep sleeps");
+    CHECK(d.suspect, "...and the log says the reading was disbelieved");
+    CHECK(!d.critical, "a disbelieved reading is never critical");
+    CHECK(d.mv_used == 4036, "the decision ran on the last believed value");
+    /* A reading of exactly 0 (ADC returned nothing) is the same case. */
+    fos_power_state_t again;
+    memset(&again, 0, sizeof(again));
+    decide(&again, 3932, true);
+    d = decide(&again, 0, true);
+    CHECK(d.on_battery && d.deep_sleep && d.suspect, "an empty read is a glitch too");
+}
+
+static void test_two_low_reads_mean_no_cell(void)
+{
+    fos_power_state_t state;
+    memset(&state, 0, sizeof(state));
+    decide(&state, 4000, true);
+    decide(&state, 100, true);
+    fos_power_decision_t d = decide(&state, 100, true);
+    CHECK(!d.on_battery, "the second sub-threshold read is believed");
+    CHECK(!d.deep_sleep, "deep_sleep_on_battery has nothing to sleep on");
+    CHECK(!d.suspect, "nothing was overridden");
+    CHECK(state.last_good_mv == 0, "the carried reading is cleared");
+    /* The cell comes back: believed immediately (no drop to disbelieve). */
+    d = decide(&state, 3900, true);
+    CHECK(d.on_battery && d.deep_sleep && !d.suspect, "a returning cell counts at once");
+}
+
+static void test_never_seen_a_cell(void)
+{
+    fos_power_state_t state;
+    memset(&state, 0, sizeof(state));
+    fos_power_decision_t d = decide(&state, 0, true);
+    CHECK(!d.on_battery && !d.deep_sleep && !d.critical && !d.suspect,
+          "no sensing, no cell, no sleep, nothing suspect");
+    fos_power_input_t always = {.mv = 0, .deep_sleep = true, .deep_sleep_on_battery = false};
+    fos_power_decision_t out;
+    fos_power_decide(&always, &state, &out);
+    CHECK(out.deep_sleep, "deep_sleep=always sleeps without a battery");
+}
+
+static void test_critical_needs_two_passes_and_still_sleeps(void)
+{
+    fos_power_state_t state;
+    memset(&state, 0, sizeof(state));
+    decide(&state, 3400, true);
+    fos_power_decision_t d = decide(&state, 3150, true);
+    CHECK(!d.critical, "the first critical read renders normally");
+    CHECK(d.suspect, "...but is flagged");
+    CHECK(d.deep_sleep, "...and sleeps");
+    d = decide(&state, 3120, true);
+    CHECK(d.critical, "the second consecutive critical read is believed");
+    CHECK(d.on_battery, "a 3.1 V cell is present");
+    CHECK(d.deep_sleep, "the critical branch deep sleeps");
+    /* Even when the presence test is lost the same pass (a cell so flat it
+     * reads below 2.5 V twice), deep_sleep_on_battery still sleeps on
+     * critical — the whole point is to stop spending the cell. */
+    fos_power_state_t flat;
+    memset(&flat, 0, sizeof(flat));
+    decide(&flat, 3150, true);
+    decide(&flat, 3100, true);
+    d = decide(&flat, 3050, true);
+    CHECK(d.critical && d.deep_sleep, "a flat cell keeps sleeping");
+    /* A recovering reading clears the streak. */
+    d = decide(&flat, 3900, true);
+    CHECK(!d.critical, "charged again: not critical");
+}
+
+static void test_big_drop_is_believed_on_repeat(void)
+{
+    fos_power_state_t state;
+    memset(&state, 0, sizeof(state));
+    decide(&state, 4100, true);
+    fos_power_decision_t d = decide(&state, 3300, true);
+    CHECK(d.suspect && d.mv_used == 4100, "an 0.8 V drop in one pass is doubted first");
+    CHECK(d.on_battery && d.deep_sleep, "...without changing the sleep decision");
+    d = decide(&state, 3280, true);
+    CHECK(!d.suspect && d.mv_used == 3280, "the repeat is believed");
+    CHECK(state.last_good_mv == 3280, "and carried forward");
+    /* A small drop is never doubted. */
+    d = decide(&state, 3260, true);
+    CHECK(!d.suspect, "20 mV between passes is ordinary");
+}
+
+int main(void)
+{
+    test_healthy_cell_sleeps_every_pass();
+    test_one_glitch_does_not_switch_deep_sleep_off();
+    test_two_low_reads_mean_no_cell();
+    test_never_seen_a_cell();
+    test_critical_needs_two_passes_and_still_sleeps();
+    test_big_drop_is_believed_on_repeat();
+    printf("%s: %d checks, %d failures\n", g_failures ? "FAILED" : "ok",
+           g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Follow-ups from the 2026-08-26 → 08-28 log of a reTerminal E1004 on battery (frame 92bef0f7, 15-minute Weather scene, `deep_sleep_on_battery`), reviewed after #405 shipped in 2026.8.42. Four things the log showed that #405 did not cover, one of which is why the frame's cloud image "hasn't updated in days".

## Firmware

**A bad ADC burst switched deep sleep off for nine hours.** On 08-27 23:42 the pass-start battery read said `battery:0%` while the post-render sample in the same second said 3932 mV. That one reading did two things at once: it parked the frame in the six-hour "critical" sleep, and — because a sub-2.5 V reading also means "no cell" — it turned `deep_sleep_on_battery` OFF for the pass, so the "protect the cell" branch sat awake with the radio on. Awake costs ~46 mV/h on this cell vs ~4.4 mV/h in 15-minute cycles.
- New `fos_power.c/h`: the pass-start decision as pure arithmetic, host-tested (`main/tests/test_fos_power.c`, run by `backend/app/tasks/tests/test_esp32_power.py` like the wake tests). Two ADC bursts 60 ms apart (the higher wins — a radio burst can only sag a reading); a cell seen a pass ago survives one implausible read (two consecutive sub-threshold reads mean "no cell"); "critical" takes two consecutive passes below 3.2 V; a critical cell always deep sleeps under `deep_sleep_on_battery`. State lives in RTC memory.
- Every deep-sleep/battery pass logs a `power` line: `deepSleep` (`battery`/`always`/`critical`/`off`), `onBattery`, `wakeCheckSeconds`, millivolts read and, when they differ, believed (`suspect: true`). "Deep sleep silently off" and "the owner switched it off" are now told apart.

**No trace when the owner changes a power setting** (Marius toggled the mode by hand on 08-27 and the log said nothing). `settings:sync … applied` now carries `changed: "deep_sleep_on_battery=false,…"` (`fos_settings_describe_changes`), and a cloud `set_settings` push logs `settings:cloud applied changed=…`. The spurious `settings:sync skipped detail:""` two seconds before every `fetched` is gone.

**SNTP flag stuck false for a whole boot.** `s_time_synced` was set once from the 10 s boot wait; a pool that answered late left the frame "unsynced" for 12 h (every log line hub-stamped, no wake-check schedule, no wall-clock alignment). The sync callback now sets it too.

**A keep-awake hold at the end of a pass rendered the same scene again.** Any verb arriving as a pass ends (a settings push, the hub's image fetch) armed the 15 s hold; the follow-up pass then rendered + refreshed a second time because the render due date was only kept in the deep-sleep branch and the check-in path was gated on `wake_check_seconds`. The due date is now kept for every wait, so the follow-up pass checks in and sleeps until it. A non-deep-sleep reset (OTA, OOM restart, power-on) clears the RTC due date so the first pass renders.

**The frame's image could never be fetched.** Serial capture on .42: `preview snapshot kept as hash only: need 960000 bytes, psram free=1785420 largest=1081344` — the E1004 never afforded the 960 KB copy, so every `image_get` answered `no_image`. The snapshot now borrows the boot-time framebuffer reservation (the bytes stay put until the next borrower; `fos_framebuffer_is_reserved` + a lend hook invalidates it), and the BMP is built a row at a time (`fos_http_preview_bmp_stream`, sink API) into one 24 KiB chunk for `image_get`, chunked for the HTTP preview, collected only for `usb_api image`. Nothing image-sized is allocated any more. An `image_get` that lands at `hello` — before the wake's render exists — waits for it (≤150 s) instead of answering `no_image`, and the deep sleep holds (≤45 s, `sleep:held reason:image`) while the stream is still going out. The device also sends the `render` announcement now, with `image: "image_get"` (no snapshot files on this profile).

## Cloud

- `image_get` / `asset_get` queued for a sleeping frame carried a 2-minute TTL and expired every 15-minute sleep. `commandTtlForFrame` (`frame-sleep.ts`, unit-tested) stretches it past the frame's announced `next_wake_at`; the image route no longer long-polls a frame that is asleep.
- The hub queues an `image_get` on a `render` that says `image: "image_get"`, and counts a page opened while the frame slept as "still looking" (watch window + the frame's last announced sleep, in-memory).
- docs/cloud-frames.md (`render` row, Previews) and the ESP32 README updated.

## Verification

- Host: `test_fos_power` 47 checks; backend pytest runners; auth-web vitest (1129) + tsc + eslint; frame-hub tsc + eslint.
- Firmware builds for the 8 MB layout (3,270,208 B, 90.7% of the slot).
- Hardware (E1004 over USB, app flashed into the running OTA slot): three boots captured over the CH340 console.
  - Wake 13:49 UTC: `power` line at pass start (`deepSleep: battery, onBattery: true, 3986 mV, 78%`); a console `status` armed the 3-min keep-awake; `usb_api image` after `render:done` returned a 960,118-byte 4-bpp BMP that decodes to the live Weather render (previously always "no preview rendered yet" on this board); the pass after the hold was `render:skipped reason: wake_check`, not a second render + refresh.
  - Final build's first boot (`wakeCause: power_on`): `power` line → render → unchanged framebuffer → `sleep wakeInSeconds: 866`; 40 s uptime.
  - Not exercised on hardware: the cloud side (`render` → hub `image_get`, the sleep-aware TTLs) — prod still runs the old hub, so the frame's `render` announcement is ignored there until this deploys; and the critical/glitch branches of `fos_power` (host-tested only).

Not touched: the double `cloud:session_ready` on ~27% of wakes (≈18 s of awake time each) — .42's `previousClose` on `session_ready` will name the close code first; and the Weather scene's PSRAM dip to 117 KB free during scene init (emergency reserve on every render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYyGKyyyFrZCf2C7TM5Kge
