### PR TITLE
Cloud MCP: personal API tokens, hosted MCP server, server-side scene previews

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -20,6 +20,11 @@ provides:
   at all — scene assignment, screenshots, logs, metrics, and signed OTA
   updates. Design: [`docs/cloud-frames.md`](docs/cloud-frames.md).
 - **Config backups** for linked self-hosted backends.
+- **API tokens and an MCP server**: personal bearer tokens for the JSON API,
+  and `POST /api/mcp` — the whole account surface (frames, scenes, store,
+  scene AI, server-side previews) as Model Context Protocol tools for AI
+  agents, implemented in `packages/mcp` as a thin wrapper over the routes.
+  Design: [`docs/mcp.md`](docs/mcp.md).
 
 **You do not need any of this to use FrameOS.** The self-hosted backend and
 the frames themselves work with zero cloud, forever — that is a hard rule of

--- a/cloud/apps/auth-web/app/account/developer/page.tsx
+++ b/cloud/apps/auth-web/app/account/developer/page.tsx
@@ -1,0 +1,148 @@
+import { createDb } from "@frameos-cloud/db";
+import {
+  ApiTokensSection,
+  type ApiTokenPayload,
+} from "../../../src/components/ApiTokensSection";
+import { CopyUrlField } from "../../../src/components/CopyUrlField";
+import {
+  listApiTokens,
+  maxApiTokensPerAccount,
+} from "../../../src/lib/api-tokens";
+import { getAccountUrl, getCloudBaseUrl } from "../../../src/lib/env";
+import {
+  hasRecentAuth,
+  reauthPath,
+  recentApprovalMaxAgeSeconds,
+} from "../../../src/lib/recent-auth";
+import { readSession } from "../../../src/lib/session";
+
+export const metadata = { title: "Developer" };
+
+// API tokens and the MCP server, for people who drive their frames and
+// scenes from scripts or an AI agent. Everything a token can do is what the
+// signed-in account can do in the UI, minus the sudo-mode actions; the MCP
+// endpoint is the same API with a vocabulary an agent can read.
+export default async function AccountDeveloperPage() {
+  const session = await readSession();
+  const accountId = session?.accountId;
+
+  let tokens: ApiTokenPayload[] = [];
+  let canCreate = false;
+  if (accountId) {
+    const db = createDb();
+    [tokens, canCreate] = await Promise.all([
+      listApiTokens(db, accountId) as Promise<ApiTokenPayload[]>,
+      hasRecentAuth(db, recentApprovalMaxAgeSeconds),
+    ]);
+  }
+
+  const cloudUrl = getCloudBaseUrl().replace(/\/$/, "");
+  const mcpUrl = `${cloudUrl}/api/mcp`;
+  const reauthUrl = new URL(reauthPath, cloudUrl);
+  reauthUrl.searchParams.set("return_to", getAccountUrl("/account/developer"));
+
+  return (
+    <>
+      <section className="section-block">
+        <div className="content-header compact-header">
+          <div>
+            <h2>API tokens</h2>
+            <p className="copy">
+              A personal API token stands in for your account on the JSON API
+              and the MCP server: frames, scenes, the store and the scene AI,
+              everything you can do here — except revoking frames and
+              approving device links, which always need a fresh sign-in in the
+              browser. Tokens are shown once and stored hashed.
+            </p>
+          </div>
+        </div>
+        <section className="card">
+          <ApiTokensSection
+            canCreate={canCreate}
+            initialTokens={tokens}
+            maxTokens={maxApiTokensPerAccount}
+            reauthHref={reauthUrl.toString()}
+          />
+        </section>
+      </section>
+
+      <section className="section-block">
+        <div className="content-header compact-header">
+          <div>
+            <h2>MCP server</h2>
+            <p className="copy">
+              Connect an AI agent (Claude Code, Claude Desktop, Cursor, or any
+              Model Context Protocol client) to your frames. The server is
+              hosted here — no local process — and speaks Streamable HTTP with
+              your API token as a bearer.
+            </p>
+          </div>
+        </div>
+        <section className="card stack">
+          <div className="field">
+            <label htmlFor="mcp-url">Endpoint</label>
+            <CopyUrlField value={mcpUrl} />
+          </div>
+          <h3>Claude Code</h3>
+          <pre className="code-block">
+            <code>{`claude mcp add --transport http frameos ${mcpUrl} \\
+  --header "Authorization: Bearer fc_api_…"`}</code>
+          </pre>
+          <h3>Claude Desktop, Cursor and other clients</h3>
+          <pre className="code-block">
+            <code>{JSON.stringify(
+              {
+                mcpServers: {
+                  frameos: {
+                    headers: { Authorization: "Bearer fc_api_…" },
+                    type: "http",
+                    url: mcpUrl,
+                  },
+                },
+              },
+              null,
+              2,
+            )}</code>
+          </pre>
+          <h3>Run it locally instead (stdio)</h3>
+          <p className="copy">
+            From a checkout of the FrameOS repository, the same server runs as
+            a subprocess and talks to this API with your token:
+          </p>
+          <pre className="code-block">
+            <code>{`FRAMEOS_CLOUD_TOKEN=fc_api_… FRAMEOS_CLOUD_URL=${cloudUrl} \\
+  pnpm --filter @frameos-cloud/mcp start`}</code>
+          </pre>
+          <h3>What it can do</h3>
+          <ul className="copy">
+            <li>
+              <strong>Frames</strong> — list and inspect, rename, push settings
+              and schedules, assign and activate scenes, screenshots, logs,
+              metrics, activity, asset files, reboot/restart, firmware updates,
+              claim tokens for new frames.
+            </li>
+            <li>
+              <strong>Scenes</strong> — list, read and save scene JSON as new
+              versions, create from JSON/zip/URL, fork, rename, publish to the
+              store, tags/category/description, gallery images, yank or
+              restore versions, delete.
+            </li>
+            <li>
+              <strong>Preview and check</strong> — render any scene on the
+              server with the real FrameOS runtime and get the image back;
+              lint scenes the way publishing does.
+            </li>
+            <li>
+              <strong>Scene AI</strong> — ask the cloud&apos;s scene assistant to
+              build or change a scene, then save or install the result.
+            </li>
+            <li>
+              <strong>Store and account</strong> — browse the public store,
+              account settings and service keys, usage against every quota.
+            </li>
+          </ul>
+        </section>
+      </section>
+    </>
+  );
+}

--- a/cloud/apps/auth-web/app/account/layout.tsx
+++ b/cloud/apps/auth-web/app/account/layout.tsx
@@ -110,6 +110,7 @@ export default async function AccountLayout({
         hrefs={{
           activity: getAccountUrl("/account/activity"),
           backups: getAccountUrl("/account/backups"),
+          developer: getAccountUrl("/account/developer"),
           installs: getAccountUrl("/account/installs"),
           security: getAccountUrl("/account/security"),
         }}

--- a/cloud/apps/auth-web/app/api/account/api-tokens/[tokenId]/route.ts
+++ b/cloud/apps/auth-web/app/api/account/api-tokens/[tokenId]/route.ts
@@ -1,0 +1,72 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { accountApiTokens } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
+import { recordAuditEvent } from "../../../../../src/lib/audit";
+import { csrfResponse } from "../../../../../src/lib/csrf";
+import {
+  jsonError,
+  requireDatabase,
+} from "../../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../../src/lib/rate-limit";
+import { readSession } from "../../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+// Revoke one personal API token. Revocation is the safe direction, so any
+// live session may do it — a token may even revoke itself, which is how an
+// agent that suspects a leak cuts its own access.
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ tokenId: string }> },
+) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(
+    request,
+    "account:api-tokens-revoke",
+    { limit: 60, windowMs: 15 * 60 * 1000 },
+  );
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const { tokenId } = await params;
+  if (!/^[0-9a-f-]{36}$/i.test(tokenId)) {
+    return jsonError("token_not_found", 404);
+  }
+  const rows = await db
+    .update(accountApiTokens)
+    .set({ revokedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(
+        eq(accountApiTokens.id, tokenId),
+        eq(accountApiTokens.accountId, session.accountId),
+        isNull(accountApiTokens.revokedAt),
+      ),
+    )
+    .returning({ id: accountApiTokens.id, name: accountApiTokens.name });
+  const revoked = rows[0];
+  if (!revoked) {
+    return jsonError("token_not_found", 404);
+  }
+  await recordAuditEvent(db, {
+    accountId: session.accountId,
+    actor: {
+      accountId: session.accountId,
+      providerSubject: session.providerSubject,
+    },
+    eventType: "account.api_token_revoked",
+    metadata: { name: revoked.name },
+    target: { apiTokenId: revoked.id },
+  });
+  return NextResponse.json({ status: "revoked" });
+}

--- a/cloud/apps/auth-web/app/api/account/api-tokens/route.test.ts
+++ b/cloud/apps/auth-web/app/api/account/api-tokens/route.test.ts
@@ -1,0 +1,174 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { recordAuditEvent } from "../../../../src/lib/audit";
+import { requireRecentAuth } from "../../../../src/lib/recent-auth";
+import { readSession } from "../../../../src/lib/session";
+import { GET, POST } from "./route";
+
+// Minting is the sensitive half: it needs a session (never a token), a
+// recent proof of credentials, a name, and room under the cap; the secret
+// leaves exactly once, and only its hash and hint are stored.
+
+vi.mock("../../../../src/lib/rate-limit", () => ({
+  rateLimitResponse: vi.fn(() => Promise.resolve(undefined)),
+}));
+vi.mock("../../../../src/lib/csrf", () => ({
+  csrfResponse: vi.fn(() => undefined),
+}));
+vi.mock("../../../../src/lib/session", () => ({
+  readSession: vi.fn(),
+}));
+vi.mock("../../../../src/lib/audit", () => ({
+  recordAuditEvent: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("../../../../src/lib/recent-auth", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  requireRecentAuth: vi.fn(() => Promise.resolve(undefined)),
+}));
+vi.mock("../../../../src/lib/device-flow", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  requireDatabase: () => ({ db: fakeDb as never, response: undefined }),
+}));
+
+const sessionMock = vi.mocked(readSession);
+const auditMock = vi.mocked(recordAuditEvent);
+const recentAuthMock = vi.mocked(requireRecentAuth);
+
+let liveCount = 0;
+let inserted: Record<string, unknown>[] = [];
+let listed: Record<string, unknown>[] = [];
+
+const fakeDb = {
+  insert: () => ({
+    values: (values: Record<string, unknown>) => {
+      inserted.push(values);
+      return {
+        returning: () =>
+          Promise.resolve([
+            {
+              ...values,
+              createdAt: new Date(),
+              id: "tok-new",
+              lastUsedAt: null,
+              revokedAt: null,
+              updatedAt: new Date(),
+            },
+          ]),
+      };
+    },
+  }),
+  select: () => ({
+    from: () => ({
+      where: () => {
+        const rows = Promise.resolve([{ count: liveCount }]);
+        return Object.assign(rows, {
+          orderBy: () => Promise.resolve(listed),
+        });
+      },
+    }),
+  }),
+};
+
+function post(body: unknown) {
+  return new NextRequest("https://cloud.example/api/account/api-tokens", {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json", origin: "https://cloud.example" },
+    method: "POST",
+  });
+}
+
+const session = {
+  accountId: "acc-1",
+  providerIssuer: "frameos-cloud",
+  providerSubject: "me",
+};
+
+beforeEach(() => {
+  liveCount = 0;
+  inserted = [];
+  listed = [];
+  sessionMock.mockResolvedValue(session);
+  auditMock.mockClear();
+  recentAuthMock.mockResolvedValue(undefined);
+});
+
+describe("POST /api/account/api-tokens", () => {
+  it("mints a token, returns the secret once and stores only its hash", async () => {
+    const response = await POST(post({ access: "read_only", expires_in_days: 30, name: "laptop" }));
+    expect(response.status).toBe(201);
+    const payload = (await response.json()) as {
+      api_token: { access: string; name: string; token_hint: string };
+      token: string;
+    };
+    expect(payload.token).toMatch(/^fc_apiro_/);
+    expect(payload.api_token).toMatchObject({ access: "read_only", name: "laptop" });
+    expect(payload.token.startsWith(payload.api_token.token_hint)).toBe(true);
+    expect(inserted[0]).toMatchObject({ access: "read_only", accountId: "acc-1", name: "laptop" });
+    expect(inserted[0]?.tokenHash).not.toContain(payload.token);
+    expect(inserted[0]?.expiresAt).toBeInstanceOf(Date);
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: "account.api_token_created" }),
+    );
+  });
+
+  it("refuses to mint from a token session", async () => {
+    sessionMock.mockResolvedValueOnce({
+      ...session,
+      apiToken: { access: "full", id: "tok-1", name: "other" },
+    });
+    const response = await POST(post({ name: "escalate" }));
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "api_token_not_allowed" });
+    expect(inserted).toHaveLength(0);
+  });
+
+  it("requires recent authentication", async () => {
+    recentAuthMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "reauth_required" }), { status: 403 }) as never,
+    );
+    const response = await POST(post({ name: "laptop" }));
+    expect(response.status).toBe(403);
+    expect(inserted).toHaveLength(0);
+  });
+
+  it("validates the name, access and expiry", async () => {
+    expect((await POST(post({}))).status).toBe(400);
+    expect((await POST(post({ access: "admin", name: "x" }))).status).toBe(400);
+    expect((await POST(post({ expires_in_days: 0, name: "x" }))).status).toBe(400);
+    expect((await POST(post({ expires_in_days: 400, name: "x" }))).status).toBe(400);
+    expect(inserted).toHaveLength(0);
+  });
+
+  it("enforces the per-account cap", async () => {
+    liveCount = 25;
+    const response = await POST(post({ name: "one more" }));
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "token_quota_exceeded", max_tokens: 25 });
+  });
+});
+
+describe("GET /api/account/api-tokens", () => {
+  it("lists tokens without secrets", async () => {
+    listed = [
+      {
+        access: "full",
+        createdAt: new Date("2026-08-01T00:00:00Z"),
+        expiresAt: null,
+        id: "tok-1",
+        lastUsedAt: null,
+        name: "laptop",
+        revokedAt: null,
+        tokenHash: "should-not-leak",
+        tokenHint: "fc_api_abcd",
+      },
+    ];
+    const response = await GET(
+      new NextRequest("https://cloud.example/api/account/api-tokens"),
+    );
+    const payload = (await response.json()) as { max_tokens: number; tokens: Record<string, unknown>[] };
+    expect(payload.max_tokens).toBe(25);
+    expect(payload.tokens[0]).toMatchObject({ id: "tok-1", token_hint: "fc_api_abcd" });
+    expect(JSON.stringify(payload)).not.toContain("should-not-leak");
+  });
+});

--- a/cloud/apps/auth-web/app/api/account/api-tokens/route.ts
+++ b/cloud/apps/auth-web/app/api/account/api-tokens/route.ts
@@ -1,0 +1,165 @@
+import { and, count, eq, isNull } from "drizzle-orm";
+import { accountApiTokens } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  apiTokenAccessValues,
+  listApiTokens,
+  maxApiTokenNameLength,
+  maxApiTokensPerAccount,
+  maxApiTokenTtlDays,
+  mintApiToken,
+  serializeApiToken,
+  type ApiTokenAccess,
+} from "../../../../src/lib/api-tokens";
+import { recordAuditEvent } from "../../../../src/lib/audit";
+import { csrfResponse } from "../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import {
+  recentApprovalMaxAgeSeconds,
+  requireRecentAuth,
+} from "../../../../src/lib/recent-auth";
+import { readSession } from "../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+// Personal API tokens (src/lib/api-tokens.ts). GET lists the live ones —
+// never the secret, only its hint. POST mints one and returns the secret
+// exactly once. Minting turns a browser session into a durable credential,
+// which is the same promotion approving a device link makes, so it asks for
+// the same recent proof of the credentials (2 h) — and it is never allowed
+// from a token itself: a leaked token must not be able to breed new ones.
+
+export async function GET(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "account:api-tokens", {
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  return NextResponse.json({
+    max_tokens: maxApiTokensPerAccount,
+    tokens: await listApiTokens(db, session.accountId),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(
+    request,
+    "account:api-tokens-create",
+    { limit: 30, windowMs: 15 * 60 * 1000 },
+  );
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  if (session.apiToken) {
+    return jsonError("api_token_not_allowed", 403);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const stale = await requireRecentAuth(
+    db,
+    session.accountId,
+    recentApprovalMaxAgeSeconds,
+  );
+  if (stale) {
+    return stale;
+  }
+
+  const body = await readJsonObject(request);
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name || name.length > maxApiTokenNameLength) {
+    return jsonError("invalid_name", 400);
+  }
+  const access = body.access === undefined ? "full" : body.access;
+  if (!apiTokenAccessValues.includes(access as ApiTokenAccess)) {
+    return jsonError("invalid_access", 400);
+  }
+  let expiresAt: Date | null = null;
+  if (body.expires_in_days !== undefined && body.expires_in_days !== null) {
+    const days = body.expires_in_days;
+    if (
+      typeof days !== "number" ||
+      !Number.isInteger(days) ||
+      days < 1 ||
+      days > maxApiTokenTtlDays
+    ) {
+      return jsonError("invalid_expiry", 400);
+    }
+    expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+  }
+
+  const [existing] = await db
+    .select({ count: count() })
+    .from(accountApiTokens)
+    .where(
+      and(
+        eq(accountApiTokens.accountId, session.accountId),
+        isNull(accountApiTokens.revokedAt),
+      ),
+    );
+  if ((existing?.count ?? 0) >= maxApiTokensPerAccount) {
+    return jsonError("token_quota_exceeded", 403, {
+      max_tokens: maxApiTokensPerAccount,
+    });
+  }
+
+  const minted = mintApiToken(access as ApiTokenAccess);
+  const [row] = await db
+    .insert(accountApiTokens)
+    .values({
+      access: access as ApiTokenAccess,
+      accountId: session.accountId,
+      expiresAt,
+      name,
+      tokenHash: minted.tokenHash,
+      tokenHint: minted.hint,
+    })
+    .returning();
+  if (!row) {
+    return jsonError("token_create_failed", 500);
+  }
+
+  await recordAuditEvent(db, {
+    accountId: session.accountId,
+    actor: {
+      accountId: session.accountId,
+      providerSubject: session.providerSubject,
+    },
+    eventType: "account.api_token_created",
+    metadata: { access, expires_at: expiresAt?.toISOString() ?? null, name },
+    target: { apiTokenId: row.id },
+  });
+
+  return NextResponse.json(
+    {
+      api_token: serializeApiToken(row),
+      status: "created",
+      token: minted.token,
+    },
+    { status: 201 },
+  );
+}

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/route.ts
@@ -1,7 +1,14 @@
-import { and, eq } from "drizzle-orm";
-import { storeScenes, storeSceneVersions } from "@frameos-cloud/db";
+import { and, desc, eq } from "drizzle-orm";
+import {
+  storeSceneImages,
+  storeScenes,
+  storeSceneVersions,
+} from "@frameos-cloud/db";
 import { recordAuditEvent } from "../../../../../src/lib/audit";
 import { NextRequest, NextResponse } from "next/server";
+import { getScenesBaseUrl } from "../../../../../src/lib/env";
+import { rateLimitResponse } from "../../../../../src/lib/rate-limit";
+import { readSession } from "../../../../../src/lib/session";
 import {
   blobNamespaces,
   readBlob,
@@ -11,6 +18,7 @@ import {
   jsonError,
   parseOptionalString,
   readJsonObject,
+  requireDatabase,
 } from "../../../../../src/lib/device-flow";
 import { normalizeCategory } from "../../../../../src/lib/categories";
 import { moderateStoreContent } from "../../../../../src/lib/moderation";
@@ -33,6 +41,109 @@ import {
 export const runtime = "nodejs";
 
 type RouteContext = { params: Promise<{ sceneId: string }> };
+
+// One owned scene with what the /s/[slug] page shows its owner: the
+// summary, every version (yanked ones included — yank hides from "latest",
+// it does not delete) and the gallery image ids. The content itself stays
+// at GET /api/store/scenes/{id}/scenes.json?version=N.
+export async function GET(request: NextRequest, context: RouteContext) {
+  const limited = await rateLimitResponse(request, "account:scene-detail", {
+    limit: 240,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const { sceneId } = await context.params;
+  if (!/^[0-9a-f-]{36}$/i.test(sceneId)) {
+    return jsonError("scene_not_found", 404);
+  }
+  const [scene] = await db
+    .select()
+    .from(storeScenes)
+    .where(
+      and(
+        eq(storeScenes.id, sceneId),
+        eq(storeScenes.accountId, session.accountId),
+      ),
+    )
+    .limit(1);
+  if (!scene) {
+    return jsonError("scene_not_found", 404);
+  }
+  const [versions, images] = await Promise.all([
+    db
+      .select({
+        createdAt: storeSceneVersions.createdAt,
+        frameosVersion: storeSceneVersions.frameosVersion,
+        message: storeSceneVersions.message,
+        riskFlags: storeSceneVersions.riskFlags,
+        sha256: storeSceneVersions.sha256,
+        sizeBytes: storeSceneVersions.sizeBytes,
+        version: storeSceneVersions.version,
+        yankedAt: storeSceneVersions.yankedAt,
+      })
+      .from(storeSceneVersions)
+      .where(eq(storeSceneVersions.sceneId, scene.id))
+      .orderBy(desc(storeSceneVersions.version)),
+    db
+      .select({
+        contentType: storeSceneImages.contentType,
+        createdAt: storeSceneImages.createdAt,
+        id: storeSceneImages.id,
+        position: storeSceneImages.position,
+        sizeBytes: storeSceneImages.sizeBytes,
+      })
+      .from(storeSceneImages)
+      .where(eq(storeSceneImages.sceneId, scene.id))
+      .orderBy(storeSceneImages.position, storeSceneImages.createdAt),
+  ]);
+  const hasPrimaryPreview =
+    scene.previewImage !== null || scene.previewObjectKey !== null;
+  return NextResponse.json(
+    {
+      images: images.map((image) => ({
+        content_type: image.contentType,
+        created_at: image.createdAt.toISOString(),
+        id: image.id,
+        position: image.position,
+        size_bytes: image.sizeBytes,
+        url: `/api/store/scenes/${scene.id}/images/${image.id}`,
+      })),
+      scene: {
+        ...sceneSummary(scene),
+        has_preview: hasPrimaryPreview || images.length > 0,
+        preview_url: hasPrimaryPreview
+          ? `/api/store/scenes/${scene.id}/image?v=${scene.latestVersion}`
+          : (images[0] && `/api/store/scenes/${scene.id}/images/${images[0].id}`) ?? null,
+        pulled_reason: scene.pulledReason,
+        share_url: scene.shareToken
+          ? `${getScenesBaseUrl()}/s/${scene.slug}?share=${scene.shareToken}`
+          : null,
+        url: `${getScenesBaseUrl()}/s/${scene.slug}`,
+      },
+      versions: versions.map((version) => ({
+        created_at: version.createdAt.toISOString(),
+        frameos_version: version.frameosVersion,
+        message: version.message,
+        risk_flags: version.riskFlags,
+        sha256: version.sha256,
+        size_bytes: version.sizeBytes,
+        version: version.version,
+        yanked: version.yankedAt !== null,
+      })),
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
 
 // Owner management of a published scene from the web: visibility toggle,
 // description/tags/minimum FrameOS version edit, delete. Moderation state

--- a/cloud/apps/auth-web/app/api/account/scenes/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/route.ts
@@ -1,8 +1,12 @@
-import { NextRequest } from "next/server";
+import { and, desc, eq, ilike, or, sql, type SQL } from "drizzle-orm";
+import { storeScenes } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
 import {
   createAccountScene,
   maxSceneNameChars,
 } from "../../../../src/lib/account-scene-create";
+import { sceneSummary } from "../../../../src/lib/store";
+import { sceneHasAnyImageSql } from "../../../../src/lib/store-preview";
 import { csrfResponse } from "../../../../src/lib/csrf";
 import {
   jsonError,
@@ -18,6 +22,85 @@ import { maxPublishesPerHour } from "../../../../src/lib/store";
 import { framePreviewForNewScene } from "../../../../src/lib/scene-images";
 
 export const runtime = "nodejs";
+
+// The account's own scenes, the same rows /my-scenes renders, as JSON —
+// for scripts and the MCP server, which have no server-rendered page to
+// read. `?q=` matches name, slug and tags; `?visibility=private|public`
+// and `?status=active|pulled|featured` narrow it the way the page's
+// filters do. Newest change first, capped at 500 like the drive index.
+export async function GET(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "account:scenes-list", {
+    limit: 240,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const params = request.nextUrl.searchParams;
+  const query = params.get("q")?.trim().slice(0, 100) ?? "";
+  const visibility = params.get("visibility") ?? "";
+  const status = params.get("status") ?? "";
+  const conditions: SQL[] = [eq(storeScenes.accountId, session.accountId)];
+  if (query) {
+    const pattern = `%${query.replace(/[%_\\]/g, "\\$&")}%`;
+    const match = or(
+      ilike(storeScenes.name, pattern),
+      ilike(storeScenes.slug, pattern),
+      sql`array_to_string(${storeScenes.tags}, ' ') ilike ${pattern}`,
+    );
+    if (match) {
+      conditions.push(match);
+    }
+  }
+  if (visibility === "private" || visibility === "public") {
+    conditions.push(eq(storeScenes.visibility, visibility));
+  }
+  if (status === "pulled" || status === "active") {
+    conditions.push(eq(storeScenes.status, status));
+  } else if (status === "featured") {
+    conditions.push(sql`${storeScenes.featuredAt} is not null`);
+  }
+  const rows = await db
+    .select({
+      category: storeScenes.category,
+      createdAt: storeScenes.createdAt,
+      description: storeScenes.description,
+      downloadCount: storeScenes.downloadCount,
+      featuredAt: storeScenes.featuredAt,
+      frameosVersion: storeScenes.frameosVersion,
+      hasPreview: sceneHasAnyImageSql,
+      id: storeScenes.id,
+      latestVersion: storeScenes.latestVersion,
+      name: storeScenes.name,
+      riskFlags: storeScenes.riskFlags,
+      slug: storeScenes.slug,
+      status: storeScenes.status,
+      tags: storeScenes.tags,
+      updatedAt: storeScenes.updatedAt,
+      visibility: storeScenes.visibility,
+    })
+    .from(storeScenes)
+    .where(and(...conditions))
+    .orderBy(desc(storeScenes.updatedAt))
+    .limit(500);
+  return NextResponse.json(
+    {
+      scenes: rows.map((row) => ({
+        ...sceneSummary(row),
+        has_preview: Boolean(row.hasPreview),
+      })),
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
 
 // Create a NEW private cloud scene from raw scenes JSON — the workspace's
 // "save this frame's edited scenes to my account" path, which has no ZIP to

--- a/cloud/apps/auth-web/app/api/account/usage/route.ts
+++ b/cloud/apps/auth-web/app/api/account/usage/route.ts
@@ -1,0 +1,136 @@
+import { eq } from "drizzle-orm";
+import { accounts } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
+import { maxApiTokensPerAccount } from "../../../../src/lib/api-tokens";
+import {
+  maxAccountSettingValueLength,
+  maxAccountSshKeys,
+} from "../../../../src/lib/account-settings";
+import { maxChatsPerAccount, maxMessagesPerChat } from "../../../../src/lib/ai/chat-store";
+import { maxBackupBytes, maxBackupsPerAccount } from "../../../../src/lib/backups";
+import { jsonError, requireDatabase } from "../../../../src/lib/device-flow";
+import { maxScenesPerFrame } from "../../../../src/lib/frame-scenes";
+import {
+  claimTokenTtlMs,
+  maxClaimTokensPerAccount,
+  maxLogsPerFrame,
+  maxMetricsPerFrame,
+  maxScheduleEvents,
+  maxScenesPayloadBytes,
+} from "../../../../src/lib/frames";
+import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { readSession } from "../../../../src/lib/session";
+import {
+  maxImagesPerScene,
+  maxNewScenesPerDay,
+  maxPreviewImageBytes,
+  maxPublishesPerHour,
+  maxSceneEditsPerHour,
+  maxScenesPerAccount,
+  maxSceneZipBytes,
+  maxTagsPerScene,
+} from "../../../../src/lib/store";
+import { accountUsage } from "../../../../src/lib/usage";
+
+export const runtime = "nodejs";
+
+// The account, its usage against every quota, and the fixed caps the rest
+// of the API enforces — one payload so a script or an agent can answer "can
+// I still add a frame / save a scene / upload this file" before trying.
+// `usage` is the same accountUsage() the account page and the backend grant
+// endpoint render; `limits` collects the constants that otherwise only show
+// up as the `max_*` field of a refusal.
+export async function GET(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "account:usage", {
+    limit: 240,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const [[account], usage] = await Promise.all([
+    db
+      .select({
+        createdAt: accounts.createdAt,
+        displayName: accounts.displayName,
+        id: accounts.id,
+        isSuperadmin: accounts.isSuperadmin,
+        primaryEmail: accounts.primaryEmail,
+        storeBannedAt: accounts.storeBannedAt,
+        verifiedPublisherAt: accounts.verifiedPublisherAt,
+      })
+      .from(accounts)
+      .where(eq(accounts.id, session.accountId))
+      .limit(1),
+    accountUsage(db, session.accountId),
+  ]);
+  if (!account) {
+    return jsonError("login_required", 401);
+  }
+
+  return NextResponse.json(
+    {
+      account: {
+        created_at: account.createdAt.toISOString(),
+        email: account.primaryEmail,
+        id: account.id,
+        is_superadmin: account.isSuperadmin,
+        name: account.displayName,
+        store_banned: account.storeBannedAt !== null,
+        verified_publisher: account.verifiedPublisherAt !== null,
+      },
+      auth: session.apiToken
+        ? {
+            kind: "api_token",
+            token_access: session.apiToken.access,
+            token_id: session.apiToken.id,
+            token_name: session.apiToken.name,
+          }
+        : { kind: "session" },
+      limits: {
+        account: {
+          max_api_tokens: maxApiTokensPerAccount,
+          max_setting_value_length: maxAccountSettingValueLength,
+          max_ssh_keys: maxAccountSshKeys,
+        },
+        ai: {
+          max_chats: maxChatsPerAccount,
+          max_messages_per_chat: maxMessagesPerChat,
+        },
+        backups: {
+          max_backup_bytes: maxBackupBytes,
+          max_backups: maxBackupsPerAccount,
+        },
+        frames: {
+          claim_token_ttl_hours: Math.round(claimTokenTtlMs / (60 * 60 * 1000)),
+          max_claim_tokens: maxClaimTokensPerAccount,
+          max_log_lines_per_frame: maxLogsPerFrame,
+          max_metrics_samples_per_frame: maxMetricsPerFrame,
+          max_scene_payload_bytes: maxScenesPayloadBytes,
+          max_scenes_per_frame: maxScenesPerFrame,
+          max_schedule_events: maxScheduleEvents,
+        },
+        scenes: {
+          max_edits_per_hour: maxSceneEditsPerHour,
+          max_images_per_scene: maxImagesPerScene,
+          max_new_scenes_per_day: maxNewScenesPerDay,
+          max_preview_image_bytes: maxPreviewImageBytes,
+          max_publishes_per_hour: maxPublishesPerHour,
+          max_scene_zip_bytes: maxSceneZipBytes,
+          max_scenes: maxScenesPerAccount,
+          max_tags_per_scene: maxTagsPerScene,
+        },
+      },
+      usage,
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/cloud/apps/auth-web/app/api/mcp/route.ts
+++ b/cloud/apps/auth-web/app/api/mcp/route.ts
@@ -1,0 +1,112 @@
+import { createFrameosMcpServer, serveStatelessHttp } from "@frameos-cloud/mcp";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  authenticateApiToken,
+  bearerToken,
+  isApiToken,
+} from "../../../src/lib/api-tokens";
+import { jsonError, requireDatabase } from "../../../src/lib/device-flow";
+import { getCloudBaseUrl, getScenesBaseUrl } from "../../../src/lib/env";
+import { logWarn } from "../../../src/lib/log";
+import { rateLimitResponse } from "../../../src/lib/rate-limit";
+import { guardedFetch } from "../../../src/lib/ssrf";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+// The hosted MCP server: Model Context Protocol over Streamable HTTP, at
+// POST /api/mcp, authenticated with a personal API token in the
+// Authorization header. Stateless — every request builds a fresh server and
+// transport, and every tool call is an HTTP request back to this same app's
+// JSON routes with the caller's token (packages/mcp is a thin wrapper, on
+// purpose: the routes stay the one place behaviour and limits live). The
+// loopback origin is the process's own request origin, so the calls never
+// leave the box and never cross Cloudflare; the client's forwarded-for
+// chain rides along so the routes' per-IP rate limits key on the real
+// caller, not on 127.0.0.1.
+//
+// GET (the optional server-initiated SSE stream) and DELETE (session end)
+// are meaningless without sessions and are answered 405 so clients fall
+// back to plain request/response.
+
+const forwardedHeaders = [
+  "cf-connecting-ip",
+  "user-agent",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-real-ip",
+];
+
+function internalOrigin(request: NextRequest): string {
+  const configured = process.env.FRAMEOS_MCP_INTERNAL_ORIGIN?.trim();
+  if (configured) {
+    return configured.replace(/\/+$/, "");
+  }
+  return new URL(request.url).origin;
+}
+
+export async function POST(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "mcp:request", {
+    limit: 1200,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const token = bearerToken(request.headers.get("authorization"));
+  if (!isApiToken(token)) {
+    return NextResponse.json(
+      {
+        error: "login_required",
+        hint: "Send `Authorization: Bearer fc_api_…` with a personal API token from /account/developer.",
+      },
+      {
+        headers: { "www-authenticate": 'Bearer realm="FrameOS Cloud"' },
+        status: 401,
+      },
+    );
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const authenticated = await authenticateApiToken(db, token);
+  if (!authenticated) {
+    return jsonError("login_required", 401);
+  }
+
+  const headers: Record<string, string> = {};
+  for (const name of forwardedHeaders) {
+    const value = request.headers.get(name);
+    if (value) {
+      headers[name] = value;
+    }
+  }
+  const publicOrigin = getCloudBaseUrl().replace(/\/+$/, "");
+  const server = createFrameosMcpServer({
+    baseUrl: internalOrigin(request),
+    fetchExternal: (input, init) => guardedFetch(input, init),
+    headers,
+    publicOrigin,
+    storeOrigin: getScenesBaseUrl().replace(/\/+$/, ""),
+    token,
+    userAgent: `frameos-cloud-mcp (account ${authenticated.account.id})`,
+  });
+  try {
+    return await serveStatelessHttp(server, request);
+  } catch (error) {
+    logWarn("mcp.request_failed", { message: String(error) });
+    return jsonError("mcp_failed", 500);
+  }
+}
+
+export function GET() {
+  return jsonError("method_not_allowed", 405, {
+    hint: "This MCP endpoint is stateless: POST JSON-RPC requests only.",
+  });
+}
+
+export function DELETE() {
+  return jsonError("method_not_allowed", 405);
+}

--- a/cloud/apps/auth-web/app/api/scenes/lint/route.test.ts
+++ b/cloud/apps/auth-web/app/api/scenes/lint/route.test.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readSession } from "../../../../src/lib/session";
+import { POST } from "./route";
+
+// The lint route is the AI's delivery gate on a public door: shape errors
+// and catalog errors block, structural warnings advise. Session-gated, no
+// database.
+
+vi.mock("../../../../src/lib/rate-limit", () => ({
+  rateLimitResponse: vi.fn(() => Promise.resolve(undefined)),
+}));
+vi.mock("../../../../src/lib/session", () => ({
+  readSession: vi.fn(),
+}));
+
+const sessionMock = vi.mocked(readSession);
+
+function request(body: unknown) {
+  return new NextRequest("https://cloud.example/api/scenes/lint", {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+}
+
+const renderEvent = {
+  data: { keyword: "render" },
+  id: "e1",
+  position: { x: 0, y: 0 },
+  type: "event",
+};
+
+beforeEach(() => {
+  sessionMock.mockResolvedValue({
+    accountId: "acc-1",
+    providerIssuer: "frameos-cloud",
+    providerSubject: "me",
+  });
+});
+
+describe("POST /api/scenes/lint", () => {
+  it("requires a session", async () => {
+    sessionMock.mockResolvedValueOnce(undefined);
+    const response = await POST(request({ scenes: [{}] }));
+    expect(response.status).toBe(401);
+  });
+
+  it("refuses an empty payload", async () => {
+    const response = await POST(request({ scenes: [] }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_scenes" });
+  });
+
+  it("reports shape errors as errors", async () => {
+    const response = await POST(request({ scenes: [{ name: "no id" }] }));
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { errors: { message: string }[]; ok: boolean };
+    expect(payload.ok).toBe(false);
+    expect(payload.errors.length).toBeGreaterThan(0);
+  });
+
+  it("passes a minimal valid scene", async () => {
+    const response = await POST(
+      request({
+        scenes: [
+          {
+            edges: [],
+            fields: [],
+            id: "s1",
+            name: "Minimal",
+            nodes: [renderEvent],
+            settings: { execution: "interpreted" },
+          },
+        ],
+      }),
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { errors: unknown[]; ok: boolean; warnings: unknown[] };
+    expect(payload.errors).toEqual([]);
+    expect(payload.ok).toBe(true);
+  });
+
+  it("flags unknown app keywords", async () => {
+    const response = await POST(
+      request({
+        scenes: [
+          {
+            edges: [],
+            fields: [],
+            id: "s1",
+            name: "Bad app",
+            nodes: [
+              renderEvent,
+              {
+                data: { keyword: "does/notExist" },
+                id: "a1",
+                position: { x: 0, y: 0 },
+                type: "app",
+              },
+            ],
+            settings: { execution: "interpreted" },
+          },
+        ],
+      }),
+    );
+    const payload = (await response.json()) as { errors: { message: string }[]; ok: boolean };
+    expect(payload.ok).toBe(false);
+    expect(payload.errors.some((issue) => issue.message.includes("does/notExist"))).toBe(true);
+  });
+});

--- a/cloud/apps/auth-web/app/api/scenes/lint/route.ts
+++ b/cloud/apps/auth-web/app/api/scenes/lint/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { appCatalog, knownAppKeywords } from "../../../../src/lib/ai/context";
+import { lintScenes } from "../../../../src/lib/ai/scene-lint";
+import {
+  type JsonObject,
+  validateAppKeywords,
+  validateScenePayload,
+} from "../../../../src/lib/ai/scene-utils";
+import { jsonError, readJsonObject } from "../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { readSession } from "../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+const maxScenesPerLint = 20;
+const maxLintBytes = 3 * 1024 * 1024;
+
+// The AI chat's delivery gate, exposed: the shape validation, the app
+// keyword check against the bundled catalog and the deep structural lint,
+// on any scenes JSON. Read-only — nothing is saved — but signed-in only, so
+// the cost of linting a 3 MB payload has an account behind it. Body:
+// {"scenes": [...]}; the reply separates hard errors (what publishing and
+// the AI refuse) from warnings (what merely looks off).
+export async function POST(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "scenes:lint", {
+    limit: 240,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const body = await readJsonObject(request);
+  if (!Array.isArray(body.scenes) || body.scenes.length === 0) {
+    return jsonError("invalid_scenes", 400);
+  }
+  if (body.scenes.length > maxScenesPerLint) {
+    return jsonError("too_many_scenes", 400, { max_scenes: maxScenesPerLint });
+  }
+  if (JSON.stringify(body.scenes).length > maxLintBytes) {
+    return jsonError("scenes_payload_too_large", 413, {
+      max_bytes: maxLintBytes,
+    });
+  }
+
+  const payload: JsonObject = { scenes: body.scenes };
+  const shape = validateScenePayload(payload);
+  const keywords = shape.length
+    ? []
+    : validateAppKeywords(payload, knownAppKeywords());
+  const lint = shape.length
+    ? { errors: [], warnings: [] }
+    : lintScenes(body.scenes, { catalog: appCatalog() });
+
+  const errors = [
+    ...shape.map((message) => ({ message, scene: "payload" })),
+    ...keywords.map((message) => ({ message, scene: "payload" })),
+    ...lint.errors.map((issue) => ({
+      message: issue.message,
+      ...(issue.node ? { node: issue.node } : {}),
+      scene: issue.scene,
+    })),
+  ];
+  const warnings = lint.warnings.map((issue) => ({
+    message: issue.message,
+    ...(issue.node ? { node: issue.node } : {}),
+    scene: issue.scene,
+  }));
+
+  return NextResponse.json(
+    { errors, ok: errors.length === 0, warnings },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/cloud/apps/auth-web/app/api/scenes/render/route.ts
+++ b/cloud/apps/auth-web/app/api/scenes/render/route.ts
@@ -1,0 +1,288 @@
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { storeScenes, storeSceneVersions } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
+import { readBlob } from "../../../../src/lib/blobs";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../src/lib/device-flow";
+import {
+  identityRateLimitResponse,
+  rateLimitResponse,
+} from "../../../../src/lib/rate-limit";
+import {
+  defaultRenderTimeoutMs,
+  maxRenderDimension,
+  maxRenderPixels,
+  minRenderDimension,
+  renderScenes,
+  SceneRenderError,
+} from "../../../../src/lib/scene-render";
+import { extractScenesFromZip } from "../../../../src/lib/scene-title";
+import { readSession } from "../../../../src/lib/session";
+import {
+  canAccessPrivateScene,
+  canViewPulledScene,
+} from "../../../../src/lib/store-auth";
+import { maxScenesPayloadBytes } from "../../../../src/lib/frames";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const maxScenesPerRender = 20;
+
+// A preview frame of a scene, rendered on the server by the same wasm
+// runtime the browser editor's live preview runs (src/lib/scene-render.ts).
+// Two sources, one call: `scene_id` (+ optional `version`) renders a stored
+// scene under the store's own access rules — public ones for everyone
+// signed in, private ones for their owner — and `scenes` renders JSON that
+// was never saved. Signed-in only and rate limited per account: a render
+// holds a 64 MB wasm heap for up to `timeout` seconds.
+//
+// Body: { scene_id? | scenes?, version?, scene?, width?, height?, time_zone?,
+//         settings?, states?, format?: "png" | "json" }
+// Reply: image/png by default; `format: "json"` (or Accept: application/json)
+// returns {png_base64, width, height, render_ms, logs, errors, state}.
+export async function POST(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "scenes:render", {
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const accountLimited = await identityRateLimitResponse(
+    session.accountId,
+    "scenes:render",
+    { limit: 60, windowMs: 15 * 60 * 1000 },
+  );
+  if (accountLimited) {
+    return accountLimited;
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+
+  const body = await readJsonObject(request);
+  const width = dimension(body.width, 800);
+  const height = dimension(body.height, 480);
+  if (width === null || height === null || width * height > maxRenderPixels) {
+    return jsonError("invalid_dimensions", 400, {
+      max_dimension: maxRenderDimension,
+      max_pixels: maxRenderPixels,
+      min_dimension: minRenderDimension,
+    });
+  }
+  const timeZone =
+    typeof body.time_zone === "string" && isValidTimeZone(body.time_zone)
+      ? body.time_zone
+      : "UTC";
+  const selectedScene =
+    typeof body.scene === "string" && body.scene.length <= 256
+      ? body.scene
+      : undefined;
+  const settings = plainObject(body.settings);
+  const states = plainObject(body.states);
+  const wantsJson =
+    body.format === "json" ||
+    (body.format === undefined &&
+      request.headers.get("accept")?.includes("application/json") === true &&
+      !request.headers.get("accept")?.includes("image/"));
+
+  let scenes: unknown[];
+  let sceneVersion: number | undefined;
+  if (typeof body.scene_id === "string") {
+    const loaded = await loadStoredScenes(db, request, body);
+    if ("response" in loaded) {
+      return loaded.response;
+    }
+    scenes = loaded.scenes;
+    sceneVersion = loaded.version;
+  } else if (Array.isArray(body.scenes) && body.scenes.length > 0) {
+    if (body.scenes.length > maxScenesPerRender) {
+      return jsonError("too_many_scenes", 400, { max_scenes: maxScenesPerRender });
+    }
+    if (JSON.stringify(body.scenes).length > maxScenesPayloadBytes) {
+      return jsonError("scenes_payload_too_large", 413, {
+        max_bytes: maxScenesPayloadBytes,
+      });
+    }
+    scenes = body.scenes;
+  } else {
+    return jsonError("invalid_scenes", 400);
+  }
+
+  try {
+    const result = await renderScenes({
+      height,
+      sceneId: selectedScene,
+      scenes,
+      settings,
+      states,
+      timeoutMs: defaultRenderTimeoutMs,
+      timeZone,
+      width,
+    });
+    if (wantsJson) {
+      return NextResponse.json(
+        {
+          errors: result.errors,
+          height: result.height,
+          logs: result.logs,
+          png_base64: result.png.toString("base64"),
+          render_ms: result.renderMs,
+          state: result.state,
+          ...(sceneVersion ? { version: sceneVersion } : {}),
+          width: result.width,
+        },
+        { headers: { "cache-control": "no-store" } },
+      );
+    }
+    return new NextResponse(result.png as unknown as BodyInit, {
+      headers: {
+        "cache-control": "no-store",
+        "content-length": String(result.png.length),
+        "content-type": "image/png",
+        "x-render-errors": String(result.errors.length),
+        "x-render-ms": String(result.renderMs),
+        ...(sceneVersion ? { "x-scene-version": String(sceneVersion) } : {}),
+      },
+    });
+  } catch (error) {
+    if (error instanceof SceneRenderError) {
+      const status =
+        error.code === "renderer_busy"
+          ? 503
+          : error.code === "renderer_unavailable"
+            ? 501
+            : error.code === "render_timeout"
+              ? 504
+              : 422;
+      return jsonError(error.code, status, {
+        detail: error.message,
+        logs: error.logs,
+      });
+    }
+    throw error;
+  }
+}
+
+function dimension(value: unknown, fallback: number): number | null {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < minRenderDimension ||
+    value > maxRenderDimension
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function plainObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isValidTimeZone(zone: string): boolean {
+  if (zone.length > 64) {
+    return false;
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The scenes.json rules, verbatim: public scenes are open, private ones
+// owner-only (session or the owner's linked client), pulled ones stay
+// visible to their owner and to superadmins; the newest non-yanked version
+// unless one is named.
+async function loadStoredScenes(
+  db: NonNullable<ReturnType<typeof requireDatabase>["db"]>,
+  request: NextRequest,
+  body: Record<string, unknown>,
+): Promise<{ scenes: unknown[]; version: number } | { response: NextResponse }> {
+  const sceneId = String(body.scene_id);
+  if (!/^[0-9a-f-]{36}$/i.test(sceneId)) {
+    return { response: jsonError("scene_not_found", 404) };
+  }
+  const [scene] = await db
+    .select({
+      accountId: storeScenes.accountId,
+      id: storeScenes.id,
+      status: storeScenes.status,
+      visibility: storeScenes.visibility,
+    })
+    .from(storeScenes)
+    .where(eq(storeScenes.id, sceneId))
+    .limit(1);
+  if (!scene) {
+    return { response: jsonError("scene_not_found", 404) };
+  }
+  if (scene.status === "pulled" && !(await canViewPulledScene(scene.accountId))) {
+    return { response: jsonError("scene_pulled", 410) };
+  }
+  if (
+    scene.visibility !== "public" &&
+    !(await canAccessPrivateScene(
+      db,
+      request.headers.get("authorization"),
+      scene.accountId,
+    ))
+  ) {
+    return { response: jsonError("scene_not_found", 404) };
+  }
+  let requestedVersion: number | undefined;
+  if (body.version !== undefined && body.version !== null) {
+    if (
+      typeof body.version !== "number" ||
+      !Number.isInteger(body.version) ||
+      body.version < 1
+    ) {
+      return { response: jsonError("invalid_version", 400) };
+    }
+    requestedVersion = body.version;
+  }
+  const [version] = await db
+    .select({
+      content: storeSceneVersions.content,
+      objectKey: storeSceneVersions.objectKey,
+      version: storeSceneVersions.version,
+    })
+    .from(storeSceneVersions)
+    .where(
+      and(
+        eq(storeSceneVersions.sceneId, scene.id),
+        requestedVersion
+          ? eq(storeSceneVersions.version, requestedVersion)
+          : isNull(storeSceneVersions.yankedAt),
+      ),
+    )
+    .orderBy(desc(storeSceneVersions.version))
+    .limit(1);
+  if (!version) {
+    return { response: jsonError("version_not_found", 404) };
+  }
+  const content = await readBlob(version);
+  if (!content) {
+    return { response: jsonError("version_not_found", 404) };
+  }
+  const scenes = extractScenesFromZip(Buffer.from(content));
+  if (!scenes || scenes.length === 0) {
+    return { response: jsonError("invalid_scene_zip", 500) };
+  }
+  return { scenes, version: version.version };
+}

--- a/cloud/apps/auth-web/app/api/store/preview-proxy/route.ts
+++ b/cloud/apps/auth-web/app/api/store/preview-proxy/route.ts
@@ -1,8 +1,7 @@
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 import { NextRequest, NextResponse } from "next/server";
 import { jsonError, readJsonObject } from "../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { hostIsBlocked } from "../../../../src/lib/ssrf";
 import { storeRoute } from "../../../../src/lib/store-cache";
 
 export const runtime = "nodejs";
@@ -108,56 +107,8 @@ async function handlePost(request: NextRequest) {
   });
 }
 
-// SSRF guard, mirroring frameos' _preview_proxy_host_is_blocked: reject hosts
-// resolving to loopback / private / link-local / reserved addresses so the
-// proxy cannot probe our internal network. DNS resolves once here; a rebind
-// between check and fetch is a residual risk accepted for a preview feature.
-async function hostIsBlocked(hostname: string): Promise<boolean> {
-  const literal = isIP(hostname) ? [hostname] : null;
-  let addresses: string[];
-  if (literal) {
-    addresses = literal;
-  } else {
-    try {
-      const results = await lookup(hostname, { all: true, verbatim: true });
-      addresses = results.map((result) => result.address);
-    } catch {
-      return true;
-    }
-  }
-  return addresses.length === 0 || addresses.some(addressIsPrivate);
-}
-
-function addressIsPrivate(address: string): boolean {
-  const plain = address.split("%")[0] ?? address;
-  if (isIP(plain) === 4) {
-    const octets = plain.split(".").map(Number);
-    const [a = -1, b = -1] = octets;
-    return (
-      a === 0 || // unspecified
-      a === 10 ||
-      a === 127 || // loopback
-      (a === 100 && b >= 64 && b <= 127) || // CGNAT
-      (a === 169 && b === 254) || // link-local
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      a >= 224 // multicast + reserved
-    );
-  }
-  const lower = plain.toLowerCase();
-  // Loopback, unspecified, link-local, unique-local, and v4-mapped forms.
-  return (
-    lower === "::" ||
-    lower === "::1" ||
-    lower.startsWith("fe8") ||
-    lower.startsWith("fe9") ||
-    lower.startsWith("fea") ||
-    lower.startsWith("feb") ||
-    lower.startsWith("fc") ||
-    lower.startsWith("fd") ||
-    lower.startsWith("::ffff:")
-  );
-}
+// The SSRF guard itself lives in src/lib/ssrf.ts, shared with the MCP
+// server's scene imports.
 
 async function readCapped(
   response: Response,

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -3891,3 +3891,18 @@ html.theme-dark .action-card__ghost {
   font-weight: 650;
   box-shadow: inset 0 0 0 1px var(--primary);
 }
+
+/* Setup snippets on /account/developer: a scrolling, copyable block that
+   keeps its line breaks and never widens the page. */
+.code-block {
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+}

--- a/cloud/apps/auth-web/next.config.ts
+++ b/cloud/apps/auth-web/next.config.ts
@@ -213,7 +213,11 @@ function createNextConfig(phase: string): NextConfig {
         },
       ];
     },
-    transpilePackages: ["@frameos-cloud/auth-client", "@frameos-cloud/db"],
+    transpilePackages: [
+      "@frameos-cloud/auth-client",
+      "@frameos-cloud/db",
+      "@frameos-cloud/mcp",
+    ],
   };
 }
 

--- a/cloud/apps/auth-web/package.json
+++ b/cloud/apps/auth-web/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@frameos-cloud/auth-client": "workspace:*",
     "@frameos-cloud/db": "workspace:*",
+    "@frameos-cloud/mcp": "workspace:*",
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.2",
     "aws4fetch": "^1.0.20",

--- a/cloud/apps/auth-web/src/components/AccountNav.tsx
+++ b/cloud/apps/auth-web/src/components/AccountNav.tsx
@@ -10,6 +10,7 @@ const sections = [
   { href: "/account/backups", key: "backups", label: "Backups" },
   { href: "/account/activity", key: "activity", label: "Activity" },
   { href: "/account/security", key: "security", label: "Security" },
+  { href: "/account/developer", key: "developer", label: "Developer" },
 ] as const;
 
 export function AccountNav({

--- a/cloud/apps/auth-web/src/components/ApiTokensSection.tsx
+++ b/cloud/apps/auth-web/src/components/ApiTokensSection.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { KeyRound, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { CopyUrlField } from "./CopyUrlField";
+
+export type ApiTokenPayload = {
+  access: "full" | "read_only";
+  created_at: string;
+  expires_at: string | null;
+  id: string;
+  last_used_at: string | null;
+  name: string;
+  token_hint: string;
+};
+
+// The personal API tokens list on /account/developer: create (the secret
+// shows exactly once, with a copy button), revoke, and what each token has
+// been up to. Creation needs a recent sign-in; the page decides whether to
+// render the form or the re-authentication link.
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "never";
+  }
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function describeError(status: number, error: string | undefined) {
+  switch (error) {
+    case "invalid_name":
+      return "Give the token a name (up to 64 characters).";
+    case "token_quota_exceeded":
+      return "This account already has the maximum number of tokens. Revoke one first.";
+    case "reauth_required":
+      return "Confirm your credentials again before creating a token.";
+    case "login_required":
+      return "Your session expired. Reload the page and sign in again.";
+    default:
+      return status === 429
+        ? "Too many attempts. Wait a few minutes and try again."
+        : "Something went wrong. Try again in a moment.";
+  }
+}
+
+export function ApiTokensSection({
+  canCreate,
+  initialTokens,
+  maxTokens,
+  reauthHref,
+}: {
+  canCreate: boolean;
+  initialTokens: ApiTokenPayload[];
+  maxTokens: number;
+  reauthHref: string;
+}) {
+  const [tokens, setTokens] = useState(initialTokens);
+  const [name, setName] = useState("");
+  const [access, setAccess] = useState<"full" | "read_only">("full");
+  const [expiresInDays, setExpiresInDays] = useState<string>("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [fresh, setFresh] = useState<
+    { id: string; name: string; token: string } | undefined
+  >();
+
+  async function create(event: React.FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    setError(undefined);
+    try {
+      const response = await fetch("/api/account/api-tokens", {
+        body: JSON.stringify({
+          access,
+          name,
+          ...(expiresInDays ? { expires_in_days: Number(expiresInDays) } : {}),
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const payload = (await response.json().catch(() => undefined)) as
+        | { api_token?: ApiTokenPayload; error?: string; token?: string }
+        | undefined;
+      const created = payload?.api_token;
+      if (!response.ok || !payload?.token || !created) {
+        setError(describeError(response.status, payload?.error));
+        return;
+      }
+      setTokens((current) => [...current, created]);
+      setFresh({ id: created.id, name, token: payload.token });
+      setName("");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revoke(token: ApiTokenPayload) {
+    if (
+      !window.confirm(
+        `Revoke the token "${token.name}"? Anything using it stops working immediately.`,
+      )
+    ) {
+      return;
+    }
+    setError(undefined);
+    const response = await fetch(`/api/account/api-tokens/${token.id}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => undefined)) as
+        | { error?: string }
+        | undefined;
+      setError(describeError(response.status, payload?.error));
+      return;
+    }
+    setTokens((current) => current.filter((entry) => entry.id !== token.id));
+    if (fresh?.id === token.id) {
+      setFresh(undefined);
+    }
+  }
+
+  return (
+    <div className="stack">
+      {fresh ? (
+        <div className="notice" role="status">
+          <p>
+            <strong>{fresh.name}</strong> is ready. Copy it now — it is shown
+            only once.
+          </p>
+          <CopyUrlField value={fresh.token} />
+        </div>
+      ) : null}
+
+      {tokens.length === 0 ? (
+        <p className="copy">No API tokens yet.</p>
+      ) : (
+        <div className="table-scroll">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Token</th>
+                <th>Access</th>
+                <th>Last used</th>
+                <th>Expires</th>
+                <th aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((token) => (
+                <tr key={token.id}>
+                  <td>
+                    <KeyRound aria-hidden size={14} /> {token.name}
+                  </td>
+                  <td>
+                    <code>{token.token_hint}…</code>
+                  </td>
+                  <td>{token.access === "read_only" ? "Read-only" : "Full"}</td>
+                  <td>{formatDate(token.last_used_at)}</td>
+                  <td>{token.expires_at ? formatDate(token.expires_at) : "never"}</td>
+                  <td>
+                    <button
+                      className="button button-danger button--small"
+                      onClick={() => void revoke(token)}
+                      type="button"
+                    >
+                      <Trash2 aria-hidden size={14} />
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {canCreate ? (
+        <form className="stack" onSubmit={(event) => void create(event)}>
+          <div className="field">
+            <label htmlFor="api-token-name">Name</label>
+            <input
+              id="api-token-name"
+              maxLength={64}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Claude Code on my laptop"
+              required
+              value={name}
+            />
+          </div>
+          <div className="field">
+            <label htmlFor="api-token-access">Access</label>
+            <select
+              id="api-token-access"
+              onChange={(event) =>
+                setAccess(event.target.value as "full" | "read_only")
+              }
+              value={access}
+            >
+              <option value="full">Full — everything the account can do</option>
+              <option value="read_only">Read-only — look, never change</option>
+            </select>
+          </div>
+          <div className="field">
+            <label htmlFor="api-token-expiry">Expires</label>
+            <select
+              id="api-token-expiry"
+              onChange={(event) => setExpiresInDays(event.target.value)}
+              value={expiresInDays}
+            >
+              <option value="">Never</option>
+              <option value="7">In 7 days</option>
+              <option value="30">In 30 days</option>
+              <option value="90">In 90 days</option>
+              <option value="365">In a year</option>
+            </select>
+          </div>
+          <div className="actions">
+            <button
+              className="button button-primary"
+              disabled={busy || tokens.length >= maxTokens}
+              type="submit"
+            >
+              <Plus aria-hidden size={16} />
+              Create token
+            </button>
+            <span className="copy">
+              {tokens.length} / {maxTokens} tokens
+            </span>
+          </div>
+        </form>
+      ) : (
+        <p className="copy">
+          Creating a token turns this session into a durable credential, so
+          it asks you to <a href={reauthHref}>confirm your credentials</a>{" "}
+          first.
+        </p>
+      )}
+
+      {error ? (
+        <p className="notice notice-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/cloud/apps/auth-web/src/lib/api-tokens.test.ts
+++ b/cloud/apps/auth-web/src/lib/api-tokens.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  apiTokenAccessFromPrefix,
+  authenticateApiToken,
+  bearerToken,
+  isApiToken,
+  mintApiToken,
+  serializeApiToken,
+  tokenHint,
+} from "./api-tokens";
+import { hashSecret } from "./secrets";
+
+// The token format is a contract with every script that ever stored one:
+// the prefix tells the kind, the hint is what the list shows, and the
+// database only ever holds the hash.
+
+describe("api tokens", () => {
+  it("mints full and read-only tokens with distinct prefixes", () => {
+    const full = mintApiToken("full");
+    const readOnly = mintApiToken("read_only");
+    expect(full.token).toMatch(/^fc_api_[A-Za-z0-9_-]{40,}$/);
+    expect(readOnly.token).toMatch(/^fc_apiro_[A-Za-z0-9_-]{40,}$/);
+    expect(apiTokenAccessFromPrefix(full.token)).toBe("full");
+    expect(apiTokenAccessFromPrefix(readOnly.token)).toBe("read_only");
+    expect(full.tokenHash).toBe(hashSecret(full.token));
+    expect(full.hint).toBe(tokenHint(full.token));
+    expect(full.hint).toBe(full.token.slice(0, "fc_api_".length + 4));
+    expect(isApiToken(full.token)).toBe(true);
+    expect(isApiToken("fc_link_abc")).toBe(false);
+    expect(isApiToken(undefined)).toBe(false);
+  });
+
+  it("parses the bearer header loosely", () => {
+    expect(bearerToken("Bearer fc_api_x")).toBe("fc_api_x");
+    expect(bearerToken("bearer   fc_api_x ")).toBe("fc_api_x");
+    expect(bearerToken("Basic abc")).toBeUndefined();
+    expect(bearerToken(null)).toBeUndefined();
+  });
+
+  it("serializes without the hash", () => {
+    const now = new Date("2026-08-29T10:00:00Z");
+    expect(
+      serializeApiToken({
+        access: "read_only",
+        createdAt: now,
+        expiresAt: null,
+        id: "t1",
+        lastUsedAt: null,
+        name: "laptop",
+        revokedAt: null,
+        tokenHint: "fc_apiro_abcd",
+      }),
+    ).toEqual({
+      access: "read_only",
+      created_at: now.toISOString(),
+      expires_at: null,
+      id: "t1",
+      last_used_at: null,
+      name: "laptop",
+      revoked_at: null,
+      token_hint: "fc_apiro_abcd",
+    });
+  });
+
+  function fakeDb(row: Record<string, unknown> | undefined) {
+    const updates: Record<string, unknown>[] = [];
+    const db = {
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({
+            where: () => ({ limit: () => Promise.resolve(row ? [row] : []) }),
+          }),
+        }),
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updates.push(values);
+          return { where: () => Promise.resolve(undefined) };
+        },
+      }),
+    };
+    return { db: db as never, updates };
+  }
+
+  const baseRow = (token: string) => ({
+    access: "full",
+    accountId: "acc-1",
+    accountName: "Marius",
+    email: "me@example.com",
+    expiresAt: null,
+    id: "tok-1",
+    lastUsedAt: null,
+    name: "laptop",
+    tokenHash: hashSecret(token),
+  });
+
+  it("resolves a live token to its account and stamps last use", async () => {
+    const { token } = mintApiToken("full");
+    const { db, updates } = fakeDb(baseRow(token));
+    const result = await authenticateApiToken(db, token);
+    expect(result).toEqual({
+      account: { email: "me@example.com", id: "acc-1", name: "Marius" },
+      token: { access: "full", id: "tok-1", name: "laptop" },
+    });
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it("throttles the last-used write", async () => {
+    const { token } = mintApiToken("full");
+    const { db, updates } = fakeDb({ ...baseRow(token), lastUsedAt: new Date() });
+    await authenticateApiToken(db, token);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("refuses expired tokens and prefix/row access mismatches", async () => {
+    const { token } = mintApiToken("full");
+    const expired = fakeDb({
+      ...baseRow(token),
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await authenticateApiToken(expired.db, token)).toBeUndefined();
+
+    // A row that says read_only behind a full-access prefix (or the other
+    // way round) is not a token we minted.
+    const mismatched = fakeDb({ ...baseRow(token), access: "read_only" });
+    expect(await authenticateApiToken(mismatched.db, token)).toBeUndefined();
+    expect(mismatched.updates).toHaveLength(0);
+  });
+
+  it("ignores things that are not api tokens without touching the db", async () => {
+    const select = vi.fn();
+    const db = { select } as never;
+    expect(await authenticateApiToken(db, "fc_link_something")).toBeUndefined();
+    expect(select).not.toHaveBeenCalled();
+  });
+});

--- a/cloud/apps/auth-web/src/lib/api-tokens.ts
+++ b/cloud/apps/auth-web/src/lib/api-tokens.ts
@@ -1,0 +1,170 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { accountApiTokens, accounts, type createDb } from "@frameos-cloud/db";
+import { createSecretToken, hashSecret } from "./secrets";
+
+// Personal API tokens: the account, as a bearer. Minted on /account/developer
+// (or POST /api/account/api-tokens), shown once, stored hashed, and accepted
+// by readSession() wherever a session cookie is — which makes every JSON route
+// and the MCP server at /api/mcp usable from a script or an agent without a
+// browser. The three sudo-mode routes (frame revoke, link revoke, device
+// approval) read the session COOKIE's freshness and therefore stay closed to
+// tokens; so do the 2FA routes, which demand a live proof in the body.
+//
+// Two kinds, told apart by prefix so the CSRF gate can refuse a mutation
+// before any database work: `fc_api_…` may do everything the account may,
+// `fc_apiro_…` only GET. The database row is still the authority — a token
+// whose row says read_only is refused for mutations even if someone forged
+// the prefix, and vice versa.
+
+export const apiTokenPrefix = "fc_api";
+export const apiTokenReadOnlyPrefix = "fc_apiro";
+export const apiTokenAccessValues = ["full", "read_only"] as const;
+export type ApiTokenAccess = (typeof apiTokenAccessValues)[number];
+
+export const maxApiTokensPerAccount = 25;
+export const maxApiTokenNameLength = 64;
+export const maxApiTokenTtlDays = 365;
+
+// Recent use is recorded at most this often; the column is for "is this
+// token still in use", not an access log.
+const lastUsedWriteIntervalMs = 60 * 1000;
+
+export type ApiTokenIdentity = {
+  access: ApiTokenAccess;
+  id: string;
+  name: string;
+};
+
+export function bearerToken(authorization: string | null | undefined) {
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || undefined;
+}
+
+export function isApiToken(token: string | undefined): token is string {
+  return (
+    typeof token === "string" &&
+    (token.startsWith(`${apiTokenPrefix}_`) ||
+      token.startsWith(`${apiTokenReadOnlyPrefix}_`))
+  );
+}
+
+export function apiTokenAccessFromPrefix(token: string): ApiTokenAccess {
+  return token.startsWith(`${apiTokenReadOnlyPrefix}_`) ? "read_only" : "full";
+}
+
+export function mintApiToken(access: ApiTokenAccess) {
+  const token = createSecretToken(
+    access === "read_only" ? apiTokenReadOnlyPrefix : apiTokenPrefix,
+    32,
+  );
+  return { hint: tokenHint(token), token, tokenHash: hashSecret(token) };
+}
+
+// Prefix plus the first four random characters. Computed from the known
+// prefix length, not by searching for "_": base64url output contains
+// underscores of its own.
+export function tokenHint(token: string) {
+  const prefix = token.startsWith(`${apiTokenReadOnlyPrefix}_`)
+    ? apiTokenReadOnlyPrefix
+    : apiTokenPrefix;
+  return token.slice(0, prefix.length + 1 + 4);
+}
+
+export type AuthenticatedApiToken = {
+  account: { email: string | null; id: string; name: string | null };
+  token: ApiTokenIdentity;
+};
+
+// Resolves a raw bearer to its account, or undefined for anything that is not
+// a live token. Stamps last_used_at (throttled) as a side effect.
+export async function authenticateApiToken(
+  db: ReturnType<typeof createDb>,
+  token: string,
+): Promise<AuthenticatedApiToken | undefined> {
+  if (!isApiToken(token)) {
+    return undefined;
+  }
+  const [row] = await db
+    .select({
+      access: accountApiTokens.access,
+      accountId: accountApiTokens.accountId,
+      email: accounts.primaryEmail,
+      expiresAt: accountApiTokens.expiresAt,
+      id: accountApiTokens.id,
+      lastUsedAt: accountApiTokens.lastUsedAt,
+      name: accountApiTokens.name,
+      accountName: accounts.displayName,
+    })
+    .from(accountApiTokens)
+    .innerJoin(accounts, eq(accounts.id, accountApiTokens.accountId))
+    .where(
+      and(
+        eq(accountApiTokens.tokenHash, hashSecret(token)),
+        isNull(accountApiTokens.revokedAt),
+      ),
+    )
+    .limit(1);
+  if (!row) {
+    return undefined;
+  }
+  const now = new Date();
+  if (row.expiresAt && row.expiresAt <= now) {
+    return undefined;
+  }
+  const access = row.access === "read_only" ? "read_only" : "full";
+  if (access !== apiTokenAccessFromPrefix(token)) {
+    return undefined;
+  }
+  if (
+    !row.lastUsedAt ||
+    now.getTime() - row.lastUsedAt.getTime() > lastUsedWriteIntervalMs
+  ) {
+    await db
+      .update(accountApiTokens)
+      .set({ lastUsedAt: now })
+      .where(eq(accountApiTokens.id, row.id));
+  }
+  return {
+    account: { email: row.email, id: row.accountId, name: row.accountName },
+    token: { access, id: row.id, name: row.name },
+  };
+}
+
+export function serializeApiToken(row: {
+  access: string;
+  createdAt: Date;
+  expiresAt: Date | null;
+  id: string;
+  lastUsedAt: Date | null;
+  name: string;
+  revokedAt: Date | null;
+  tokenHint: string;
+}) {
+  return {
+    access: row.access === "read_only" ? "read_only" : "full",
+    created_at: row.createdAt.toISOString(),
+    expires_at: row.expiresAt?.toISOString() ?? null,
+    id: row.id,
+    last_used_at: row.lastUsedAt?.toISOString() ?? null,
+    name: row.name,
+    revoked_at: row.revokedAt?.toISOString() ?? null,
+    token_hint: row.tokenHint,
+  };
+}
+
+export async function listApiTokens(
+  db: ReturnType<typeof createDb>,
+  accountId: string,
+) {
+  const rows = await db
+    .select()
+    .from(accountApiTokens)
+    .where(
+      and(
+        eq(accountApiTokens.accountId, accountId),
+        isNull(accountApiTokens.revokedAt),
+      ),
+    )
+    .orderBy(accountApiTokens.createdAt);
+  return rows.map(serializeApiToken);
+}

--- a/cloud/apps/auth-web/src/lib/audit-labels.ts
+++ b/cloud/apps/auth-web/src/lib/audit-labels.ts
@@ -8,6 +8,8 @@ const eventLabels: Record<string, string> = {
   "account.password_changed": "Password changed",
   "account.password_reset": "Password reset completed",
   "account.password_reset_requested": "Password reset requested",
+  "account.api_token_created": "API token created",
+  "account.api_token_revoked": "API token revoked",
   "account.passkey_added": "Passkey added",
   "account.passkey_removed": "Passkey removed",
   "account.passkey_renamed": "Passkey renamed",

--- a/cloud/apps/auth-web/src/lib/csrf.test.ts
+++ b/cloud/apps/auth-web/src/lib/csrf.test.ts
@@ -39,6 +39,38 @@ describe("csrfResponse", () => {
     }
   });
 
+  it("exempts requests that carry a personal API token", () => {
+    process.env.FRAMEOS_CLOUD_APP_URL = "https://cloud.frameos.net";
+    // No Origin at all — a script, not a browser tab.
+    const request = new NextRequest("https://cloud.frameos.net/api/frames/x", {
+      headers: { authorization: "Bearer fc_api_abcdef" },
+      method: "POST",
+    });
+    expect(csrfResponse(request)).toBeUndefined();
+  });
+
+  it("stops read-only tokens before the route does any work", async () => {
+    process.env.FRAMEOS_CLOUD_APP_URL = "https://cloud.frameos.net";
+    const request = new NextRequest("https://cloud.frameos.net/api/frames/x", {
+      headers: { authorization: "Bearer fc_apiro_abcdef" },
+      method: "POST",
+    });
+    const response = csrfResponse(request);
+    expect(response?.status).toBe(403);
+    expect(await response?.json()).toEqual({ error: "read_only_token" });
+  });
+
+  it("still demands an origin for other bearer kinds", async () => {
+    process.env.FRAMEOS_CLOUD_APP_URL = "https://cloud.frameos.net";
+    const request = new NextRequest("https://cloud.frameos.net/api/frames/x", {
+      headers: { authorization: "Bearer fc_link_abcdef" },
+      method: "POST",
+    });
+    const response = csrfResponse(request);
+    expect(response?.status).toBe(403);
+    expect(await response?.json()).toEqual({ error: "missing_origin" });
+  });
+
   it("rejects other origins", async () => {
     process.env.FRAMEOS_CLOUD_APP_URL = "https://cloud.frameos.net";
     process.env.FRAMEOS_ACCOUNT_APP_URL = "https://account.frameos.net";

--- a/cloud/apps/auth-web/src/lib/csrf.ts
+++ b/cloud/apps/auth-web/src/lib/csrf.ts
@@ -1,7 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  apiTokenAccessFromPrefix,
+  bearerToken,
+  isApiToken,
+} from "./api-tokens";
 import { getAppOrigins } from "./env";
 
+// Origin check for cookie-authenticated mutations. A request that carries a
+// personal API token instead is exempt — a browser never attaches a bearer
+// on its own, so there is no ambient credential to forge a request with —
+// but a read-only token is stopped right here, before the route does any
+// work: every mutating route calls this first, which makes it the one place
+// that sees the method and the credential together. (readSession() still
+// verifies the token's row says the same thing as its prefix.)
 export function csrfResponse(request: NextRequest) {
+  const token = bearerToken(request.headers.get("authorization"));
+  if (isApiToken(token)) {
+    if (apiTokenAccessFromPrefix(token) === "read_only") {
+      return NextResponse.json({ error: "read_only_token" }, { status: 403 });
+    }
+    return undefined;
+  }
+
   const origin = request.headers.get("origin");
   if (!origin) {
     return NextResponse.json({ error: "missing_origin" }, { status: 403 });

--- a/cloud/apps/auth-web/src/lib/scene-origin.test.ts
+++ b/cloud/apps/auth-web/src/lib/scene-origin.test.ts
@@ -95,7 +95,7 @@ describe("scene origin stamps", () => {
     const stamped = withStoreSceneOrigin([null, "x", { name: "no id" }], source);
     expect(stamped[0]).toBeNull();
     expect(stamped[1]).toBe("x");
-    expect((stamped[2] as { origin: { sceneId?: string } }).origin.sceneId).toBeUndefined();
+    expect((stamped[2] as unknown as { origin: { sceneId?: string } }).origin.sceneId).toBeUndefined();
   });
 
   it("rewrites scenes.json inside the interchange zip and keeps the manifest and image bytes", () => {
@@ -119,9 +119,9 @@ describe("scene origin stamps", () => {
       "Visited World Map/scenes.json",
       "Visited World Map/template.json",
     ]);
-    expect(Buffer.from(files["Visited World Map/template.json"])).toEqual(Buffer.from(manifest));
-    expect(Buffer.from(files["Visited World Map/image.jpg"])).toEqual(Buffer.from(image));
-    const scenes = JSON.parse(Buffer.from(files["Visited World Map/scenes.json"]).toString("utf8"));
+    expect(Buffer.from(files["Visited World Map/template.json"]!)).toEqual(Buffer.from(manifest));
+    expect(Buffer.from(files["Visited World Map/image.jpg"]!)).toEqual(Buffer.from(image));
+    const scenes = JSON.parse(Buffer.from(files["Visited World Map/scenes.json"]!).toString("utf8"));
     expect(scenes).toEqual([
       {
         edges: [],

--- a/cloud/apps/auth-web/src/lib/scene-origin.ts
+++ b/cloud/apps/auth-web/src/lib/scene-origin.ts
@@ -106,7 +106,8 @@ export function rebuildZipWithSceneOrigins(
       manifestPath.length - "template.json".length,
     );
     const scenesBytes = files[`${folder}scenes.json`];
-    if (!scenesBytes) {
+    const manifestBytes = files[manifestPath];
+    if (!scenesBytes || !manifestBytes) {
       return undefined;
     }
     const scenes: unknown = JSON.parse(Buffer.from(scenesBytes).toString("utf8"));
@@ -114,7 +115,7 @@ export function rebuildZipWithSceneOrigins(
       return undefined;
     }
     const next: Record<string, Uint8Array> = {
-      [manifestPath]: files[manifestPath],
+      [manifestPath]: manifestBytes,
       [`${folder}scenes.json`]: strToU8(
         JSON.stringify(withStoreSceneOrigin(scenes, source), null, 2),
       ),

--- a/cloud/apps/auth-web/src/lib/scene-render.test.ts
+++ b/cloud/apps/auth-web/src/lib/scene-render.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodePng,
+  isRenderErrorLine,
+  rendererAvailable,
+  renderScenes,
+} from "./scene-render";
+
+// The PNG writer and the error classifier are pure. The end-to-end render
+// needs the wasm bundle under public/frameos-wasm, which the dev/build
+// scripts copy in; without it (a bare checkout) that test skips rather
+// than fails, the same way the route answers renderer_unavailable.
+
+describe("encodePng", () => {
+  it("writes a well-formed RGBA PNG", () => {
+    const rgba = new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]);
+    const png = encodePng(rgba, 2, 1);
+    expect([...png.subarray(0, 8)]).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(png.subarray(12, 16).toString("ascii")).toBe("IHDR");
+    expect(png.readUInt32BE(16)).toBe(2);
+    expect(png.readUInt32BE(20)).toBe(1);
+    expect(png.subarray(png.length - 8, png.length - 4).toString("ascii")).toBe("IEND");
+  });
+
+  it("refuses a buffer that does not match the dimensions", () => {
+    expect(() => encodePng(new Uint8Array(3), 1, 1)).toThrow(/expected 4/);
+  });
+});
+
+describe("isRenderErrorLine", () => {
+  it("classifies runtime events and plain lines", () => {
+    expect(isRenderErrorLine('{"event":"error:4","error":"no key"}')).toBe(true);
+    expect(isRenderErrorLine('{"event":"render:done"}')).toBe(false);
+    expect(isRenderErrorLine("http error while fetching")).toBe(true);
+    expect(isRenderErrorLine("scene initialized")).toBe(false);
+  });
+});
+
+describe.skipIf(!rendererAvailable())("renderScenes", () => {
+  it("renders a scene to a PNG with its logs and state", async () => {
+    const result = await renderScenes({
+      height: 120,
+      scenes: [
+        {
+          edges: [],
+          fields: [{ access: "public", name: "text", type: "string", value: "hi" }],
+          id: "s1",
+          name: "Blank",
+          nodes: [
+            { data: { keyword: "render" }, id: "e1", position: { x: 0, y: 0 }, type: "event" },
+          ],
+          settings: { backgroundColor: "#ffffff", execution: "interpreted" },
+        },
+      ],
+      timeZone: "Europe/Brussels",
+      width: 160,
+    });
+    expect(result.width).toBe(160);
+    expect(result.height).toBe(120);
+    expect(result.png.subarray(1, 4).toString("ascii")).toBe("PNG");
+    expect(result.logs.some((line) => line.includes("initialized"))).toBe(true);
+    expect(result.state).toMatchObject({ text: "hi" });
+  }, 60_000);
+});

--- a/cloud/apps/auth-web/src/lib/scene-render.ts
+++ b/cloud/apps/auth-web/src/lib/scene-render.ts
@@ -1,0 +1,555 @@
+import { Buffer } from "node:buffer";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+import { zlibSync } from "fflate";
+import { logWarn } from "./log";
+
+// Headless scene rendering on the server: the same frameos-wasm bundle the
+// browser live preview runs (public/frameos-wasm, built with `node` in its
+// emscripten ENVIRONMENT — the self-hosted backend's thin-client renderer
+// drives it the same way, backend/tools/embedded_wasm_render.mjs). No
+// Chromium, no Playwright: a worker thread loads the module, runs the
+// scene once (plus a short settle for scenes that re-render themselves),
+// hands back raw RGBA, and the main thread PNG-encodes it with fflate.
+//
+// Why a worker: the Nim/pixie pipeline is synchronous and so is the HTTP
+// bridge scene apps fetch through (a sync XHR; here each request runs in a
+// short-lived child Node, exactly as the backend's renderer does). Neither
+// may sit on the server's event loop. Every render gets a fresh worker and
+// a fresh module — nothing leaks between two accounts' scenes — and the
+// pool below bounds how many 64 MB wasm heaps exist at once.
+
+export type SceneRenderOptions = {
+  height: number;
+  /** Scene to select; defaults to the runtime's default scene. */
+  sceneId?: string | undefined;
+  scenes: unknown[];
+  /** Frame settings the runtime reads (service keys etc.). */
+  settings?: Record<string, unknown> | undefined;
+  /** Give up after this long, worker included; default 30 s. */
+  timeoutMs?: number | undefined;
+  /** IANA zone the simulated frame lives in; default UTC. */
+  timeZone?: string | undefined;
+  /** Seed per-scene state: { [sceneId]: state }. */
+  states?: Record<string, unknown> | undefined;
+  width: number;
+};
+
+export type SceneRenderResult = {
+  errors: string[];
+  height: number;
+  logs: string[];
+  png: Buffer;
+  renderMs: number;
+  /** The selected scene's state after the render (what it changed). */
+  state: unknown;
+  width: number;
+};
+
+export const defaultRenderTimeoutMs = 30_000;
+export const maxRenderPixels = 8 * 1024 * 1024;
+export const maxRenderDimension = 4096;
+export const minRenderDimension = 16;
+const maxConcurrentRenders = 2;
+const maxQueuedRenders = 8;
+const maxCollectedLogs = 200;
+const settleMs = 1_500;
+
+export class SceneRenderError extends Error {
+  constructor(
+    public readonly code:
+      | "render_failed"
+      | "render_timeout"
+      | "renderer_busy"
+      | "renderer_unavailable",
+    message: string,
+    public readonly logs: string[] = [],
+  ) {
+    super(message);
+  }
+}
+
+export function wasmAssetsDir(): string {
+  return path.join(process.cwd(), "public", "frameos-wasm");
+}
+
+export function rendererAvailable(): boolean {
+  const dir = wasmAssetsDir();
+  return (
+    existsSync(path.join(dir, "frameos.js")) &&
+    existsSync(path.join(dir, "frameos.wasm"))
+  );
+}
+
+// Same classification the in-browser render check uses: a JSON log whose
+// event starts with "error" or carries an `error` key, or a plain line that
+// mentions the word.
+export function isRenderErrorLine(line: string): boolean {
+  try {
+    const payload: unknown = JSON.parse(line);
+    if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+      const record = payload as Record<string, unknown>;
+      const event = typeof record.event === "string" ? record.event : "";
+      return event.startsWith("error") || "error" in record;
+    }
+  } catch {
+    // plain text
+  }
+  return /\berror\b/i.test(line);
+}
+
+let running = 0;
+const waiting: (() => void)[] = [];
+
+async function acquireSlot(): Promise<() => void> {
+  if (running < maxConcurrentRenders) {
+    running += 1;
+  } else {
+    if (waiting.length >= maxQueuedRenders) {
+      throw new SceneRenderError(
+        "renderer_busy",
+        "Too many renders in flight; try again in a moment.",
+      );
+    }
+    await new Promise<void>((resolve) => waiting.push(resolve));
+    running += 1;
+  }
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    running -= 1;
+    waiting.shift()?.();
+  };
+}
+
+export async function renderScenes(
+  options: SceneRenderOptions,
+): Promise<SceneRenderResult> {
+  if (!rendererAvailable()) {
+    throw new SceneRenderError(
+      "renderer_unavailable",
+      "The wasm runtime is not installed on this server.",
+    );
+  }
+  const release = await acquireSlot();
+  try {
+    return await runWorker(options);
+  } finally {
+    release();
+  }
+}
+
+type WorkerResult =
+  | {
+      buffer: ArrayBuffer;
+      height: number;
+      logs: string[];
+      ok: true;
+      renderMs: number;
+      state: unknown;
+      width: number;
+    }
+  | { logs: string[]; message: string; ok: false };
+
+function runWorker(options: SceneRenderOptions): Promise<SceneRenderResult> {
+  const timeoutMs = options.timeoutMs ?? defaultRenderTimeoutMs;
+  return new Promise<SceneRenderResult>((resolve, reject) => {
+    const worker = new Worker(workerSourceText(), {
+      eval: true,
+      // No IDBFS, no assets: a plain MEMFS is all a preview needs.
+      resourceLimits: { maxOldGenerationSizeMb: 512 },
+      workerData: {
+        assetsDir: wasmAssetsDir(),
+        height: options.height,
+        maxLogs: maxCollectedLogs,
+        sceneId: options.sceneId ?? "",
+        scenesJson: JSON.stringify(options.scenes),
+        settingsJson: JSON.stringify(options.settings ?? {}),
+        settleMs,
+        statesJson: JSON.stringify(options.states ?? {}),
+        timeZone: options.timeZone || "UTC",
+        width: options.width,
+      },
+    });
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      fn();
+      void worker.terminate();
+    };
+    const timer = setTimeout(() => {
+      finish(() =>
+        reject(
+          new SceneRenderError(
+            "render_timeout",
+            `The scene did not render within ${Math.round(timeoutMs / 1000)}s.`,
+          ),
+        ),
+      );
+    }, timeoutMs);
+    worker.once("message", (result: WorkerResult) => {
+      finish(() => {
+        if (!result.ok) {
+          reject(new SceneRenderError("render_failed", result.message, result.logs));
+          return;
+        }
+        try {
+          resolve({
+            errors: result.logs.filter(isRenderErrorLine),
+            height: result.height,
+            logs: result.logs,
+            png: encodePng(
+              new Uint8Array(result.buffer),
+              result.width,
+              result.height,
+            ),
+            renderMs: result.renderMs,
+            state: result.state,
+            width: result.width,
+          });
+        } catch (error) {
+          reject(
+            new SceneRenderError(
+              "render_failed",
+              error instanceof Error ? error.message : String(error),
+              result.logs,
+            ),
+          );
+        }
+      });
+    });
+    worker.once("error", (error) => {
+      logWarn("scene_render.worker_error", { message: String(error) });
+      finish(() =>
+        reject(new SceneRenderError("render_failed", String(error))),
+      );
+    });
+    worker.once("exit", (code) => {
+      finish(() =>
+        reject(
+          new SceneRenderError(
+            "render_failed",
+            `The renderer exited early (code ${code}).`,
+          ),
+        ),
+      );
+    });
+  });
+}
+
+// Minimal PNG writer: 8-bit RGBA, filter type 0 on every scanline, one
+// IDAT. fflate already ships for the zip handling, so no native encoder is
+// needed for a preview.
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (crcTable[(crc ^ byte) & 0xff] ?? 0) ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type: string, data: Uint8Array): Buffer {
+  const typeBytes = Buffer.from(type, "ascii");
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])), 0);
+  return Buffer.concat([length, typeBytes, data, crc]);
+}
+
+export function encodePng(
+  rgba: Uint8Array,
+  width: number,
+  height: number,
+): Buffer {
+  if (rgba.length !== width * height * 4) {
+    throw new Error(
+      `pixel buffer is ${rgba.length} bytes, expected ${width * height * 4}`,
+    );
+  }
+  const stride = width * 4;
+  const raw = new Uint8Array((stride + 1) * height);
+  for (let y = 0; y < height; y += 1) {
+    raw[y * (stride + 1)] = 0;
+    raw.set(rgba.subarray(y * stride, (y + 1) * stride), y * (stride + 1) + 1);
+  }
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8; // bit depth
+  header[9] = 6; // colour type RGBA
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk("IHDR", header),
+    chunk("IDAT", zlibSync(raw, { level: 6 })),
+    chunk("IEND", new Uint8Array(0)),
+  ]);
+}
+
+// The worker body, as source: `eval: true` keeps it out of Next's bundler
+// (frameos.js uses import.meta.url and createRequire, which the bundler
+// would rewrite) and out of the standalone file tracer's blind spot.
+// Built lazily so the child script below is defined by the time it is
+// interpolated.
+let workerSourceCache: string | undefined;
+function workerSourceText(): string {
+  workerSourceCache ??= String.raw`
+const { parentPort, workerData } = require("node:worker_threads");
+const { spawnSync } = require("node:child_process");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const logs = [];
+const pushLog = (line) => {
+  if (logs.length < workerData.maxLogs) {
+    logs.push(String(line));
+  }
+};
+
+// Synchronous HTTP for the runtime's XHR bridge: one short-lived child Node
+// per request so the wait blocks this worker only. Private, loopback,
+// link-local and metadata addresses are refused after resolution, the same
+// guard the preview proxy applies for the browser.
+const FETCH_CHILD = ${JSON.stringify(fetchChildScript)};
+const MAX_REQUESTS = 24;
+let requests = 0;
+class SyncXMLHttpRequest {
+  open(method, url) {
+    this._method = method;
+    this._url = url;
+    this._headers = {};
+    this.status = 0;
+    this.response = null;
+    this.responseText = "";
+  }
+  setRequestHeader(name, value) {
+    this._headers[name] = value;
+  }
+  send(body) {
+    requests += 1;
+    if (requests > MAX_REQUESTS) {
+      throw new Error("too many HTTP requests for one preview");
+    }
+    const request = {
+      method: this._method,
+      url: this._url,
+      headers: this._headers,
+      timeoutMs: Math.min(this.timeout || 15000, 15000),
+      bodyBase64: body ? Buffer.from(body).toString("base64") : "",
+    };
+    const child = spawnSync(process.execPath, ["-e", FETCH_CHILD], {
+      input: JSON.stringify(request),
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: request.timeoutMs + 5000,
+    });
+    if (child.status !== 0 || !child.stdout) {
+      throw new Error("fetch failed: " + (child.stderr || child.status));
+    }
+    const result = JSON.parse(child.stdout.toString("utf-8"));
+    if (result.status === 0) {
+      throw new Error(result.error || "request failed");
+    }
+    this.status = result.status;
+    const bytes = Buffer.from(result.bodyBase64 || "", "base64");
+    if (this.responseType === "arraybuffer") {
+      this.response = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    } else {
+      this.responseText = bytes.toString("utf-8");
+      this.response = this.responseText;
+    }
+  }
+}
+globalThis.XMLHttpRequest = SyncXMLHttpRequest;
+
+const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+async function main() {
+  const wasmBinary = readFileSync(join(workerData.assetsDir, "frameos.wasm"));
+  const { default: createFrameOS } = await import(
+    pathToFileURL(join(workerData.assetsDir, "frameos.js")).href
+  );
+  const Module = await createFrameOS({
+    wasmBinary,
+    print: pushLog,
+    printErr: pushLog,
+    onFrameosLog: pushLog,
+  });
+  const call = (name, ret, argTypes, args) => Module.ccall(name, ret, argTypes, args);
+  const lastError = () => {
+    try {
+      return call("frameos_wasm_last_error", "string", [], []);
+    } catch (error) {
+      return String(error);
+    }
+  };
+  const fail = (message) => {
+    parentPort.postMessage({ ok: false, message, logs });
+  };
+
+  const started = Date.now();
+  const ok = call(
+    "frameos_wasm_init",
+    "boolean",
+    ["number", "number", "string", "string", "string"],
+    [workerData.width, workerData.height, "preview", workerData.timeZone, workerData.settingsJson],
+  );
+  if (!ok) {
+    return fail("init failed: " + lastError());
+  }
+  const loaded = call("frameos_wasm_load_scenes", "number", ["string"], [workerData.scenesJson]);
+  if (!loaded) {
+    return fail("no scenes loaded: " + lastError());
+  }
+  if (workerData.sceneId) {
+    if (!call("frameos_wasm_select_scene", "boolean", ["string"], [workerData.sceneId])) {
+      return fail("scene " + workerData.sceneId + " not found: " + lastError());
+    }
+  }
+  let states = {};
+  try {
+    states = JSON.parse(workerData.statesJson) || {};
+  } catch {
+    states = {};
+  }
+  for (const [sceneId, state] of Object.entries(states)) {
+    if (!state || typeof state !== "object") continue;
+    try {
+      call("frameos_wasm_set_scene_state", "boolean", ["string", "string"], [sceneId, JSON.stringify(state)]);
+    } catch {
+      break;
+    }
+  }
+
+  const renderOnce = () => {
+    const rc = call("frameos_wasm_render", "number", [], []);
+    return rc !== 2;
+  };
+  if (!renderOnce()) {
+    return fail("render failed: " + lastError());
+  }
+  // Scenes that fetch or animate ask for another pass right after the first
+  // one; give them a moment, like the browser preview's settle window.
+  const settleUntil = Date.now() + workerData.settleMs;
+  let extra = 0;
+  while (Date.now() < settleUntil && extra < 3) {
+    sleep(100);
+    let requested = 0;
+    try {
+      requested = call("frameos_wasm_render_requested", "number", [], []);
+    } catch {
+      break;
+    }
+    if (!requested) continue;
+    extra += 1;
+    if (!renderOnce()) break;
+  }
+
+  const width = call("frameos_wasm_width", "number", [], []);
+  const height = call("frameos_wasm_height", "number", [], []);
+  const ptr = call("frameos_wasm_buffer", "number", [], []);
+  const len = call("frameos_wasm_buffer_len", "number", [], []);
+  if (!ptr || !len || len !== width * height * 4) {
+    return fail("unexpected frame buffer: " + lastError());
+  }
+  const buffer = Module.HEAPU8.buffer.slice(ptr, ptr + len);
+  let state = null;
+  try {
+    state = JSON.parse(call("frameos_wasm_scene_state", "string", [], []));
+  } catch {
+    state = null;
+  }
+  parentPort.postMessage(
+    { ok: true, buffer, width, height, logs, renderMs: Date.now() - started, state },
+    [buffer],
+  );
+}
+
+main().catch((error) => {
+  parentPort.postMessage({ ok: false, message: String(error && error.stack || error), logs });
+});
+`;
+  return workerSourceCache;
+}
+
+// Runs in a child Node per HTTP request: resolves the host first and refuses
+// anything private before a byte leaves the box; caps the body at 10 MB.
+const fetchChildScript = String.raw`
+const dns = require("node:dns/promises");
+const { isIP } = require("node:net");
+const chunks = [];
+function addressIsPrivate(address) {
+  const plain = address.split("%")[0] || address;
+  if (isIP(plain) === 4) {
+    const [a = -1, b = -1] = plain.split(".").map(Number);
+    return a === 0 || a === 10 || a === 127 || (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) || a >= 224;
+  }
+  const lower = plain.toLowerCase();
+  return lower === "::" || lower === "::1" || /^fe[89ab]/.test(lower) || lower.startsWith("fc") ||
+    lower.startsWith("fd") || lower.startsWith("::ffff:");
+}
+async function hostIsBlocked(hostname) {
+  let addresses;
+  if (isIP(hostname)) {
+    addresses = [hostname];
+  } else {
+    try {
+      addresses = (await dns.lookup(hostname, { all: true, verbatim: true })).map((r) => r.address);
+    } catch {
+      return true;
+    }
+  }
+  return addresses.length === 0 || addresses.some(addressIsPrivate);
+}
+process.stdin.on("data", (c) => chunks.push(c));
+process.stdin.on("end", async () => {
+  const req = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+  try {
+    const url = new URL(req.url);
+    if ((url.protocol !== "http:" && url.protocol !== "https:") || (await hostIsBlocked(url.hostname))) {
+      throw new Error("host not allowed");
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), req.timeoutMs || 15000);
+    const response = await fetch(url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.bodyBase64 ? Buffer.from(req.bodyBase64, "base64") : undefined,
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    const body = Buffer.from(await response.arrayBuffer());
+    if (body.length > 10 * 1024 * 1024) {
+      throw new Error("response too large");
+    }
+    process.stdout.write(JSON.stringify({ status: response.status, bodyBase64: body.toString("base64") }));
+  } catch (error) {
+    process.stdout.write(JSON.stringify({ status: 0, error: String(error) }));
+  }
+});
+`;

--- a/cloud/apps/auth-web/src/lib/session.ts
+++ b/cloud/apps/auth-web/src/lib/session.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import { jwtVerify, SignJWT } from "jose";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { createDb, sessions } from "@frameos-cloud/db";
 import { hasDatabaseUrl } from "./env";
 import { derivedSigningKey } from "./keys";
+import { authenticateApiToken, bearerToken, isApiToken } from "./api-tokens";
 import { hashSecret } from "./secrets";
 import {
   sessionAbsoluteMaxAgeSeconds,
@@ -25,12 +26,18 @@ export {
 
 export type SessionProfile = {
   accountId?: string | undefined;
+  // Set when the request authenticated with a personal API token (lib/api-tokens)
+  // instead of a session cookie. Routes that must not run on a token — minting
+  // more tokens, say — check this; everything else treats both alike.
+  apiToken?: { access: "full" | "read_only"; id: string; name: string } | undefined;
   email?: string | undefined;
   emailVerified?: boolean | undefined;
   name?: string | undefined;
   providerIssuer: string;
   providerSubject: string;
 };
+
+export const apiTokenProviderIssuer = "frameos-cloud-api-token";
 
 function secretKey() {
   return derivedSigningKey("session");
@@ -107,7 +114,7 @@ export async function readSession() {
     const cookieStore = await cookies();
     const token = cookieStore.get(sessionCookieName)?.value;
     if (!token) {
-      return undefined;
+      return readApiTokenSession();
     }
 
     const verified = await jwtVerify(token, secretKey());
@@ -140,6 +147,34 @@ export async function readSession() {
     }
 
     return sessionProfile;
+  } catch {
+    return undefined;
+  }
+}
+
+// A personal API token in the Authorization header stands in for the cookie:
+// same profile shape, so every route's `readSession()` gate accepts it
+// unchanged. Only consulted when there is no cookie — a browser tab never
+// sends a bearer, and a script never has the cookie.
+async function readApiTokenSession(): Promise<SessionProfile | undefined> {
+  try {
+    const token = bearerToken((await headers()).get("authorization"));
+    if (!isApiToken(token) || !hasDatabaseUrl()) {
+      return undefined;
+    }
+    const authenticated = await authenticateApiToken(createDb(), token);
+    if (!authenticated) {
+      return undefined;
+    }
+    return {
+      accountId: authenticated.account.id,
+      apiToken: authenticated.token,
+      email: authenticated.account.email ?? undefined,
+      emailVerified: true,
+      name: authenticated.account.name ?? undefined,
+      providerIssuer: apiTokenProviderIssuer,
+      providerSubject: `api-token:${authenticated.token.id}`,
+    };
   } catch {
     return undefined;
   }

--- a/cloud/apps/auth-web/src/lib/ssrf.ts
+++ b/cloud/apps/auth-web/src/lib/ssrf.ts
@@ -1,0 +1,80 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+// SSRF guard shared by every server-side fetch of a user-supplied URL (the
+// preview proxy, the MCP server's scene imports): reject hosts resolving to
+// loopback / private / link-local / reserved addresses so the server cannot
+// be used to probe its own network. DNS resolves once here; a rebind between
+// check and fetch is a residual risk accepted for these features.
+export async function hostIsBlocked(hostname: string): Promise<boolean> {
+  const literal = isIP(hostname) ? [hostname] : null;
+  let addresses: string[];
+  if (literal) {
+    addresses = literal;
+  } else {
+    try {
+      const results = await lookup(hostname, { all: true, verbatim: true });
+      addresses = results.map((result) => result.address);
+    } catch {
+      return true;
+    }
+  }
+  return addresses.length === 0 || addresses.some(addressIsPrivate);
+}
+
+export function addressIsPrivate(address: string): boolean {
+  const plain = address.split("%")[0] ?? address;
+  if (isIP(plain) === 4) {
+    const octets = plain.split(".").map(Number);
+    const [a = -1, b = -1] = octets;
+    return (
+      a === 0 || // unspecified
+      a === 10 ||
+      a === 127 || // loopback
+      (a === 100 && b >= 64 && b <= 127) || // CGNAT
+      (a === 169 && b === 254) || // link-local
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      a >= 224 // multicast + reserved
+    );
+  }
+  const lower = plain.toLowerCase();
+  // Loopback, unspecified, link-local, unique-local, and v4-mapped forms.
+  return (
+    lower === "::" ||
+    lower === "::1" ||
+    lower.startsWith("fe8") ||
+    lower.startsWith("fe9") ||
+    lower.startsWith("fea") ||
+    lower.startsWith("feb") ||
+    lower.startsWith("fc") ||
+    lower.startsWith("fd") ||
+    lower.startsWith("::ffff:")
+  );
+}
+
+// A fetch that applies the guard before every request (redirects included:
+// each hop is checked, so a public URL cannot bounce to an internal one).
+export async function guardedFetch(
+  input: string,
+  init?: RequestInit,
+  maxRedirects = 5,
+): Promise<Response> {
+  let url = new URL(input);
+  for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("invalid_url");
+    }
+    if (await hostIsBlocked(url.hostname)) {
+      throw new Error("host_not_allowed");
+    }
+    const response = await fetch(url, { ...init, redirect: "manual" });
+    const location = response.headers.get("location");
+    if (response.status >= 300 && response.status < 400 && location) {
+      url = new URL(location, url);
+      continue;
+    }
+    return response;
+  }
+  throw new Error("too_many_redirects");
+}

--- a/cloud/docs/mcp.md
+++ b/cloud/docs/mcp.md
@@ -1,0 +1,149 @@
+# FrameOS Cloud MCP and API tokens
+
+FrameOS Cloud exposes everything a signed-in account can do — frames, scenes,
+the store, the scene AI — to scripts and AI agents in two layers:
+
+1. **Personal API tokens** (`fc_api_…`): a bearer credential accepted by every
+   account-scoped JSON route exactly where the session cookie is.
+2. **The MCP server** at `POST /api/mcp`: the same API as [Model Context
+   Protocol](https://modelcontextprotocol.io) tools, with descriptions an
+   agent can act on. It lives in `packages/mcp` and is, by design, a thin
+   wrapper — every tool is one (occasionally two) HTTP calls to the routes
+   under `apps/auth-web/app/api`, so the routes remain the single place
+   behaviour, validation, quotas and audit live.
+
+Both are managed on `/account/developer`.
+
+## API tokens
+
+| | |
+|---|---|
+| Table | `account_api_tokens` (migration 0040): hash, hint, `access`, expiry, last use, revocation |
+| Mint | `POST /api/account/api-tokens` `{name, access?: "full"\|"read_only", expires_in_days?}` → `{token, api_token}` — the secret is returned once. Needs a session (never a token) and a recent proof of credentials (`recentApprovalMaxAgeSeconds`, 2 h) because it turns a session into a durable credential — the same gate device approval has. |
+| List / revoke | `GET /api/account/api-tokens`, `DELETE /api/account/api-tokens/{id}`. A token may revoke itself. |
+| Cap | 25 live tokens per account (`maxApiTokensPerAccount`). |
+| Use | `Authorization: Bearer fc_api_…` on any route that calls `readSession()`. |
+
+How it plugs in (`src/lib/api-tokens.ts`):
+
+- `readSession()` falls back to the bearer when there is no session cookie and
+  returns the usual `SessionProfile` plus `apiToken: {id, name, access}`, so
+  no route changed. `providerIssuer` is `frameos-cloud-api-token`.
+- `csrfResponse()` exempts bearer-token requests from the Origin check (a
+  browser never attaches one on its own) and refuses read-only tokens
+  (`fc_apiro_…`) outright with `403 read_only_token` — it is the one helper
+  every mutating route calls first, and it sees method and credential
+  together. The database row's `access` is verified again in
+  `authenticateApiToken`, so a forged prefix buys nothing.
+- What tokens cannot do: the sudo-mode routes (`/api/frames/{id}/revoke`,
+  `/api/device/revoke`, `/api/device/authorize`) read the session cookie's
+  `authenticated_at` and answer `403 reauth_required`; the 2FA routes demand a
+  live proof in the body; minting tokens answers `403 api_token_not_allowed`.
+- Rate limits are per client IP, unchanged. Audit events:
+  `account.api_token_created`, `account.api_token_revoked`.
+
+## Routes added for the MCP (usable directly too)
+
+| Route | Purpose |
+|---|---|
+| `GET /api/account/usage` | Account, the auth kind in use, usage against every quota (`accountUsage()`), and the fixed caps (`limits`). |
+| `GET /api/account/scenes` | The account's scenes as JSON (`?q=&visibility=&status=`), the rows `/my-scenes` renders. |
+| `GET /api/account/scenes/{id}` | One scene: summary, all versions, gallery images, preview/share URLs. |
+| `POST /api/scenes/lint` | `{scenes}` → `{ok, errors, warnings}`: the AI's delivery gate (shape, app keywords, deep lint). |
+| `POST /api/scenes/render` | `{scene_id\|scenes, version?, scene?, width?, height?, time_zone?, settings?, states?, format?}` → PNG (or JSON with `png_base64`, logs, errors, state). |
+
+### Server-side rendering
+
+`src/lib/scene-render.ts` runs the same `frameos-wasm` bundle the browser
+live preview uses (`public/frameos-wasm`, built with `node` in its emscripten
+`ENVIRONMENT`) in a `worker_threads` Worker: init → load scenes → render →
+a 1.5 s settle for scenes that ask to re-render → raw RGBA → PNG (fflate).
+No Chromium. Scene apps' HTTP goes through a synchronous XHR shim that runs
+each request in a short-lived child Node with the same SSRF guard as the
+preview proxy (`src/lib/ssrf.ts`), capped at 24 requests and 10 MB per
+render. Two renders run concurrently, eight queue, 30 s timeout, one fresh
+64 MB wasm heap per render — nothing is shared between two accounts' scenes.
+`renderer_unavailable` (501) means the bundle is not on disk.
+
+## The MCP server
+
+### Connecting
+
+Hosted (no local process), from Claude Code:
+
+```sh
+claude mcp add --transport http frameos https://cloud.frameos.net/api/mcp \
+  --header "Authorization: Bearer fc_api_…"
+```
+
+Any Streamable-HTTP client: `{"type": "http", "url": "https://cloud.frameos.net/api/mcp", "headers": {"Authorization": "Bearer fc_api_…"}}`.
+
+Local stdio process (from a checkout, for clients without HTTP transport):
+
+```sh
+FRAMEOS_CLOUD_TOKEN=fc_api_… pnpm --filter @frameos-cloud/mcp start
+# FRAMEOS_CLOUD_URL / FRAMEOS_STORE_URL override the origins
+```
+
+### How the hosted endpoint works
+
+`app/api/mcp/route.ts` authenticates the bearer, builds a `McpServer` and a
+stateless `WebStandardStreamableHTTPServerTransport` (JSON responses, no
+sessions, no SSE) per request, and hands the request to it. Tool calls go
+back to this same process's own JSON routes over loopback (`request.url`'s
+origin, or `FRAMEOS_MCP_INTERNAL_ORIGIN`), carrying the caller's token and
+the forwarded-for chain so per-IP rate limits key on the real client. `GET`
+and `DELETE` answer 405: there is nothing to stream or end.
+
+### Tools
+
+Around 70 tools in five groups; every one documents its parameters. Read-only
+tools are annotated `readOnlyHint`, destructive ones `destructiveHint` and
+take `confirm: true`.
+
+- **account** — `account_info`, `account_quota`, `account_settings_get`
+  (secrets masked unless `reveal`), `account_settings_update` (merges over the
+  current group before posting), `api_tokens_list`, `api_token_revoke`.
+- **frames** — `frames_list`, `frame_get`, `frame_rename`, `frame_delete`,
+  `frame_revoke` (always refused for tokens; kept so the agent learns why),
+  `frame_confirm`, `frame_claim_token_create`, `frame_settings_update`,
+  `frame_scenes_list`, `frame_scenes_set`, `frame_scene_install` (from a store
+  id, a URL — store page, zip, scenes.json — or raw JSON; optional activate),
+  `frame_scene_remove`, `frame_scene_activate`, `frame_render`,
+  `frame_screenshot`, `frame_scene_preview`, `frame_logs` (filter + cap),
+  `frame_metrics`, `frame_metrics_request`, `frame_activity`,
+  `frame_commands_list`, `frame_command_cancel`, `frame_command_send`,
+  `frame_reboot`, `frame_restart`, `frame_schedule_get`, `frame_schedule_set`,
+  `frame_service_settings_enable`, `frame_telemetry_enable`,
+  `frame_assets_list`, `frame_asset_get`, `frame_asset_upload`,
+  `frame_asset_delete`, `frame_asset_mkdir`, `frame_asset_rename`,
+  `frame_assets_sync_fonts`, `frame_firmware_info`, `frame_firmware_update`.
+- **scenes** — `scenes_list`, `scene_get`, `scene_get_content`,
+  `scene_create` (JSON / zip URL / scenes.json URL; a store reference forks),
+  `scene_update_content` (new version), `scene_update` (description, tags,
+  category, frameos_version), `scene_rename` (through a content save, which
+  is what renames the listing), `scene_publish`, `scene_delete`,
+  `scene_fork`, `scene_version_restore`, `scene_version_yank`,
+  `scene_image_get`, `scene_image_add`, `scene_image_remove`,
+  `scene_images_reorder`, `scene_render`, `scene_lint`.
+- **store** — `store_browse`, `store_scene_get`, `store_scene_report`.
+- **ai** — `ai_scene_chat` (follows the NDJSON turn up to `wait_seconds`,
+  then `apply`: none / new_scene / save_version), `ai_turn_wait`,
+  `ai_turn_cancel`, `ai_chats_list`, `ai_chat_get`, `ai_chat_delete`.
+
+Resources: `frameos://frames`, `frameos://frames/{id}`, `frameos://scenes`,
+`frameos://scenes/{id}/content`. Prompts: `diagnose_frame`, `build_scene`.
+
+API refusals reach the model as `isError` results with the status, the code,
+the details the route sent, and — for the codes whose fix is not obvious
+(`reauth_required`, `read_only_token`, `settings_need_newer_firmware`,
+`turn_in_progress`, quota errors, …) — one sentence on what to do
+(`packages/mcp/src/result.ts`).
+
+### Tests
+
+`pnpm --filter @frameos-cloud/mcp test` drives the server through an
+in-memory MCP client against a fake cloud and pins, per tool, which routes
+are hit with what. The auth-web suite covers the token library, the CSRF
+bearer path, the token routes, the lint route and the renderer (the render
+test skips when `public/frameos-wasm` is absent).

--- a/cloud/packages/db/drizzle/0040_account_api_tokens.sql
+++ b/cloud/packages/db/drizzle/0040_account_api_tokens.sql
@@ -1,0 +1,27 @@
+-- Personal API tokens: a bearer credential that stands in for the account on
+-- the JSON API (and so for the MCP server at /api/mcp). Until now every
+-- account-scoped route accepted only the browser session cookie; a bearer
+-- resolved to a linked backend or frame, never to a person. Tokens are minted
+-- once, shown once, and stored as a SHA-256 hash like every other secret
+-- here. `access` is either 'full' or 'read_only'; the read-only kind is also
+-- recognisable from its prefix (fc_apiro_ vs fc_api_) so the CSRF gate can
+-- refuse a mutation before touching the database. Sudo-mode routes (frame
+-- revoke, device approval) keep requiring a fresh browser session; a token
+-- can never do those.
+CREATE TABLE "account_api_tokens" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "account_id" uuid NOT NULL REFERENCES "accounts"("id") ON DELETE CASCADE,
+  "name" text NOT NULL,
+  "access" text NOT NULL DEFAULT 'full',
+  "token_hash" text NOT NULL,
+  -- The first characters of the token, kept so the list can say which one
+  -- a leaked or configured token is without storing the token itself.
+  "token_hint" text NOT NULL,
+  "expires_at" timestamptz,
+  "last_used_at" timestamptz,
+  "revoked_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX "account_api_tokens_token_hash_unique" ON "account_api_tokens" ("token_hash");
+CREATE INDEX "account_api_tokens_account_idx" ON "account_api_tokens" ("account_id");

--- a/cloud/packages/db/src/schema.ts
+++ b/cloud/packages/db/src/schema.ts
@@ -301,6 +301,35 @@ export const sessions = pgTable(
   }),
 );
 
+// Personal API tokens (migration 0040): a bearer credential for the JSON API
+// and the MCP server that stands in for the account. Hash-at-rest like a
+// session; `access` is "full" or "read_only" and is mirrored by the token's
+// prefix (fc_api_ / fc_apiro_) so a mutation can be refused before any lookup.
+export const accountApiTokens = pgTable(
+  "account_api_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    accountId: uuid("account_id")
+      .notNull()
+      .references(() => accounts.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    access: text("access").default("full").notNull(),
+    tokenHash: text("token_hash").notNull(),
+    // Leading characters of the token, for telling tokens apart in a list.
+    tokenHint: text("token_hint").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    ...timestamps,
+  },
+  (table) => ({
+    accountIdx: index("account_api_tokens_account_idx").on(table.accountId),
+    tokenHashUnique: uniqueIndex("account_api_tokens_token_hash_unique").on(
+      table.tokenHash,
+    ),
+  }),
+);
+
 // Optional second factors (migration 0034). Two-factor is ON for an account
 // exactly when it has a confirmed TOTP secret or at least one passkey — the
 // credentials are the flag, so nothing can drift out of sync with them.

--- a/cloud/packages/mcp/bin/frameos-cloud-mcp.mjs
+++ b/cloud/packages/mcp/bin/frameos-cloud-mcp.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Runs the stdio server straight from the TypeScript sources through tsx,
+// so the workspace needs no build step for a local MCP process.
+import { register } from "tsx/esm/api";
+
+register();
+await import("../src/stdio.ts");

--- a/cloud/packages/mcp/package.json
+++ b/cloud/packages/mcp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@frameos-cloud/mcp",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "description": "FrameOS Cloud MCP server: frames, scenes, the store and the scene AI as Model Context Protocol tools, a thin wrapper over the cloud HTTP API.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "frameos-cloud-mcp": "./bin/frameos-cloud-mcp.mjs"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings=0",
+    "start": "tsx src/stdio.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "eslint": "^9.39.1",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/cloud/packages/mcp/src/client.ts
+++ b/cloud/packages/mcp/src/client.ts
@@ -1,0 +1,236 @@
+// The one thing every tool does: an HTTP call to the FrameOS Cloud API with
+// a personal API token. Nothing here knows what a frame or a scene is —
+// that stays in the routes; this only speaks bearer + JSON + the API's
+// `{error, ...}` refusal shape, and turns a refusal into a CloudApiError
+// the tool layer can explain.
+
+export type FetchLike = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type FrameosCloudClientOptions = {
+  /** Origin of the cloud API, e.g. https://cloud.frameos.net */
+  baseUrl: string;
+  /** Extra headers on every request (the remote host forwards the caller's IP). */
+  headers?: Record<string, string> | undefined;
+  /** Custom fetch — tests and the in-process host inject theirs. */
+  fetch?: FetchLike | undefined;
+  /** The personal API token (fc_api_… / fc_apiro_…). */
+  token: string;
+  /** Sent as User-Agent. */
+  userAgent?: string | undefined;
+};
+
+export type RequestOptions = {
+  body?: unknown;
+  /** application/json when `body` is set, unless overridden. */
+  contentType?: string | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean | undefined> | undefined;
+  /** Raw body bytes (uploads); wins over `body`. */
+  raw?: Uint8Array | FormData | undefined;
+  signal?: AbortSignal | undefined;
+};
+
+export class CloudApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    public readonly details: Record<string, unknown>,
+    public readonly method: string,
+    public readonly path: string,
+  ) {
+    super(`${method} ${path} → ${status} ${code}`);
+  }
+}
+
+export class FrameosCloudClient {
+  readonly baseUrl: string;
+  private readonly token: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly extraHeaders: Record<string, string>;
+  private readonly userAgent: string;
+
+  constructor(options: FrameosCloudClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.token = options.token;
+    this.fetchImpl = options.fetch ?? ((input, init) => fetch(input, init));
+    this.extraHeaders = options.headers ?? {};
+    this.userAgent = options.userAgent ?? "frameos-cloud-mcp";
+  }
+
+  url(path: string, query?: RequestOptions["query"]): string {
+    const url = new URL(path, `${this.baseUrl}/`);
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url.toString();
+  }
+
+  async request(
+    method: string,
+    path: string,
+    options: RequestOptions = {},
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      authorization: `Bearer ${this.token}`,
+      "user-agent": this.userAgent,
+      ...this.extraHeaders,
+      ...(options.headers ?? {}),
+    };
+    let body: BodyInit | undefined;
+    if (options.raw !== undefined) {
+      body = options.raw as BodyInit;
+      if (options.contentType) {
+        headers["content-type"] = options.contentType;
+      }
+    } else if (options.body !== undefined) {
+      body = JSON.stringify(options.body);
+      headers["content-type"] = options.contentType ?? "application/json";
+    }
+    const init: RequestInit = { headers, method };
+    if (body !== undefined) {
+      init.body = body;
+    }
+    if (options.signal) {
+      init.signal = options.signal;
+    }
+    const response = await this.fetchImpl(this.url(path, options.query), init);
+    if (!response.ok) {
+      throw await this.toError(response, method, path);
+    }
+    return response;
+  }
+
+  async json<T = Record<string, unknown>>(
+    method: string,
+    path: string,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const response = await this.request(method, path, options);
+    const text = await response.text();
+    if (!text) {
+      return {} as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new CloudApiError(
+        response.status,
+        "invalid_json",
+        { body: text.slice(0, 500) },
+        method,
+        path,
+      );
+    }
+  }
+
+  async bytes(
+    method: string,
+    path: string,
+    options: RequestOptions = {},
+  ): Promise<{ bytes: Uint8Array; contentType: string; headers: Headers }> {
+    const response = await this.request(method, path, {
+      ...options,
+      headers: { accept: "*/*", ...(options.headers ?? {}) },
+    });
+    return {
+      bytes: new Uint8Array(await response.arrayBuffer()),
+      contentType:
+        response.headers.get("content-type") ?? "application/octet-stream",
+      headers: response.headers,
+    };
+  }
+
+  /**
+   * Reads an NDJSON stream line by line, calling `onEvent` for each parsed
+   * object, until the stream ends, `until` returns true, or the signal fires.
+   */
+  async ndjson(
+    method: string,
+    path: string,
+    options: RequestOptions & {
+      onEvent: (event: Record<string, unknown>) => void;
+      until?: ((event: Record<string, unknown>) => boolean) | undefined;
+    },
+  ): Promise<void> {
+    const response = await this.request(method, path, {
+      ...options,
+      headers: { accept: "application/x-ndjson", ...(options.headers ?? {}) },
+    });
+    if (!response.body) {
+      return;
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    // The signal must end a read that is blocked on a quiet stream too, not
+    // only the request itself — a turn that is thinking sends nothing.
+    const onAbort = () => void reader.cancel().catch(() => undefined);
+    if (options.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffered += decoder.decode(value, { stream: true });
+        let newline = buffered.indexOf("\n");
+        while (newline >= 0) {
+          const line = buffered.slice(0, newline).trim();
+          buffered = buffered.slice(newline + 1);
+          if (line) {
+            let event: Record<string, unknown> | undefined;
+            try {
+              event = JSON.parse(line) as Record<string, unknown>;
+            } catch {
+              event = undefined;
+            }
+            if (event) {
+              options.onEvent(event);
+              if (options.until?.(event)) {
+                await reader.cancel().catch(() => undefined);
+                return;
+              }
+            }
+          }
+          newline = buffered.indexOf("\n");
+        }
+      }
+    } finally {
+      options.signal?.removeEventListener("abort", onAbort);
+      reader.releaseLock?.();
+    }
+  }
+
+  private async toError(
+    response: Response,
+    method: string,
+    path: string,
+  ): Promise<CloudApiError> {
+    let payload: Record<string, unknown> = {};
+    const text = await response.text().catch(() => "");
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        payload = parsed as Record<string, unknown>;
+      }
+    } catch {
+      if (text) {
+        payload = { body: text.slice(0, 500) };
+      }
+    }
+    const code =
+      typeof payload.error === "string" ? payload.error : `http_${response.status}`;
+    const { error: _error, ...details } = payload;
+    return new CloudApiError(response.status, code, details, method, path);
+  }
+}

--- a/cloud/packages/mcp/src/http.ts
+++ b/cloud/packages/mcp/src/http.ts
@@ -1,0 +1,23 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+
+// Serve one Streamable-HTTP request statelessly: fresh transport, JSON
+// response (no SSE), nothing kept afterwards. Web-standard Request/Response,
+// so any host that has them — a Next.js route handler, Hono, a Worker — can
+// mount the server with one call.
+export async function serveStatelessHttp(
+  server: McpServer,
+  request: Request,
+): Promise<Response> {
+  // Omitting sessionIdGenerator (not passing undefined) is what the SDK
+  // reads as "stateless".
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    enableJsonResponse: true,
+  });
+  await server.connect(transport);
+  try {
+    return await transport.handleRequest(request);
+  } finally {
+    void transport.close().catch(() => undefined);
+  }
+}

--- a/cloud/packages/mcp/src/index.ts
+++ b/cloud/packages/mcp/src/index.ts
@@ -1,0 +1,6 @@
+export { CloudApiError, FrameosCloudClient } from "./client";
+export type { FetchLike, FrameosCloudClientOptions } from "./client";
+export { createFrameosMcpServer, serverVersion } from "./server";
+export type { FrameosMcpServerOptions } from "./server";
+export { explainError } from "./result";
+export { serveStatelessHttp } from "./http";

--- a/cloud/packages/mcp/src/result.ts
+++ b/cloud/packages/mcp/src/result.ts
@@ -1,0 +1,150 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { CloudApiError, type FetchLike, type FrameosCloudClient } from "./client";
+
+// What every tool hands back to the model, and how a refusal from the API
+// is worded. The API's `{error: code}` bodies are precise but terse; the
+// model gets the code, the status, whatever detail rode along, and — for
+// the handful of codes whose fix is not obvious — a sentence on what to do.
+
+export type ToolContext = {
+  client: FrameosCloudClient;
+  /**
+   * Fetch for URLs the user hands us (scene zips to import). The in-process
+   * host injects an SSRF-guarded one; the stdio host uses plain fetch.
+   */
+  fetchExternal: FetchLike;
+  /** Public origin of the cloud UI, for links in tool output. */
+  publicOrigin: string;
+  /** Public origin of the scene store, for scene page links. */
+  storeOrigin: string;
+};
+
+export function text(value: unknown): CallToolResult {
+  const body =
+    typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  return { content: [{ text: body, type: "text" }] };
+}
+
+export function structured(value: Record<string, unknown>): CallToolResult {
+  return {
+    content: [{ text: JSON.stringify(value, null, 2), type: "text" }],
+    structuredContent: value,
+  };
+}
+
+export function image(
+  bytes: Uint8Array,
+  mimeType: string,
+  caption?: string,
+): CallToolResult {
+  const content: CallToolResult["content"] = [];
+  if (caption) {
+    content.push({ text: caption, type: "text" });
+  }
+  content.push({
+    data: Buffer.from(bytes).toString("base64"),
+    mimeType,
+    type: "image",
+  });
+  return { content };
+}
+
+export function failure(message: string, extra?: Record<string, unknown>): CallToolResult {
+  return {
+    content: [
+      {
+        text: extra ? `${message}\n${JSON.stringify(extra, null, 2)}` : message,
+        type: "text",
+      },
+    ],
+    isError: true,
+  };
+}
+
+const hints: Record<string, string> = {
+  api_token_not_allowed:
+    "This action cannot be performed with an API token; the account owner must do it in the browser.",
+  content_rejected:
+    "The store's moderation refused this text or image. Reword it and try again.",
+  frame_not_active:
+    "The frame is pending or revoked. Pending frames need frame_confirm; revoked ones cannot be used.",
+  frame_quota_exceeded:
+    "The account is at its frame limit. Check account_quota; revoke a frame to free a slot (revoked frames count for 24 h).",
+  frame_unreachable:
+    "The frame did not acknowledge in time. It is offline or asleep — check frame_get for connected/next_wake_at and retry later.",
+  image_unavailable:
+    "The frame did not deliver a screenshot in time (offline, asleep, or still rendering). Retry in a moment.",
+  invalid_scene:
+    "No such scene, or it is private to another account. Use scenes_list / store_browse to find a valid id.",
+  login_required:
+    "The API token was refused: revoked, expired, or wrong for this server. Create a new one at /account/developer.",
+  missing_api_key:
+    "The AI needs an OpenAI API key: set openAI.apiKey with account_settings_update, or ask an admin about the shared key.",
+  rate_limited: "Rate limited. Wait retry_after seconds and try again.",
+  read_only_token:
+    "This token is read-only. Mutations need a token created with full access.",
+  reauth_required:
+    "This action needs a fresh browser sign-in (sudo mode) and is never available to API tokens: do it at the cloud UI.",
+  renderer_unavailable:
+    "This server has no wasm runtime installed, so it cannot render previews.",
+  scene_name_taken:
+    "The account already has a scene by that name. Pick another name.",
+  scene_not_found:
+    "No such scene, or it belongs to another account and is private.",
+  scene_quota_exceeded:
+    "The account is at its scene limit. Delete scenes you no longer need (see account_quota).",
+  settings_need_newer_firmware:
+    "The frame's firmware is too old for one of these settings; see min_frameos_version. Update the frame first (frame_firmware_update).",
+  storage_quota_exceeded:
+    "The account's private scene storage is full. Delete scenes or images, or publish scenes (public scenes are free).",
+  too_many_scenes:
+    "The frame already holds the maximum number of scenes. Remove one first (frame_scene_remove).",
+  turn_in_progress:
+    "This chat already has a running AI turn. Wait for it with ai_turn_wait or cancel it with ai_turn_cancel.",
+  turn_not_found:
+    "The AI turn is gone: finished more than 10 minutes ago, or the server restarted. Read the chat with ai_chat_get.",
+};
+
+export function explainError(error: unknown): CallToolResult {
+  if (error instanceof CloudApiError) {
+    const hint = hints[error.code];
+    const lines = [
+      `FrameOS Cloud refused ${error.method} ${error.path}: ${error.status} ${error.code}`,
+    ];
+    if (hint) {
+      lines.push(hint);
+    }
+    if (Object.keys(error.details).length > 0) {
+      lines.push(JSON.stringify(error.details));
+    }
+    return { content: [{ text: lines.join("\n"), type: "text" }], isError: true };
+  }
+  if (error instanceof Error) {
+    return failure(error.message);
+  }
+  return failure(String(error));
+}
+
+export async function run(
+  fn: () => Promise<CallToolResult>,
+): Promise<CallToolResult> {
+  try {
+    return await fn();
+  } catch (error) {
+    return explainError(error);
+  }
+}
+
+export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return uuidPattern.test(value);
+}
+
+// The API's own id check (any 8-4-4-4-12 hex string), not zod's RFC 4122
+// version/variant check: ids are what the cloud handed out, not what a
+// validator thinks a uuid should look like.
+export function uuid() {
+  return z.string().regex(uuidPattern, "Expected an id like 123e4567-e89b-42d3-a456-426614174000");
+}

--- a/cloud/packages/mcp/src/server.test.ts
+++ b/cloud/packages/mcp/src/server.test.ts
@@ -1,0 +1,444 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createFrameosMcpServer } from "./server";
+import { serveStatelessHttp } from "./http";
+
+// The server against a fake cloud: every tool is one or two HTTP calls, so
+// the tests pin exactly which route each tool hits, with what, and how the
+// API's refusals come back to the model. No network, no database.
+
+type Recorded = { body: unknown; headers: Record<string, string>; method: string; url: string };
+
+const frameId = "11111111-2222-3333-4444-555555555555";
+const sceneId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const pngBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+let calls: Recorded[] = [];
+let responders: ((call: Recorded) => Response | undefined)[] = [];
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", ...headers },
+    status,
+  });
+}
+
+async function fakeFetch(input: string, init?: RequestInit): Promise<Response> {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(init?.headers ?? {})) {
+    headers[key.toLowerCase()] = String(value);
+  }
+  let body: unknown = undefined;
+  if (typeof init?.body === "string") {
+    try {
+      body = JSON.parse(init.body);
+    } catch {
+      body = init.body;
+    }
+  } else if (init?.body instanceof FormData) {
+    body = Object.fromEntries(
+      [...init.body.entries()].map(([key, value]) => [
+        key,
+        value instanceof File ? { name: value.name, size: value.size } : value,
+      ]),
+    );
+  }
+  const call: Recorded = { body, headers, method: init?.method ?? "GET", url: input };
+  calls.push(call);
+  for (const responder of responders) {
+    const response = responder(call);
+    if (response) {
+      return response;
+    }
+  }
+  const path = new URL(input).pathname;
+  if (path === "/api/frames" && call.method === "GET") {
+    return json({
+      frames: [
+        {
+          assigned_checksum: "abc",
+          connected: true,
+          frameos_version: "2026.8.40",
+          hardware: { platform: "esp32-s3" },
+          id: frameId,
+          interval: 300,
+          last_seen_at: "2026-08-29T10:00:00.000Z",
+          name: "Kitchen",
+          next_wake_at: null,
+          scenes_checksum: "abc",
+          sleep_reason: null,
+          status: "active",
+          timezone: "Europe/Brussels",
+        },
+      ],
+    });
+  }
+  if (path === `/api/frames/${frameId}` && call.method === "GET") {
+    return json({ frame: { id: frameId, name: "Kitchen", schedule: { events: [] }, timezone: "UTC" } });
+  }
+  if (path === `/api/frames/${frameId}/scenes` && call.method === "GET") {
+    return json({
+      assigned_checksum: "abc",
+      scenes: [
+        { name: "A", position: 0, scene_id: sceneId, scene_version: 2 },
+        { name: "B", position: 1, scene_id: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee", scene_version: null },
+      ],
+      scenes_checksum: "abc",
+    });
+  }
+  if (path === `/api/frames/${frameId}/scenes` && call.method === "POST") {
+    return json({ assigned_checksum: "def", command_id: "cmd-1", status: "queued" });
+  }
+  if (path === `/api/frames/${frameId}/scenes/add`) {
+    return json({ already_assigned: false, command_id: "cmd-2", connected: true, status: "queued" });
+  }
+  if (path === `/api/frames/${frameId}/event/setCurrentScene`) {
+    return json({ command_id: "cmd-3", status: "queued", type: "set_current_scene" });
+  }
+  if (path === `/api/frames/${frameId}/image`) {
+    return new Response(pngBytes, { headers: { "content-type": "image/png" } });
+  }
+  if (path === `/api/frames/${frameId}/logs`) {
+    return json({
+      has_more: false,
+      logs: [
+        { id: 1, line: '{"event":"render:done"}', timestamp: "t1", type: "log" },
+        { id: 2, line: '{"event":"error:1","error":"boom"}', timestamp: "t2", type: "log" },
+        { id: 3, line: "plain", timestamp: "t3", type: "log" },
+      ],
+    });
+  }
+  if (path === "/api/account/usage") {
+    return json({
+      account: { email: "me@example.com", id: "acc-1" },
+      auth: { kind: "api_token", token_access: "full" },
+      limits: { frames: { max_scenes_per_frame: 20 } },
+      usage: { frames: { count: 1, max_count: 50 } },
+    });
+  }
+  if (path === "/api/settings" && call.method === "GET") {
+    return json({ openAI: { apiKey: "sk-1234567890abcdef", chatModel: "gpt-5.5" }, unsplash: { accessKey: "" } });
+  }
+  if (path === "/api/settings" && call.method === "POST") {
+    return json(body);
+  }
+  if (path === "/api/account/scenes" && call.method === "GET") {
+    return json({ scenes: [{ id: sceneId, latest_version: 3, name: "Clock", slug: "clock", visibility: "private" }] });
+  }
+  if (path === "/api/account/scenes" && call.method === "POST") {
+    return json({ scene: { id: "cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee", name: "New", slug: "new" }, status: "published" });
+  }
+  if (path === `/api/account/scenes/${sceneId}` && call.method === "GET") {
+    return json({ images: [], scene: { id: sceneId, name: "Clock", slug: "clock" }, versions: [{ version: 3 }, { version: 2 }, { version: 1 }] });
+  }
+  if (path === `/api/account/scenes/${sceneId}/content`) {
+    return json({ scene: { id: sceneId, latest_version: 4, name: (body as { scenes: { name: string }[] }).scenes[0]?.name ?? "Clock" }, status: "published", version: 4 });
+  }
+  if (path === `/api/store/scenes/${sceneId}/scenes.json`) {
+    return json([{ edges: [], fields: [], id: "runtime-1", name: "Clock", nodes: [{ id: "n1" }], origin: { storeSceneId: sceneId } }]);
+  }
+  if (path === "/api/store/repository.json") {
+    return json({ templates: [{ id: "clock", name: "Clock", sceneId }] });
+  }
+  if (path === "/api/store/account/repository.json") {
+    return json({ templates: [] });
+  }
+  if (path === "/api/scenes/render") {
+    return json({ errors: [], height: 480, logs: ["ok"], png_base64: pngBytes.toString("base64"), render_ms: 12, state: {}, width: 800 });
+  }
+  if (path === "/api/ai/chat" && call.method === "POST") {
+    const lines = [
+      { chatId: "chat-1", turnId: "turn-1", type: "chat" },
+      { text: "Building", type: "delta" },
+      { label: "Create scenes", name: "create_scenes", status: "done", type: "tool" },
+      { scenes: [{ id: "s1", name: "Made", nodes: [] }], title: "Made", tool: "build_scene", type: "scenes" },
+      { reply: "Done!", tool: "build_scene", type: "done" },
+    ];
+    return new Response(lines.map((line) => JSON.stringify(line)).join("\n") + "\n", {
+      headers: { "content-type": "application/x-ndjson" },
+    });
+  }
+  return json({ error: "not_found", path }, 404);
+}
+
+async function connect() {
+  const server = createFrameosMcpServer({
+    baseUrl: "https://cloud.example",
+    fetch: fakeFetch,
+    fetchExternal: fakeFetch,
+    publicOrigin: "https://cloud.example",
+    storeOrigin: "https://scenes.example",
+    token: "fc_api_test",
+  });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+function textOf(result: Awaited<ReturnType<Client["callTool"]>>) {
+  const content = result.content as { text?: string; type: string }[];
+  return content.filter((entry) => entry.type === "text").map((entry) => entry.text).join("\n");
+}
+
+beforeEach(() => {
+  calls = [];
+  responders = [];
+});
+
+describe("frameos-cloud MCP server", () => {
+  it("lists the expected tool families", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    const names = tools.map((tool) => tool.name);
+    for (const expected of [
+      "account_quota",
+      "frames_list",
+      "frame_scene_install",
+      "frame_screenshot",
+      "scenes_list",
+      "scene_update_content",
+      "scene_render",
+      "scene_lint",
+      "store_browse",
+      "ai_scene_chat",
+      "api_tokens_list",
+    ]) {
+      expect(names).toContain(expected);
+    }
+    expect(tools.length).toBeGreaterThan(60);
+    // Destructive tools say so.
+    expect(tools.find((tool) => tool.name === "frame_delete")?.annotations?.destructiveHint).toBe(true);
+    expect(tools.find((tool) => tool.name === "frames_list")?.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("sends the bearer token and reads the frames list", async () => {
+    const client = await connect();
+    const result = await client.callTool({ arguments: {}, name: "frames_list" });
+    expect(calls[0]?.headers.authorization).toBe("Bearer fc_api_test");
+    const payload = JSON.parse(textOf(result)) as { frames: { in_sync: boolean; name: string; platform: string }[] };
+    expect(payload.frames[0]).toMatchObject({ in_sync: true, name: "Kitchen", platform: "esp32-s3" });
+  });
+
+  it("removes one scene by re-assigning the rest with their pins", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: { frame_id: frameId, scene_id: sceneId },
+      name: "frame_scene_remove",
+    });
+    const post = calls.find((call) => call.method === "POST");
+    expect(post?.url).toContain(`/api/frames/${frameId}/scenes`);
+    expect(post?.body).toEqual({
+      scenes: [{ scene_id: "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee", scene_version: null }],
+    });
+    expect(JSON.parse(textOf(result))).toMatchObject({ removed: sceneId, remaining: 1 });
+  });
+
+  it("installs a scene from raw JSON by creating a private scene first, then activates it", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: {
+        activate: true,
+        frame_id: frameId,
+        name: "Fresh",
+        scenes: [{ id: "x", name: "Fresh", nodes: [], edges: [], fields: [], settings: {} }],
+      },
+      name: "frame_scene_install",
+    });
+    const paths = calls.map((call) => `${call.method} ${new URL(call.url).pathname}`);
+    expect(paths).toEqual([
+      "POST /api/account/scenes",
+      `POST /api/frames/${frameId}/scenes/add`,
+      `POST /api/frames/${frameId}/event/setCurrentScene`,
+    ]);
+    expect(calls[0]?.body).toMatchObject({ name: "Fresh" });
+    expect(calls[1]?.body).toEqual({ scene_id: "cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee" });
+    expect(JSON.parse(textOf(result))).toMatchObject({ created_private_scene: true, command_id: "cmd-2" });
+  });
+
+  it("resolves a store page URL to its scene id for installs", async () => {
+    const client = await connect();
+    await client.callTool({
+      arguments: { frame_id: frameId, url: "https://scenes.example/s/clock" },
+      name: "frame_scene_install",
+    });
+    const add = calls.find((call) => call.url.includes("/scenes/add"));
+    expect(add?.body).toEqual({ scene_id: sceneId });
+  });
+
+  it("returns screenshots as image content", async () => {
+    const client = await connect();
+    const result = await client.callTool({ arguments: { frame_id: frameId, refresh: true }, name: "frame_screenshot" });
+    const content = result.content as { data?: string; mimeType?: string; type: string }[];
+    const img = content.find((entry) => entry.type === "image");
+    expect(img?.mimeType).toBe("image/png");
+    expect(img?.data).toBe(pngBytes.toString("base64"));
+    expect(new URL(calls[0]!.url).searchParams.get("t")).not.toBe("-1");
+  });
+
+  it("filters and caps frame logs", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: { frame_id: frameId, limit: 5, search: "error" },
+      name: "frame_logs",
+    });
+    const payload = JSON.parse(textOf(result)) as { logs: { id: number }[]; matched: number; newest_id: number };
+    expect(payload.matched).toBe(1);
+    expect(payload.logs.map((entry) => entry.id)).toEqual([2]);
+    expect(payload.newest_id).toBe(3);
+  });
+
+  it("masks secrets in settings unless asked to reveal", async () => {
+    const client = await connect();
+    const masked = JSON.parse(textOf(await client.callTool({ arguments: {}, name: "account_settings_get" }))) as {
+      openAI: { apiKey: string; chatModel: string };
+    };
+    expect(masked.openAI.apiKey).toMatch(/^•+cdef$/);
+    expect(masked.openAI.chatModel).toBe("gpt-5.5");
+    const revealed = JSON.parse(
+      textOf(await client.callTool({ arguments: { reveal: true }, name: "account_settings_get" })),
+    ) as { openAI: { apiKey: string } };
+    expect(revealed.openAI.apiKey).toBe("sk-1234567890abcdef");
+  });
+
+  it("merges a settings update over the current group before posting", async () => {
+    const client = await connect();
+    await client.callTool({
+      arguments: { settings: { openAI: { apiKey: "sk-new" } } },
+      name: "account_settings_update",
+    });
+    const post = calls.find((call) => call.method === "POST");
+    expect(post?.body).toEqual({ openAI: { apiKey: "sk-new", chatModel: "gpt-5.5" } });
+  });
+
+  it("renames a scene through a content save and reports whether the listing followed", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: { name: "Wall clock", scene_id: sceneId },
+      name: "scene_rename",
+    });
+    const save = calls.find((call) => call.url.endsWith("/content"));
+    const body = save?.body as { message: string; scenes: { name: string; origin?: unknown }[] };
+    expect(body.scenes[0]?.name).toBe("Wall clock");
+    expect(body.scenes[0]?.origin).toBeUndefined();
+    expect(body.message).toBe("Renamed to Wall clock");
+    expect(JSON.parse(textOf(result))).toMatchObject({ listing_renamed: true, previous_name: "Clock" });
+  });
+
+  it("restores a version by re-saving its content", async () => {
+    const client = await connect();
+    await client.callTool({ arguments: { scene_id: sceneId, version: 2 }, name: "scene_version_restore" });
+    expect(new URL(calls[0]!.url).searchParams.get("version")).toBe("2");
+    expect((calls[1]?.body as { message: string }).message).toBe("Restored version 2");
+  });
+
+  it("renders a scene and returns the image with the runtime's logs", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: { scene_id: sceneId, width: 400, height: 300, time_zone: "Europe/Brussels" },
+      name: "scene_render",
+    });
+    const render = calls.find((call) => call.url.endsWith("/api/scenes/render"));
+    expect(render?.body).toMatchObject({ format: "json", height: 300, scene_id: sceneId, time_zone: "Europe/Brussels", width: 400 });
+    const content = result.content as { type: string }[];
+    expect(content.map((entry) => entry.type)).toEqual(["text", "image"]);
+    expect(JSON.parse(textOf(result))).toMatchObject({ render_ms: 12, errors: [] });
+  });
+
+  it("drives an AI turn to completion and saves the result as a new scene", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: { apply: "new_scene", prompt: "a clock", wait_seconds: 10 },
+      name: "ai_scene_chat",
+    });
+    const chat = calls.find((call) => call.url.endsWith("/api/ai/chat"));
+    expect(chat?.body).toMatchObject({ prompt: "a clock", surface: "store-new" });
+    const save = calls.find((call) => call.url.endsWith("/api/account/scenes") && call.method === "POST");
+    expect(save?.body).toMatchObject({ name: "Made" });
+    const payload = JSON.parse(textOf(result)) as Record<string, unknown>;
+    expect(payload).toMatchObject({ chat_id: "chat-1", reply: "Done!", status: "done", turn_id: "turn-1" });
+    expect(payload.saved).toBeDefined();
+  });
+
+  it("hands the model a turn id when the turn outlives the wait", async () => {
+    responders.push((call) => {
+      if (!call.url.endsWith("/api/ai/chat")) {
+        return undefined;
+      }
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(JSON.stringify({ chatId: "chat-2", turnId: "turn-2", type: "chat" }) + "\n"),
+          );
+          // Never closes: the turn is still thinking.
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "application/x-ndjson" } });
+    });
+    const client = await connect();
+    const result = await client.callTool({
+      arguments: { prompt: "slow", wait_seconds: 5 },
+      name: "ai_scene_chat",
+    });
+    const payload = JSON.parse(textOf(result)) as Record<string, unknown>;
+    expect(payload).toMatchObject({ events_seen: 1, status: "running", turn_id: "turn-2" });
+  }, 15_000);
+
+  it("explains API refusals instead of throwing", async () => {
+    responders.push((call) =>
+      call.url.endsWith("/revoke") ? json({ error: "reauth_required", reauth: { path: "/login/reauth" } }, 403) : undefined,
+    );
+    const client = await connect();
+    const result = await client.callTool({ arguments: { confirm: true, frame_id: frameId }, name: "frame_revoke" });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("403 reauth_required");
+    expect(textOf(result)).toContain("sudo mode");
+  });
+
+  it("refuses to delete without confirm", async () => {
+    const client = await connect();
+    const result = await client.callTool({ arguments: { frame_id: frameId }, name: "frame_delete" });
+    expect(result.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("serves resources", async () => {
+    const client = await connect();
+    const { resources } = await client.listResources();
+    expect(resources.map((resource) => resource.uri)).toContain("frameos://frames");
+    const frame = await client.readResource({ uri: `frameos://frames/${frameId}` });
+    expect(JSON.parse((frame.contents[0] as { text: string }).text)).toMatchObject({ frame: { name: "Kitchen" } });
+  });
+});
+
+describe("serveStatelessHttp", () => {
+  it("answers a JSON-RPC request over a web-standard Request", async () => {
+    const server = createFrameosMcpServer({
+      baseUrl: "https://cloud.example",
+      fetch: fakeFetch,
+      token: "fc_api_test",
+    });
+    const request = new Request("https://cloud.example/api/mcp", {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "t", version: "0" },
+          protocolVersion: "2025-06-18",
+        },
+      }),
+      headers: { accept: "application/json, text/event-stream", "content-type": "application/json" },
+      method: "POST",
+    });
+    const response = await serveStatelessHttp(server, request);
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { result: { serverInfo: { name: string } } };
+    expect(payload.result.serverInfo.name).toBe("frameos-cloud");
+  });
+});

--- a/cloud/packages/mcp/src/server.ts
+++ b/cloud/packages/mcp/src/server.ts
@@ -1,0 +1,232 @@
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FrameosCloudClient, type FetchLike } from "./client";
+import { explainError, type ToolContext } from "./result";
+import { registerAccountTools } from "./tools/account";
+import { registerAiTools } from "./tools/ai";
+import { registerFrameTools } from "./tools/frames";
+import { registerSceneTools } from "./tools/scenes";
+
+// One McpServer per connection. Stateless by design: every tool call is
+// an HTTP request to the cloud with the caller's token, so a server can be
+// built per request (the /api/mcp route does) or once for a stdio process.
+
+export const serverVersion = "0.1.0";
+
+export type FrameosMcpServerOptions = {
+  /** Cloud API origin the tools call. */
+  baseUrl: string;
+  /** Fetch for user-supplied URLs (zip imports); defaults to global fetch. */
+  fetchExternal?: FetchLike | undefined;
+  /** Fetch for the cloud API itself; defaults to global fetch. */
+  fetch?: FetchLike | undefined;
+  /** Extra headers on every API call (the remote host forwards the client IP). */
+  headers?: Record<string, string> | undefined;
+  /** Public origin of the cloud UI for links (defaults to baseUrl). */
+  publicOrigin?: string | undefined;
+  /** Public origin of the scene store for links (defaults to publicOrigin). */
+  storeOrigin?: string | undefined;
+  token: string;
+  userAgent?: string | undefined;
+};
+
+const instructions = `FrameOS Cloud: cloud-managed e-paper/LCD frames, the scenes they display, the public scene store, and an AI that builds scenes.
+
+Vocabulary: a *frame* is a device enrolled with the cloud (frames_list). A *scene* is a graph of nodes (apps, code, events, state) that renders one screen; scenes live in the account as store scenes (private drafts or published), each with immutable numbered versions. A frame holds up to 20 assigned scenes and shows one at a time; a *schedule* switches between them. Scene JSON is the array from scenes.json — objects with id, name, nodes, edges, fields, settings (execution: "interpreted").
+
+Typical flows:
+- See what is on a frame: frame_get → frame_scenes_list → frame_screenshot; frame_logs when something looks wrong.
+- Put a scene on a frame: store_browse or scenes_list → frame_scene_install (activate=true to show it now).
+- Make a new scene: ai_scene_chat(prompt, apply="new_scene") or scene_create(scenes=…) → scene_render to preview → frame_scene_install.
+- Change a scene: scene_get_content → edit → scene_lint → scene_update_content (new version) → frame_scene_install to re-deploy; or ai_scene_chat(scene_id, prompt, apply="save_version").
+- Preview without a device: scene_render (real runtime, returns the image and logs).
+
+Device actions are asynchronous: they return a command_id the frame applies when it next talks to the hub (frame_commands_list shows what is still queued). Deep-sleeping battery frames apply commands when they wake (frame_get: next_wake_at).
+
+Destructive tools require confirm=true. Sudo-mode actions (revoking a frame, approving a device link) are never available to API tokens.`;
+
+export function createFrameosMcpServer(options: FrameosMcpServerOptions) {
+  const client = new FrameosCloudClient({
+    baseUrl: options.baseUrl,
+    fetch: options.fetch,
+    headers: options.headers,
+    token: options.token,
+    userAgent: options.userAgent ?? `frameos-cloud-mcp/${serverVersion}`,
+  });
+  const publicOrigin = (options.publicOrigin ?? options.baseUrl).replace(/\/+$/, "");
+  const ctx: ToolContext = {
+    client,
+    fetchExternal: options.fetchExternal ?? ((input, init) => fetch(input, init)),
+    publicOrigin,
+    storeOrigin: (options.storeOrigin ?? publicOrigin).replace(/\/+$/, ""),
+  };
+
+  const server = new McpServer(
+    { name: "frameos-cloud", version: serverVersion },
+    { capabilities: { logging: {} }, instructions },
+  );
+
+  registerAccountTools(server, ctx);
+  registerFrameTools(server, ctx);
+  registerSceneTools(server, ctx);
+  registerAiTools(server, ctx);
+  registerResources(server, ctx);
+  registerPrompts(server);
+
+  return server;
+}
+
+// Resources: the read-only views an MCP client may want to attach as
+// context without a tool call — the frame list, one frame, one scene's JSON.
+function registerResources(server: McpServer, ctx: ToolContext) {
+  server.registerResource(
+    "frames",
+    "frameos://frames",
+    {
+      description: "The account's cloud-managed frames (summary list).",
+      mimeType: "application/json",
+      title: "Frames",
+    },
+    async (uri) => {
+      const payload = await ctx.client.json("GET", "/api/frames");
+      return {
+        contents: [
+          { mimeType: "application/json", text: JSON.stringify(payload, null, 2), uri: uri.href },
+        ],
+      };
+    },
+  );
+
+  server.registerResource(
+    "frame",
+    new ResourceTemplate("frameos://frames/{frameId}", {
+      list: async () => {
+        const payload = await ctx.client.json<{ frames: { id: string; name: string }[] }>(
+          "GET",
+          "/api/frames",
+        );
+        return {
+          resources: payload.frames.map((frame) => ({
+            description: `Frame "${frame.name}"`,
+            mimeType: "application/json",
+            name: frame.name,
+            uri: `frameos://frames/${frame.id}`,
+          })),
+        };
+      },
+    }),
+    { description: "One frame's full detail.", mimeType: "application/json", title: "Frame" },
+    async (uri, { frameId }) => {
+      const payload = await ctx.client.json("GET", `/api/frames/${String(frameId)}`);
+      return {
+        contents: [
+          { mimeType: "application/json", text: JSON.stringify(payload, null, 2), uri: uri.href },
+        ],
+      };
+    },
+  );
+
+  server.registerResource(
+    "scenes",
+    "frameos://scenes",
+    {
+      description: "The account's own scenes (summary list).",
+      mimeType: "application/json",
+      title: "My scenes",
+    },
+    async (uri) => {
+      const payload = await ctx.client.json("GET", "/api/account/scenes");
+      return {
+        contents: [
+          { mimeType: "application/json", text: JSON.stringify(payload, null, 2), uri: uri.href },
+        ],
+      };
+    },
+  );
+
+  server.registerResource(
+    "scene-content",
+    new ResourceTemplate("frameos://scenes/{sceneId}/content", {
+      list: async () => {
+        const payload = await ctx.client.json<{ scenes: { id: string; name: string }[] }>(
+          "GET",
+          "/api/account/scenes",
+        );
+        return {
+          resources: payload.scenes.map((scene) => ({
+            description: `Scene "${scene.name}" (scenes.json)`,
+            mimeType: "application/json",
+            name: scene.name,
+            uri: `frameos://scenes/${scene.id}/content`,
+          })),
+        };
+      },
+    }),
+    {
+      description: "A scene's scenes.json (latest non-yanked version).",
+      mimeType: "application/json",
+      title: "Scene content",
+    },
+    async (uri, { sceneId }) => {
+      const payload = await ctx.client.json(
+        "GET",
+        `/api/store/scenes/${String(sceneId)}/scenes.json`,
+      );
+      return {
+        contents: [
+          { mimeType: "application/json", text: JSON.stringify(payload, null, 2), uri: uri.href },
+        ],
+      };
+    },
+  );
+}
+
+function registerPrompts(server: McpServer) {
+  server.registerPrompt(
+    "diagnose_frame",
+    {
+      argsSchema: { frame_id: z.string().describe("Frame id from frames_list") },
+      description: "Walk through a frame's status, recent logs, metrics and queued commands and explain what is wrong.",
+      title: "Diagnose a frame",
+    },
+    ({ frame_id }) => ({
+      messages: [
+        {
+          content: {
+            text: `Diagnose frame ${frame_id}. Use frame_get for status/connectivity/sleep forecast, frame_commands_list for anything stuck in the queue, frame_logs (search for "error" first, then the last 100 lines), frame_metrics for memory/battery trends, and frame_screenshot to see what is on the display. Summarise the likely cause and the concrete next step (a tool call, or something the owner must do physically).`,
+            type: "text",
+          },
+          role: "user",
+        },
+      ],
+    }),
+  );
+
+  server.registerPrompt(
+    "build_scene",
+    {
+      argsSchema: {
+        description: z.string().describe("What the scene should show"),
+        frame_id: z.string().optional().describe("Frame to build it for and install on"),
+      },
+      description: "Create a scene with the scene AI, preview it, and optionally install it on a frame.",
+      title: "Build a scene",
+    },
+    ({ description, frame_id }) => ({
+      messages: [
+        {
+          content: {
+            text: `Build a FrameOS scene: ${description}${frame_id ? ` It is for frame ${frame_id} (call frame_get first for its size and platform).` : ""}
+1. Call ai_scene_chat with a precise prompt (include the frame's width/height and platform) and apply="new_scene".
+2. Preview it with scene_render at the frame's resolution; if the logs show errors, fix them with scene_get_content + scene_update_content (or another ai_scene_chat with scene_id) and re-render.
+3. Show me the preview and, ${frame_id ? `if it looks right, install it with frame_scene_install(frame_id, scene_id, activate=true)` : "ask whether to install it on a frame"}.`,
+            type: "text",
+          },
+          role: "user",
+        },
+      ],
+    }),
+  );
+}
+
+export { explainError };

--- a/cloud/packages/mcp/src/stdio.ts
+++ b/cloud/packages/mcp/src/stdio.ts
@@ -1,0 +1,32 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createFrameosMcpServer } from "./server";
+
+// Local (stdio) entry point, for MCP clients that cannot speak Streamable
+// HTTP or that prefer a subprocess:
+//
+//   FRAMEOS_CLOUD_TOKEN=fc_api_… pnpm --filter @frameos-cloud/mcp start
+//
+// FRAMEOS_CLOUD_URL overrides the API origin (default https://cloud.frameos.net);
+// FRAMEOS_STORE_URL the store origin used in links (default https://scenes.frameos.net).
+// The hosted endpoint at ${FRAMEOS_CLOUD_URL}/api/mcp needs no local process.
+
+const token = process.env.FRAMEOS_CLOUD_TOKEN?.trim();
+if (!token) {
+  process.stderr.write(
+    "frameos-cloud-mcp: set FRAMEOS_CLOUD_TOKEN to a personal API token (create one at /account/developer)\n",
+  );
+  process.exit(2);
+}
+
+const baseUrl = (process.env.FRAMEOS_CLOUD_URL?.trim() || "https://cloud.frameos.net").replace(/\/+$/, "");
+const storeOrigin = process.env.FRAMEOS_STORE_URL?.trim() || undefined;
+
+const server = createFrameosMcpServer({
+  baseUrl,
+  publicOrigin: baseUrl,
+  storeOrigin: storeOrigin ?? (baseUrl.includes("cloud.frameos.net") ? "https://scenes.frameos.net" : baseUrl),
+  token,
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/cloud/packages/mcp/src/tools/account.ts
+++ b/cloud/packages/mcp/src/tools/account.ts
@@ -1,0 +1,197 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { run, structured, text, uuid, type ToolContext } from "../result";
+
+// Account-level tools: who am I, how much room is left, the service keys
+// scenes use, and the API tokens themselves.
+
+type UsagePayload = {
+  account: Record<string, unknown>;
+  auth: Record<string, unknown>;
+  limits: Record<string, unknown>;
+  usage: Record<string, unknown>;
+};
+
+const secretField = /(key|token|secret|password)/i;
+
+function maskSecret(value: string): string {
+  if (value.length <= 8) {
+    return "••••";
+  }
+  return `${"•".repeat(Math.min(12, value.length - 4))}${value.slice(-4)}`;
+}
+
+function maskSettings(
+  settings: Record<string, unknown>,
+): Record<string, unknown> {
+  const masked: Record<string, unknown> = {};
+  for (const [group, value] of Object.entries(settings)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const fields: Record<string, unknown> = {};
+      for (const [field, fieldValue] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        fields[field] =
+          typeof fieldValue === "string" &&
+          fieldValue &&
+          secretField.test(field)
+            ? maskSecret(fieldValue)
+            : fieldValue;
+      }
+      masked[group] = fields;
+    } else {
+      masked[group] = value;
+    }
+  }
+  return masked;
+}
+
+export function registerAccountTools(server: McpServer, ctx: ToolContext) {
+  server.registerTool(
+    "account_info",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Who the current API token belongs to: account id, email, name, superadmin/verified-publisher flags, and whether this token is full or read-only.",
+      inputSchema: {},
+    },
+    async () =>
+      run(async () => {
+        const payload = await ctx.client.json<UsagePayload>(
+          "GET",
+          "/api/account/usage",
+        );
+        return structured({
+          account: payload.account,
+          auth: payload.auth,
+          cloud_url: ctx.publicOrigin,
+          store_url: ctx.storeOrigin,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "account_quota",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Usage against every account quota (frames, private scene bytes, backups, frame logs) plus the fixed limits the API enforces (scenes per frame, max zip size, scenes per day, AI chat caps, …). Call this before adding a frame or saving a scene when an earlier call was refused with a quota error.",
+      inputSchema: {},
+    },
+    async () =>
+      run(async () => {
+        const payload = await ctx.client.json<UsagePayload>(
+          "GET",
+          "/api/account/usage",
+        );
+        return structured({ limits: payload.limits, usage: payload.usage });
+      }),
+  );
+
+  server.registerTool(
+    "account_settings_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Account-level service settings that scenes and the AI use: openAI (apiKey, backendApiKey, chatModel, chatReasoningEffort), unsplash.accessKey, homeAssistant (url, accessToken), immich (url, apiKey), github.api_key, frameOS.apiKey, ssh_keys. Secrets are masked unless reveal=true.",
+      inputSchema: {
+        reveal: z
+          .boolean()
+          .optional()
+          .describe("Return secret values in the clear (default false)."),
+      },
+    },
+    async ({ reveal }) =>
+      run(async () => {
+        const settings = await ctx.client.json<Record<string, unknown>>(
+          "GET",
+          "/api/settings",
+        );
+        return text(reveal ? settings : maskSettings(settings));
+      }),
+  );
+
+  server.registerTool(
+    "account_settings_update",
+    {
+      annotations: { destructiveHint: false, idempotentHint: true },
+      description:
+        "Set account-level service settings. Pass only the groups and fields to change, e.g. {\"openAI\": {\"apiKey\": \"sk-…\"}} or {\"unsplash\": {\"accessKey\": \"…\"}}; other fields in a group are preserved. Cloud-managed frames re-pull the keys automatically.",
+      inputSchema: {
+        settings: z
+          .record(z.string(), z.record(z.string(), z.string()))
+          .describe("{group: {field: value}} — string values only; an empty string clears a field."),
+      },
+    },
+    async ({ settings }) =>
+      run(async () => {
+        // POST replaces each posted group wholesale, so merge over the
+        // current values first: setting one key must not wipe its siblings.
+        const current = await ctx.client.json<Record<string, unknown>>(
+          "GET",
+          "/api/settings",
+        );
+        const body: Record<string, Record<string, string>> = {};
+        for (const [group, fields] of Object.entries(settings)) {
+          const existing = current[group];
+          const merged: Record<string, string> = {};
+          if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+            for (const [key, value] of Object.entries(
+              existing as Record<string, unknown>,
+            )) {
+              if (typeof value === "string") {
+                merged[key] = value;
+              }
+            }
+          }
+          Object.assign(merged, fields);
+          body[group] = merged;
+        }
+        const updated = await ctx.client.json<Record<string, unknown>>(
+          "POST",
+          "/api/settings",
+          { body },
+        );
+        return text({
+          settings: maskSettings(updated),
+          status: "updated",
+          updated_groups: Object.keys(body),
+        });
+      }),
+  );
+
+  server.registerTool(
+    "api_tokens_list",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "List the account's personal API tokens (name, hint, access, last use, expiry). Secrets are never returned; new tokens are created in the browser at /account/developer.",
+      inputSchema: {},
+    },
+    async () =>
+      run(async () =>
+        text(await ctx.client.json("GET", "/api/account/api-tokens")),
+      ),
+  );
+
+  server.registerTool(
+    "api_token_revoke",
+    {
+      annotations: { destructiveHint: true },
+      description:
+        "Revoke a personal API token by id. Revoking the token this session uses ends the session on the next call — do that if you believe it leaked.",
+      inputSchema: {
+        token_id: uuid(),
+      },
+    },
+    async ({ token_id }) =>
+      run(async () =>
+        text(
+          await ctx.client.json(
+            "DELETE",
+            `/api/account/api-tokens/${token_id}`,
+          ),
+        ),
+      ),
+  );
+}

--- a/cloud/packages/mcp/src/tools/ai.ts
+++ b/cloud/packages/mcp/src/tools/ai.ts
@@ -1,0 +1,365 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { CloudApiError } from "../client";
+import { failure, run, text, uuid, type ToolContext } from "../result";
+import { resolveStoreSceneId } from "./scene-source";
+
+// The scene AI (the cloud's agentic chat that builds and edits scenes),
+// driven as tools. A turn runs detached on the server and streams NDJSON;
+// the MCP tool follows the stream for up to `wait_seconds`, then either
+// reports the finished turn or hands back a turn_id to resume with
+// ai_turn_wait — an MCP call cannot sit on a 15-minute turn.
+//
+// What a turn delivers is unsaved scene JSON. `apply` decides what to do
+// with it: save it as a new version of the scene being edited, create a new
+// private scene, or just return it.
+
+const maxWaitSeconds = 55;
+const defaultWaitSeconds = 45;
+
+type StreamEvent = Record<string, unknown> & { type: string };
+
+type TurnOutcome = {
+  chat_id: string | undefined;
+  delivered: { scenes: Record<string, unknown>[]; title?: string; tool: string }[];
+  error: string | undefined;
+  events_seen: number;
+  finished: boolean;
+  reply: string;
+  reply_partial: string;
+  tools: string[];
+  turn_id: string | undefined;
+};
+
+function newOutcome(): TurnOutcome {
+  return {
+    chat_id: undefined,
+    delivered: [],
+    error: undefined,
+    events_seen: 0,
+    finished: false,
+    reply: "",
+    reply_partial: "",
+    tools: [],
+    turn_id: undefined,
+  };
+}
+
+function absorb(outcome: TurnOutcome, event: StreamEvent) {
+  if (event.type !== "ping") {
+    outcome.events_seen += 1;
+  }
+  switch (event.type) {
+    case "chat":
+      outcome.chat_id = typeof event.chatId === "string" ? event.chatId : outcome.chat_id;
+      outcome.turn_id = typeof event.turnId === "string" ? event.turnId : outcome.turn_id;
+      break;
+    case "delta":
+      outcome.reply_partial += typeof event.text === "string" ? event.text : "";
+      break;
+    case "tool":
+      if (event.status === "done" || event.status === "error") {
+        outcome.tools.push(
+          `${String(event.label ?? event.name)}${event.status === "error" ? " (failed)" : ""}${
+            typeof event.detail === "string" && event.detail ? `: ${event.detail}` : ""
+          }`,
+        );
+      }
+      break;
+    case "scenes":
+      if (Array.isArray(event.scenes)) {
+        outcome.delivered.push({
+          scenes: event.scenes as Record<string, unknown>[],
+          ...(typeof event.title === "string" ? { title: event.title } : {}),
+          tool: String(event.tool ?? "build_scene"),
+        });
+      }
+      break;
+    case "done":
+      outcome.finished = true;
+      outcome.reply = typeof event.reply === "string" ? event.reply : outcome.reply_partial;
+      break;
+    case "error":
+      outcome.finished = true;
+      outcome.error = typeof event.detail === "string" ? event.detail : "AI turn failed";
+      break;
+    default:
+      break;
+  }
+}
+
+function isTerminal(event: Record<string, unknown>) {
+  return event.type === "done" || event.type === "error";
+}
+
+async function follow(
+  ctx: ToolContext,
+  method: string,
+  path: string,
+  body: Record<string, unknown> | undefined,
+  query: Record<string, string | number | undefined> | undefined,
+  waitSeconds: number,
+  outcome: TurnOutcome,
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), waitSeconds * 1000);
+  try {
+    await ctx.client.ndjson(method, path, {
+      ...(body ? { body } : {}),
+      onEvent: (event) => absorb(outcome, event as StreamEvent),
+      ...(query ? { query } : {}),
+      signal: controller.signal,
+      until: isTerminal,
+    });
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      throw error;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+type ApplyMode = "none" | "new_scene" | "save_version";
+
+async function finalize(
+  ctx: ToolContext,
+  outcome: TurnOutcome,
+  apply: ApplyMode,
+  targetSceneId: string | undefined,
+  message: string | undefined,
+) {
+  if (!outcome.finished) {
+    return text({
+      chat_id: outcome.chat_id,
+      events_seen: outcome.events_seen,
+      hint: `The turn is still running. Call ai_turn_wait with turn_id and after=${outcome.events_seen} to keep following it.`,
+      reply_so_far: outcome.reply_partial.slice(-2000),
+      status: "running",
+      tools_so_far: outcome.tools,
+      turn_id: outcome.turn_id,
+    });
+  }
+  if (outcome.error) {
+    return failure(`The AI turn failed: ${outcome.error}`, {
+      chat_id: outcome.chat_id,
+      reply_so_far: outcome.reply_partial.slice(-2000),
+      tools: outcome.tools,
+      turn_id: outcome.turn_id,
+    });
+  }
+  const last = outcome.delivered.at(-1);
+  let saved: Record<string, unknown> | undefined;
+  let saveError: string | undefined;
+  if (last && apply !== "none") {
+    const scenes = last.scenes.map((scene) => {
+      const copy = { ...scene };
+      delete copy.origin;
+      return copy;
+    });
+    try {
+      if (apply === "save_version") {
+        if (!targetSceneId) {
+          saveError = "apply=save_version needs scene_id.";
+        } else {
+          saved = await ctx.client.json("POST", `/api/account/scenes/${targetSceneId}/content`, {
+            body: { message: (message ?? outcome.reply).slice(0, 200), scenes },
+          });
+        }
+      } else {
+        saved = await ctx.client.json("POST", "/api/account/scenes", {
+          body: {
+            scenes,
+            ...(last.title ? { name: last.title } : {}),
+          },
+        });
+      }
+    } catch (error) {
+      saveError =
+        error instanceof CloudApiError
+          ? `${error.status} ${error.code} ${JSON.stringify(error.details)}`
+          : String(error);
+    }
+  }
+  return text({
+    chat_id: outcome.chat_id,
+    reply: outcome.reply,
+    status: "done",
+    tools: outcome.tools,
+    turn_id: outcome.turn_id,
+    ...(last
+      ? {
+          delivered: {
+            scene_count: last.scenes.length,
+            scenes: saved ? undefined : last.scenes,
+            summary: last.scenes.map((scene) => ({
+              id: scene.id,
+              name: scene.name,
+              nodes: Array.isArray(scene.nodes) ? scene.nodes.length : 0,
+            })),
+            title: last.title,
+            tool: last.tool,
+          },
+        }
+      : { delivered: null }),
+    ...(saved ? { saved } : {}),
+    ...(saveError ? { save_error: saveError } : {}),
+    ...(last && !saved && apply === "none"
+      ? {
+          hint: "The scenes above are not saved anywhere. Save them with scene_update_content (existing scene) or scene_create (new scene), or re-run with apply=save_version / new_scene.",
+        }
+      : {}),
+  });
+}
+
+export function registerAiTools(server: McpServer, ctx: ToolContext) {
+  const api = ctx.client;
+
+  server.registerTool(
+    "ai_scene_chat",
+    {
+      description:
+        "Ask the FrameOS scene AI to build a new scene or change an existing one, in plain language. Without scene_id it creates scenes from scratch; with scene_id (one of the account's scenes) the AI edits that scene's current JSON. It runs the cloud's own agent (app catalog, docs, examples, linting, frame context when frame_id is given). Waits up to wait_seconds (default 45, max 55) — if the turn is longer, you get a turn_id for ai_turn_wait. apply: none (default; returns the JSON), save_version (save as a new version of scene_id), new_scene (save as a new private scene). chat_id continues an earlier conversation.",
+      inputSchema: {
+        apply: z.enum(["none", "new_scene", "save_version"]).optional(),
+        chat_id: uuid().optional(),
+        frame_id: uuid().optional().describe("A frame to give the AI context (size, platform, logs)."),
+        message: z.string().max(200).optional().describe("Version message when apply=save_version."),
+        prompt: z.string().min(1).max(20000),
+        scene_id: z.string().optional().describe("Scene to modify (uuid, slug or URL of one of the account's scenes)."),
+        version: z.number().int().min(1).optional().describe("Edit this version of scene_id instead of the latest."),
+        wait_seconds: z.number().int().min(5).max(maxWaitSeconds).optional(),
+      },
+    },
+    async ({ apply, chat_id, frame_id, message, prompt, scene_id, version, wait_seconds }) =>
+      run(async () => {
+        const body: Record<string, unknown> = { prompt };
+        let storeId: string | undefined;
+        if (chat_id) {
+          body.chatId = chat_id;
+        }
+        if (frame_id) {
+          body.frameId = frame_id;
+        }
+        if (scene_id) {
+          storeId = await resolveStoreSceneId(ctx, scene_id);
+          if (!storeId) {
+            return failure(`No store scene matches "${scene_id}".`);
+          }
+          const scenes = await api.json<Record<string, unknown>[]>(
+            "GET",
+            `/api/store/scenes/${storeId}/scenes.json`,
+            { query: { version } },
+          );
+          const primary = scenes[0];
+          if (!primary) {
+            return failure("The scene has no content.");
+          }
+          body.scene = primary;
+          body.sceneId = primary.id;
+          body.scenes = scenes;
+          body.storeSceneId = storeId;
+          body.surface = "store";
+        } else {
+          body.surface = "store-new";
+        }
+        const outcome = newOutcome();
+        await follow(
+          ctx,
+          "POST",
+          "/api/ai/chat",
+          body,
+          undefined,
+          wait_seconds ?? defaultWaitSeconds,
+          outcome,
+        );
+        return finalize(ctx, outcome, apply ?? "none", storeId, message);
+      }),
+  );
+
+  server.registerTool(
+    "ai_turn_wait",
+    {
+      description:
+        "Keep following a running AI turn (from ai_scene_chat) for up to wait_seconds more; pass `after` = events_seen from the previous call to skip what you already saw. Same apply/scene_id semantics as ai_scene_chat once the turn finishes.",
+      inputSchema: {
+        after: z.number().int().min(0).optional(),
+        apply: z.enum(["none", "new_scene", "save_version"]).optional(),
+        message: z.string().max(200).optional(),
+        scene_id: uuid().optional(),
+        turn_id: z.string(),
+        wait_seconds: z.number().int().min(5).max(maxWaitSeconds).optional(),
+      },
+    },
+    async ({ after, apply, message, scene_id, turn_id, wait_seconds }) =>
+      run(async () => {
+        const outcome = newOutcome();
+        outcome.turn_id = turn_id;
+        outcome.events_seen = after ?? 0;
+        await follow(
+          ctx,
+          "GET",
+          `/api/ai/chat/turns/${turn_id}`,
+          undefined,
+          { after },
+          wait_seconds ?? defaultWaitSeconds,
+          outcome,
+        );
+        return finalize(ctx, outcome, apply ?? "none", scene_id, message);
+      }),
+  );
+
+  server.registerTool(
+    "ai_turn_cancel",
+    {
+      description: "Stop a running AI turn.",
+      inputSchema: { turn_id: z.string() },
+    },
+    async ({ turn_id }) =>
+      run(async () => text(await api.json("DELETE", `/api/ai/chat/turns/${turn_id}`))),
+  );
+
+  server.registerTool(
+    "ai_chats_list",
+    {
+      annotations: { readOnlyHint: true },
+      description: "List the account's AI chats (title, context, message count), newest first; frame_id narrows to one frame's chats.",
+      inputSchema: {
+        frame_id: uuid().optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+        offset: z.number().int().min(0).optional(),
+      },
+    },
+    async ({ frame_id, limit, offset }) =>
+      run(async () =>
+        text(
+          await api.json("GET", "/api/ai/chats", {
+            query: { frameId: frame_id, limit, offset },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "ai_chat_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "One AI chat with its messages. Assistant messages that delivered scenes carry them in payload.delivered — the way to recover a result whose stream was lost.",
+      inputSchema: { chat_id: uuid() },
+    },
+    async ({ chat_id }) =>
+      run(async () => text(await api.json("GET", `/api/ai/chats/${chat_id}`))),
+  );
+
+  server.registerTool(
+    "ai_chat_delete",
+    {
+      annotations: { destructiveHint: true },
+      description: "Delete an AI chat and its messages.",
+      inputSchema: { chat_id: uuid() },
+    },
+    async ({ chat_id }) =>
+      run(async () => text(await api.json("DELETE", `/api/ai/chats/${chat_id}`))),
+  );
+}

--- a/cloud/packages/mcp/src/tools/frames.ts
+++ b/cloud/packages/mcp/src/tools/frames.ts
@@ -1,0 +1,896 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { failure, image, run, text, uuid, type ToolContext } from "../result";
+import { resolveSceneSource, sceneSourceSchema } from "./scene-source";
+
+// Cloud-managed frames. Every call here is one of the /api/frames routes;
+// the few "compound" tools (remove one scene, install from a URL) are two
+// routes back to back and say so in their description. Device-facing work
+// is asynchronous on the API — a `command_id` comes back and the frame
+// applies it when it next talks to the hub — so the tools return that id
+// and point at frame_commands_list.
+
+type FrameSummary = Record<string, unknown> & {
+  assigned_checksum?: string | null;
+  connected?: boolean;
+  frameos_version?: string | null;
+  hardware?: { platform?: string } | null;
+  id: string;
+  last_seen_at?: string | null;
+  name: string;
+  next_wake_at?: string | null;
+  scenes_checksum?: string | null;
+  sleep_reason?: string | null;
+  status: string;
+};
+
+const frameId = uuid().describe("Frame id (uuid) from frames_list.");
+
+function compactFrame(frame: FrameSummary) {
+  return {
+    connected: frame.connected ?? false,
+    frameos_version: frame.frameos_version ?? null,
+    id: frame.id,
+    in_sync:
+      frame.assigned_checksum == null ||
+      frame.assigned_checksum === frame.scenes_checksum,
+    interval: frame.interval ?? null,
+    last_seen_at: frame.last_seen_at ?? null,
+    name: frame.name,
+    next_wake_at: frame.next_wake_at ?? null,
+    platform: frame.hardware?.platform ?? null,
+    sleep_reason: frame.sleep_reason ?? null,
+    status: frame.status,
+    timezone: frame.timezone ?? null,
+  };
+}
+
+function formBody(fields: Record<string, string | Blob>, filename?: string) {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value instanceof Blob && filename) {
+      form.append(key, value, filename);
+    } else {
+      form.append(key, value);
+    }
+  }
+  return form;
+}
+
+export function registerFrameTools(server: McpServer, ctx: ToolContext) {
+  const api = ctx.client;
+
+  server.registerTool(
+    "frames_list",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "List the account's cloud-managed frames with their status (pending/active/revoked), whether they are connected right now, last seen / next wake time, platform, firmware version and whether they hold the assigned scenes (in_sync).",
+      inputSchema: {},
+    },
+    async () =>
+      run(async () => {
+        const payload = await api.json<{ frames: FrameSummary[] }>(
+          "GET",
+          "/api/frames",
+        );
+        return text({
+          frames: payload.frames.map(compactFrame),
+          workspace_url: `${ctx.publicOrigin}/frames`,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Everything the cloud knows about one frame: settings (interval, rotate, timezone, ESP32 power settings…), schedule, assigned scenes state, hardware, last metrics and last reported state, telemetry/service-settings switches.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () => text(await api.json("GET", `/api/frames/${frame_id}`))),
+  );
+
+  server.registerTool(
+    "frame_rename",
+    {
+      annotations: { idempotentHint: true },
+      description: "Rename a frame (1–256 characters).",
+      inputSchema: { frame_id: frameId, name: z.string().min(1).max(256) },
+    },
+    async ({ frame_id, name }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}`, { body: { name } })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_delete",
+    {
+      annotations: { destructiveHint: true },
+      description:
+        "Permanently delete a frame from the account: revokes its link and removes its logs, metrics, commands and scene assignments. The device itself keeps running whatever it last rendered. Requires confirm=true.",
+      inputSchema: {
+        confirm: z.literal(true).describe("Must be true — this cannot be undone."),
+        frame_id: frameId,
+      },
+    },
+    async ({ frame_id }) =>
+      run(async () => text(await api.json("DELETE", `/api/frames/${frame_id}`))),
+  );
+
+  server.registerTool(
+    "frame_revoke",
+    {
+      annotations: { destructiveHint: true },
+      description:
+        "Revoke a frame's cloud link without deleting its history. NOTE: this is a sudo-mode action — it needs a fresh browser sign-in and is refused for API tokens (reauth_required). Prefer asking the owner to do it at /account/frames.",
+      inputSchema: { confirm: z.literal(true), frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}/revoke`, { body: {} })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_confirm",
+    {
+      description:
+        "Confirm a frame that enrolled with a multi-use claim token and is waiting in `pending` status; makes it active and pushes the provisioning scenes.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}/confirm`, { body: {} })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_claim_token_create",
+    {
+      description:
+        "Mint a claim token for enrolling a new frame (shown once). The token goes into the FrameOS web flasher / SD image builder at /frames → Add frame, or into an existing frame's console with `cloud enroll`. `multi_use` tokens enroll many frames (each lands as `pending` until frame_confirm). `frame_id` re-enrolls an existing frame (single use, 1 h).",
+      inputSchema: {
+        frame_id: uuid().optional().describe("Re-enroll this existing frame."),
+        max_uses: z.number().int().min(1).optional(),
+        multi_use: z.boolean().optional(),
+        name: z.string().max(256).optional().describe("Name the new frame will get."),
+        scene_source_frame_id: z
+          .string()
+          .uuid()
+          .optional()
+          .describe("Copy this frame's scenes onto the new one at enrollment."),
+        timezone: z.string().max(64).optional().describe("IANA zone for the new frame."),
+        ttl_days: z
+          .union([z.number().int().min(1).max(365), z.literal("forever")])
+          .optional(),
+      },
+    },
+    async (input) =>
+      run(async () => {
+        const result = await api.json<Record<string, unknown>>(
+          "POST",
+          "/api/frames/claim-tokens",
+          { body: input },
+        );
+        return text({
+          ...result,
+          how_to_use: `Open ${ctx.publicOrigin}/frames, choose "Add frame", and paste the claim token when the flasher or SD-image builder asks for it. Frames enrolled with a multi-use token appear as pending; confirm them with frame_confirm.`,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_settings_update",
+    {
+      annotations: { idempotentHint: true },
+      description:
+        "Push device settings to a frame. Allowed keys: debug, interval (seconds 1–86400), name, rotate (0/90/180/270), scaling_mode (contain/cover/stretch/center), timezone (IANA), flip, error_behavior, control_code, metrics_interval, max_http_response_bytes, save_assets, timezone_updater, palette, device_config, gpio_buttons, and on ESP32 the power keys deep_sleep, deep_sleep_on_battery, wake_check_seconds, battery_pin, battery_divider, battery_enable_pin. Unknown keys or values are refused as a whole (setting_not_allowed); old firmware is refused with settings_need_newer_firmware. Returns a command_id.",
+      inputSchema: {
+        frame_id: frameId,
+        settings: z.record(z.string(), z.unknown()).describe("Only the keys to change."),
+      },
+    },
+    async ({ frame_id, settings }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/settings`, {
+            body: { settings },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_scenes_list",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The scenes assigned to a frame, in order, with the pinned version (null = follow latest), the store's latest version, and whether the device currently holds this exact set (assigned_checksum vs scenes_checksum).",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () => text(await api.json("GET", `/api/frames/${frame_id}/scenes`))),
+  );
+
+  server.registerTool(
+    "frame_scenes_set",
+    {
+      annotations: { idempotentHint: true },
+      description:
+        "Replace a frame's whole scene list (order = display order, max 20). Omitting a scene removes it; scene_version pins a version (null = follow latest). active_scene_id (a store scene id or runtime scene id) chooses which scene shows after the deploy. Deploys to the device as one set_scenes command.",
+      inputSchema: {
+        active_scene_id: z.string().max(256).optional(),
+        frame_id: frameId,
+        scenes: z
+          .array(
+            z.object({
+              scene_id: uuid(),
+              scene_version: z.number().int().min(1).nullable().optional(),
+            }),
+          )
+          .max(20),
+      },
+    },
+    async ({ active_scene_id, frame_id, scenes }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/scenes`, {
+            body: { scenes, ...(active_scene_id ? { scene_id: active_scene_id } : {}) },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_scene_install",
+    {
+      description:
+        "Add a scene to a frame and deploy it. The scene comes from exactly one of: scene_id (a store scene — public, or one of the account's own — from scenes_list / store_browse), url (a scene page on the store, a scene zip, or a scenes.json), or scenes (raw scene JSON, saved first as a new private scene). Re-installing an already-assigned scene re-pins/re-deploys it. activate=true switches the frame to it right away.",
+      inputSchema: {
+        activate: z.boolean().optional(),
+        frame_id: frameId,
+        name: z.string().max(128).optional().describe("Name for a scene created from `scenes`."),
+        scene_version: z.number().int().min(1).nullable().optional(),
+        ...sceneSourceSchema,
+      },
+    },
+    async ({ activate, frame_id, name, scene_version, ...source }) =>
+      run(async () => {
+        const resolved = await resolveSceneSource(ctx, { ...source, name });
+        if ("error" in resolved) {
+          return failure(resolved.error);
+        }
+        const added = await api.json<Record<string, unknown>>(
+          "POST",
+          `/api/frames/${frame_id}/scenes/add`,
+          {
+            body: {
+              scene_id: resolved.sceneId,
+              ...(scene_version !== undefined ? { scene_version } : {}),
+            },
+          },
+        );
+        let activated: Record<string, unknown> | undefined;
+        if (activate) {
+          activated = await api.json<Record<string, unknown>>(
+            "POST",
+            `/api/frames/${frame_id}/event/setCurrentScene`,
+            { body: { sceneId: resolved.sceneId } },
+          );
+        }
+        return text({
+          ...added,
+          scene: resolved.summary ?? { id: resolved.sceneId },
+          ...(resolved.created ? { created_private_scene: true } : {}),
+          ...(activated ? { activate: activated } : {}),
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_scene_remove",
+    {
+      annotations: { destructiveHint: true },
+      description:
+        "Remove one scene from a frame (reads the current list and re-assigns it without that scene, keeping the other pins and the order). The store scene itself is untouched.",
+      inputSchema: { frame_id: frameId, scene_id: uuid() },
+    },
+    async ({ frame_id, scene_id }) =>
+      run(async () => {
+        const current = await api.json<{
+          scenes: { scene_id: string; scene_version: number | null }[];
+        }>("GET", `/api/frames/${frame_id}/scenes`);
+        const remaining = current.scenes.filter((scene) => scene.scene_id !== scene_id);
+        if (remaining.length === current.scenes.length) {
+          return failure(`Scene ${scene_id} is not assigned to frame ${frame_id}.`);
+        }
+        const result = await api.json("POST", `/api/frames/${frame_id}/scenes`, {
+          body: {
+            scenes: remaining.map((scene) => ({
+              scene_id: scene.scene_id,
+              scene_version: scene.scene_version,
+            })),
+          },
+        });
+        return text({ ...result, remaining: remaining.length, removed: scene_id });
+      }),
+  );
+
+  server.registerTool(
+    "frame_scene_activate",
+    {
+      description:
+        "Switch the frame to a scene now (store scene id or the runtime scene id from the device's scene list). Optional `state` seeds the scene's public fields (max 16 KiB). If the device is out of sync with its assigned scenes, the whole set is re-pushed with this scene active.",
+      inputSchema: {
+        frame_id: frameId,
+        scene_id: z.string().max(256),
+        state: z.record(z.string(), z.unknown()).optional(),
+      },
+    },
+    async ({ frame_id, scene_id, state }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/event/setCurrentScene`, {
+            body: { sceneId: scene_id, ...(state ? { state } : {}) },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_render",
+    {
+      description: "Ask the frame to re-render its current scene now.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}/event/render`, { body: {} })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_screenshot",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The image currently on the frame's display, as an image. refresh=true asks the device for a fresh capture and waits up to ~25 s (the frame must be online; asleep frames answer when they wake); otherwise the cloud's last cached copy is returned immediately.",
+      inputSchema: { frame_id: frameId, refresh: z.boolean().optional() },
+    },
+    async ({ frame_id, refresh }) =>
+      run(async () => {
+        const { bytes, contentType } = await api.bytes(
+          "GET",
+          `/api/frames/${frame_id}/image`,
+          { query: { t: refresh ? Date.now() : -1 } },
+        );
+        return image(bytes, contentType, `Frame ${frame_id} display (${contentType}, ${bytes.length} bytes)`);
+      }),
+  );
+
+  server.registerTool(
+    "frame_scene_preview",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The frame's cached preview image for one of its scenes (the device's own render when it has one, else the store cover), by store scene id or runtime scene id.",
+      inputSchema: {
+        frame_id: frameId,
+        scene_id: z.string().max(200),
+        thumb: z.boolean().optional(),
+      },
+    },
+    async ({ frame_id, scene_id, thumb }) =>
+      run(async () => {
+        const { bytes, contentType } = await api.bytes(
+          "GET",
+          `/api/frames/${frame_id}/scene_images/${encodeURIComponent(scene_id)}`,
+          { query: { thumb: thumb ? 1 : undefined } },
+        );
+        return image(bytes, contentType, `Preview of scene ${scene_id} on frame ${frame_id}`);
+      }),
+  );
+
+  server.registerTool(
+    "frame_logs",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Recent log lines from a frame (newest last). `limit` caps the lines returned (default 100, max 1000); `search` keeps only lines containing the text; `after_id` pages forward from a previous newest id. Lines are JSON events from the runtime ({event: …}) or plain text.",
+      inputSchema: {
+        after_id: z.number().int().min(0).optional(),
+        frame_id: frameId,
+        limit: z.number().int().min(1).max(1000).optional(),
+        search: z.string().max(200).optional(),
+      },
+    },
+    async ({ after_id, frame_id, limit, search }) =>
+      run(async () => {
+        const payload = await api.json<{
+          has_more: boolean;
+          logs: { id: number; line: string; timestamp: string; type: string }[];
+        }>("GET", `/api/frames/${frame_id}/logs`, { query: { after_id } });
+        const needle = search?.toLowerCase();
+        const filtered = needle
+          ? payload.logs.filter((entry) => entry.line.toLowerCase().includes(needle))
+          : payload.logs;
+        const lines = filtered.slice(-(limit ?? 100));
+        return text({
+          has_more: payload.has_more,
+          logs: lines.map((entry) => ({
+            id: entry.id,
+            line: entry.line,
+            timestamp: entry.timestamp,
+            type: entry.type,
+          })),
+          matched: filtered.length,
+          newest_id: payload.logs.at(-1)?.id ?? null,
+          oldest_id: payload.logs[0]?.id ?? null,
+          returned: lines.length,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_metrics",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Metrics samples the frame reported (memory, temperature, battery, uptime…) plus reboot markers. `since` (ISO time) narrows to recent samples; `limit` caps the newest samples returned (default 50).",
+      inputSchema: {
+        frame_id: frameId,
+        limit: z.number().int().min(1).max(1000).optional(),
+        since: z.string().optional(),
+      },
+    },
+    async ({ frame_id, limit, since }) =>
+      run(async () => {
+        const payload = await api.json<{
+          metrics: unknown[];
+          reboots: unknown[];
+        }>(
+          "GET",
+          since
+            ? `/api/frames/${frame_id}/metrics/recent`
+            : `/api/frames/${frame_id}/metrics`,
+          { query: { since } },
+        );
+        return text({
+          metrics: payload.metrics.slice(-(limit ?? 50)),
+          reboots: payload.reboots.slice(-20),
+          total_samples: payload.metrics.length,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_metrics_request",
+    {
+      description: "Ask the frame to report a fresh metrics sample now (read it with frame_metrics a moment later).",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}/event/metrics`, { body: {} })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_activity",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The audit trail for a frame: enrollments, scene deploys, settings pushes, commands, reboots — who did what, when, from where.",
+      inputSchema: {
+        before: z.string().optional().describe("Cursor `before` from a previous call."),
+        before_id: uuid().optional(),
+        frame_id: frameId,
+        limit: z.number().int().min(1).max(200).optional(),
+      },
+    },
+    async ({ before, before_id, frame_id, limit }) =>
+      run(async () =>
+        text(
+          await api.json("GET", `/api/frames/${frame_id}/activity`, {
+            query: { before, before_id, limit },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_commands_list",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Commands queued for the frame that it has not applied yet (pending) or that were sent and await an ack. Empty means everything was applied.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () => text(await api.json("GET", `/api/frames/${frame_id}/commands`))),
+  );
+
+  server.registerTool(
+    "frame_command_cancel",
+    {
+      description: "Cancel a queued command that the frame has not picked up yet.",
+      inputSchema: { command_id: uuid(), frame_id: frameId },
+    },
+    async ({ command_id, frame_id }) =>
+      run(async () =>
+        text(await api.json("DELETE", `/api/frames/${frame_id}/commands/${command_id}`)),
+      ),
+  );
+
+  server.registerTool(
+    "frame_command_send",
+    {
+      description:
+        "Queue a raw device command. Types: render, get_metrics, reboot, restart_runtime, refresh_service_settings, set_schedule (re-push the stored schedule), set_current_scene (needs scene_id = runtime scene id; prefer frame_scene_activate), notify_update_available (start a signed OTA firmware update).",
+      inputSchema: {
+        frame_id: frameId,
+        scene_id: z.string().max(256).optional(),
+        type: z.enum([
+          "get_metrics",
+          "notify_update_available",
+          "reboot",
+          "refresh_service_settings",
+          "render",
+          "restart_runtime",
+          "set_current_scene",
+          "set_schedule",
+        ]),
+      },
+    },
+    async ({ frame_id, scene_id, type }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/command`, {
+            body: { type, ...(scene_id ? { scene_id } : {}) },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_reboot",
+    {
+      description: "Reboot the frame (full device reboot).",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}/reboot`, { body: {} })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_restart",
+    {
+      description: "Restart the FrameOS runtime on the frame (keeps the device up).",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(await api.json("POST", `/api/frames/${frame_id}/restart`, { body: {} })),
+      ),
+  );
+
+  server.registerTool(
+    "frame_schedule_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The frame's stored schedule: events with minute, hour, weekday (0 daily, 1–7 Mon–Sun, 8 weekdays, 9 weekends), event name (e.g. setCurrentScene) and payload (e.g. {sceneId}), plus disabled flags.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () => {
+        const payload = await api.json<{ frame: { schedule?: unknown; timezone?: unknown } }>(
+          "GET",
+          `/api/frames/${frame_id}`,
+        );
+        return text({
+          schedule: payload.frame.schedule ?? { events: [] },
+          timezone: payload.frame.timezone ?? null,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_schedule_set",
+    {
+      annotations: { idempotentHint: true },
+      description:
+        "Replace the frame's schedule. Each event: {id, minute 0–59, hour 0–23, weekday? 0–9, event (e.g. \"setCurrentScene\"), payload? (e.g. {\"sceneId\": \"<store scene id>\"}), disabled?}. Max 64 events. Hours are in the frame's local time; utc_offset_minutes overrides the offset used when the device lacks a zone.",
+      inputSchema: {
+        frame_id: frameId,
+        schedule: z.object({
+          disabled: z.boolean().optional(),
+          events: z
+            .array(
+              z.object({
+                disabled: z.boolean().optional(),
+                event: z.string().min(1).max(63),
+                hour: z.number().int().min(0).max(23),
+                id: z.string().min(1).max(64),
+                minute: z.number().int().min(0).max(59),
+                payload: z.record(z.string(), z.unknown()).optional(),
+                weekday: z.number().int().min(0).max(9).optional(),
+              }),
+            )
+            .max(64),
+        }),
+        utc_offset_minutes: z.number().int().min(-720).max(840).optional(),
+      },
+    },
+    async ({ frame_id, schedule, utc_offset_minutes }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/schedule`, {
+            body: {
+              schedule,
+              ...(utc_offset_minutes !== undefined
+                ? { utcOffsetMinutes: utc_offset_minutes }
+                : {}),
+            },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_service_settings_enable",
+    {
+      annotations: { idempotentHint: true },
+      description:
+        "Allow (or stop allowing) this frame to pull the account's service API keys (OpenAI, Unsplash, Home Assistant, …) that scenes need.",
+      inputSchema: { enabled: z.boolean(), frame_id: frameId },
+    },
+    async ({ enabled, frame_id }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/service-settings/enabled`, {
+            body: { enabled },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_telemetry_enable",
+    {
+      annotations: { idempotentHint: true },
+      description:
+        "Turn log and metrics shipping from this frame on or off (frames enrolled before August 2026 may need this switched on once). Restarts the runtime so it takes effect now.",
+      inputSchema: { enabled: z.boolean(), frame_id: frameId },
+    },
+    async ({ enabled, frame_id }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/telemetry/enabled`, {
+            body: { enabled },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_assets_list",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Files on the frame's asset storage (photos, fonts, saved images) with size and mtime. refresh=true asks a connected frame for a fresh listing; otherwise the cached one is returned.",
+      inputSchema: { frame_id: frameId, refresh: z.boolean().optional() },
+    },
+    async ({ frame_id, refresh }) =>
+      run(async () =>
+        text(
+          await api.json("GET", `/api/frames/${frame_id}/assets`, {
+            query: { refresh: refresh ? 1 : undefined },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_asset_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Fetch a file from the frame (max 8 MiB; waits up to ~25 s for an online frame). Images come back as images, text files as text, anything else as a size/type summary. thumb=true asks for a small thumbnail of an image.",
+      inputSchema: {
+        frame_id: frameId,
+        path: z.string().min(1).max(1024),
+        thumb: z.boolean().optional(),
+      },
+    },
+    async ({ frame_id, path, thumb }) =>
+      run(async () => {
+        const { bytes, contentType } = await api.bytes(
+          "GET",
+          `/api/frames/${frame_id}/asset`,
+          { query: { path, thumb: thumb ? 1 : undefined } },
+        );
+        if (contentType.startsWith("image/")) {
+          return image(bytes, contentType, `${path} (${contentType}, ${bytes.length} bytes)`);
+        }
+        if (
+          contentType.startsWith("text/") ||
+          contentType.includes("json") ||
+          contentType.includes("xml")
+        ) {
+          const body = new TextDecoder().decode(bytes.subarray(0, 200_000));
+          return text({ content: body, content_type: contentType, path, size: bytes.length });
+        }
+        return text({ content_type: contentType, path, size: bytes.length });
+      }),
+  );
+
+  server.registerTool(
+    "frame_asset_upload",
+    {
+      description:
+        "Upload a file to the frame's asset storage (directory `path`, defaults to the root). Provide the content as base64 or as text. Large files are chunked by the cloud; the frame must be online (waits up to 30 s for the ack).",
+      inputSchema: {
+        content_base64: z.string().optional(),
+        filename: z.string().min(1).max(255),
+        frame_id: frameId,
+        path: z.string().max(1024).optional().describe("Target directory on the frame."),
+        text: z.string().optional(),
+      },
+    },
+    async ({ content_base64, filename, frame_id, path, text: textContent }) =>
+      run(async () => {
+        if (!content_base64 && textContent === undefined) {
+          return failure("Provide content_base64 or text.");
+        }
+        const bytes = content_base64
+          ? Buffer.from(content_base64, "base64")
+          : Buffer.from(textContent ?? "", "utf8");
+        const form = formBody(
+          {
+            file: new Blob([bytes]),
+            ...(path ? { path } : {}),
+          },
+          filename,
+        );
+        return text(
+          await api.json("POST", `/api/frames/${frame_id}/assets/upload`, { raw: form }),
+        );
+      }),
+  );
+
+  server.registerTool(
+    "frame_asset_delete",
+    {
+      annotations: { destructiveHint: true },
+      description: "Delete a file or empty directory on the frame.",
+      inputSchema: { frame_id: frameId, path: z.string().min(1).max(1024) },
+    },
+    async ({ frame_id, path }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/assets/delete`, {
+            raw: formBody({ path }),
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_asset_mkdir",
+    {
+      description: "Create a directory on the frame's asset storage.",
+      inputSchema: { frame_id: frameId, path: z.string().min(1).max(1024) },
+    },
+    async ({ frame_id, path }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/assets/mkdir`, {
+            raw: formBody({ path }),
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_asset_rename",
+    {
+      description: "Rename or move a file on the frame.",
+      inputSchema: {
+        dst: z.string().min(1).max(1024),
+        frame_id: frameId,
+        src: z.string().min(1).max(1024),
+      },
+    },
+    async ({ dst, frame_id, src }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/assets/rename`, {
+            raw: formBody({ dst, src }),
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "frame_assets_sync_fonts",
+    {
+      description:
+        "Push the bundled font catalogue onto the frame's fonts/ folder (skips fonts already there). Streams per-font results; returns the summary when done.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () => {
+        const events: Record<string, unknown>[] = [];
+        await api.ndjson("POST", `/api/frames/${frame_id}/assets/sync`, {
+          body: {},
+          onEvent: (event) => events.push(event),
+        });
+        const done = events.find((event) => event.type === "done");
+        const failed = events.filter(
+          (event) => event.type === "font" && event.status === "failed",
+        );
+        return text({ failed, summary: done ?? { type: "incomplete" } });
+      }),
+  );
+
+  server.registerTool(
+    "frame_firmware_info",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The latest published FrameOS release and its firmware assets per platform; with frame_id, also that frame's current version so you can tell whether an update is available.",
+      inputSchema: { frame_id: uuid().optional() },
+    },
+    async ({ frame_id }) =>
+      run(async () => {
+        const release = await api.json<Record<string, unknown>>(
+          "GET",
+          "/api/frames/firmware",
+        );
+        if (!frame_id) {
+          return text(release);
+        }
+        const detail = await api.json<{ frame: FrameSummary }>(
+          "GET",
+          `/api/frames/${frame_id}`,
+        );
+        return text({
+          frame: {
+            frameos_version: detail.frame.frameos_version ?? null,
+            id: detail.frame.id,
+            platform: detail.frame.hardware?.platform ?? null,
+          },
+          release,
+          update_available:
+            typeof release.release === "string" &&
+            typeof detail.frame.frameos_version === "string" &&
+            release.release.replace(/^v/, "") !==
+              detail.frame.frameos_version.replace(/^v/, ""),
+        });
+      }),
+  );
+
+  server.registerTool(
+    "frame_firmware_update",
+    {
+      description:
+        "Tell the frame a signed firmware update is available; the device downloads and applies it on its own schedule (usually within a minute when online). Same as frame_command_send type=notify_update_available.",
+      inputSchema: { frame_id: frameId },
+    },
+    async ({ frame_id }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/frames/${frame_id}/command`, {
+            body: { type: "notify_update_available" },
+          }),
+        ),
+      ),
+  );
+}

--- a/cloud/packages/mcp/src/tools/scene-source.ts
+++ b/cloud/packages/mcp/src/tools/scene-source.ts
@@ -1,0 +1,243 @@
+import { z } from "zod";
+import { CloudApiError } from "../client";
+import { isUuid, type ToolContext } from "../result";
+
+// "Which scene do you mean?" answered once for every tool that takes one:
+// a store scene id, a URL (store page, scenes.json, or a zip), or raw
+// scene JSON. URLs and JSON that are not already in the account become a
+// private scene first — the frame routes only take store ids.
+
+export const sceneSourceSchema = {
+  scene_id: z
+    .string()
+    .optional()
+    .describe("A store scene id (uuid) — public, or one of the account's own."),
+  scenes: z
+    .array(z.record(z.string(), z.unknown()))
+    .optional()
+    .describe("Raw scenes JSON (the array from a scenes.json)."),
+  url: z
+    .string()
+    .url()
+    .optional()
+    .describe("A scene page URL on the store (…/s/<slug>), a scenes.json URL, or a scene zip URL."),
+};
+
+export type SceneSourceInput = {
+  description?: string | undefined;
+  name?: string | undefined;
+  scene_id?: string | undefined;
+  scenes?: Record<string, unknown>[] | undefined;
+  url?: string | undefined;
+};
+
+export type ResolvedSceneSource =
+  | { created: boolean; sceneId: string; summary?: Record<string, unknown> | undefined }
+  | { error: string };
+
+type RepositoryTemplate = {
+  id: string;
+  name: string;
+  sceneId: string;
+  url?: string;
+  version?: string;
+  visibility?: string;
+};
+
+const repositoryCache = new WeakMap<
+  ToolContext,
+  { fetchedAt: number; templates: RepositoryTemplate[] }
+>();
+
+export async function storeRepository(
+  ctx: ToolContext,
+): Promise<RepositoryTemplate[]> {
+  const cached = repositoryCache.get(ctx);
+  if (cached && Date.now() - cached.fetchedAt < 5 * 60 * 1000) {
+    return cached.templates;
+  }
+  const [store, drive] = await Promise.all([
+    ctx.client.json<{ templates: RepositoryTemplate[] }>(
+      "GET",
+      "/api/store/repository.json",
+    ),
+    ctx.client
+      .json<{ templates: RepositoryTemplate[] }>(
+        "GET",
+        "/api/store/account/repository.json",
+      )
+      .catch(() => ({ templates: [] as RepositoryTemplate[] })),
+  ]);
+  const templates = [...drive.templates, ...store.templates];
+  repositoryCache.set(ctx, { fetchedAt: Date.now(), templates });
+  return templates;
+}
+
+/** Store scene id for a slug, a uuid, or a store page URL. */
+export async function resolveStoreSceneId(
+  ctx: ToolContext,
+  reference: string,
+): Promise<string | undefined> {
+  const trimmed = reference.trim();
+  if (isUuid(trimmed)) {
+    return trimmed;
+  }
+  let slug = trimmed;
+  try {
+    const url = new URL(trimmed);
+    const match = url.pathname.match(/\/(?:s|scenes)\/([^/]+)\/?$/);
+    if (match?.[1]) {
+      slug = decodeURIComponent(match[1]);
+    }
+  } catch {
+    // not a URL — treat as a slug
+  }
+  const templates = await storeRepository(ctx);
+  return templates.find((template) => template.id === slug)?.sceneId;
+}
+
+function sceneNameOf(scenes: Record<string, unknown>[]): string | undefined {
+  const first = scenes[0];
+  return first && typeof first.name === "string" && first.name.trim()
+    ? first.name.trim()
+    : undefined;
+}
+
+async function createPrivateScene(
+  ctx: ToolContext,
+  scenes: Record<string, unknown>[],
+  name: string | undefined,
+  description: string | undefined,
+): Promise<ResolvedSceneSource> {
+  const created = await ctx.client.json<{ scene: Record<string, unknown> }>(
+    "POST",
+    "/api/account/scenes",
+    {
+      body: {
+        scenes,
+        ...(name || sceneNameOf(scenes) ? { name: name ?? sceneNameOf(scenes) } : {}),
+        ...(description ? { description } : {}),
+      },
+    },
+  );
+  return {
+    created: true,
+    sceneId: String(created.scene.id),
+    summary: created.scene,
+  };
+}
+
+async function uploadSceneZip(
+  ctx: ToolContext,
+  bytes: Uint8Array,
+  filename: string,
+): Promise<ResolvedSceneSource> {
+  const form = new FormData();
+  // slice() re-homes the bytes on a plain ArrayBuffer, which Blob demands.
+  form.append(
+    "file",
+    new Blob([bytes.slice()], { type: "application/zip" }),
+    filename,
+  );
+  const created = await ctx.client.json<{ scene: Record<string, unknown> }>(
+    "POST",
+    "/api/account/scenes/upload",
+    { raw: form },
+  );
+  return {
+    created: true,
+    sceneId: String(created.scene.id),
+    summary: created.scene,
+  };
+}
+
+const maxImportBytes = 8 * 1024 * 1024;
+
+export async function resolveSceneSource(
+  ctx: ToolContext,
+  input: SceneSourceInput,
+): Promise<ResolvedSceneSource> {
+  const provided = [input.scene_id, input.url, input.scenes].filter(
+    (value) => value !== undefined,
+  ).length;
+  if (provided !== 1) {
+    return { error: "Provide exactly one of scene_id, url, or scenes." };
+  }
+  if (input.scene_id !== undefined) {
+    const sceneId = await resolveStoreSceneId(ctx, input.scene_id);
+    if (!sceneId) {
+      return { error: `No store scene matches "${input.scene_id}".` };
+    }
+    return { created: false, sceneId };
+  }
+  if (input.scenes !== undefined) {
+    if (input.scenes.length === 0) {
+      return { error: "`scenes` must be a non-empty array." };
+    }
+    return createPrivateScene(ctx, input.scenes, input.name, input.description);
+  }
+  const url = input.url ?? "";
+  // A store page: already in the store, no copy needed.
+  const storeId = await resolveStoreSceneId(ctx, url).catch(() => undefined);
+  if (storeId) {
+    return { created: false, sceneId: storeId };
+  }
+  // A cloud scenes.json / download URL of ours: read it through the API so
+  // private scenes the token may see resolve too.
+  const ownRoute = url.match(/\/api\/store\/scenes\/([0-9a-f-]{36})\//i);
+  if (ownRoute?.[1]) {
+    return { created: false, sceneId: ownRoute[1] };
+  }
+  let response: Response;
+  try {
+    response = await ctx.fetchExternal(url, {
+      headers: { accept: "application/zip, application/json, */*" },
+      redirect: "follow",
+    });
+  } catch (error) {
+    return { error: `Could not fetch ${url}: ${String(error)}` };
+  }
+  if (!response.ok) {
+    return { error: `Could not fetch ${url}: HTTP ${response.status}` };
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length > maxImportBytes) {
+    return { error: `${url} is larger than ${maxImportBytes} bytes.` };
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  const isZip =
+    contentType.includes("zip") ||
+    (bytes[0] === 0x50 && bytes[1] === 0x4b);
+  try {
+    if (isZip) {
+      const filename =
+        decodeURIComponent(new URL(url).pathname.split("/").pop() || "scene.zip") ||
+        "scene.zip";
+      return await uploadSceneZip(
+        ctx,
+        bytes,
+        filename.endsWith(".zip") ? filename : `${filename}.zip`,
+      );
+    }
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+    const scenes = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === "object" && Array.isArray((parsed as { scenes?: unknown }).scenes)
+        ? (parsed as { scenes: unknown[] }).scenes
+        : undefined;
+    if (!scenes || scenes.length === 0) {
+      return { error: `${url} is neither a scene zip nor a scenes.json.` };
+    }
+    return await createPrivateScene(
+      ctx,
+      scenes as Record<string, unknown>[],
+      input.name,
+      input.description,
+    );
+  } catch (error) {
+    if (error instanceof CloudApiError) {
+      throw error;
+    }
+    return { error: `${url} could not be imported: ${String(error)}` };
+  }
+}

--- a/cloud/packages/mcp/src/tools/scenes.ts
+++ b/cloud/packages/mcp/src/tools/scenes.ts
@@ -1,0 +1,587 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { failure, image, run, text, uuid, type ToolContext } from "../result";
+import {
+  resolveSceneSource,
+  resolveStoreSceneId,
+  sceneSourceSchema,
+  storeRepository,
+} from "./scene-source";
+
+// Scenes: the account's own (private or published) and the public store.
+// One id space — a store scene id names both — so scene_get_content,
+// scene_render and scene_lint work on anything the token may read.
+
+const sceneId = uuid().describe("Store scene id (uuid) from scenes_list or store_browse.");
+const scenesJson = z
+  .array(z.record(z.string(), z.unknown()))
+  .describe("The scenes array (each with id, name, nodes, edges, fields, settings).");
+
+type SceneSummary = Record<string, unknown> & { id: string; name: string };
+
+const storeCategories = [
+  "photos",
+  "art",
+  "calendar",
+  "weather",
+  "ai",
+  "dashboards",
+  "fun",
+  "utilities",
+  "demos",
+] as const;
+
+function sceneStats(scenes: Record<string, unknown>[]) {
+  return scenes.map((scene) => ({
+    edges: Array.isArray(scene.edges) ? scene.edges.length : 0,
+    fields: Array.isArray(scene.fields) ? scene.fields.length : 0,
+    id: scene.id,
+    name: scene.name,
+    nodes: Array.isArray(scene.nodes) ? scene.nodes.length : 0,
+  }));
+}
+
+export function registerSceneTools(server: McpServer, ctx: ToolContext) {
+  const api = ctx.client;
+
+  const fetchContent = (id: string, version?: number) =>
+    api.json<Record<string, unknown>[]>("GET", `/api/store/scenes/${id}/scenes.json`, {
+      query: { version },
+    });
+
+  server.registerTool(
+    "scenes_list",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The account's own scenes (private drafts and published ones): id, name, slug, visibility, status, latest_version, tags, category, download_count, has_preview. Filter with q (name/slug/tags), visibility (private|public) and status (active|pulled|featured).",
+      inputSchema: {
+        q: z.string().max(100).optional(),
+        status: z.enum(["active", "pulled", "featured"]).optional(),
+        visibility: z.enum(["private", "public"]).optional(),
+      },
+    },
+    async ({ q, status, visibility }) =>
+      run(async () => {
+        const payload = await api.json<{ scenes: SceneSummary[] }>(
+          "GET",
+          "/api/account/scenes",
+          { query: { q, status, visibility } },
+        );
+        return text({
+          my_scenes_url: `${ctx.storeOrigin}/my-scenes`,
+          scenes: payload.scenes.map((scene) => ({
+            ...scene,
+            url: `${ctx.storeOrigin}/s/${scene.slug}`,
+          })),
+        });
+      }),
+  );
+
+  server.registerTool(
+    "scene_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "One of the account's scenes in full: summary, every version (number, message, size, yanked, risk flags), gallery images, preview and share URLs. For the scene JSON itself use scene_get_content.",
+      inputSchema: { scene_id: sceneId },
+    },
+    async ({ scene_id }) =>
+      run(async () => text(await api.json("GET", `/api/account/scenes/${scene_id}`))),
+  );
+
+  server.registerTool(
+    "scene_get_content",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "The scenes JSON of a store scene (the account's own, or any public one) — the array of scene objects with nodes, edges, fields and settings, each stamped with its `origin`. `version` picks a specific version; default is the newest non-yanked one. Accepts a uuid, a store slug, or a store page URL.",
+      inputSchema: {
+        scene: z.string().describe("Store scene id, slug, or page URL."),
+        version: z.number().int().min(1).optional(),
+      },
+    },
+    async ({ scene, version }) =>
+      run(async () => {
+        const id = await resolveStoreSceneId(ctx, scene);
+        if (!id) {
+          return failure(`No store scene matches "${scene}".`);
+        }
+        return text(await fetchContent(id, version));
+      }),
+  );
+
+  server.registerTool(
+    "scene_create",
+    {
+      description:
+        "Create a new private scene in the account from exactly one of: scenes (raw scenes JSON), url (a scene zip or scenes.json to import; a store page URL forks that store scene into the account), or scene_id (fork a store scene). Returns the new scene's summary; install it on a frame with frame_scene_install.",
+      inputSchema: {
+        description: z.string().max(2000).optional(),
+        name: z.string().max(128).optional(),
+        ...sceneSourceSchema,
+      },
+    },
+    async ({ description, name, ...source }) =>
+      run(async () => {
+        if (source.scene_id !== undefined || source.url !== undefined) {
+          // A store reference means "make me a copy", unlike the frame
+          // install, where the store scene is used as-is.
+          const storeId = await resolveStoreSceneId(
+            ctx,
+            source.scene_id ?? source.url ?? "",
+          ).catch(() => undefined);
+          if (storeId) {
+            const scenes = await fetchContent(storeId);
+            const forked = await api.json<Record<string, unknown>>(
+              "POST",
+              `/api/account/scenes/${storeId}/fork`,
+              { body: { scenes } },
+            );
+            return text({ ...forked, forked_from: storeId });
+          }
+        }
+        const resolved = await resolveSceneSource(ctx, {
+          ...source,
+          description,
+          name,
+        });
+        if ("error" in resolved) {
+          return failure(resolved.error);
+        }
+        if (!resolved.created) {
+          return failure("That reference is already a store scene; use scene_id with fork semantics (scene_fork) instead.");
+        }
+        return text({ scene: resolved.summary, status: "created" });
+      }),
+  );
+
+  server.registerTool(
+    "scene_update_content",
+    {
+      description:
+        "Save new scenes JSON to one of the account's scenes as a new immutable version (versions are never overwritten). `message` is the changelog note (max 200 chars). Frames following 'latest' pick the new version up on their next deploy (frame_scene_install re-deploys).",
+      inputSchema: {
+        message: z.string().max(200).optional(),
+        scene_id: sceneId,
+        scenes: scenesJson,
+      },
+    },
+    async ({ message, scene_id, scenes }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/account/scenes/${scene_id}/content`, {
+            body: { scenes, ...(message ? { message } : {}) },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "scene_update",
+    {
+      annotations: { idempotentHint: true },
+      description:
+        "Edit a scene's listing: description, tags (max 5, lowercase a-z0-9-), category (photos|art|calendar|weather|ai|dashboards|fun|utilities|demos, null to clear), frameos_version (minimum FrameOS version; changing it appends a version). For the name use scene_rename; for publishing use scene_publish.",
+      inputSchema: {
+        category: z.enum(storeCategories).nullable().optional(),
+        description: z.string().max(2000).nullable().optional(),
+        frameos_version: z.string().max(32).nullable().optional(),
+        scene_id: sceneId,
+        tags: z.array(z.string().max(24)).max(5).optional(),
+      },
+    },
+    async ({ category, description, frameos_version, scene_id, tags }) =>
+      run(async () =>
+        text(
+          await api.json("PATCH", `/api/account/scenes/${scene_id}`, {
+            body: {
+              ...(category !== undefined ? { category } : {}),
+              ...(description !== undefined ? { description } : {}),
+              ...(frameos_version !== undefined ? { frameosVersion: frameos_version } : {}),
+              ...(tags !== undefined ? { tags } : {}),
+            },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "scene_rename",
+    {
+      description:
+        "Rename one of the account's scenes: rewrites the scene's name inside its JSON and saves a new version, which also renames the store listing when the two were in sync (the API keeps a deliberately different listing title).",
+      inputSchema: { name: z.string().min(1).max(128), scene_id: sceneId },
+    },
+    async ({ name, scene_id }) =>
+      run(async () => {
+        const detail = await api.json<{ scene: SceneSummary }>(
+          "GET",
+          `/api/account/scenes/${scene_id}`,
+        );
+        const scenes = await fetchContent(scene_id);
+        const target =
+          scenes.find((scene) => scene.name === detail.scene.name) ?? scenes[0];
+        if (!target) {
+          return failure("The scene has no content to rename.");
+        }
+        target.name = name;
+        for (const scene of scenes) {
+          delete scene.origin;
+        }
+        const saved = await api.json<{ scene: SceneSummary }>(
+          "POST",
+          `/api/account/scenes/${scene_id}/content`,
+          { body: { message: `Renamed to ${name}`, scenes } },
+        );
+        return text({
+          listing_renamed: saved.scene.name === name,
+          previous_name: detail.scene.name,
+          scene: saved.scene,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "scene_publish",
+    {
+      description:
+        "Publish one of the account's scenes to the public store (or with public=false, make it private again). Public scenes are free of the storage quota; moderation may refuse names/descriptions (content_rejected).",
+      inputSchema: { public: z.boolean().optional(), scene_id: sceneId },
+    },
+    async ({ public: makePublic, scene_id }) =>
+      run(async () => {
+        const result = await api.json<{ scene: SceneSummary & { slug: string } }>(
+          "PATCH",
+          `/api/account/scenes/${scene_id}`,
+          { body: { visibility: makePublic === false ? "private" : "public" } },
+        );
+        return text({ ...result, url: `${ctx.storeOrigin}/s/${result.scene.slug}` });
+      }),
+  );
+
+  server.registerTool(
+    "scene_delete",
+    {
+      annotations: { destructiveHint: true },
+      description:
+        "Delete one of the account's scenes with all versions and images. Frames that had it assigned keep running what they hold until their next deploy. Requires confirm=true.",
+      inputSchema: { confirm: z.literal(true), scene_id: sceneId },
+    },
+    async ({ scene_id }) =>
+      run(async () => text(await api.json("DELETE", `/api/account/scenes/${scene_id}`))),
+  );
+
+  server.registerTool(
+    "scene_fork",
+    {
+      description:
+        "Copy a store scene (public, or one of the account's own) into the account as a new private scene, carrying over its description, tags and images. Accepts a uuid, slug, or store URL.",
+      inputSchema: { scene: z.string() },
+    },
+    async ({ scene }) =>
+      run(async () => {
+        const id = await resolveStoreSceneId(ctx, scene);
+        if (!id) {
+          return failure(`No store scene matches "${scene}".`);
+        }
+        const scenes = await fetchContent(id);
+        return text(
+          await api.json("POST", `/api/account/scenes/${id}/fork`, { body: { scenes } }),
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scene_version_restore",
+    {
+      description:
+        "Roll a scene back to an earlier version by saving that version's content as a new latest version (history is preserved).",
+      inputSchema: { scene_id: sceneId, version: z.number().int().min(1) },
+    },
+    async ({ scene_id, version }) =>
+      run(async () => {
+        const scenes = await fetchContent(scene_id, version);
+        for (const scene of scenes) {
+          delete scene.origin;
+        }
+        return text(
+          await api.json("POST", `/api/account/scenes/${scene_id}/content`, {
+            body: { message: `Restored version ${version}`, scenes },
+          }),
+        );
+      }),
+  );
+
+  server.registerTool(
+    "scene_version_yank",
+    {
+      description:
+        "Yank (hide from 'latest') or un-yank a version of one of the account's scenes. A yanked version is still downloadable by number; the last non-yanked version cannot be yanked.",
+      inputSchema: {
+        scene_id: sceneId,
+        version: z.number().int().min(1),
+        yanked: z.boolean(),
+      },
+    },
+    async ({ scene_id, version, yanked }) =>
+      run(async () =>
+        text(
+          await api.json(
+            "PATCH",
+            `/api/account/scenes/${scene_id}/versions/${version}`,
+            { body: { yanked } },
+          ),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "scene_image_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "A scene's cover image (default) or one gallery image by image_id, as an image. Works for public store scenes too.",
+      inputSchema: { image_id: uuid().optional(), scene_id: sceneId },
+    },
+    async ({ image_id, scene_id }) =>
+      run(async () => {
+        const { bytes, contentType } = await api.bytes(
+          "GET",
+          image_id
+            ? `/api/store/scenes/${scene_id}/images/${image_id}`
+            : `/api/store/scenes/${scene_id}/image`,
+        );
+        return image(bytes, contentType, `Scene ${scene_id} ${image_id ? `image ${image_id}` : "cover"}`);
+      }),
+  );
+
+  server.registerTool(
+    "scene_image_add",
+    {
+      description:
+        "Add a gallery image (jpeg/png/webp/gif, max 4 MiB) to one of the account's scenes; the first gallery image doubles as the cover when the scene has none. Tip: scene_render produces a PNG you can upload here.",
+      inputSchema: { content_base64: z.string(), scene_id: sceneId },
+    },
+    async ({ content_base64, scene_id }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/account/scenes/${scene_id}/images`, {
+            body: { content_base64 },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "scene_image_remove",
+    {
+      annotations: { destructiveHint: true },
+      description:
+        "Remove a gallery image (image_id) or, without image_id, the primary cover image of one of the account's scenes.",
+      inputSchema: { image_id: uuid().optional(), scene_id: sceneId },
+    },
+    async ({ image_id, scene_id }) =>
+      run(async () =>
+        text(
+          await api.json(
+            "DELETE",
+            image_id
+              ? `/api/account/scenes/${scene_id}/images/${image_id}`
+              : `/api/account/scenes/${scene_id}/image`,
+          ),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "scene_images_reorder",
+    {
+      annotations: { idempotentHint: true },
+      description: "Reorder a scene's gallery images: pass the complete list of image ids in the new order.",
+      inputSchema: { order: z.array(uuid()).max(10), scene_id: sceneId },
+    },
+    async ({ order, scene_id }) =>
+      run(async () =>
+        text(
+          await api.json("PATCH", `/api/account/scenes/${scene_id}/images`, {
+            body: { order },
+          }),
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "scene_render",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Render a scene on the server with the real FrameOS runtime and return the frame as an image plus the runtime's logs — a live preview without a device. Give scene_id (store scene, optional version) or raw scenes JSON; width/height default to 800×480; time_zone (IANA) and settings (e.g. {\"unsplash\": {\"accessKey\": \"…\"}}) shape the simulated frame; states seeds field values per scene id. Errors the scene logged are listed so you can fix and re-render.",
+      inputSchema: {
+        height: z.number().int().min(16).max(4096).optional(),
+        scene: z.string().max(256).optional().describe("Runtime scene id to select in a multi-scene set."),
+        scene_id: z.string().optional().describe("Store scene id, slug or URL."),
+        scenes: scenesJson.optional(),
+        settings: z.record(z.string(), z.unknown()).optional(),
+        states: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+        time_zone: z.string().max(64).optional(),
+        version: z.number().int().min(1).optional(),
+        width: z.number().int().min(16).max(4096).optional(),
+      },
+    },
+    async ({ height, scene, scene_id, scenes, settings, states, time_zone, version, width }) =>
+      run(async () => {
+        let storeId: string | undefined;
+        if (scene_id) {
+          storeId = await resolveStoreSceneId(ctx, scene_id);
+          if (!storeId) {
+            return failure(`No store scene matches "${scene_id}".`);
+          }
+        } else if (!scenes) {
+          return failure("Provide scene_id or scenes.");
+        }
+        const result = await api.json<{
+          errors: string[];
+          height: number;
+          logs: string[];
+          png_base64: string;
+          render_ms: number;
+          state: unknown;
+          width: number;
+        }>("POST", "/api/scenes/render", {
+          body: {
+            format: "json",
+            height,
+            scene,
+            ...(storeId ? { scene_id: storeId } : { scenes }),
+            settings,
+            states,
+            time_zone,
+            version,
+            width,
+          },
+        });
+        const summary = {
+          errors: result.errors,
+          height: result.height,
+          logs: result.logs.slice(-40),
+          render_ms: result.render_ms,
+          state: result.state,
+          width: result.width,
+        };
+        return {
+          content: [
+            { text: JSON.stringify(summary, null, 2), type: "text" },
+            { data: result.png_base64, mimeType: "image/png", type: "image" },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "scene_lint",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Validate scenes JSON the way publishing and the scene AI do: structural checks, app keywords against the catalog, and a deep lint of nodes, edges, fields and JS app sources. Errors block; warnings are advice. Pass scenes JSON or a scene_id.",
+      inputSchema: {
+        scene_id: z.string().optional(),
+        scenes: scenesJson.optional(),
+        version: z.number().int().min(1).optional(),
+      },
+    },
+    async ({ scene_id, scenes, version }) =>
+      run(async () => {
+        let payload = scenes;
+        if (!payload) {
+          if (!scene_id) {
+            return failure("Provide scene_id or scenes.");
+          }
+          const id = await resolveStoreSceneId(ctx, scene_id);
+          if (!id) {
+            return failure(`No store scene matches "${scene_id}".`);
+          }
+          payload = await fetchContent(id, version);
+        }
+        return text(await api.json("POST", "/api/scenes/lint", { body: { scenes: payload } }));
+      }),
+  );
+
+  server.registerTool(
+    "store_browse",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Browse the public scene store: full-text q (name, description, publisher, tags), one tag, a category (photos|art|calendar|weather|ai|dashboards|fun|utilities|demos), frameos_version (only scenes that run on that version), page (48 per page). Featured and popular scenes come first. Install a result on a frame with frame_scene_install(scene_id).",
+      inputSchema: {
+        category: z.enum(storeCategories).optional(),
+        frameos_version: z.string().max(40).optional(),
+        page: z.number().int().min(1).max(200).optional(),
+        q: z.string().max(100).optional(),
+        tag: z.string().max(24).optional(),
+      },
+    },
+    async ({ category, frameos_version, page, q, tag }) =>
+      run(async () => {
+        const payload = await api.json<{
+          hasMore: boolean;
+          page: number;
+          scenes: (Record<string, unknown> & { slug: string })[];
+        }>("GET", "/api/store/browse", {
+          query: { category, page, q, tag, version: frameos_version },
+        });
+        return text({
+          has_more: payload.hasMore,
+          page: payload.page,
+          scenes: payload.scenes.map((scene) => ({
+            ...scene,
+            url: `${ctx.storeOrigin}/s/${scene.slug}`,
+          })),
+        });
+      }),
+  );
+
+  server.registerTool(
+    "store_scene_get",
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        "Details of a store scene by uuid, slug or store URL: name, author, description, tags, category, version, cover image URL and zip URL, plus the scene JSON's scene ids/names and node counts.",
+      inputSchema: { scene: z.string() },
+    },
+    async ({ scene }) =>
+      run(async () => {
+        const id = await resolveStoreSceneId(ctx, scene);
+        if (!id) {
+          return failure(`No store scene matches "${scene}".`);
+        }
+        const [templates, scenes] = await Promise.all([
+          storeRepository(ctx),
+          fetchContent(id),
+        ]);
+        const template = templates.find((entry) => entry.sceneId === id);
+        return text({
+          content_summary: sceneStats(scenes),
+          scene_id: id,
+          template: template ?? null,
+          url: template ? `${ctx.storeOrigin}/s/${template.id}` : null,
+        });
+      }),
+  );
+
+  server.registerTool(
+    "store_scene_report",
+    {
+      description: "Report a public store scene to the moderators, with a reason (max 1000 chars).",
+      inputSchema: { reason: z.string().min(1).max(1000), scene_id: sceneId },
+    },
+    async ({ reason, scene_id }) =>
+      run(async () =>
+        text(
+          await api.json("POST", `/api/store/scenes/${scene_id}/report`, {
+            body: { reason },
+          }),
+        ),
+      ),
+  );
+}

--- a/cloud/packages/mcp/tsconfig.json
+++ b/cloud/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       '@frameos-cloud/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@frameos-cloud/mcp':
+        specifier: workspace:*
+        version: link:../../packages/mcp
       '@simplewebauthn/browser':
         specifier: ^13.3.0
         version: 13.3.0
@@ -431,6 +434,31 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.5(jiti@1.21.7)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.10(@types/node@25.9.5)(jsdom@29.1.1)(vite@7.3.6(@types/node@25.9.5)(jiti@1.21.7)(less@4.8.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.23.1))
+
+  cloud/packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.2
+        version: 25.9.5
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.5(jiti@1.21.7)
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1969,6 +1997,12 @@ packages:
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -2160,6 +2194,16 @@ packages:
     peerDependencies:
       react: '>= 15'
       react-dom: '>= 15'
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -3067,6 +3111,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3077,8 +3125,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3179,6 +3238,10 @@ packages:
   body-parser@1.20.6:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -3339,15 +3402,27 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -3849,13 +3924,31 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3872,6 +3965,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3906,6 +4002,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3935,6 +4035,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
@@ -4034,6 +4138,10 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4051,6 +4159,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -4085,6 +4197,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4136,6 +4252,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
@@ -4176,6 +4295,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4378,8 +4503,16 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -4485,9 +4618,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -4542,6 +4683,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   next@16.2.12:
@@ -4664,6 +4809,9 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -4685,6 +4833,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -5153,6 +5305,10 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   react-base16-styling@0.10.0:
     resolution: {integrity: sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==}
 
@@ -5325,6 +5481,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5479,9 +5639,17 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -5750,6 +5918,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript-eslint@8.65.0:
     resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
@@ -6081,6 +6253,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -7259,6 +7439,10 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
+  '@hono/node-server@2.1.1(hono@4.13.5)':
+    dependencies:
+      hono: 4.13.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -7412,6 +7596,28 @@ snapshots:
       react-textarea-autosize: 8.5.9(@types/react@19.2.18)(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.5)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.5
+      jose: 6.2.6
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -8467,11 +8673,20 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
 
   acorn@8.18.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -8479,6 +8694,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -8584,6 +8806,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8751,11 +8987,17 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -9208,7 +9450,21 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   expect-type@1.4.0: {}
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   express@4.22.1:
     dependencies:
@@ -9246,6 +9502,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -9261,6 +9550,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:
@@ -9298,6 +9589,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -9322,6 +9624,8 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@11.3.4:
     dependencies:
@@ -9435,6 +9739,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hono@4.13.5: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
@@ -9460,6 +9766,10 @@ snapshots:
       safer-buffer: 2.1.2
     optional: true
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -9483,6 +9793,8 @@ snapshots:
   inline-style-parser@0.2.7: {}
 
   internmap@2.0.3: {}
+
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9520,6 +9832,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-what@4.1.16: {}
 
@@ -9566,6 +9880,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -9876,7 +10194,11 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -10082,9 +10404,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -10134,6 +10462,8 @@ snapshots:
     optional: true
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   next@16.2.12(@playwright/test@1.60.0)(@types/node@25.9.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.97.3):
     dependencies:
@@ -10250,6 +10580,8 @@ snapshots:
 
   path-to-regexp@0.1.13: {}
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -10261,6 +10593,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.60.0: {}
 
@@ -10763,6 +11097,13 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
   react-base16-styling@0.10.0:
     dependencies:
       '@types/lodash': 4.17.24
@@ -11021,6 +11362,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -11160,12 +11511,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11478,6 +11854,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript-eslint@8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
@@ -11772,6 +12154,12 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.18)(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## What

The FrameOS Cloud MCP: everything a signed-in account can do in the UI, available to scripts and AI agents. Design doc: `cloud/docs/mcp.md`; UI: **Account → Developer**.

### Personal API tokens
- `account_api_tokens` (migration 0040), `src/lib/api-tokens.ts`. Two kinds by prefix: `fc_api_…` (full) and `fc_apiro_…` (read-only).
- `readSession()` falls back to `Authorization: Bearer` when there is no cookie, so **no route changed** — the profile just carries `apiToken`.
- `csrfResponse()` exempts token requests from the Origin check and refuses read-only tokens' mutations before any work (it is the one helper every mutating route calls first; the DB row's access is verified again on lookup).
- Minting: `POST /api/account/api-tokens` needs a cookie session + recent auth (2 h, same gate as device approval), never a token. Revoke: `DELETE …/{id}`. Sudo-mode routes (frame revoke, device revoke/authorize) stay closed to tokens by construction. Audit events + labels added.

### `packages/mcp` — `@frameos-cloud/mcp`
A thin wrapper: every tool is one (occasionally two) HTTP calls to the existing routes with the caller's token. 71 tools:
- **account**: info, quota, settings get (secrets masked unless `reveal`) / update (merges over the current group), api tokens list/revoke
- **frames**: list/get/rename/delete/revoke/confirm, claim tokens, settings, scene list/set/install (store id, URL, or raw JSON — with activate)/remove/activate, render, screenshot (image content), scene preview, logs (filter+cap), metrics, activity, command queue, reboot/restart, schedule get/set, service-settings/telemetry switches, assets list/get/upload/delete/mkdir/rename/sync fonts, firmware info/update
- **scenes/store**: list, get (versions + images), content, create (JSON / zip URL / scenes.json URL / fork), update content (new version), update metadata, rename, publish/unpublish, delete, fork, version restore/yank, images, **render**, **lint**, store browse/get/report
- **ai**: `ai_scene_chat` (follows the NDJSON turn ≤55 s, then `apply`: none / new_scene / save_version), `ai_turn_wait`, `ai_turn_cancel`, chats list/get/delete
- Resources (`frameos://frames`, `frameos://scenes/{id}/content`, …), prompts (`diagnose_frame`, `build_scene`), server instructions, read-only/destructive annotations, `confirm: true` on destructive tools, API refusals explained with a hint per code.
- Hosted at `POST /api/mcp` (stateless Streamable HTTP, JSON responses, self-fetch over loopback forwarding the client's XFF chain). Stdio: `FRAMEOS_CLOUD_TOKEN=… pnpm --filter @frameos-cloud/mcp start`.

### New routes (usable directly too)
- `GET /api/account/usage` — account, auth kind, `accountUsage()`, and every fixed cap (the quota tool)
- `GET /api/account/scenes` (`?q/visibility/status`), `GET /api/account/scenes/{id}` (versions, images, URLs)
- `POST /api/scenes/lint` — the AI's delivery gate on a public door
- `POST /api/scenes/render` — **server-side live preview**: the `frameos-wasm` bundle (already built with `node` in its emscripten ENVIRONMENT) run in a `worker_threads` Worker; sync-XHR shim with the SSRF guard; RGBA → PNG via fflate. No Chromium. ~1.6 s/render, 2 concurrent / 8 queued / 30 s timeout, fresh heap per render.
- SSRF guard extracted to `src/lib/ssrf.ts` (shared with the preview proxy).

### Also
- Fixes the pre-existing `scene-origin.ts` typecheck failure that made Cloud CI red on `main` (78346daf).

## Verified
- `pnpm typecheck` (auth-web, frame-hub, mcp), eslint on the new/changed files, auth-web unit suite (1174 tests) + 18 new MCP tests (in-memory MCP client against a fake cloud, pinning which routes each tool hits).
- End to end against the local dev server with a real token: `/api/account/usage`, MCP `initialize` / `tools/list` (71) / `tools/call` for reads, lint, a live server-side render, and a full write cycle (create → rename → tags → versions → render stored scene → restore v1 → delete → 404).
- `/account/developer` renders (re-auth gate shown for a stale session).

## Not verified
- Frame tools against a real frame (no frames on the dev account); they are direct route calls.
- `next build` locally (the dev server compiled every new route; CI builds).
- Token creation UI end to end (needs a fresh sign-in; the route is unit-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JyLCN6bF4sS4nNEYvxmUY
