### PR TITLE
JS apps: import the app's own .ts/.tsx/.js/.jsx/.json files

### DIFF
--- a/cloud/apps/auth-web/src/lib/ai/app-chat.ts
+++ b/cloud/apps/auth-web/src/lib/ai/app-chat.ts
@@ -91,8 +91,10 @@ export function buildAppChatInstructions(): string {
 You are the FrameOS Cloud assistant, helping with the source of ONE app inside a FrameOS scene.
 
 A FrameOS app is a small TypeScript/JavaScript module that runs in QuickJS on the frame itself. Its files
-are typically config.json (name, category, fields, output) and app.ts (the code). Apps receive their
-declared fields as inputs and either render onto the shared canvas or return a value other nodes consume.
+are config.json (name, category, fields, output), app.ts (the entry module the runtime calls), and
+optionally helper .ts/.tsx/.js/.jsx and .json files that app.ts imports with relative paths
+(import { x } from "./helper", import data from "./data.json"). Apps receive their declared fields as
+inputs and either render onto the shared canvas or return a value other nodes consume.
 
 You can do exactly two things:
 - Answer questions about this app's code and configuration. Reply in prose; be concrete and quote the
@@ -104,8 +106,9 @@ You can do exactly two things:
 Rules for edits:
 - Keep the existing file layout and the app's declared fields unless the user asks to change them; if you
   change a field, update config.json in the same call.
-- The runtime is QuickJS, not Node: no require/import of npm packages, no filesystem, no DOM. Use the
-  ambient FrameOS helpers already visible in the app's own source.
+- The runtime is QuickJS, not Node: no npm packages, no require(), no filesystem, no DOM. Relative
+  imports of the app's own files are fine (and you may add a file by writing it through the tool);
+  JSX only in .tsx/.jsx. Use the ambient FrameOS helpers already visible in the app's own source.
 - Keep it TypeScript-shaped and readable; match the surrounding style.
 - If the request is ambiguous, ask one question instead of guessing at a rewrite.
 

--- a/cloud/apps/auth-web/src/lib/ai/prompts.ts
+++ b/cloud/apps/auth-web/src/lib/ai/prompts.ts
@@ -65,6 +65,11 @@ Rules:
   the API reference (frameos.fetchJson, frameos.fetchText, frameos.svg, frameos.image, ...), but NOT
   format/now/parseTs and NOT the scene's state — pass what they need through their fields. Their Date
   is UTC-only; feed local time in from a code node or data/clock field when the app needs it.
+- An app's sources may hold more than app.ts: helper .ts/.tsx/.js/.jsx files and .json data files
+  (e.g. "icons.tsx", "lib/format.ts", "data.json"), imported with relative paths — import { x } from
+  "./lib/format", import data from "./data.json". Only the app's own files resolve; there are no npm
+  packages. JSX is only lowered in .tsx/.jsx files. Split an app when app.ts grows past a few hundred
+  lines or when data (lookup tables, icon SVG strings) would swamp the code.
 - app.frame.width / app.frame.height / app.frame.timeZone are ALWAYS set in a JS app (the frame's real
   size, also in previews): size full-screen output from them directly, without "fallback" size fields
   or "|| 800" guesses. Explicit width/height fields are only for an app that must draw into a sub-area

--- a/cloud/apps/auth-web/src/lib/ai/scene-lint.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/scene-lint.test.ts
@@ -335,6 +335,49 @@ describe("lintScenes", () => {
     expect(messages([app]).errors).toEqual([expect.stringContaining("JS apps have no format()/now()/parseTs()")]);
   });
 
+  it("lets a scene-local app import its own files, and nothing else", () => {
+    const withApp = (sources: Record<string, string>) =>
+      scene({
+        apps: {
+          multi: {
+            category: "data",
+            fields: [],
+            name: "Multi-file app",
+            output: [{ name: "out", type: "string" }],
+            sources,
+          },
+        },
+        edges: [
+          { id: "e1", source: "ev", sourceHandle: "next", target: "text", targetHandle: "prev", type: "appNodeEdge" },
+          { id: "e2", source: "my", sourceHandle: "fieldOutput", target: "text", targetHandle: "fieldInput/text", type: "codeNodeEdge" },
+        ],
+        nodes: [
+          { data: { keyword: "render" }, id: "ev", type: "event" },
+          { data: { config: {}, keyword: "render/text" }, id: "text", type: "app" },
+          { data: { config: {}, keyword: "multi" }, id: "my", type: "app" },
+        ],
+      });
+
+    // Helpers are not held to the get() contract, and ./, ../ and .json resolve like on the frame.
+    const fine = withApp({
+      "app.ts": "import { label } from './lib/util'\nimport data from './data.json'\nexport function get() { return label(data.name) }",
+      "lib/util.ts": "import { prefix } from '../prefix.js'\nexport const label = (name: string) => prefix + name",
+      "prefix.ts": "export const prefix = '> '",
+      "data.json": '{"name": "frame"}',
+      "config.json": "{}",
+    });
+    expect(messages([fine]).errors).toEqual([]);
+
+    const broken = withApp({
+      "app.ts": "import dayjs from 'dayjs'\nimport { x } from './missing'\nexport function get() { return x }",
+      "config.json": "{}",
+    });
+    expect(messages([broken]).errors).toEqual([
+      expect.stringContaining('Scene app "multi" (app.ts): imports "dayjs" — npm packages are not available'),
+      expect.stringContaining('Scene app "multi" (app.ts): imports "./missing", but the app has no such file'),
+    ]);
+  });
+
   it("rejects code nodes that claim to output an image", () => {
     const { errors } = messages([
       scene({

--- a/cloud/apps/auth-web/src/lib/ai/scene-lint.ts
+++ b/cloud/apps/auth-web/src/lib/ai/scene-lint.ts
@@ -303,6 +303,67 @@ export function lintCodeNodeJs(code: string, argNames: string[] = []): string[] 
 
 // JS apps run in the app sandbox: frameos.* helpers exist, the code-node time
 // helpers do not.
+const mainAppSourceFile = /^app\.(ts|tsx|js|jsx)$/;
+const importableAppFile = /\.(ts|tsx|js|jsx|json)$/;
+const importExtensions = [".ts", ".tsx", ".js", ".jsx", ".json"];
+// `import x from '…'`, `import { a } from '…'`, `import '…'`, `export { a } from '…'`.
+const importSpecifierPattern = /^\s*(?:import|export)\b[^'"\n]*?\bfrom\s*['"]([^'"\n]+)['"]|^\s*import\s*['"]([^'"\n]+)['"]/gm;
+
+export function importSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(importSpecifierPattern)) {
+    const specifier = match[1] ?? match[2];
+    if (specifier) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
+
+/** Mirrors the frame's loader: `./`/`../` relative to the importing file, then the usual extensions. */
+export function resolveAppImport(fromFile: string, specifier: string, files: string[]): string | undefined {
+  if (!specifier.startsWith(".")) {
+    return undefined;
+  }
+  const parts = fromFile.split("/").slice(0, -1);
+  for (const segment of specifier.split("/")) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+    if (segment === ".." && parts.length > 0 && parts[parts.length - 1] !== "..") {
+      parts.pop();
+    } else {
+      parts.push(segment);
+    }
+  }
+  const joined = parts.join("/");
+  const candidates = [joined, ...importExtensions.map((ext) => joined + ext)];
+  if (joined.endsWith(".js")) {
+    candidates.push(joined.slice(0, -3) + ".ts", joined.slice(0, -3) + ".tsx");
+  } else if (joined.endsWith(".jsx")) {
+    candidates.push(joined.slice(0, -4) + ".tsx");
+  }
+  return candidates.find((candidate) => files.includes(candidate));
+}
+
+/** Import problems in one of an app's files: npm packages, or files the app does not have. */
+export function lintAppImports(file: string, source: string, files: string[]): string[] {
+  const problems: string[] = [];
+  const importable = files.filter((name) => importableAppFile.test(name));
+  for (const specifier of importSpecifiers(source)) {
+    if (!specifier.startsWith(".")) {
+      problems.push(
+        `imports "${specifier}" — npm packages are not available on a frame; an app can only import its own files (import { x } from "./helper", import data from "./data.json").`,
+      );
+    } else if (!resolveAppImport(file, specifier, importable)) {
+      problems.push(
+        `imports "${specifier}", but the app has no such file (its files: ${importable.join(", ") || "none"}). Add it to sources or fix the path.`,
+      );
+    }
+  }
+  return problems;
+}
+
 export function lintJsAppSource(source: string, category?: string): string[] {
   const problems: string[] = [];
   const exportsFn = (name: string) =>
@@ -460,11 +521,15 @@ export function lintScene(
         }
       }
       const sources = obj(obj(raw)?.sources) ?? {};
+      const fileNames = Object.keys(sources);
       for (const [file, content] of Object.entries(sources)) {
         if (typeof content !== "string" || !/\.(ts|js|tsx|jsx)$/.test(file)) {
           continue;
         }
-        for (const problem of [...lintJsAppSource(content, str(obj(raw)?.category)), ...lintSvgMarkup(content)]) {
+        // Only the main module must export get(); helpers export whatever
+        // app.ts imports from them.
+        const contract = mainAppSourceFile.test(file) ? lintJsAppSource(content, str(obj(raw)?.category)) : [];
+        for (const problem of [...contract, ...lintAppImports(file, content, fileNames), ...lintSvgMarkup(content)]) {
           push("error", `Scene app "${keyword}" (${file}): ${problem}`);
         }
         const fixed = hardcodedCanvasSize(content);

--- a/cloud/apps/auth-web/src/lib/ai/tools.ts
+++ b/cloud/apps/auth-web/src/lib/ai/tools.ts
@@ -572,7 +572,8 @@ export const toolDefinitions: ResponsesToolDefinition[] = [
           type: "array",
         },
         file: {
-          description: 'File name inside the app\'s sources, e.g. "app.ts" or "config.json". Omit for a code node.',
+          description:
+            'File name inside the app\'s sources, e.g. "app.ts", "config.json", or a helper like "lib/util.ts". Omit for a code node.',
           type: "string",
         },
         node_id: { description: "Node id (for node-level sources or a code node).", type: "string" },

--- a/docs/js-apps-and-code-nodes.md
+++ b/docs/js-apps-and-code-nodes.md
@@ -81,6 +81,31 @@ App nodes then use `keyword: "myPanel"`. Inside `app.ts` the app sees
 node helpers (`format`, `now`, `parseTs`); pass such values in through fields.
 `Date` is UTC-only here as well.
 
+### More than one file
+
+`sources` can hold helper modules and data next to `app.ts`, and `app.ts`
+imports them with relative paths:
+
+```json
+"sources": {
+  "config.json": "…",
+  "app.ts": "import { panel } from './panel'\nimport icons from './icons.json'\nexport function get(app) { return panel(app, icons) }",
+  "panel.tsx": "export const panel = (app, icons) => <image width={app.frame.width} … />",
+  "icons.json": "{ \"sun\": \"<svg …>\" }"
+}
+```
+
+- `./name` resolves to `name.ts`, `name.tsx`, `name.js`, `name.jsx` or
+  `name.json` (also `./name.js` for a `name.ts`, as TypeScript allows);
+  `../` climbs folders inside the app (`lib/util.ts` → `../data.json`).
+- A `.json` file's parsed value is its default export.
+- JSX is lowered only in `.tsx`/`.jsx` files; `import { x, type T }` erases
+  the type specifier.
+- Only the app's own files resolve. There are no npm packages, no
+  `require()`, and no dynamic `import()`.
+- Each file is evaluated once per app, however many files import it, and
+  errors name the file and line they came from (`util.ts:5`).
+
 ### The export that runs
 
 | category | export the runtime calls | how the node is wired |

--- a/frameos/src/frameos/js_runtime/README.md
+++ b/frameos/src/frameos/js_runtime/README.md
@@ -133,10 +133,41 @@ uses QuickJS only to execute the resulting JavaScript.
   - `getSetting(...path)`: read `frameConfig.settings` values (API keys etc.);
     only namespaces listed in the app config's `"settings"` array are
     accessible, so access travels visibly with the scene JSON.
+- Installs a QuickJS module loader so the main module can `import` the app's
+  other files (see Module Loading below).
 - Calls exported app lifecycle functions such as `init` and `get`.
 - Tracks persistent and transient image references so overwritten dynamic image
   fields can be released.
 - Maps app runtime errors through the same compact source-location mechanism.
+
+## Module Loading
+
+An app's `sources` map is the whole module graph. `app_runtime.nim` evaluates
+the main file (`app.ts`, `.tsx`, `.js` or `.jsx`) as a real ES module under
+its own file name and registers a normalize/loader pair on the QuickJS
+runtime (`burrito.setModuleLoader`):
+
+- `jsAppModuleNormalize` joins `./` and `../` specifiers against the importing
+  module's folder (`joinModulePath`, QuickJS's own rule) and canonicalises
+  the result to the file it names (`resolveAppModule`: as written, then
+  `.ts/.tsx/.js/.jsx/.json`, then `./x.js` → `x.ts`). Canonical names are
+  what QuickJS keys loaded modules by, so a file evaluates once however many
+  importers spell its path differently.
+- `jsAppModuleLoader` transpiles a script file (TypeScript erased, JSX only for
+  `.tsx`/`.jsx`) and compiles it with `JS_EVAL_FLAG_COMPILE_ONLY`; a `.json`
+  file becomes a synthetic C module whose default export is the parsed value.
+  Transpiled output is kept per file, like the main module's, so an evicted
+  and re-created interpreter does not transpile again.
+- Bare specifiers and files the app does not have fail with a ReferenceError
+  that says so; compile and JSON errors are re-thrown with the file name and
+  position in the message.
+- Every loaded file registers its own lazy line map under its file name, so
+  runtime stacks read `util.ts:5:3` in source lines. `rewriteQuickJsLocations`
+  matches names at path boundaries only (`util.ts:` never matches inside
+  `lib/util.ts:`).
+
+There is no package registry, no `require()`, and no dynamic `import()` (the
+app runtime is synchronous and does not pump the job queue).
 
 ## Native Transpiler Policy
 
@@ -146,7 +177,8 @@ or snippets, then preserve the rest for QuickJS.
 
 The current transform set is:
 
-- TypeScript erasure for common annotations, type-only declarations/imports,
+- TypeScript erasure for common annotations, type-only declarations/imports
+  (including inline `import { a, type B }` specifiers),
   interfaces, type aliases, assertions, `satisfies`, non-null assertions,
   modifiers, overloads, `declare`, abstract members, generics, constructor
   parameter properties, and enums.

--- a/frameos/src/frameos/js_runtime/app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/app_runtime.nim
@@ -15,10 +15,31 @@ import frameos/utils/system
 import frameos/js_runtime/burrito
 
 type
+  JsAppModule = ref object
+    ## One of the app's other files, loaded because something imported it.
+    ## Keeps the same transpiled output the main module keeps, for the same
+    ## reason: re-creating the interpreter must not re-transpile. The source
+    ## itself is not copied here; it is read from the runtime's `sources`.
+    name: string
+    allowJsx: bool
+    transpiled: bool
+    transpiledCode: string
+    map: SourceLineMap
+    mapBuilt: bool
+
   JsAppRuntime* = ref object
     category*: string
     outputType*: string
     source*: string
+    ## The main module's file name (app.ts, app.tsx, ...). Imports resolve
+    ## relative to it, and error locations name it.
+    sourceName*: string
+    ## Every file of the app by name, as the scene JSON carries it — the pool
+    ## `import './x'` draws from. Held as the JsonNode rather than copied out:
+    ## on a frame the scene keeps these strings alive anyway, and a second
+    ## copy of every helper file is memory an ESP32 does not have.
+    sources*: JsonNode
+    modules: Table[string, JsAppModule]
     ## Only .tsx/.jsx sources get the JSX transform, as in TypeScript itself.
     allowJsx*: bool
     settingsKeys*: seq[string]
@@ -47,6 +68,9 @@ type
     contextImageJson: JsonNode
 
 var jsAppEnvByCtx = initTable[ptr JSContext, JsAppEvalEnv]()
+## The runtime behind each live interpreter, for the module loader: QuickJS
+## hands the loader a context, and the app's files live on the runtime.
+var jsAppRuntimeByCtx = initTable[ptr JSContext, JsAppRuntime]()
 
 proc teardownJsRuntime(runtime: JsAppRuntime) =
   ## Close one JS app node's interpreter. Not embedded-only: JsAppRuntime has
@@ -57,6 +81,8 @@ proc teardownJsRuntime(runtime: JsAppRuntime) =
   if not runtime.js.context.isNil:
     if jsAppEnvByCtx.hasKey(runtime.js.context):
       jsAppEnvByCtx.del(runtime.js.context)
+    if jsAppRuntimeByCtx.hasKey(runtime.js.context):
+      jsAppRuntimeByCtx.del(runtime.js.context)
     # The transpiler's source map is held in a global keyed by context, and
     # for a large app it is a bigger object than the QuickJS runtime itself.
     # Dropping the runtime without this recovers only the interpreter.
@@ -728,13 +754,20 @@ proc jsGetAppKeys(ctx: ptr JSContext, scope: JSValue): JSValue {.nimcall.} =
   return jsonToJS(ctx, arr)
 
 proc newJsAppRuntime*(category: string, outputType: string, source: string,
-    settingsKeys: seq[string] = @[], sourceName: string = ""): JsAppRuntime =
+    settingsKeys: seq[string] = @[], sourceName: string = "",
+    sources: JsonNode = nil): JsAppRuntime =
+  ## `sources` is the app's file map (name → contents) that `source` may
+  ## import from; `sourceName` names the main module among them.
   when defined(memProbe): memProbe("  NEW JsAppRuntime " & category & " src=" & $source.len & "B")
+  let mainName = if sourceName.len > 0: sourceName else: "app.ts"
   return JsAppRuntime(
     category: category,
     outputType: outputType,
     source: source,
-    allowJsx: sourceName.endsWith(".tsx") or sourceName.endsWith(".jsx"),
+    sourceName: mainName,
+    sources: sources,
+    modules: initTable[string, JsAppModule](),
+    allowJsx: mainName.endsWith(".tsx") or mainName.endsWith(".jsx"),
     settingsKeys: settingsKeys,
     nextImageId: 0,
     images: initTable[int, Image](),
@@ -763,6 +796,192 @@ proc sourceMapForRuntime(runtime: JsAppRuntime): SourceLineMap {.gcsafe, raises:
     runtime.transpiledMap = emptySourceLineMap(runtime.transpiledName, runtime.transpiledName)
   runtime.transpiledMapBuilt = true
   runtime.transpiledMap
+
+proc appFile(runtime: JsAppRuntime, name: string): string =
+  ## Contents of one of the app's files, "" when absent.
+  if runtime.sources.isNil or runtime.sources.kind != JObject:
+    return ""
+  runtime.sources{name}.getStr("")
+
+proc hasAppFile(sources: JsonNode, name: string): bool =
+  not sources.isNil and sources.kind == JObject and sources.hasKey(name) and
+    sources[name].kind == JString
+
+proc sourceMapForModule(runtime: JsAppRuntime, module: JsAppModule): SourceLineMap {.gcsafe, raises: [].} =
+  ## An imported file's line map, built lazily like the main module's.
+  if module.mapBuilt:
+    return module.map
+  try:
+    module.map = lineBasedSourceLineMap(runtime.appFile(module.name), module.transpiledCode,
+                                        module.name, module.name)
+  except CatchableError, Defect:
+    module.map = emptySourceLineMap(module.name, module.name)
+  module.mapBuilt = true
+  module.map
+
+const JsAppModuleExtensions = [".ts", ".tsx", ".js", ".jsx", ".json"]
+
+proc resolveAppModule*(sources: JsonNode, name: string): string =
+  ## The file an import specifier names, or "" when the app has no such file.
+  ## `name` is already joined against the importer (`./util` from app.ts is
+  ## `util`; from lib/a.ts it is `lib/util`). Tries the name as written, then
+  ## the usual extensions, then the TypeScript convention of spelling
+  ## `./util.js` for a file that is really `util.ts`.
+  if name.len == 0:
+    return ""
+  if sources.hasAppFile(name):
+    return name
+  for ext in JsAppModuleExtensions:
+    if sources.hasAppFile(name & ext):
+      return name & ext
+  if name.endsWith(".js"):
+    let stem = name[0 ..< name.len - 3]
+    for ext in [".ts", ".tsx"]:
+      if sources.hasAppFile(stem & ext):
+        return stem & ext
+  elif name.endsWith(".jsx"):
+    let stem = name[0 ..< name.len - 4]
+    if sources.hasAppFile(stem & ".tsx"):
+      return stem & ".tsx"
+  ""
+
+proc resolveModuleName(runtime: JsAppRuntime, name: string): string =
+  ## `resolveAppModule` over this app's files, where the main module counts
+  ## as a file too (a helper may import `./app` back; QuickJS then finds the
+  ## already-loaded module under that name instead of asking for it again).
+  if name == runtime.sourceName:
+    return name
+  for ext in JsAppModuleExtensions:
+    if name & ext == runtime.sourceName:
+      return runtime.sourceName
+  resolveAppModule(runtime.sources, name)
+
+proc joinModulePath*(baseName, name: string): string =
+  ## QuickJS's own rule, in Nim: a specifier starting with `.` is taken relative
+  ## to the importing module's folder (`./util` in lib/a.ts is lib/util), and
+  ## anything else is left as written. A `..` that climbs above the app stays
+  ## in the result, so the error can show what was asked for.
+  if name.len == 0 or name[0] != '.':
+    return name
+  var parts: seq[string] = @[]
+  let slash = baseName.rfind('/')
+  if slash > 0:
+    for part in baseName[0 ..< slash].split('/'):
+      if part.len > 0:
+        parts.add(part)
+  for segment in name.split('/'):
+    if segment.len == 0 or segment == ".":
+      continue
+    if segment == ".." and parts.len > 0 and parts[^1] != "..":
+      discard parts.pop()
+    else:
+      parts.add(segment)
+  parts.join("/")
+
+proc jsAppModuleNormalize(ctx: ptr JSContext, baseName: cstring, name: cstring,
+                          opaque: pointer): cstring {.cdecl.} =
+  ## Canonicalise every specifier to the file it names, so `./counter` and
+  ## `./counter.ts` from two importers are one module, evaluated once.
+  var canonical = ""
+  try:
+    canonical = joinModulePath($baseName, $name)
+    let runtime = jsAppRuntimeByCtx.getOrDefault(ctx)
+    if not runtime.isNil:
+      let resolved = runtime.resolveModuleName(canonical)
+      if resolved.len > 0:
+        canonical = resolved
+  except CatchableError:
+    canonical = $name
+  js_strdup(ctx, canonical.cstring)
+
+proc rethrowNamingModule(ctx: ptr JSContext, name: string) =
+  ## QuickJS's compile and JSON errors carry the location only in `stack`;
+  ## the message alone ("expecting '}'") would leave the author guessing
+  ## which of the app's files it means. Re-throw with the file and position
+  ## in the message, where the app's error log will show it.
+  let exception = JS_GetException(ctx)
+  defer: JS_FreeValue(ctx, exception)
+  var text = toNimString(ctx, exception)
+  var location = ""
+  if jsIsObject(exception):
+    let stackVal = JS_GetPropertyStr(ctx, exception, "stack")
+    defer: JS_FreeValue(ctx, stackVal)
+    location = toNimString(ctx, stackVal).strip()
+    if location.contains('\n'):
+      location = location.split('\n')[0].strip()
+    if location.startsWith("at "):
+      location = location[3 .. ^1]
+    if location == "undefined":
+      location = ""
+  if not text.contains(name):
+    text = name & ": " & text
+  if location.len > 0 and not text.contains(location):
+    text.add(" (" & location & ")")
+  discard JS_ThrowSyntaxError(ctx, "%s", text.cstring)
+
+proc jsAppJsonModuleInit(ctx: ptr JSContext, m: ptr JSModuleDef): cint {.cdecl.} =
+  ## `import data from './x.json'`: the parsed value is the default export.
+  discard JS_SetModuleExport(ctx, m, "default", JS_GetModulePrivateValue(ctx, m))
+  0
+
+proc loadAppJsonModule(ctx: ptr JSContext, name: string, text: string): ptr JSModuleDef =
+  let parsed = JS_ParseJSON(ctx, text.cstring, text.len.csize_t, name.cstring)
+  if JS_IsException(parsed) != 0:
+    rethrowNamingModule(ctx, name)
+    return nil
+  result = JS_NewCModule(ctx, name.cstring, jsAppJsonModuleInit)
+  if result == nil:
+    JS_FreeValue(ctx, parsed)
+    return nil
+  discard JS_AddModuleExport(ctx, result, "default")
+  discard JS_SetModulePrivateValue(ctx, result, parsed)
+
+proc loadAppScriptModule(ctx: ptr JSContext, runtime: JsAppRuntime, name: string): ptr JSModuleDef =
+  var module = runtime.modules.getOrDefault(name)
+  if module.isNil:
+    module = JsAppModule(name: name, allowJsx: name.endsWith(".tsx") or name.endsWith(".jsx"))
+    runtime.modules[name] = module
+  if not module.transpiled:
+    try:
+      module.transpiledCode = transpileAppSource(runtime.appFile(name), name, module.allowJsx)
+    except CatchableError as error:
+      discard JS_ThrowSyntaxError(ctx, "%s", (name & ": " & error.msg).cstring)
+      return nil
+    module.transpiled = true
+  let loaded = module
+  registerJsSourceMapProvider(ctx, name,
+    proc(): SourceLineMap {.closure, gcsafe, raises: [].} = runtime.sourceMapForModule(loaded))
+  result = compileModule(ctx, module.transpiledCode, name)
+  if result == nil:
+    rethrowNamingModule(ctx, name)
+
+proc jsAppModuleLoader(ctx: ptr JSContext, moduleName: cstring, opaque: pointer): ptr JSModuleDef {.cdecl.} =
+  ## QuickJS calls this for every `import` the app's modules make. Modules are
+  ## the app's own files and nothing else: there is no package registry on a
+  ## frame, so a bare specifier fails the same way a missing file does.
+  let name = $moduleName
+  try:
+    let runtime = jsAppRuntimeByCtx.getOrDefault(ctx)
+    if runtime.isNil:
+      discard JS_ThrowReferenceError(ctx, "could not load module '%s'", name.cstring)
+      return nil
+    let resolved = resolveAppModule(runtime.sources, name)
+    if resolved.len == 0:
+      discard JS_ThrowReferenceError(ctx, "%s",
+        ("Cannot import '" & name & "': it is not one of this app's files. Import the app's own " &
+         "files with a relative path (./helper, ./data.json); npm packages are not available.").cstring)
+      return nil
+    if resolved.endsWith(".json"):
+      return loadAppJsonModule(ctx, resolved, runtime.appFile(resolved))
+    return loadAppScriptModule(ctx, runtime, resolved)
+  except CatchableError as error:
+    discard JS_ThrowInternalError(ctx, "%s", ("Could not load module '" & name & "': " & error.msg).cstring)
+    return nil
+
+proc mapAppErrorText(runtime: JsAppRuntime, ctx: ptr JSContext, text: string): string =
+  ## Rewrite locations in the main module, then in any imported module whose
+  ## map was registered while it loaded.
+  mapJsErrorText(ctx, text.mapJsErrorText(runtime.sourceMapForRuntime()))
 
 proc storeImageJson(runtime: JsAppRuntime, image: Image): JsonNode =
   if image.isNil:
@@ -923,7 +1142,7 @@ proc initDynamicJsApp*(keyword: string, node: DiagramNode, scene: FrameScene, so
       if key.kind == JString and key.getStr().len > 0:
         settingsKeys.add(key.getStr())
   let runtime = newJsAppRuntime(category, outputType, source, settingsKeys,
-                                jsAppSourceNameFromSources(sources))
+                                jsAppSourceNameFromSources(sources), sources)
   return DynamicJsApp(
     nodeId: node.id,
     nodeName: node.data{"name"}.getStr(keyword),
@@ -984,6 +1203,8 @@ proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig) =
   when defined(memProbe): memProbe("    newQuickJS BEFORE")
   runtime.js = newQuickJS(sceneJsConfig(frameConfig))
   when defined(memProbe): memProbe("    newQuickJS AFTER")
+  jsAppRuntimeByCtx[runtime.js.context] = runtime
+  runtime.js.setModuleLoader(jsAppModuleLoader, jsAppModuleNormalize)
   runtime.js.registerFunction("jsAppLog", jsAppLog)
   runtime.js.registerFunction("jsSetNextSleep", jsSetNextSleep)
   runtime.js.registerFunction("jsSetState", jsSetState)
@@ -1094,7 +1315,9 @@ proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig) =
       : undefined;
   }
   """ & sceneJsPrelude)
-  let filename = "<frameos:app:" & runtime.category & ":" & runtime.outputType & ">"
+  # Named after the real file so `./helper` resolves beside it and error
+  # locations read `app.ts:12:3`.
+  let filename = runtime.sourceName
   if not runtime.transpiled:
     when defined(memProbe): memProbe("      prelude done, transpile src=" & $runtime.source.len & "B BEFORE")
     # Erase types and stop: the module form goes to QuickJS as-is, and no line
@@ -1128,9 +1351,9 @@ proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig) =
       try:
         namespace = runtime.js.evalModuleNamespace(runtime.transpiledCode, filename)
       except CatchableError as retryError:
-        raise newException(JSException, retryError.msg.mapJsErrorText(runtime.sourceMapForRuntime()))
+        raise newException(JSException, runtime.mapAppErrorText(ctx, retryError.msg))
     else:
-      raise newException(JSException, error.msg.mapJsErrorText(runtime.sourceMapForRuntime()))
+      raise newException(JSException, runtime.mapAppErrorText(ctx, error.msg))
   let globalObj = JS_GetGlobalObject(ctx)
   let installed = JS_SetPropertyStr(ctx, globalObj, "__frameosModule", namespace)
   JS_FreeValue(ctx, globalObj)

--- a/frameos/src/frameos/js_runtime/burrito.nim
+++ b/frameos/src/frameos/js_runtime/burrito.nim
@@ -212,6 +212,7 @@ proc JS_ThrowTypeError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 proc JS_ThrowReferenceError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 proc JS_ThrowRangeError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 proc JS_ThrowInternalError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
+proc JS_ThrowSyntaxError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 
 # Global object
 proc JS_GetGlobalObject*(ctx: ptr JSContext): JSValue
@@ -244,8 +245,9 @@ proc JS_FreeAtom*(ctx: ptr JSContext, atom: JSAtom)
 proc JS_AtomToString*(ctx: ptr JSContext, atom: JSAtom): JSValue
 
 # Module loading
-proc JS_SetModuleLoaderFunc*(rt: ptr JSRuntime, module_normalize: pointer, module_loader: proc(ctx: ptr JSContext,
-    moduleName: cstring, opaque: pointer): ptr JSModuleDef {.cdecl.}, opaque: pointer)
+# `module_loader` is a `JSModuleLoaderFunc *` (const char * module name); Nim's
+# cstring is char *, so the callback is passed as an untyped pointer.
+proc JS_SetModuleLoaderFunc*(rt: ptr JSRuntime, module_normalize: pointer, module_loader: pointer, opaque: pointer)
 proc JS_SetModuleLoaderFunc2*(rt: ptr JSRuntime, module_normalize: pointer, module_loader: proc(ctx: ptr JSContext,
     moduleName: cstring, opaque: pointer, attributes: JSValueConst): ptr JSModuleDef {.cdecl.},
     module_check_attrs: proc(ctx: ptr JSContext, opaque: pointer, attributes: JSValueConst): cint {.cdecl.},
@@ -257,6 +259,18 @@ proc JS_PromiseResult*(ctx: ptr JSContext, promise: JSValueConst): JSValue
 # Module-related functions
 proc JS_DetectModule*(input: cstring, inputLen: csize_t): cint
 proc JS_GetModuleNamespace*(ctx: ptr JSContext, m: ptr JSModuleDef): JSValue
+# Synthetic ("C") modules: a module whose exports are set from native code,
+# e.g. a JSON file exposed as `export default <parsed value>`.
+proc JS_NewCModule*(ctx: ptr JSContext, name: cstring,
+    initFunc: proc(ctx: ptr JSContext, m: ptr JSModuleDef): cint {.cdecl.}): ptr JSModuleDef
+proc JS_AddModuleExport*(ctx: ptr JSContext, m: ptr JSModuleDef, name: cstring): cint
+proc JS_SetModuleExport*(ctx: ptr JSContext, m: ptr JSModuleDef, name: cstring, val: JSValue): cint
+proc JS_SetModulePrivateValue*(ctx: ptr JSContext, m: ptr JSModuleDef, val: JSValue): cint
+proc JS_GetModulePrivateValue*(ctx: ptr JSContext, m: ptr JSModuleDef): JSValue
+proc JS_ParseJSON*(ctx: ptr JSContext, buf: cstring, bufLen: csize_t, filename: cstring): JSValue
+# For strings handed back to QuickJS that it will js_free — module names from
+# a normaliser callback.
+proc js_strdup*(ctx: ptr JSContext, str: cstring): cstring
 
 # Job execution (needed for proper module cleanup)
 proc JS_ExecutePendingJob*(rt: ptr JSRuntime, pctx: ptr ptr JSContext): cint
@@ -1340,6 +1354,45 @@ proc evalModule*(js: QuickJS, code: string, filename: string = "<module>"): stri
     if js.config.enableStdHandlers:
       js_std_loop(js.context)
 
+proc moduleDefOf*(compiled: JSValue): ptr JSModuleDef =
+  ## The module definition behind a value returned by a
+  ## `JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY` eval, or nil when the
+  ## value is not a module. The definition is owned by the context's loaded
+  ## module list, so the caller may JS_FreeValue the value and keep the pointer.
+  var moduleDef: ptr JSModuleDef = nil
+  {.emit: """
+  if (JS_VALUE_GET_TAG(`compiled`) == JS_TAG_MODULE) {
+    `moduleDef` = JS_VALUE_GET_PTR(`compiled`);
+  }
+  """.}
+  moduleDef
+
+proc compileModule*(ctx: ptr JSContext, code: string, filename: string): ptr JSModuleDef =
+  ## Compile `code` as an ES module named `filename` without running it — the
+  ## shape a module loader callback returns. On a syntax error the exception
+  ## is left pending on the context and nil comes back, which is exactly what
+  ## QuickJS expects from a loader.
+  let compiled = JS_Eval(ctx, code.cstring, code.len.csize_t, filename.cstring,
+                         (JS_EVAL_TYPE_MODULE or JS_EVAL_FLAG_COMPILE_ONLY).cint)
+  if JS_IsException(compiled) != 0:
+    return nil
+  result = moduleDefOf(compiled)
+  # The module is already referenced from the loaded-modules list.
+  JS_FreeValue(ctx, compiled)
+
+proc setModuleLoader*(js: QuickJS,
+    loader: proc(ctx: ptr JSContext, moduleName: cstring, opaque: pointer): ptr JSModuleDef {.cdecl.},
+    normalize: proc(ctx: ptr JSContext, baseName: cstring, name: cstring,
+                    opaque: pointer): cstring {.cdecl.} = nil,
+    opaque: pointer = nil) =
+  ## Install the callbacks behind `import`. QuickJS first asks `normalize` to
+  ## turn a specifier into the module's canonical name (with nil it applies
+  ## its own rule: `./` and `../` relative to the importing module, anything
+  ## else untouched), looks that name up among loaded modules, and only then
+  ## calls `loader` for a name it has not seen. `normalize` must return a
+  ## js_strdup'd string; QuickJS frees it.
+  JS_SetModuleLoaderFunc(js.runtime, cast[pointer](normalize), cast[pointer](loader), opaque)
+
 proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module>"): JSValue =
   ## Evaluate `code` as a real ES module and return its namespace object —
   ## the thing that carries its `export`s.
@@ -1363,15 +1416,8 @@ proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module
     JS_FreeValue(ctx, compiled)
     raise newException(JSException, errorMsg)
 
-  var moduleDef: ptr JSModuleDef = nil
-  var isModuleValue = false
-  {.emit: """
-  if (JS_VALUE_GET_TAG(`compiled`) == JS_TAG_MODULE) {
-    `isModuleValue` = NIM_TRUE;
-    `moduleDef` = JS_VALUE_GET_PTR(`compiled`);
-  }
-  """.}
-  if not isModuleValue or moduleDef == nil:
+  let moduleDef = moduleDefOf(compiled)
+  if moduleDef == nil:
     JS_FreeValue(ctx, compiled)
     raise newException(JSException, "Compiled source is not a module: " & filename)
 

--- a/frameos/src/frameos/js_runtime/source_map.nim
+++ b/frameos/src/frameos/js_runtime/source_map.nim
@@ -93,6 +93,23 @@ proc addLineSegments(result: var SourceLineMap, generatedLine: int, generatedTex
 # distance ahead, which is what the table was being asked for.
 const LineLookahead = 64
 
+proc erasedFrom(generated, source: string): bool =
+  ## Whether `generated` could be `source` with its TypeScript removed: every
+  ## character appears in `source` in order, and at least half the line is
+  ## left. Erasure only deletes, so `export function f(){` still matches
+  ## `export function f(): string {` after the annotation is gone — without
+  ## this, such a line anchored on nothing and the lines after it drifted.
+  if generated.len == 0 or generated.len > source.len or generated.len * 2 < source.len:
+    return false
+  var j = 0
+  for ch in generated:
+    while j < source.len and source[j] != ch:
+      inc j
+    if j >= source.len:
+      return false
+    inc j
+  true
+
 proc lineBasedSourceLineMap*(source, generated, generatedName, sourceName: string): SourceLineMap =
   let sourceLines = source.splitLines()
   let generatedLines = generated.splitLines()
@@ -113,7 +130,8 @@ proc lineBasedSourceLineMap*(source, generated, generatedName, sourceName: strin
 
   while generatedIndex < generatedLines.len and sourceIndex < sourceLines.len:
     let generatedNorm = normalizedLine(generatedLines[generatedIndex])
-    if generatedNorm == normalizedSource[sourceIndex]:
+    if generatedNorm == normalizedSource[sourceIndex] or
+        generatedNorm.erasedFrom(normalizedSource[sourceIndex]):
       result.generatedToSourceLine[generatedIndex + 1] = sourceIndex + 1
       result.addLineSegments(generatedIndex + 1, generatedLines[generatedIndex],
                              sourceIndex + 1, sourceLines[sourceIndex])
@@ -127,19 +145,34 @@ proc lineBasedSourceLineMap*(source, generated, generatedName, sourceName: strin
     # Lines diverged. Look ahead a bounded distance on each side: a match
     # found ahead in the source means lines were dropped (a stripped type),
     # a match ahead in the generated code means lines were inserted.
+    # A blank line is not an anchor: the one an erased interface leaves
+    # behind would otherwise latch onto the next blank line anywhere in the
+    # file and drag every line after it out of place.
     var sourceAhead = -1
     var limit = min(sourceLines.len, sourceIndex + 1 + LineLookahead)
-    for candidate in sourceIndex + 1 ..< limit:
-      if normalizedSource[candidate] == generatedNorm:
-        sourceAhead = candidate
-        break
+    if generatedNorm.len > 0:
+      for candidate in sourceIndex + 1 ..< limit:
+        if normalizedSource[candidate] == generatedNorm:
+          sourceAhead = candidate
+          break
 
     var generatedAhead = -1
     limit = min(generatedLines.len, generatedIndex + 1 + LineLookahead)
-    for candidate in generatedIndex + 1 ..< limit:
-      if normalizedLine(generatedLines[candidate]) == normalizedSource[sourceIndex]:
-        generatedAhead = candidate
-        break
+    if normalizedSource[sourceIndex].len > 0:
+      for candidate in generatedIndex + 1 ..< limit:
+        if normalizedLine(generatedLines[candidate]) == normalizedSource[sourceIndex]:
+          generatedAhead = candidate
+          break
+
+    # No exact anchor either way: accept a source line ahead that this
+    # generated line is an erasure of (the usual case right after a stripped
+    # interface or type alias).
+    if sourceAhead < 0 and generatedAhead < 0:
+      limit = min(sourceLines.len, sourceIndex + 1 + LineLookahead)
+      for candidate in sourceIndex + 1 ..< limit:
+        if generatedNorm.erasedFrom(normalizedSource[candidate]):
+          sourceAhead = candidate
+          break
 
     if sourceAhead >= 0 and (generatedAhead < 0 or
         sourceAhead - sourceIndex <= generatedAhead - generatedIndex):
@@ -233,6 +266,13 @@ proc rewriteQuickJsLocations*(text: string, sourceMap: SourceLineMap): string =
     if at < 0:
       result.add(text[i..^1])
       break
+
+    # Module names are file names now, so `util.ts:` must not match inside
+    # `lib/util.ts:` — the shorter name's map would rewrite the longer's lines.
+    if at > 0 and text[at - 1] in {'/', '.', '-', '_', 'a'..'z', 'A'..'Z', '0'..'9'}:
+      result.add(text[i..at])
+      i = at + 1
+      continue
 
     result.add(text[i..<at])
     var lineStart = at + sourceMap.generatedName.len + 1

--- a/frameos/src/frameos/js_runtime/tests/test_js_app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_app_runtime.nim
@@ -2,6 +2,7 @@ import std/[base64, json, net, os, sequtils, strutils, tables, unittest]
 import pixie
 
 import frameos/js_runtime/app_runtime
+import frameos/js_runtime/burrito
 import frameos/types
 import frameos/utils/http_client
 import frameos/values
@@ -366,7 +367,7 @@ suite "js app runtime":
     discard runtime.get(owner, %*{}, context)
     let stackLogs = logged.filterIt("jsApp:error" in it{"event"}.getStr())
     check stackLogs.len == 1
-    check ">:3:" in stackLogs[0]{"stack"}.getStr()
+    check "app.ts:3:" in stackLogs[0]{"stack"}.getStr()
 
   test "asset management bindings":
     let assetsDir = getTempDir() / "frameos-js-assets-test"
@@ -805,3 +806,248 @@ export const get = () => helper()""",
     let value = runtime.get(owner, %*{}, context)
     check value.kind == fkString
     check value.asString() == "default:render"
+
+suite "js app imports":
+  # An app is a set of files, not one: `import` pulls in the app's own .ts,
+  # .tsx, .js, .jsx, and .json files through a QuickJS module loader that
+  # knows only the sources map. Nothing else is importable on a frame.
+
+  proc importScene(id: string): (FrameScene, AppRoot, ExecutionContext) =
+    let config = testConfig()
+    let scene = FrameScene(id: id.SceneId, frameConfig: config, state: %*{},
+                           logger: testLogger(config))
+    let owner = AppRoot(nodeId: 5.NodeId, nodeName: "imports", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    (scene, owner, context)
+
+  proc loadFailure(runtime: JsAppRuntime, owner: AppRoot, context: ExecutionContext): string =
+    try:
+      discard runtime.get(owner, %*{}, context)
+      ""
+    except JSException as error:
+      error.msg
+
+  test "joins specifiers the way QuickJS does":
+    check joinModulePath("app.ts", "./util") == "util"
+    check joinModulePath("app.ts", "./lib/sum.ts") == "lib/sum.ts"
+    check joinModulePath("lib/sum.ts", "./numbers") == "lib/numbers"
+    check joinModulePath("lib/sum.ts", "../scale.js") == "scale.js"
+    check joinModulePath("lib/deep/x.ts", "../../y") == "y"
+    check joinModulePath("app.ts", "../outside") == "../outside"
+    check joinModulePath("app.ts", "dayjs") == "dayjs"
+    check joinModulePath("app.ts", "data.json") == "data.json"
+
+  test "resolves specifiers against the app's files":
+    let files = %*{"app.ts": "", "util.ts": "", "icon.tsx": "", "data.json": "",
+                   "lib/a.ts": "", "lib/b.js": "", "plain.js": ""}
+    check resolveAppModule(files, "util") == "util.ts"
+    check resolveAppModule(files, "util.ts") == "util.ts"
+    check resolveAppModule(files, "util.js") == "util.ts"      # TS spelling
+    check resolveAppModule(files, "icon") == "icon.tsx"
+    check resolveAppModule(files, "icon.jsx") == "icon.tsx"
+    check resolveAppModule(files, "data.json") == "data.json"
+    check resolveAppModule(files, "data") == "data.json"
+    check resolveAppModule(files, "lib/a") == "lib/a.ts"
+    check resolveAppModule(files, "lib/b") == "lib/b.js"
+    check resolveAppModule(files, "plain") == "plain.js"
+    check resolveAppModule(files, "missing") == ""
+    check resolveAppModule(files, "react") == ""
+    check resolveAppModule(files, "") == ""
+    check resolveAppModule(nil, "util") == ""
+
+  test "imports named, default, JSX and JSON exports from sibling files":
+    let (_, owner, context) = importScene("tests/js-imports")
+    let sources = %*{
+      "app.ts": """
+        import { label, type Labelled } from './util'
+        import greet from './greet'
+        import { icon } from './icon'
+        import data from './data.json'
+        export const get = (app: FrameOSApp, context: FrameOSContext): string => {
+          const item: Labelled = { name: data.name }
+          const image = icon(3)
+          return `${label(item)}|${greet(data.greeting)}|${image.props.width}|${data.sizes.length}`
+        }
+      """,
+      "util.ts": """
+        export interface Labelled { name: string }
+        export const label = (item: Labelled): string => `<${item.name}>`
+      """,
+      "greet.ts": """
+        export default function greet(word: string): string { return word.toUpperCase() }
+      """,
+      "icon.tsx": """
+        export const icon = (width: number) => <image width={width} height={2} color="#000000" />
+      """,
+      "data.json": """{"name": "frame", "greeting": "hi", "sizes": [1, 2, 3]}""",
+      "config.json": """{"name": "imports", "category": "data"}""",
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    let value = runtime.get(owner, %*{}, context)
+    check value.kind == fkString
+    check value.asString() == "<frame>|HI|3|3"
+
+  test "imports chain through folders, and ../ climbs back out":
+    let (_, owner, context) = importScene("tests/js-imports-nested")
+    let sources = %*{
+      "app.ts": """
+        import { total } from './lib/sum'
+        export const get = () => String(total())
+      """,
+      "lib/sum.ts": """
+        import { numbers } from './numbers'
+        import { scale } from '../scale.js'
+        export const total = () => numbers.reduce((a, b) => a + b, 0) * scale
+      """,
+      "lib/numbers.ts": "export const numbers = [1, 2, 3]",
+      "scale.ts": "export const scale = 10",
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    check runtime.get(owner, %*{}, context).asString() == "60"
+
+  test "a module is evaluated once, however many files import it":
+    let (_, owner, context) = importScene("tests/js-imports-once")
+    let sources = %*{
+      "app.ts": """
+        import { counter } from './counter'
+        import { fromA } from './a'
+        import { fromB } from './b'
+        export const get = () => `${fromA()},${fromB()},${counter.evaluations}`
+      """,
+      "counter.ts": """
+        export const counter = { evaluations: 0, ticks: 0 }
+        counter.evaluations += 1
+      """,
+      "a.ts": "import { counter } from './counter'\nexport const fromA = () => ++counter.ticks",
+      "b.ts": "import { counter } from './counter'\nexport const fromB = () => ++counter.ticks",
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    check runtime.get(owner, %*{}, context).asString() == "1,2,1"
+
+  test "a helper may import the main module back":
+    let (_, owner, context) = importScene("tests/js-imports-cycle")
+    let sources = %*{
+      "app.ts": """
+        import { describe } from './helper'
+        export const NAME = 'main'
+        export const get = () => describe()
+      """,
+      "helper.ts": """
+        import { NAME } from './app'
+        export const describe = () => `helper of ${NAME}`
+      """,
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    check runtime.get(owner, %*{}, context).asString() == "helper of main"
+
+  test "a bare specifier fails with a message that says why":
+    let (_, owner, context) = importScene("tests/js-imports-bare")
+    let sources = %*{
+      "app.ts": """
+        import dayjs from 'dayjs'
+        export const get = () => dayjs()
+      """,
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    let failure = loadFailure(runtime, owner, context)
+    check "Cannot import 'dayjs'" in failure
+    check "npm packages are not available" in failure
+
+  test "a missing file fails by name":
+    let (_, owner, context) = importScene("tests/js-imports-missing")
+    let sources = %*{
+      "app.ts": """
+        import { x } from './helpers/missing'
+        export const get = () => x
+      """,
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    check "Cannot import 'helpers/missing'" in loadFailure(runtime, owner, context)
+
+  test "invalid JSON fails naming the file":
+    let (_, owner, context) = importScene("tests/js-imports-badjson")
+    let sources = %*{
+      "app.ts": """
+        import data from './data.json'
+        export const get = () => data.x
+      """,
+      "data.json": "{\"x\": 1,}",
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    check "data.json" in loadFailure(runtime, owner, context)
+
+  test "a syntax error in an imported file names that file and line":
+    let (_, owner, context) = importScene("tests/js-imports-syntax")
+    let sources = %*{
+      "app.ts": """
+        import { broken } from './broken'
+        export const get = () => broken()
+      """,
+      "broken.ts": "export const broken = () => {\n  return 1 +\n}\n",
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    let failure = loadFailure(runtime, owner, context)
+    check "broken.ts" in failure
+
+  test "a runtime error inside an imported file maps to that file's source line":
+    # The helper's `throw` sits on line 5 of util.ts as written; the interface
+    # above it is erased, so the generated code has it earlier. The message
+    # must still say util.ts:5.
+    let config = testConfig()
+    var logged: seq[JsonNode] = @[]
+    var logger = testLogger(config)
+    logger.log = proc(payload: JsonNode) =
+      logged.add(payload)
+    let scene = FrameScene(id: "tests/js-imports-runtime-error".SceneId, frameConfig: config,
+                           state: %*{}, logger: logger)
+    let owner = AppRoot(nodeId: 6.NodeId, nodeName: "importErr", scene: scene, frameConfig: config)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    let sources = %*{
+      "app.ts": "import { explode } from './util'\nexport const get = () => explode()\n",
+      "util.ts": "export interface Unused {\n  a: number\n}\nexport function explode(): string {\n  throw new Error(\"imported boom\")\n}\n",
+    }
+    let runtime = newJsAppRuntime(
+      category = "data", outputType = "text", source = sources["app.ts"].getStr(),
+      sourceName = "app.ts", sources = sources)
+    discard runtime.get(owner, %*{}, context)
+    var stack = ""
+    for entry in logged:
+      if "jsApp:error" in entry{"event"}.getStr():
+        stack = entry{"stack"}.getStr()
+    check "util.ts:5:" in stack
+    check "app.ts:2:" in stack
+
+  test "a scene node's sources map feeds the loader":
+    let config = testConfig()
+    let scene = FrameScene(id: "tests/js-imports-node".SceneId, frameConfig: config, state: %*{},
+                           logger: testLogger(config))
+    let node = DiagramNode(id: 9.NodeId, data: %*{"name": "withHelper"})
+    let sources = %*{
+      "config.json": """{"name": "withHelper", "category": "data", "output": [{"name": "text", "type": "string"}]}""",
+      "app.ts": "import { text } from './helper'\nexport const get = () => text",
+      "helper.ts": "export const text = 'from helper'",
+    }
+    let app = initDynamicJsApp("withHelper", node, scene, sources)
+    let context = ExecutionContext(scene: scene, event: "render", payload: %*{},
+                                   hasImage: false, loopIndex: 0, loopKey: ".", nextSleep: -1)
+    let value = app.getDynamicJsApp(context)
+    check value.kind == fkString
+    check value.asString() == "from helper"

--- a/frameos/src/frameos/js_runtime/tests/test_js_transpiler.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_transpiler.nim
@@ -312,3 +312,37 @@ export function get() {
     check "this.count = count;" in output
     check "public value" notin output
     check "private readonly" notin output
+
+  proc eraseTypes(code: string): string =
+    # What the app runtime does: TypeScript off, module syntax left for QuickJS.
+    transform(code, TransformOptions(filePath: "app.ts", transforms: @["typescript"], skipSourceMap: true)).code
+
+  test "erases inline type-only import specifiers":
+    # TypeScript 4.5 `import { a, type B }`: the value import stays, the type
+    # goes, and an import that was nothing but types disappears without
+    # moving the lines under it.
+    let mixed = eraseTypes("""import { label, type Labelled, type Other as O } from './util'
+export const get = () => label()
+""")
+    check "import { label } from './util'" in mixed
+    check "Labelled" notin mixed
+    check "export const get = () => label()" in mixed
+
+    let typesOnly = eraseTypes("""import { type A, type B } from './types'
+import { value } from './value'
+export const get = () => value
+""")
+    check "./types" notin typesOnly
+    check typesOnly.startsWith("\nimport { value } from './value'")
+
+    let withDefault = eraseTypes("""import helper, { type Shape } from './helper'
+export const get = () => helper()
+""")
+    check "import helper from './helper'" in withDefault
+    check "Shape" notin withDefault
+
+    # `type` is a legal binding name; only `type Name` is a modifier.
+    let named = eraseTypes("""import { type } from './kinds'
+export const get = () => type
+""")
+    check "import { type } from './kinds'" in named

--- a/frameos/src/frameos/js_runtime/tests/test_source_map_lines.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_source_map_lines.nim
@@ -70,3 +70,22 @@ suite "source map line mapping":
     let map = lineBasedSourceLineMap(text, text, "gen.js", "src.ts")
     check text.len > 10_000
     check map.segments.len <= lineCount * 3
+
+  test "a file name only matches at a path boundary":
+    # Modules are named after their files, and `util.ts` is the tail of
+    # `lib/util.ts`. The shorter name's map must leave the longer's alone.
+    let map = lineBasedSourceLineMap("a\nb", "// prelude\na\nb", "util.ts", "util.ts")
+    check "at f (util.ts:3:1)".rewriteQuickJsLocations(map) == "at f (util.ts:2:1)"
+    check "at f (lib/util.ts:3:1)".rewriteQuickJsLocations(map) == "at f (lib/util.ts:3:1)"
+    check "at f (myutil.ts:3:1)".rewriteQuickJsLocations(map) == "at f (myutil.ts:3:1)"
+
+  test "a line that only lost its type annotation still anchors":
+    # After an erased interface, `export function f(): string {` comes out
+    # as `export function f(){`. That line used to match nothing, so the
+    # throw under it was reported one line off or not mapped at all.
+    let source = "export interface Unused {\n  a: number\n}\nexport function explode(): string {\n  throw new Error(\"boom\")\n}\n"
+    let generated = "\nexport function explode(){\n  throw new Error(\"boom\")\n}\n"
+    let map = lineBasedSourceLineMap(source, generated, "util.ts", "util.ts")
+    check map.mapGeneratedLine(2) == 4
+    check map.mapGeneratedLine(3) == 5
+    check map.mapGeneratedLine(4) == 6

--- a/frameos/src/frameos/js_runtime/transpiler.nim
+++ b/frameos/src/frameos/js_runtime/transpiler.nim
@@ -1276,6 +1276,52 @@ proc looksLikeInterfaceDeclarationAt(code: string, i: int): bool =
   skipSpaces(code, j)
   j < code.len and code[j] == '{'
 
+proc stripInlineTypeImportSpecifiers(code: string, start: int): (int, string) =
+  ## `import { a, type B, type C as D } from './x'` — TypeScript 4.5's inline
+  ## type-only specifiers. Returns where the statement ends and what to emit in
+  ## its place: the import without those specifiers, or (when nothing but
+  ## types was imported) just the statement's newlines so lines stay put.
+  ## A statement with no inline `type` specifiers comes back as (-1, "").
+  let stop = findStatementEnd(code, start)
+  let stmt = code[start ..< stop]
+  let fromAt = stmt.find(" from ")
+  let brace = stmt.find('{')
+  if brace < 0 or (fromAt >= 0 and brace > fromAt):
+    return (-1, "")
+  let close = findMatching(stmt, brace, '{', '}')
+  if close < 0 or (fromAt >= 0 and close > fromAt):
+    return (-1, "")
+  var kept: seq[string] = @[]
+  var dropped = false
+  for part in stmt[brace + 1 ..< close].split(','):
+    let specifier = part.strip()
+    if specifier.len == 0:
+      continue
+    if startsWordAt(specifier, 0, "type"):
+      var after = "type".len
+      skipSpaces(specifier, after)
+      # `type` alone is a legal import name; only `type Name` is a modifier.
+      if after < specifier.len and isIdentStart(specifier[after]):
+        dropped = true
+        continue
+    kept.add(specifier)
+  if not dropped:
+    return (-1, "")
+  if kept.len > 0:
+    return (stop, stmt[0 .. brace] & " " & kept.join(", ") & " " & stmt[close .. ^1])
+  # Nothing left inside the braces. A default binding before them survives
+  # on its own; otherwise the whole statement was type-only.
+  var head = stmt["import".len ..< brace].strip()
+  if head.endsWith(","):
+    head = head[0 ..< head.len - 1].strip()
+  if head.len > 0 and fromAt >= 0:
+    return (stop, "import " & head & stmt[fromAt .. ^1])
+  var newlines = ""
+  for ch in stmt:
+    if ch == '\n':
+      newlines.add(ch)
+  (stop, newlines)
+
 proc stripTypeOnlyStatements(code: string): string =
   result = newStringOfCap(code.len)
   var i = 0
@@ -1314,6 +1360,12 @@ proc stripTypeOnlyStatements(code: string): string =
       if startsWordAt(code, j, "type"):
         i = findStatementEnd(code, i)
         continue
+      if j < code.len and code[j] != '(':
+        let (stop, replacement) = stripInlineTypeImportSpecifiers(code, i)
+        if stop >= 0:
+          result.add(replacement)
+          i = stop
+          continue
 
     result.add(code[i])
     inc i

--- a/frontend/src/scenes/frame/panels/EditApp/EditApp.tsx
+++ b/frontend/src/scenes/frame/panels/EditApp/EditApp.tsx
@@ -43,12 +43,25 @@ export function appSourceEditorLanguage(file: string): string {
     : 'python'
 }
 
+/** Files the frame's module loader can `import`: the app's own code and JSON. */
+export function isImportableAppSource(file: string): boolean {
+  return /\.(ts|tsx|js|jsx|json)$/.test(file)
+}
+
 export function configureAppSourceEditor(monaco: Monaco) {
   const compilerOptions = {
     allowJs: true,
     allowNonTsExtensions: true,
     target: monaco.languages.typescript.ScriptTarget.ES2020,
     jsx: monaco.languages.typescript.JsxEmit.Preserve,
+    // An app can `import { x } from './helper'` and `import data from
+    // './data.json'` — the frame resolves both against the app's own files,
+    // and so must the type checker here.
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    resolveJsonModule: true,
+    allowSyntheticDefaultImports: true,
+    esModuleInterop: true,
   }
   monaco.languages.typescript.typescriptDefaults.setCompilerOptions(compilerOptions)
   monaco.languages.typescript.javascriptDefaults.setCompilerOptions({ ...compilerOptions, checkJs: true })
@@ -224,6 +237,9 @@ export function EditApp({
     [null, null]
   )
   const appTypesLibsRef = useRef<{ dispose: () => void }[]>([])
+  // Models for the app's other files, so `./helper` resolves while editing
+  // app.ts. The Editor below adopts one of these when its tab is opened.
+  const siblingModelsRef = useRef<Map<string, importedEditor.ITextModel>>(new Map())
 
   useEffect(() => {
     if (editorKey) {
@@ -239,6 +255,45 @@ export function EditApp({
       }
     }
   }, [monaco, activeFile, modelMarkers])
+
+  useEffect(() => {
+    if (!monaco) {
+      return
+    }
+    const present = new Set<string>()
+    for (const [file, content] of Object.entries(sources)) {
+      if (!isImportableAppSource(file)) {
+        continue
+      }
+      present.add(file)
+      const uri = monaco.Uri.parse(`inmemory://app-editor/${nodeId}/${file}`)
+      const existing = monaco.editor.getModel(uri)
+      if (!existing) {
+        siblingModelsRef.current.set(file, monaco.editor.createModel(content ?? '', appSourceEditorLanguage(file), uri))
+      } else if (file !== activeFile && existing.getValue() !== content) {
+        existing.setValue(content ?? '')
+      }
+    }
+    for (const [file, model] of siblingModelsRef.current) {
+      if (!present.has(file) && file !== activeFile) {
+        if (!model.isDisposed()) {
+          model.dispose()
+        }
+        siblingModelsRef.current.delete(file)
+      }
+    }
+  }, [monaco, sources, nodeId, activeFile])
+
+  useEffect(() => {
+    return () => {
+      for (const model of siblingModelsRef.current.values()) {
+        if (!model.isDisposed()) {
+          model.dispose()
+        }
+      }
+      siblingModelsRef.current.clear()
+    }
+  }, [nodeId])
 
   useEffect(() => {
     if (!monaco) {

--- a/frontend/src/scenes/frame/panels/EditApp/editAppLogic.tsx
+++ b/frontend/src/scenes/frame/panels/EditApp/editAppLogic.tsx
@@ -527,7 +527,7 @@ export const editAppLogic = kea<editAppLogicType>([
       actions.setSourceErrors(file, errors || [])
     },
     addFile: () => {
-      const fileName = window.prompt('Enter file name')
+      const fileName = window.prompt('Enter file name (e.g. helper.ts, icons.tsx, data.json)')
       if (fileName) {
         actions.updateFile(fileName, '')
         actions.setActiveFile(fileName)


### PR DESCRIPTION
## What

An app's `sources` map is now its whole module graph. `app.ts` can

```ts
import { label } from './lib/util'      // util.ts / .tsx / .js / .jsx, ./x.js → x.ts
import icons from './icons.json'        // default export = parsed value
import { panel } from './panel'         // JSX lowered only in .tsx/.jsx
```

Only the app's own files resolve — no npm packages, no `require()`, no dynamic `import()`.

## How

- **Runtime** (`app_runtime.nim`, `burrito.nim`): a QuickJS module loader per app runtime. A custom *normaliser* joins `./`/`../` against the importing file and canonicalises to the file name, so `./counter` and `./counter.ts` from two importers are one module, evaluated once. `.json` → synthetic C module (`JS_NewCModule` + private value). Transpiled output is cached per file like the main module's (ESP32 eviction must not re-transpile); sources stay a `JsonNode`, not a second copy. Bare specifiers and missing files fail with a message that says why; compile/JSON errors name the file and position; every loaded file registers its own lazy line map so stacks read `util.ts:5:3`. Main module is now named after its file (`app.ts`) instead of `<frameos:app:…>`.
- **Transpiler**: inline type-only specifiers (`import { a, type B }`) were mangled into `import { a, from './x'` — fixed.
- **Line mapper**: the blank line an erased interface leaves behind anchored onto any later blank line, dragging every mapping after it out of place. Blank lines are no longer anchors, and a generated line that is an erasure (subsequence) of a source line matches. File names only match at path boundaries (`util.ts:` never inside `lib/util.ts:`).
- **Editor**: Monaco models for sibling files + `moduleResolution: NodeJs` / `resolveJsonModule`, so `./helper` type-checks while editing `app.ts`. Add-file prompt hints at helper names.
- **Cloud AI**: prompts + app-chat describe the convention; `scene-lint` flags npm imports and files the app doesn't have (`lintAppImports`, mirrors the runtime's resolution), and only holds the main module to the `get()` contract.
- **Docs**: `docs/js-apps-and-code-nodes.md` "More than one file"; `js_runtime/README.md` Module Loading section.

Assets/binary files are deliberately out of scope.

## Verified

- Nim: `test_js_app_runtime` (+12 import tests), `test_js_transpiler`, `test_source_map_lines`, helpers/cleanup/resource-limits/parser/tokens, `test_interpreter_smoke`, `test_interpreter_cache`, `test_hub_verbs` — all pass.
- `tools/tests/test_native_js_transpiler_parity.py`: 23 passed.
- ESP32 `nim c --compileOnly … -d:frameosEmbedded` (CI flags) and `tools/build_wasm.sh` both build.
- Cloud: `vitest run src/lib/ai` (129), eslint, `tsc --noEmit`. Frontend: `tsc --noEmit`, prettier.

Not verified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCnCsVdvKfchUMzYeXEj91
