### PR TITLE
JS format(): render in the frame's configured zone, not /etc/localtime

### DIFF
--- a/frameos/src/frameos/js_runtime/runtime.nim
+++ b/frameos/src/frameos/js_runtime/runtime.nim
@@ -490,18 +490,38 @@ proc jsChronoParseTs(ctx: ptr JSContext, fmt: JSValue, text: JSValue): JSValue {
     raise newException(ValueError, "parseTs failed: " & e.msg)
 
 proc setJsTimeZone*(name: string) =
-  ## The zone `frameos.format` and friends render in. On a device it is
-  ## detected from /etc/localtime; the wasm preview has no such file and
-  ## sets the frame's configured zone here.
+  ## Fallback zone for `format` when the JS call has no scene behind it (a
+  ## bare context outside a render). Whenever a scene is evaluating, its
+  ## frameConfig.timeZone wins — see jsTimeZone.
   tzName = name.strip()
+
+proc jsTimeZone(ctx: ptr JSContext): string =
+  ## The zone `format(ts, fmt)` renders in: the frame's configured zone.
+  ##
+  ## frameConfig.timeZone is the one value every platform keeps current —
+  ## frame.json (or /etc/localtime) on a Pi, the cloud/console zone pushed
+  ## every render pass on an ESP32, the preview's zone in wasm. The previous
+  ## fallback, detectSystemTimeZone(), reads /etc/localtime, which does not
+  ## exist on an ESP32: every `format()` there rendered UTC no matter what
+  ## zone the frame had, so a word clock in Brussels ran two hours behind
+  ## while the Nim-side clock apps (which read frameConfig) were right.
+  ## Chrono treats a zone it has no data for as UTC, so a name whose slice
+  ## has not arrived yet degrades to what the old code did, never an error.
+  let e = env(ctx)
+  if e != nil and e.scene != nil and e.scene.frameConfig != nil:
+    let configured = e.scene.frameConfig.timeZone.strip()
+    if configured.len > 0:
+      return configured
+  if tzName.len == 0:
+    tzName = detectSystemTimeZone()
+  tzName
 
 proc jsChronoFormat(ctx: ptr JSContext, tsVal: JSValue, fmt: JSValue): JSValue {.nimcall.} =
   let ts = toNimFloat(ctx, tsVal).Timestamp
   let fmtStr = toNimString(ctx, fmt)
-  if tzName.len == 0:
-    tzName = detectSystemTimeZone()
+  let zone = jsTimeZone(ctx)
   try:
-    let output = format(ts, fmtStr, tzName = tzName)
+    let output = format(ts, fmtStr, tzName = zone)
     return nimStringToJS(ctx, output)
   except CatchableError as e:
     raise newException(ValueError, "format failed: " & e.msg)

--- a/frameos/src/frameos/js_runtime/tests/test_js_runtime_helpers.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_runtime_helpers.nim
@@ -3,6 +3,7 @@ import std/[json, sequtils, strutils, unittest]
 import frameos/js_runtime/runtime
 import frameos/types
 import frameos/values
+import lib/tz
 
 proc testScene(): InterpretedFrameScene =
   InterpretedFrameScene(
@@ -131,6 +132,49 @@ function demo(input: number) {
     check errorLogs.len == 1
     check "mapped boom" in errorLogs[0]{"message"}.getStr()
     check ">:3:18" in errorLogs[0]{"stack"}.getStr()
+    cleanupSceneJs(scene)
+    cleanupCompilerJs()
+
+  test "format renders in the scene's configured time zone":
+    # A Word clock scene asks `format(now(), "{hour}")`. It must answer in
+    # the frame's zone on every platform — the ESP32 has no /etc/localtime,
+    # so the old detectSystemTimeZone() fallback rendered UTC there.
+    initTimeZone()
+    var scene = testScene()
+    scene.frameConfig = FrameConfig(timeZone: "Europe/Brussels")
+    # 2026-08-30T08:00:00Z; Brussels is on CEST (UTC+2).
+    let summer = evalSnippet(scene, testContext(scene), 3.NodeId,
+      "format(1788076800, \"{hour/2}:{minute/2}\")")
+    check summer.asString() == "10:00"
+    # 2026-01-15T08:00:00Z; CET (UTC+1) — the DST fold must follow the date.
+    let winter = evalSnippet(scene, testContext(scene), 3.NodeId,
+      "format(1768464000, \"{hour/2}:{minute/2}\")")
+    check winter.asString() == "09:00"
+
+    # The ESP32 pushes a changed zone into the same frameConfig every render
+    # pass; the running QuickJS context must pick it up without a rebuild.
+    scene.frameConfig.timeZone = "America/New_York"
+    let moved = evalSnippet(scene, testContext(scene), 3.NodeId,
+      "format(1788076800, \"{hour/2}:{minute/2}\")")
+    check moved.asString() == "04:00"
+
+    # A zone chrono has no data for renders as UTC rather than failing the
+    # node (an ESP32 whose tz slice has not arrived yet).
+    scene.frameConfig.timeZone = "Mars/Olympus_Mons"
+    let unknown = evalSnippet(scene, testContext(scene), 3.NodeId,
+      "format(1788076800, \"{hour/2}:{minute/2}\")")
+    check unknown.asString() == "08:00"
+    cleanupSceneJs(scene)
+    cleanupCompilerJs()
+
+  test "format falls back to setJsTimeZone without a frameConfig":
+    initTimeZone()
+    setJsTimeZone("Asia/Tokyo")
+    var scene = testScene()
+    let tokyo = evalSnippet(scene, testContext(scene), 4.NodeId,
+      "format(1788076800, \"{hour/2}:{minute/2}\")")
+    check tokyo.asString() == "17:00"
+    setJsTimeZone("")
     cleanupSceneJs(scene)
     cleanupCompilerJs()
 


### PR DESCRIPTION
## Summary

The **Word clock** store scene ran two hours behind on a cloud-managed ESP32 (frame `acc88c25`, fw 2026.8.43, zone `Europe/Brussels` set) — i.e. it showed UTC.

The scene never uses `new Date()` (so #398's QuickJS `tm_gmtoff` fix was not the missing piece). It calls the runtime's chrono bridge, `format(now(), "{hour}")`, from a code node. `jsChronoFormat` in `js_runtime/runtime.nim` took its zone from a `tzName` global that only the wasm preview ever set; every other platform fell through to `detectSystemTimeZone()`, which reads `/etc/localtime` — a file an ESP32 doesn't have — and answered `"UTC"`. The docs and the AI prompt already promise "`format(ts, pattern)` → string in the frame's time zone"; the runtime just didn't deliver it on the ESP32.

## Fix

- `format()` now renders in the evaluating scene's `frameConfig.timeZone` — the one value every platform already keeps current (frame.json / `/etc/localtime` on a Pi, the cloud/console zone the firmware pushes into `frameConfig` every render pass on an ESP32 via `fos_nim_set_time_zone_impl`, the preview's zone in wasm). A zone change lands in the running QuickJS context without a rebuild.
- `setJsTimeZone` stays as the fallback for calls with no scene behind them.
- Chrono treats a zone it has no data for as UTC, so a board whose tz slice hasn't arrived yet renders what it did before rather than failing the node.

## Tests

`test_js_runtime_helpers.nim`: CEST vs CET folding for Brussels, a live zone switch on the same context (New York), an unknown zone (→ UTC), and the no-`frameConfig` fallback through `setJsTimeZone`. All 13 tests in the file pass locally.

## Not changed

- The store page's live preview (`scenes.frameos.net/s/word-clock`) already follows the browser's zone (`Intl.DateTimeFormat().resolvedOptions().timeZone` in `frameos-wasm`), and prod's bundle has the 2026-08-27 wasm tz shim — verified in the browser tonight: it renders 01:02 local while UTC is 23:02. There is no per-preview zone picker; it's always the visitor's zone.
- `parseTs()` still parses as UTC (unchanged behaviour, separate question).
- Needs a firmware release + OTA to reach the frame; no cloud change involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmbHXVhnjXMp8nsRZxNPTE