### PR TITLE
Simulate real devices (ESP32 memory crunch) in the scene editor preview

### DIFF
--- a/cloud/apps/auth-web/app/api/ai/chat/route.ts
+++ b/cloud/apps/auth-web/app/api/ai/chat/route.ts
@@ -324,6 +324,23 @@ export async function POST(request: NextRequest) {
       );
     }
   }
+  // The device the user's preview simulates (an ESP32's memory limits, a
+  // Pi, ...). Client-declared and advisory: it only steers the design, while
+  // the client's render checks enforce the actual limits.
+  const device = objectOrNull(body.device);
+  const deviceLabel =
+    device && typeof device.label === "string" ? device.label.slice(0, 120).trim() : "";
+  if (deviceLabel) {
+    const deviceDetails =
+      device && typeof device.details === "string" ? device.details.slice(0, 400).trim() : "";
+    contextParts.push(
+      `The user is previewing this scene as it would run on: ${deviceLabel}` +
+        (deviceDetails ? ` (${deviceDetails})` : "") +
+        ". The automatic render checks run under this device's simulated limits, so keep images, JS data " +
+        "structures and fetched payloads within them — precompute compact data instead of large object literals, " +
+        "and prefer image sources that fit the memory budget.",
+    );
+  }
   const selectedNodes = Array.isArray(body.selectedNodes) ? body.selectedNodes : [];
   const selectedEdges = Array.isArray(body.selectedEdges) ? body.selectedEdges : [];
   if (selectedNodes.length > 0 || selectedEdges.length > 0) {

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -3081,6 +3081,14 @@ a.stat-tile:hover {
   font-size: 13px;
 }
 
+/* The device simulation ran out of memory: the frame on screen is a degraded
+   render (an image decoded smaller and upscaled), flagged in amber. */
+.live-preview__degraded {
+  border-color: color-mix(in srgb, var(--warning), transparent 55%);
+  color: var(--text);
+  font-size: 13px;
+}
+
 /* The preview's "this scene wants to go faster" prompt, and the toggle it
    turns into once answered. */
 .live-preview__fast {

--- a/cloud/apps/auth-web/src/components/SceneAiPanel.tsx
+++ b/cloud/apps/auth-web/src/components/SceneAiPanel.tsx
@@ -31,6 +31,12 @@ import {
 } from "../lib/ai-chat-client";
 import type { AiScenesEvent, SceneJson } from "../lib/ai-scenes-apply";
 import { renderSceneCheck } from "../lib/scene-render-check";
+import {
+  describeDeviceLimits,
+  deviceLimitsFor,
+  devicePresetFor,
+  type DevicePresetKey,
+} from "frameos-wasm";
 
 export const RENDER_CHECK_PREFIX = "[Automatic render check]";
 export const MAX_RENDER_CHECK_ROUNDS = 2;
@@ -124,6 +130,10 @@ export type SceneAiPanelProps = {
   /** The AI edited the listing (description, tags, category, minimum
    * FrameOS version): applied to the draft like scenes, published by Save. */
   onListing?: ((changes: AiListingChanges) => void) | undefined;
+  /** The device the preview panel simulates ("browser" = none). Render
+   * checks run under the same limits, and the model is told what it is
+   * building for. */
+  devicePreset?: DevicePresetKey | undefined;
 };
 
 function newId(): string {
@@ -139,10 +149,10 @@ function historyFromMessages(messages: ChatMessage[]): AiChatHistoryItem[] {
     .slice(-MAX_HISTORY_ITEMS);
 }
 
-function formatCheckFeedback(errors: string[], rendered: boolean): string {
+function formatCheckFeedback(errors: string[], rendered: boolean, deviceLabel?: string | null): string {
   const reported = errors.slice(0, 8);
   return (
-    `${RENDER_CHECK_PREFIX} The scene rendered${rendered ? "" : " no image and"} with these errors:\n` +
+    `${RENDER_CHECK_PREFIX} The scene rendered${rendered ? "" : " no image and"}${deviceLabel ? ` under simulated "${deviceLabel}" device limits` : ""} with these errors:\n` +
     reported.map((error) => `- ${error}`).join("\n") +
     (errors.length > reported.length ? `\n(and ${errors.length - reported.length} more)` : "") +
     "\nPlease fix the scene so it renders without errors and deliver the corrected version."
@@ -380,6 +390,7 @@ export function SceneAiPanel({
   saveHint,
   getListing,
   onListing,
+  devicePreset = "browser",
 }: SceneAiPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -401,8 +412,8 @@ export function SceneAiPanel({
   chatIdRef.current = chatId;
 
   // Always the freshest props for the in-flight turn (it spans awaits).
-  const propsRef = useRef({ getListing, getScenes, height, mode, onListing, onScenes, selectedSceneId, storeSceneId, width });
-  propsRef.current = { getListing, getScenes, height, mode, onListing, onScenes, selectedSceneId, storeSceneId, width };
+  const propsRef = useRef({ devicePreset, getListing, getScenes, height, mode, onListing, onScenes, selectedSceneId, storeSceneId, width });
+  propsRef.current = { devicePreset, getListing, getScenes, height, mode, onListing, onScenes, selectedSceneId, storeSceneId, width };
 
   useEffect(() => {
     setReturnTo(window.location.href);
@@ -462,6 +473,16 @@ export function SceneAiPanel({
       const draftListing = propsRef.current.getListing?.() ?? null;
       const targetScene =
         editorScenes.find((scene) => scene.id === selected) ?? editorScenes[0];
+      // The device the preview simulates: the model is told what hardware
+      // (and which ceilings) the scene must live within.
+      const devicePresetInfo = devicePresetFor(propsRef.current.devicePreset);
+      const deviceLimits = devicePresetInfo
+        ? deviceLimitsFor(devicePresetInfo.key, propsRef.current.width, propsRef.current.height)
+        : null;
+      const devicePayload =
+        devicePresetInfo && deviceLimits
+          ? { details: describeDeviceLimits(deviceLimits), label: devicePresetInfo.label }
+          : null;
 
       let content = "";
       let streamError: string | null = null;
@@ -478,6 +499,7 @@ export function SceneAiPanel({
             ...(targetScene ? { scene: targetScene, sceneId: targetScene.id } : {}),
             ...(editorScenes.length > 0 ? { scenes: editorScenes } : {}),
             ...(draftListing ? { listing: draftListing } : {}),
+            ...(devicePayload ? { device: devicePayload } : {}),
           },
           {
             onEvent: (event) => {
@@ -638,8 +660,11 @@ export function SceneAiPanel({
         // hand runtime errors straight back to the agent — a scene that
         // validated as JSON can still fail at render time.
         setStatus("Checking that the scene renders…");
-        const { getScenes: readLatest, height: checkHeight, width: checkWidth } = propsRef.current;
+        const { devicePreset: checkDevice, getScenes: readLatest, height: checkHeight, width: checkWidth } = propsRef.current;
         const check = await renderSceneCheck({
+          // The same simulated limits the preview panel runs under, so an
+          // ESP32-only failure (memory, JS heap, HTTP cap) reaches the agent.
+          deviceLimits: deviceLimitsFor(checkDevice, checkWidth, checkHeight),
           height: checkHeight,
           sceneId: deliveredSceneId,
           scenes: readLatest() ?? editorScenes,
@@ -679,7 +704,10 @@ export function SceneAiPanel({
           if (round < MAX_RENDER_CHECK_ROUNDS) {
             busyRef.current = false;
             setBusy(false);
-            await submit(formatCheckFeedback(uniqueErrors, check.rendered), round + 1);
+            await submit(
+              formatCheckFeedback(uniqueErrors, check.rendered, devicePresetFor(checkDevice)?.label ?? null),
+              round + 1,
+            );
             return;
           }
         }

--- a/cloud/apps/auth-web/src/components/SceneEditorModal.test.tsx
+++ b/cloud/apps/auth-web/src/components/SceneEditorModal.test.tsx
@@ -336,6 +336,7 @@ describe("SceneEditorModal landing", () => {
       "canSaveToGallery",
       "editorSceneId",
       "height",
+      "onDevicePresetChange",
       "onImageRegistered",
       "sceneId",
       "scenes",

--- a/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
+++ b/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
@@ -50,7 +50,8 @@ import {
   type SceneListingData,
 } from "./SceneInfoPanel";
 import { SceneInstallDialog } from "./SceneInstallDialog";
-import { SceneLivePreviewPanel } from "./SceneLivePreview";
+import { DEVICE_STORAGE_KEY, SceneLivePreviewPanel } from "./SceneLivePreview";
+import { devicePresets, type DevicePresetKey } from "frameos-wasm";
 import { SceneSaveDialog } from "./SceneSaveDialog";
 import { SceneVersionsDialog } from "./SceneVersionsDialog";
 
@@ -577,7 +578,7 @@ type SceneEditorWorkspaceProps = {
   /** Filled with the mounted editor's API (rename in place). */
   editorApiRef?: { current: EmbeddedSceneEditorApi | null } | undefined;
   panels: SceneEditorPanels;
-  ai: Omit<SceneAiPanelProps, "width" | "height" | "selectedSceneId">;
+  ai: Omit<SceneAiPanelProps, "width" | "height" | "selectedSceneId" | "devicePreset">;
   preview: SceneEditorPreviewOptions;
   /** The Info column's content (left of the diagram); none for a scene
    * that has no page yet. */
@@ -1053,6 +1054,21 @@ export function SceneEditorWorkspace({
     info: useResizableWidth(panelWidths.info),
     preview: useResizableWidth(panelWidths.preview),
   };
+  // The device being simulated (an ESP32's memory limits, a Pi, ...). The
+  // Preview panel owns the control and the localStorage key; the workspace
+  // mirrors it (hydrating itself, so the AI panel runs its render checks
+  // under the same limits even while the Preview panel is closed).
+  const [devicePreset, setDevicePreset] = useState<DevicePresetKey>("browser");
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(DEVICE_STORAGE_KEY);
+      if (stored && devicePresets.some((entry) => entry.key === stored)) {
+        setDevicePreset(stored as DevicePresetKey);
+      }
+    } catch {
+      // Storage blocked: the session simply starts on "browser".
+    }
+  }, []);
   const open: SceneEditorPanels = { ...panels, info: panels.info && info !== undefined };
   const layout = sceneEditorPanelNames.filter((name) => open[name]);
   // The editor is heavy (kea, Monaco, wasm): mounted the first time its
@@ -1197,7 +1213,13 @@ export function SceneEditorWorkspace({
         <>
           {resizerBefore("ai")}
           <aside aria-label="AI assistant" className="editor-modal__ai">
-            <SceneAiPanel {...ai} height={height} selectedSceneId={sceneId ?? null} width={width} />
+            <SceneAiPanel
+              {...ai}
+              devicePreset={devicePreset}
+              height={height}
+              selectedSceneId={sceneId ?? null}
+              width={width}
+            />
           </aside>
         </>
       ) : null}
@@ -1212,6 +1234,7 @@ export function SceneEditorWorkspace({
                 canSaveToGallery={preview.canSaveToGallery}
                 editorSceneId={sceneId ?? null}
                 height={height}
+                onDevicePresetChange={setDevicePreset}
                 onImageRegistered={preview.onImageRegistered}
                 sceneId={preview.sceneId}
                 scenes={preview.scenes}

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.test.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.test.tsx
@@ -14,10 +14,17 @@ type PreviewCallbacks = {
   onReady?: (info: unknown) => void;
   onFrame?: (frame: { width: number; height: number; renderMs: number }) => void;
   onState?: (state: Record<string, unknown>) => void;
+  onLog?: (message: string) => void;
   onFastRenderRequest?: (intervalMs: number) => void;
   onAssetsChanged?: () => void;
   fastMode?: boolean;
   panelPalette?: string | null;
+  deviceLimits?: {
+    availableRenderBytes: number;
+    jsMemoryLimitMb: number;
+    jsMaxStackKb: number;
+    maxHttpResponseBytes: number;
+  } | null;
 };
 
 // The wasm runtime is a worker + emscripten bundle — not something jsdom can
@@ -633,6 +640,80 @@ describe("SceneLivePreviewPanel panel dither", () => {
     fireEvent.click(screen.getByRole("button", { name: "Restart" }));
     await waitFor(() => expect(previews).toHaveLength(2));
     expect(previews[1]!.options.panelPalette).toBe("blackWhite");
+  });
+});
+
+describe("SceneLivePreviewPanel device simulation", () => {
+  async function open(onDevicePresetChange?: (key: string) => void) {
+    render(
+      <SceneLivePreviewPanel
+        onDevicePresetChange={onDevicePresetChange}
+        sceneId="scene-1"
+        scenes={[clockScene]}
+      />,
+    );
+    await waitFor(() => expect(previews).toHaveLength(1));
+    act(() =>
+      previews[0]!.options.onReady!({
+        currentSceneId: "scene-runtime-1",
+        scenes: [{ id: "scene-runtime-1", name: "Clock", refreshInterval: 60 }],
+      }),
+    );
+  }
+
+  it("runs without limits by default", async () => {
+    await open();
+    expect(
+      (screen.getByRole("combobox", { name: "Device to simulate" }) as HTMLSelectElement).value,
+    ).toBe("browser");
+    expect(previews[0]!.options.deviceLimits ?? null).toBeNull();
+  });
+
+  it("reboots the runtime under the chosen device's limits, remembers it, and tells the workspace", async () => {
+    const onChange = vi.fn();
+    await open(onChange);
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Device to simulate" }), {
+      target: { value: "esp32" },
+    });
+    // Unlike Dither, the device changes what the runtime can do: a reboot.
+    await waitFor(() => expect(previews).toHaveLength(2));
+    const limits = previews[1]!.options.deviceLimits!;
+    // The firmware math for an 8 MB board at the default 800×480: a few MB
+    // of render memory, the ESP32's JS heap/stack and HTTP ceilings.
+    expect(limits.availableRenderBytes).toBeGreaterThan(2 * 1024 * 1024);
+    expect(limits.availableRenderBytes).toBeLessThan(6 * 1024 * 1024);
+    expect(limits.jsMemoryLimitMb).toBe(4);
+    expect(limits.jsMaxStackKb).toBe(20);
+    expect(limits.maxHttpResponseBytes).toBe(6 * 1024 * 1024);
+    expect(window.localStorage.getItem("frameos.preview.device")).toBe("esp32");
+    expect(onChange).toHaveBeenLastCalledWith("esp32");
+  });
+
+  it("boots straight into the device it was left on, and reports it to the workspace", async () => {
+    window.localStorage.setItem("frameos.preview.device", "piZero");
+    const onChange = vi.fn();
+    await open(onChange);
+
+    expect(
+      (screen.getByRole("combobox", { name: "Device to simulate" }) as HTMLSelectElement).value,
+    ).toBe("piZero");
+    expect(previews[0]!.options.deviceLimits?.availableRenderBytes).toBe(256 * 1024 * 1024);
+    expect(onChange).toHaveBeenCalledWith("piZero");
+  });
+
+  it("flags a degraded render while it is on screen, and clears once a full render lands", async () => {
+    window.localStorage.setItem("frameos.preview.device", "esp32");
+    await open();
+
+    const log = (line: string) => act(() => previews[0]!.options.onLog!(line));
+    log(JSON.stringify({ event: "render:scene", height: 480, width: 800 }));
+    log(JSON.stringify({ divisor: 2, event: "render:degraded" }));
+    expect(screen.getByRole("status").textContent).toContain("1/2 size");
+
+    log(JSON.stringify({ event: "render:scene", height: 480, width: 800 }));
+    log(JSON.stringify({ event: "render:done", ms: 12 }));
+    expect(screen.queryByText(/ran low on memory/)).toBeNull();
   });
 });
 

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
@@ -2,11 +2,14 @@
 
 import {
   coerceStateFieldValue,
+  deviceLimitsFor,
+  devicePresets,
   evaluateShowIf,
   FrameOSPreview,
   panelPalettes,
   sceneEventButtons,
   stateFieldShowIfValues,
+  type DevicePresetKey,
   type FrameOSScene,
   type PanelPaletteKey,
   type SceneInfo,
@@ -65,6 +68,10 @@ type SceneLivePreviewPanelProps = {
   /** The account's settings page (where service keys are saved), linked from
    * the credentials hint when a scene needs keys. */
   settingsUrl?: string | undefined;
+  /** The workspace is told which device is being simulated (also on the
+   * initial localStorage restore), so the AI panel's render checks run under
+   * the same limits. */
+  onDevicePresetChange?: ((key: DevicePresetKey) => void) | undefined;
 };
 
 type SceneJsonLike = { id: string } & Record<string, unknown>;
@@ -90,6 +97,9 @@ const PANEL_STORAGE_KEY = "frameos.preview.panel";
 /** Which panel the dither checkbox turns on first — the newest colour e-ink,
  * and what the 13.3" boards FrameOS ships for use. */
 const DEFAULT_PANEL: PanelPaletteKey = "spectra6";
+/** Where the device simulation is remembered (this browser). "browser" (or
+ * anything unknown) means no simulation. */
+export const DEVICE_STORAGE_KEY = "frameos.preview.device";
 
 /** "every 42 ms (about 24 times a second)" for the fast-render prompt. */
 export function describeRenderRate(intervalMs: number): string {
@@ -133,6 +143,7 @@ export function SceneLivePreviewPanel({
   canSaveToGallery = false,
   onImageRegistered,
   settingsUrl,
+  onDevicePresetChange,
 }: SceneLivePreviewPanelProps) {
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -305,6 +316,40 @@ export function SceneLivePreviewPanel({
     }
   }
 
+  // "Device": run the scene under a real device's limits — render-memory
+  // budget, JS heap/stack ceilings, HTTP cap. Unlike Dither this changes how
+  // the scene actually renders (a big photo degrades or fails like on an
+  // ESP32), so switching reboots the runtime. Remembered per browser.
+  const [devicePreset, setDevicePreset] = useState<DevicePresetKey>("browser");
+  const onDevicePresetChangeRef = useRef(onDevicePresetChange);
+  onDevicePresetChangeRef.current = onDevicePresetChange;
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(DEVICE_STORAGE_KEY);
+      if (stored && devicePresets.some((entry) => entry.key === stored)) {
+        setDevicePreset(stored as DevicePresetKey);
+        onDevicePresetChangeRef.current?.(stored as DevicePresetKey);
+      }
+    } catch {
+      // Storage blocked: the controls still work for this session.
+    }
+  }, []);
+  function chooseDevice(next: DevicePresetKey) {
+    setDevicePreset(next);
+    onDevicePresetChangeRef.current?.(next);
+    try {
+      window.localStorage.setItem(DEVICE_STORAGE_KEY, next);
+    } catch {
+      // See above.
+    }
+  }
+  // "Memory crunch" feedback: the runtime logs render:degraded when an image
+  // had to be decoded smaller (and upscaled) to fit the simulated budget.
+  // Tracked per render — set while a degraded render is on screen, cleared
+  // once a render completes without one.
+  const [degradedNotice, setDegradedNotice] = useState<string | null>(null);
+  const degradedThisRenderRef = useRef(false);
+
   // Runtime plumbing: the canvas the worker paints onto, the live preview
   // handle, and what the runtime has reported so far.
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -429,6 +474,27 @@ export function SceneLivePreviewPanel({
       if (cancelled) {
         return;
       }
+      // The degraded chip follows the runtime's own memory events: shown
+      // while the frame on screen was rendered degraded, gone once a render
+      // completes at full quality again.
+      if (line.includes('"render:scene"')) {
+        degradedThisRenderRef.current = false;
+      } else if (line.includes('"render:degraded"')) {
+        degradedThisRenderRef.current = true;
+        let divisor = 0;
+        try {
+          divisor = Number(JSON.parse(line)?.divisor) || 0;
+        } catch {
+          // Not JSON after all; the generic message still tells the story.
+        }
+        setDegradedNotice(
+          divisor > 1
+            ? `The simulated device ran low on memory: an image was decoded at 1/${divisor} size and upscaled, like it would be on the real frame.`
+            : "The simulated device ran low on memory: an image was decoded smaller and upscaled, like it would be on the real frame.",
+        );
+      } else if (line.includes('"render:done"') && !degradedThisRenderRef.current) {
+        setDegradedNotice(null);
+      }
       logQueue.push({ id: logIdRef.current++, line, receivedAt: Date.now() });
       scheduleFlush("log", () => {
         const lines = logQueue;
@@ -442,6 +508,8 @@ export function SceneLivePreviewPanel({
         });
       });
     };
+    degradedThisRenderRef.current = false;
+    setDegradedNotice(null);
     try {
       preview = new FrameOSPreview({
         canvas: canvasRef.current,
@@ -455,6 +523,7 @@ export function SceneLivePreviewPanel({
         proxyUrl: "/api/store/preview-proxy",
         fastMode,
         panelPalette: panelRef.current,
+        deviceLimits: deviceLimitsFor(devicePreset, viewport.width, viewport.height),
         onFastRenderRequest: (intervalMs) => {
           if (cancelled) {
             return;
@@ -561,7 +630,7 @@ export function SceneLivePreviewPanel({
     };
     // fastMode reaches a running runtime through setFastMode below; only a
     // fresh runtime reads it from the options, so it is no dependency here.
-  }, [scenes, viewport, storedSettings, previewSettings, restartCount, previewGated]);
+  }, [scenes, viewport, storedSettings, previewSettings, restartCount, previewGated, devicePreset]);
 
   function answerFastRender(enabled: boolean) {
     setFastMode(enabled);
@@ -1184,6 +1253,34 @@ export function SceneLivePreviewPanel({
           ))}
         </select>
       </div>
+      {/* Which hardware the runtime pretends to be. Dither shows what the
+          panel makes of the picture; this changes what the runtime can do at
+          all — an ESP32's few MB of render memory, its 4 MB JS heap, its
+          HTTP cap. The AI panel's render checks run under the same limits. */}
+      <div className="viewport-controls">
+        <label className="viewport-controls__label" htmlFor={`${fieldIdPrefix}-device`}>
+          Device
+        </label>
+        <select
+          aria-label="Device to simulate"
+          className="viewport-controls__select"
+          id={`${fieldIdPrefix}-device`}
+          onChange={(event) => chooseDevice(event.target.value as DevicePresetKey)}
+          title={devicePresets.find((entry) => entry.key === devicePreset)?.description}
+          value={devicePreset}
+        >
+          {devicePresets.map((entry) => (
+            <option key={entry.key} title={entry.description} value={entry.key}>
+              {entry.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {degradedNotice ? (
+        <p className="notice live-preview__degraded" role="status">
+          {degradedNotice}
+        </p>
+      ) : null}
       {assetsOpen ? (
         <PreviewAssetsDialog
           assetsVersion={assetsVersion}

--- a/cloud/apps/auth-web/src/lib/ai-chat-client.ts
+++ b/cloud/apps/auth-web/src/lib/ai-chat-client.ts
@@ -63,6 +63,9 @@ export type AiChatRequest = {
    * so the assistant edits what the user sees, not what was published. */
   listing?: AiListingChanges | undefined;
   history?: AiChatHistoryItem[] | undefined;
+  /** The device the preview simulates (label + a one-line description of its
+   * limits); the model designs within them and render checks enforce them. */
+  device?: { label: string; details?: string } | undefined;
 };
 
 // A non-2xx answer before the stream started: `code` is the server's

--- a/cloud/apps/auth-web/src/lib/device-limits.test.ts
+++ b/cloud/apps/auth-web/src/lib/device-limits.test.ts
@@ -1,0 +1,80 @@
+// The device presets the preview simulates (frameos-wasm/src/devices.ts).
+// The ESP32 numbers mirror the firmware/backend constants; these tests pin
+// the budget math so a drive-by edit cannot quietly hand the simulated board
+// more (or less) memory than the real one has.
+import { describe, expect, it } from "vitest";
+import {
+  describeDeviceLimits,
+  deviceLimitsFor,
+  devicePresetFor,
+  devicePresets,
+  esp32RenderBudgetBytes,
+} from "frameos-wasm";
+
+describe("deviceLimitsFor", () => {
+  it("simulates nothing for the browser preset and unknown keys", () => {
+    expect(deviceLimitsFor("browser", 800, 480)).toBeNull();
+    expect(deviceLimitsFor(null, 800, 480)).toBeNull();
+    expect(deviceLimitsFor("no-such-device", 800, 480)).toBeNull();
+    expect(devicePresetFor("browser")).toBeNull();
+    expect(devicePresetFor("esp32")?.label).toContain("ESP32");
+  });
+
+  it("gives the ESP32 the firmware's ceilings", () => {
+    const limits = deviceLimitsFor("esp32", 800, 480)!;
+    expect(limits.jsMemoryLimitMb).toBe(4); // FOS_JS_MEMORY_LIMIT
+    expect(limits.jsMaxStackKb).toBe(20); // FOS_JS_STACK_SIZE
+    expect(limits.maxHttpResponseBytes).toBe(6 * 1024 * 1024); // the spill cap
+  });
+
+  it("keeps the Pi presets on default JS/HTTP limits with a capped render budget", () => {
+    const pi = deviceLimitsFor("pi", 800, 480)!;
+    expect(pi.availableRenderBytes).toBe(512 * 1024 * 1024);
+    expect(pi.jsMemoryLimitMb).toBe(-1);
+    const zero = deviceLimitsFor("piZero", 800, 480)!;
+    expect(zero.availableRenderBytes).toBe(256 * 1024 * 1024);
+    expect(zero.maxHttpResponseBytes).toBe(0);
+  });
+
+  it("lists every preset the picker offers", () => {
+    for (const preset of devicePresets) {
+      if (preset.key === "browser") {
+        expect(deviceLimitsFor(preset.key, 800, 480)).toBeNull();
+      } else {
+        expect(deviceLimitsFor(preset.key, 800, 480)).not.toBeNull();
+      }
+    }
+  });
+});
+
+describe("esp32RenderBudgetBytes", () => {
+  it("lands near the 4 MB the ESP32 test corpus pins at 800×480", () => {
+    const budget = esp32RenderBudgetBytes(800, 480);
+    expect(budget).toBeGreaterThan(3 * 1024 * 1024);
+    expect(budget).toBeLessThan(5 * 1024 * 1024);
+  });
+
+  it("flips to an RGB565 canvas on the 13.3\" panel and leaves under 1 MB", () => {
+    // 1200×1600 RGBX would need the whole 8 MB twice over; the firmware
+    // falls back to 2 bytes/pixel and the board really is this tight.
+    const budget = esp32RenderBudgetBytes(1200, 1600);
+    expect(budget).toBeGreaterThanOrEqual(512 * 1024);
+    expect(budget).toBeLessThan(1024 * 1024);
+  });
+
+  it("a bigger canvas always leaves the same or less to render with (per format)", () => {
+    expect(esp32RenderBudgetBytes(960, 640)).toBeLessThan(esp32RenderBudgetBytes(800, 480));
+  });
+});
+
+describe("describeDeviceLimits", () => {
+  it("names every ceiling in effect and skips the defaults", () => {
+    const esp32 = describeDeviceLimits(deviceLimitsFor("esp32", 800, 480)!);
+    expect(esp32).toContain("MB render memory");
+    expect(esp32).toContain("4 MB JS heap");
+    expect(esp32).toContain("20 KB JS stack");
+    expect(esp32).toContain("6 MB max HTTP response");
+    const pi = describeDeviceLimits(deviceLimitsFor("pi", 800, 480)!);
+    expect(pi).toBe("about 512 MB render memory");
+  });
+});

--- a/cloud/apps/auth-web/src/lib/scene-render-check.ts
+++ b/cloud/apps/auth-web/src/lib/scene-render-check.ts
@@ -8,6 +8,8 @@
 // account (GET /api/settings) and CORS-blocked fetches go through the
 // store's preview proxy.
 
+import type { DeviceLimits } from "frameos-wasm";
+
 export const RENDER_CHECK_SETTLE_MS = 2000;
 export const RENDER_CHECK_TIMEOUT_MS = 30_000;
 const MAX_COLLECTED_LOGS = 100;
@@ -26,6 +28,10 @@ export interface SceneRenderCheckOptions {
   /** Pre-fetched account settings; fetched from /api/settings when omitted. */
   settings?: Record<string, Record<string, string>> | undefined;
   timeZone?: string | undefined;
+  /** Simulated device limits (render-memory budget, JS ceilings, HTTP cap) —
+   * the check then fails the way the chosen device would. Null/omitted runs
+   * without limits (see frameos-wasm's deviceLimitsFor). */
+  deviceLimits?: DeviceLimits | null | undefined;
 }
 
 export interface SceneRenderCheckResult {
@@ -225,6 +231,7 @@ export async function renderSceneCheck({
   height,
   settings,
   timeZone,
+  deviceLimits,
 }: SceneRenderCheckOptions): Promise<SceneRenderCheckResult> {
   const errors: string[] = [];
   const logs: string[] = [];
@@ -333,6 +340,7 @@ export async function renderSceneCheck({
       settingsJson,
       proxyUrl: RENDER_CHECK_PROXY_URL,
       sceneId: scene.id,
+      deviceLimits: deviceLimits ?? null,
     });
   });
   const frame = lastFrame as RawFrame | null;

--- a/frameos/src/frameos/js_runtime/burrito.nim
+++ b/frameos/src/frameos/js_runtime/burrito.nim
@@ -1194,6 +1194,13 @@ proc newQuickJS*(config: QuickJSConfig = defaultConfig()): QuickJS =
     proc fos_js_new_runtime(): ptr JSRuntime {.importc: "fos_js_new_runtime",
         header: "fos_qjs_glue.h".}
     let rt = fos_js_new_runtime()
+  elif defined(frameosWasm):
+    # tools/wasm/fos_quickjs_mem.c: QuickJS's default allocator with a real
+    # usable-size probe. QuickJS's own is `return 0` under emscripten, which
+    # disables JS_SetMemoryLimit — and with it the preview's simulated
+    # device JS-heap ceiling (frameos_wasm_set_device_limits).
+    proc fos_js_new_runtime_wasm(): ptr JSRuntime {.importc, cdecl.}
+    let rt = fos_js_new_runtime_wasm()
   else:
     let rt = JS_NewRuntime()
   if rt == nil:

--- a/frameos/src/frameos/utils/memory.nim
+++ b/frameos/src/frameos/utils/memory.nim
@@ -39,9 +39,10 @@ elif defined(linux) and not defined(frameosWasm):
       discard
     0
 
-when defined(testing):
-  # Lets tests simulate a memory-constrained device (e.g. ESP32 PSRAM
-  # headroom) on a development host. 0 disables the override.
+when defined(testing) or defined(frameosWasm):
+  # Lets tests — and the wasm preview's device simulation — pretend to be a
+  # memory-constrained device (e.g. ESP32 PSRAM headroom) on a host with
+  # plenty. 0 disables the override.
   var availableRenderBytesOverride* = 0
 
 when defined(memProbe):
@@ -81,7 +82,7 @@ proc renderMemoryInUse*(): tuple[known: bool, bytes: int] =
 proc availableRenderBytes*(): int =
   ## Best-effort estimate of memory currently available for image-sized
   ## render allocations. 0 means "unknown"; callers treat that as unlimited.
-  when defined(testing):
+  when defined(testing) or defined(frameosWasm):
     if availableRenderBytesOverride > 0:
       return availableRenderBytesOverride
   when defined(frameosEmbedded):
@@ -107,7 +108,7 @@ proc availableRenderHeadroomBytes*(): int =
   ## image-sized allocation; measured on the 7.3" bench frame, the largest
   ## contiguous block sits near 1.7MB while over 5MB is free, and a headroom
   ## question asked against the block answer refuses everything.
-  when defined(testing):
+  when defined(testing) or defined(frameosWasm):
     if availableRenderBytesOverride > 0:
       return availableRenderBytesOverride
   when defined(frameosEmbedded):

--- a/frameos/src/wasm/wasm_main.nim
+++ b/frameos/src/wasm/wasm_main.nim
@@ -165,6 +165,7 @@ proc frameos_wasm_init(width, height: cint, name: cstring,
     renderRequested = false
     lastImage = nil
     pendingSceneStates = initTable[string, JsonNode]()
+    availableRenderBytesOverride = 0
 
     var settings = %*{}
     let settingsText = $settingsJson
@@ -317,6 +318,43 @@ proc frameos_wasm_set_scene_state(sceneId: cstring, stateJson: cstring): bool {.
     true
   except Exception as e:
     setLastError("setSceneState failed: " & e.msg)
+    false
+
+proc frameos_wasm_set_device_limits(payloadJson: cstring): bool {.exportc, cdecl.} =
+  ## Simulate a memory-constrained device (an ESP32-class frame) in the
+  ## preview. JSON object with any of:
+  ##   availableRenderBytes  render-memory budget; feeds the same decode
+  ##                         budgets and degrade ladder the device uses
+  ##   jsMemoryLimitMb       QuickJS heap ceiling per scene context
+  ##   jsMaxStackKb          QuickJS stack ceiling
+  ##   maxHttpResponseBytes  HTTP response cap (the ESP32 spill cap)
+  ## Missing keys (or 0 / -1) keep the browser defaults; an empty object
+  ## resets everything. Call after init and before scenes load, so scene JS
+  ## contexts are created under the ceilings.
+  try:
+    if frameConfig.isNil:
+      setLastError("setDeviceLimits: init not called")
+      return false
+    let parsed = parseJson($payloadJson)
+    if parsed.kind != JObject:
+      setLastError("setDeviceLimits: payload must be a JSON object")
+      return false
+    availableRenderBytesOverride = max(0, parsed{"availableRenderBytes"}.getInt(0))
+    let jsMemoryLimitMb = parsed{"jsMemoryLimitMb"}.getInt(-1)
+    let jsMaxStackKb = parsed{"jsMaxStackKb"}.getInt(-1)
+    if jsMemoryLimitMb >= 0 or jsMaxStackKb >= 0:
+      frameConfig.js = JsRuntimeConfig(executionTimeoutMs: -1,
+        memoryLimitMb: jsMemoryLimitMb, maxStackKb: jsMaxStackKb,
+        assetSandbox: "frame")
+    else:
+      frameConfig.js = nil
+    let maxHttp = parsed{"maxHttpResponseBytes"}.getInt(0)
+    frameConfig.maxHttpResponseBytes =
+      if maxHttp > 0: maxHttp else: DefaultMaxHttpResponseBytes
+    refreshDecodeBudget()
+    true
+  except Exception as e:
+    setLastError("setDeviceLimits failed: " & e.msg)
     false
 
 proc frameos_wasm_set_fusion(enabled: bool) {.exportc, cdecl.} =

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -96,7 +96,11 @@ if ! grep -q 'localtime_r(&ti, &tm);' "$QJS_SRC/quickjs.c"; then
     exit 1
 fi
 QJS_TZ_SHIM="$FRAMEOS_DIR/tools/wasm/fos_quickjs_tz.c"
-if [[ "$qjs_needs_build" == "0" && ( "$QJS_TZ_SHIM" -nt "$QJS_BUILD/libquickjs.a" || "${QJS_TZ_SHIM%.c}.h" -nt "$QJS_BUILD/libquickjs.a" ) ]]; then
+# Allocator glue: QuickJS's own usable-size probe is `return 0` under
+# emscripten, which silently disables JS_SetMemoryLimit — the preview's
+# device simulation needs the real accounting.
+QJS_MEM_SHIM="$FRAMEOS_DIR/tools/wasm/fos_quickjs_mem.c"
+if [[ "$qjs_needs_build" == "0" && ( "$QJS_TZ_SHIM" -nt "$QJS_BUILD/libquickjs.a" || "${QJS_TZ_SHIM%.c}.h" -nt "$QJS_BUILD/libquickjs.a" || "$QJS_MEM_SHIM" -nt "$QJS_BUILD/libquickjs.a" ) ]]; then
     qjs_needs_build=1
 fi
 if [[ "$qjs_needs_build" == "1" || ! -f "$QJS_BUILD/libquickjs.a" ]]; then
@@ -111,6 +115,7 @@ if [[ "$qjs_needs_build" == "1" || ! -f "$QJS_BUILD/libquickjs.a" ]]; then
             "$QJS_SRC/$src" -o "$QJS_BUILD/${src%.c}.o"
     done
     emcc -c -O2 -w "$QJS_TZ_SHIM" -o "$QJS_BUILD/fos_quickjs_tz.o"
+    emcc -c -O2 -w -I "$QJS_SRC" "$QJS_MEM_SHIM" -o "$QJS_BUILD/fos_quickjs_mem.o"
     rm -f "$QJS_BUILD/libquickjs.a"
     emar rcs "$QJS_BUILD/libquickjs.a" "$QJS_BUILD"/*.o
 fi
@@ -121,7 +126,7 @@ FRAMEOS_VERSION="$(python3 tools/frameos_version.py ../versions.json)"
 # _main keeps Nim's generated main() alive: emscripten calls it on module
 # startup and that runs NimMain (all Nim module initializers, e.g. the
 # baked-in font asset tables).
-EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error,_frameos_wasm_tz_offset_seconds
+EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_device_limits,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error,_frameos_wasm_tz_offset_seconds
 # FS lets the render harness preload a virtual frame's assets into MEMFS;
 # IDBFS (linked below with -lidbfs.js) backs the browser preview's
 # /srv/assets folder with IndexedDB (see tools/wasm/preview-worker.js).

--- a/frameos/tools/wasm/fos_quickjs_mem.c
+++ b/frameos/tools/wasm/fos_quickjs_mem.c
@@ -1,0 +1,81 @@
+// QuickJS allocator glue for the wasm build.
+//
+// QuickJS's own js_def_malloc_usable_size is `return 0;` under
+// __EMSCRIPTEN__, which makes the runtime's memory accounting count only
+// MALLOC_OVERHEAD per allocation — JS_SetMemoryLimit can then never trip,
+// and the preview's device simulation (frameos_wasm_set_device_limits)
+// could not enforce the ESP32's 4 MB JS heap. Emscripten's dlmalloc does
+// provide a real malloc_usable_size, so this mirrors QuickJS's default
+// allocator with that plugged in — the same pattern as the ESP32's
+// fos_qjs_glue.c, which sizes allocations via heap_caps.
+//
+// Compiled into build/wasm/libquickjs.a by tools/build_wasm.sh; the runtime
+// is created via fos_js_new_runtime_wasm() (js_runtime/burrito.nim).
+
+#include <assert.h>
+#include <malloc.h>
+#include <stdlib.h>
+
+#include "quickjs.h"
+
+// QuickJS's MALLOC_OVERHEAD for 32-bit targets (quickjs.c keeps it private).
+#define FOS_JS_MALLOC_OVERHEAD 8
+
+static size_t fos_js_usable_size(const void *ptr) {
+  return malloc_usable_size((void *)ptr);
+}
+
+static void *fos_js_malloc(JSMallocState *s, size_t size) {
+  void *ptr;
+  assert(size != 0);
+  if (s->malloc_size + size > s->malloc_limit)
+    return NULL;
+  ptr = malloc(size);
+  if (!ptr)
+    return NULL;
+  s->malloc_count++;
+  s->malloc_size += fos_js_usable_size(ptr) + FOS_JS_MALLOC_OVERHEAD;
+  return ptr;
+}
+
+static void fos_js_free(JSMallocState *s, void *ptr) {
+  if (!ptr)
+    return;
+  s->malloc_count--;
+  s->malloc_size -= fos_js_usable_size(ptr) + FOS_JS_MALLOC_OVERHEAD;
+  free(ptr);
+}
+
+static void *fos_js_realloc(JSMallocState *s, void *ptr, size_t size) {
+  size_t old_size;
+  if (!ptr) {
+    if (size == 0)
+      return NULL;
+    return fos_js_malloc(s, size);
+  }
+  old_size = fos_js_usable_size(ptr);
+  if (size == 0) {
+    s->malloc_count--;
+    s->malloc_size -= old_size + FOS_JS_MALLOC_OVERHEAD;
+    free(ptr);
+    return NULL;
+  }
+  if (s->malloc_size + size - old_size > s->malloc_limit)
+    return NULL;
+  ptr = realloc(ptr, size);
+  if (!ptr)
+    return NULL;
+  s->malloc_size += fos_js_usable_size(ptr) - old_size;
+  return ptr;
+}
+
+static const JSMallocFunctions fos_js_malloc_funcs = {
+    fos_js_malloc,
+    fos_js_free,
+    fos_js_realloc,
+    fos_js_usable_size,
+};
+
+JSRuntime *fos_js_new_runtime_wasm(void) {
+  return JS_NewRuntime2(&fos_js_malloc_funcs, NULL);
+}

--- a/frameos/tools/wasm/preview-worker.js
+++ b/frameos/tools/wasm/preview-worker.js
@@ -7,7 +7,10 @@
 //
 // Messages in:
 //   {type: 'init', width, height, timeZone, scenesJson, sceneId, settingsJson, proxyUrl,
-//    fastMode?, saveAssets?, browserAssets?}
+//    fastMode?, saveAssets?, browserAssets?, deviceLimits?}
+//     deviceLimits: {availableRenderBytes?, jsMemoryLimitMb?, jsMaxStackKb?,
+//     maxHttpResponseBytes?} — simulate a constrained device (ESP32-class);
+//     omit for the browser's own (unconstrained) limits.
 //   {type: 'render'}                       force a render now
 //   {type: 'event', name, payload}         dispatch a scene event
 //   {type: 'selectScene', sceneId}
@@ -658,6 +661,16 @@ async function init(msg) {
     )
     if (!ok) {
       throw new Error('init failed: ' + lastError())
+    }
+    // Device simulation: cap render memory / JS heap / HTTP responses the way
+    // the chosen device would. Must land before scenes load so scene JS
+    // contexts are created under the ceilings.
+    if (msg.deviceLimits && typeof msg.deviceLimits === 'object') {
+      try {
+        call('frameos_wasm_set_device_limits', 'boolean', ['string'], [JSON.stringify(msg.deviceLimits)])
+      } catch (e) {
+        log('device simulation unavailable (older wasm bundle); previewing without limits')
+      }
     }
     // Apps may save into the browser folder (a device's saveAssets setting;
     // on by default here — it's the visitor's own browser storage). Pass

--- a/frameos/wasm/src/devices.ts
+++ b/frameos/wasm/src/devices.ts
@@ -1,0 +1,149 @@
+// Device simulation presets for the wasm preview.
+//
+// A preset turns into `DeviceLimits` — the ceilings the preview runtime
+// enforces via frameos_wasm_set_device_limits: render-memory budget (feeding
+// the same decode budgets and degrade-to-blur ladder a real device uses),
+// QuickJS heap/stack ceilings, and the HTTP response cap. The ESP32 numbers
+// mirror the firmware and backend constants; keep them in step with
+// embedded/esp32/components/frameos_display/frameos_display.c,
+// components/frameos_quickjs/fos_qjs_glue.c and
+// backend/app/tasks/embedded_firmware.py.
+
+export interface DeviceLimits {
+  /** Render-memory budget in bytes (availableRenderBytes on the device). */
+  availableRenderBytes: number
+  /** QuickJS heap ceiling per scene context, in MB; -1 keeps the host default (256 MB). */
+  jsMemoryLimitMb: number
+  /** QuickJS stack ceiling in KB; -1 keeps the host default (256 KB). */
+  jsMaxStackKb: number
+  /** HTTP response cap in bytes; 0 keeps the host default (64 MB). */
+  maxHttpResponseBytes: number
+}
+
+export type DevicePresetKey = 'browser' | 'pi' | 'piZero' | 'esp32'
+
+export interface DevicePreset {
+  key: DevicePresetKey
+  label: string
+  /** One-line summary of what the preset constrains. */
+  description: string
+}
+
+// FOS_RENDER_PSRAM_RESERVE / EMBEDDED_RENDER_PSRAM_RESERVE_BYTES: packed
+// framebuffer headroom, preview snapshot and C-side HTTP/TLS buffers.
+const ESP32_PSRAM_RESERVE_BYTES = 1536 * 1024
+// FOS_NIM_EMERGENCY_RESERVE_BYTES: armed at boot, unavailable to renders.
+const ESP32_EMERGENCY_RESERVE_BYTES = 1024 * 1024
+// FOS_RENDER_CANVAS_RGBX_MAX_PSRAM_SHARE: RGBX canvas only while it fits
+// twice into PSRAM, otherwise the firmware falls back to RGB565.
+const ESP32_RGBX_MAX_PSRAM_SHARE = 2
+// Current ESP32-S3 modules (reTerminal E1002/E1004) ship 8 MB of PSRAM.
+const ESP32_PSRAM_BYTES = 8 * 1024 * 1024
+// FOS_JS_MEMORY_LIMIT / FOS_JS_STACK_SIZE (fos_qjs_glue.c).
+const ESP32_JS_MEMORY_LIMIT_MB = 4
+const ESP32_JS_MAX_STACK_KB = 20
+// The /state spill cap on PSRAM-tight boards ("response exceeded ... bytes").
+const ESP32_MAX_HTTP_RESPONSE_BYTES = 6 * 1024 * 1024
+
+export const devicePresets: DevicePreset[] = [
+  {
+    key: 'browser',
+    label: 'Browser (no limits)',
+    description: 'Renders with the browser’s own memory; nothing is simulated.',
+  },
+  {
+    key: 'pi',
+    label: 'Raspberry Pi · 1 GB+',
+    description: 'A Pi 3/4/5-class frame: ample render memory, default JS limits.',
+  },
+  {
+    key: 'piZero',
+    label: 'Raspberry Pi Zero · 512 MB',
+    description: 'A Pi Zero-class frame: render memory capped near what a Zero has free.',
+  },
+  {
+    key: 'esp32',
+    label: 'ESP32 · 8 MB PSRAM',
+    description:
+      'A reTerminal-class ESP32-S3 frame: a few MB of render memory, a 4 MB JS heap, a 20 KB JS stack and a 6 MB HTTP cap.',
+  },
+]
+
+export function devicePresetFor(key: string | null | undefined): DevicePreset | null {
+  if (!key || key === 'browser') {
+    return null
+  }
+  return devicePresets.find((preset) => preset.key === key) ?? null
+}
+
+/** The render-memory budget an 8 MB ESP32-S3 board has left for a given
+ * panel size: PSRAM minus the boot-reserved canvas (RGBX while it fits twice
+ * into PSRAM, RGB565 beyond), the packed panel buffer (4 bpp, Spectra-class),
+ * the PSRAM reserve and the armed emergency reserve. 800×480 lands near the
+ * 4 MB the ESP32 test corpus pins; 1200×1600 lands under 1 MB, which is what
+ * the 13.3" boards really have. */
+export function esp32RenderBudgetBytes(width: number, height: number): number {
+  const pixels = Math.max(1, width) * Math.max(1, height)
+  const canvasBytesPerPixel = pixels * 4 * ESP32_RGBX_MAX_PSRAM_SHARE <= ESP32_PSRAM_BYTES ? 4 : 2
+  const canvasBytes = pixels * canvasBytesPerPixel
+  const packedBytes = Math.ceil(pixels / 2)
+  const budget =
+    ESP32_PSRAM_BYTES - canvasBytes - packedBytes - ESP32_PSRAM_RESERVE_BYTES - ESP32_EMERGENCY_RESERVE_BYTES
+  return Math.max(budget, 512 * 1024)
+}
+
+/** One line naming the ceilings, for people and for the AI's context:
+ * "about 3.9 MB render memory, 4 MB JS heap, 20 KB JS stack, 6 MB max HTTP
+ * response". */
+export function describeDeviceLimits(limits: DeviceLimits): string {
+  const parts: string[] = []
+  if (limits.availableRenderBytes > 0) {
+    const mb = limits.availableRenderBytes / (1024 * 1024)
+    parts.push(`about ${mb >= 10 ? Math.round(mb) : Math.round(mb * 10) / 10} MB render memory`)
+  }
+  if (limits.jsMemoryLimitMb >= 0) {
+    parts.push(`${limits.jsMemoryLimitMb} MB JS heap`)
+  }
+  if (limits.jsMaxStackKb >= 0) {
+    parts.push(`${limits.jsMaxStackKb} KB JS stack`)
+  }
+  if (limits.maxHttpResponseBytes > 0) {
+    parts.push(`${Math.round(limits.maxHttpResponseBytes / (1024 * 1024))} MB max HTTP response`)
+  }
+  return parts.join(', ')
+}
+
+/** The limits to pass to the preview for a preset, or null for no simulation
+ * (the browser preset, or an unknown key). Depends on the viewport: the ESP32
+ * canvas is reserved at boot, so a bigger panel leaves less to render with. */
+export function deviceLimitsFor(
+  key: string | null | undefined,
+  width: number,
+  height: number
+): DeviceLimits | null {
+  switch (key) {
+    case 'pi':
+      return {
+        availableRenderBytes: 512 * 1024 * 1024,
+        jsMemoryLimitMb: -1,
+        jsMaxStackKb: -1,
+        maxHttpResponseBytes: 0,
+      }
+    case 'piZero':
+      return {
+        availableRenderBytes: 256 * 1024 * 1024,
+        jsMemoryLimitMb: -1,
+        jsMaxStackKb: -1,
+        maxHttpResponseBytes: 0,
+      }
+    case 'esp32':
+      return {
+        availableRenderBytes: esp32RenderBudgetBytes(width, height),
+        jsMemoryLimitMb: ESP32_JS_MEMORY_LIMIT_MB,
+        jsMaxStackKb: ESP32_JS_MAX_STACK_KB,
+        maxHttpResponseBytes: ESP32_MAX_HTTP_RESPONSE_BYTES,
+      }
+    default:
+      return null
+  }
+}

--- a/frameos/wasm/src/index.ts
+++ b/frameos/wasm/src/index.ts
@@ -6,6 +6,16 @@
 // release the runtime was built from (versions.json in the FrameOS repo).
 export { FrameOSPreview, createFrameOSPreview, type FrameOSPreviewOptions } from './preview'
 export { ditherFrame, panelPalettes, panelPaletteFor, type PanelPaletteKey } from './dither'
+export {
+  describeDeviceLimits,
+  devicePresets,
+  devicePresetFor,
+  deviceLimitsFor,
+  esp32RenderBudgetBytes,
+  type DeviceLimits,
+  type DevicePreset,
+  type DevicePresetKey,
+} from './devices'
 export { mountFrameOSManager, type FrameOSManagerHandle, type FrameOSManagerOptions } from './manager'
 export { selectFieldOptions } from './options'
 export {

--- a/frameos/wasm/src/preview.ts
+++ b/frameos/wasm/src/preview.ts
@@ -3,6 +3,7 @@
 // and drives renders; this class owns the worker lifecycle, paints frames onto
 // a canvas, and exposes events/state as callbacks.
 import { ditherFrame, panelPaletteFor, type PanelPaletteKey } from './dither'
+import type { DeviceLimits } from './devices'
 import type { FrameOSScene, PreviewAssetEntry, PreviewAssetsInfo, PreviewFrame, SceneInfo } from './types'
 
 export interface FrameOSPreviewOptions {
@@ -38,6 +39,13 @@ export interface FrameOSPreviewOptions {
   /** Set to false to run with an empty in-memory /srv/assets instead of the
    * browser's persistent folder. */
   browserAssets?: boolean
+  /** Simulate a constrained device: render-memory budget, QuickJS ceilings
+   * and HTTP cap (compute one with `deviceLimitsFor` from ./devices). Unlike
+   * `panelPalette` this changes how scenes actually render — big images
+   * degrade or fail like on the device — and is fixed for the life of the
+   * runtime: create a new preview to change it. Null/undefined simulates
+   * nothing. */
+  deviceLimits?: DeviceLimits | null
   /** Show frames the way an e-ink panel would: dithered to that panel's
    * inks or greys (see ./dither). Display only — the scene renders in full
    * colour either way. Null (the default) paints the frame as rendered. */
@@ -115,6 +123,7 @@ export class FrameOSPreview {
       fastMode: this.fastMode,
       saveAssets: options.saveAssets === undefined ? true : options.saveAssets,
       browserAssets: options.browserAssets === undefined ? true : options.browserAssets,
+      deviceLimits: options.deviceLimits ?? null,
     })
   }
 


### PR DESCRIPTION
## What

The cloud scene editor's live preview always rendered with the browser's memory, so a scene that OOMs on an ESP32 looked perfect until it hit hardware. This adds a **Device** picker next to the existing Dither control — the wasm runtime then actually runs under that device's ceilings, and the AI panel's render checks run under the same ones.

**Presets** (`frameos-wasm`'s new `devices.ts`): Browser (no limits) · Raspberry Pi 1 GB+ · Pi Zero 512 MB · ESP32 8 MB PSRAM. The ESP32 render budget is computed the way the firmware/backend do: canvas format flips to RGB565 past PSRAM/2, packed panel buffer, 1.5 MB PSRAM reserve, 1 MB emergency reserve — ~3.9 MB at 800×480 (the test corpus pins 4 MB), under 1 MB at 1200×1600, which is what a 13.3" board really has. Plus the firmware's 4 MB QuickJS heap, 20 KB JS stack and 6 MB HTTP response cap.

## How

- **`frameos_wasm_set_device_limits`** — new wasm export. The render budget reuses the ESP32 test corpus's `availableRenderBytesOverride` (now also compiled under `-d:frameosWasm`), so the whole existing ladder — decode budgets, degrade-to-blur, `ensureRenderAllocation` — applies unchanged. JS ceilings go through `frameConfig.js`; the HTTP cap through `maxHttpResponseBytes`. Reset on every init; the worker feature-detects the export so old bundles keep working.
- **QuickJS bug found on the way**: `js_def_malloc_usable_size` is `return 0;` under `__EMSCRIPTEN__`, so `JS_SetMemoryLimit` was silently inert in every wasm build. New `tools/wasm/fos_quickjs_mem.c` installs the default allocator with emscripten's real `malloc_usable_size` (the ESP32's `fos_qjs_glue.c` pattern).
- **Preview panel**: Device select (persisted per browser, reboots the runtime like Resize), and an amber notice while the frame on screen was rendered degraded (`render:degraded` from the runtime), cleared when a full-quality render lands.
- **AI generation at the chosen level**: the workspace shares the device choice with `SceneAiPanel`; its post-delivery render checks pass the same `deviceLimits`, so an ESP32-only failure (JS OOM, memory-budget degrade, HTTP cap) feeds back to the agent within the existing retry rounds, failure feedback names the simulated device, and `/api/ai/chat` gets a context line telling the model what hardware and ceilings it is designing for.

## Verified

- Node smoke test against the rebuilt bundle (same ABI as the server renderer): 48 MB of JS allocations pass without limits, die with `out of memory` under the 4 MB ESP32 heap (allocation probe: 7 × ¼ MB strings fit vs 200 without), re-init clears the limits, and a plain text scene still renders under full ESP32 limits.
- The same memory-limit path verified natively (`nim c` scratch, OOM raised) before tracking the wasm divergence to the QuickJS usable-size stub.
- `auth-web`: typecheck, eslint on touched files, full vitest suite (1269 tests) green; new `device-limits.test.ts` pins the ESP32 budget math against the firmware constants.

## Notes

- The server-side render route (`/api/scenes/render`, MCP `scene_render`) doesn't take device limits yet — a natural follow-up for parity.
- The frameos-wasm runtime assets (`frameos.js`/`frameos.wasm`/`preview-worker.js`) are rebuilt by CI/`build_wasm.sh`; local copies were rebuilt and synced for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKu7EcyqJbzsHmLYjmnJ7G