### PR TITLE
ESP32 battery: read the cell in rounds, report what the pass believed

### DIFF
--- a/backend/app/tasks/tests/test_esp32_battery_filter.py
+++ b/backend/app/tasks/tests/test_esp32_battery_filter.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Runs embedded/esp32/main/tests/test_fos_battery_filter.c.
+#
+# Same arrangement as test_esp32_power.py next door: host tests that nothing
+# invokes are host tests that do not exist.
+#
+# fos_battery_filter.c reduces one ADC burst to a believable raw count — the
+# median inside a round, the highest round across a read. It is the fix for
+# the glitched battery readings the prod logs are full of (E1002 and E1004,
+# 2026-08-29..31): the mean it replaces turned a few dropped samples, or a
+# divider that had not finished charging, into a confident 1 % on a cell at
+# 74 %. Pure arithmetic; the ADC and the GPIO live in fos_battery.c.
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ESP32_DIR = REPO_ROOT / "embedded" / "esp32"
+MAIN_DIR = ESP32_DIR / "main"
+FILTER_SOURCE = MAIN_DIR / "fos_battery_filter.c"
+FILTER_TEST_SOURCE = MAIN_DIR / "tests" / "test_fos_battery_filter.c"
+
+
+def test_sources_exist():
+    assert FILTER_SOURCE.is_file(), f"missing {FILTER_SOURCE}"
+    assert FILTER_TEST_SOURCE.is_file(), f"missing {FILTER_TEST_SOURCE}"
+
+
+def test_filter_helper_is_pure():
+    """The point of the split: it must stay buildable without the IDF."""
+    source = FILTER_SOURCE.read_text()
+    assert "#include" in source
+    assert "esp_" not in source, "fos_battery_filter.c must not pull in IDF headers or calls"
+    assert "freertos" not in source
+    assert "adc_" not in source, "the ADC itself belongs in fos_battery.c"
+
+
+def test_fos_battery_read_does_not_average_samples():
+    """The regression this module exists for.
+
+    A mean over the burst is what turned a minority of dropped samples into a
+    reading a quarter of the truth. If someone reintroduces one in the read
+    path, say so here rather than in a battery graph three days later.
+    """
+    battery = (MAIN_DIR / "fos_battery.c").read_text()
+    assert "fos_battery_burst_add" in battery, "the read path must go through the filter"
+    assert "raw_sum" not in battery, "the read path must not average raw samples again"
+
+
+@pytest.mark.skipif(shutil.which("cc") is None, reason="no C compiler on PATH")
+def test_fos_battery_filter_host_tests_pass(tmp_path: Path):
+    binary = tmp_path / "test_fos_battery_filter"
+    compile_result = subprocess.run(
+        [
+            "cc",
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-O2",
+            "-I",
+            str(MAIN_DIR),
+            str(FILTER_SOURCE),
+            str(FILTER_TEST_SOURCE),
+            "-o",
+            str(binary),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert compile_result.returncode == 0, (
+        "battery filter host tests do not compile:\n" + compile_result.stderr
+    )
+
+    run_result = subprocess.run(
+        [str(binary)], capture_output=True, text=True, timeout=180
+    )
+    assert run_result.returncode == 0, (
+        "battery filter host tests failed:\n" + run_result.stdout[-4000:]
+    )
+
+    # Assert the count too: a binary that asserted nothing would also exit 0.
+    summary = re.search(r"(\d+) checks, (\d+) failures", run_result.stdout)
+    assert summary is not None, (
+        "could not find the check summary in the output:\n" + run_result.stdout[-4000:]
+    )
+    assert int(summary.group(1)) >= 25
+    assert int(summary.group(2)) == 0

--- a/embedded/esp32/README.md
+++ b/embedded/esp32/README.md
@@ -433,6 +433,34 @@ millivolts believed (`suspect: true`) — so "deep sleep silently off" and
 push or poll that changes anything logs `settings:cloud` / `settings:sync`
 `applied` with the keys and values that changed.
 
+**The reading itself** (`fos_battery_filter.c`, host-tested by
+`main/tests/test_fos_battery_filter.c`) stopped being a mean. The old read
+averaged 16 back-to-back samples, and two different faults both came out of
+that as a confident, far-too-low number: a *minority* of samples returning
+near zero (the mean is dragged down in proportion — four zeros in sixteen
+turn a 4018 mV cell into 3013 mV), and the *whole* burst reading low because
+the divider had not finished charging (16 samples span well under a
+millisecond, so they all sit at the same point on the ramp and no average
+recovers the truth). Across 2026-08-29..31, 20 of 293 on-battery samples on
+E1002 and 44 of 396 on E1004 were wrong this way, the worst reading 1050 mV
+against a true ~4018 mV. The read now takes rounds of 9 samples spread over
+a few milliseconds, takes the **median** inside a round (killing the
+dropouts) and the **highest** round across the read (killing the ramp) — the
+maximum is the right estimator because every way this read goes wrong pulls
+it down and none pushes it up, the same reasoning `fos_client.c` already
+used when it kept the higher of two whole reads. A settled divider agrees
+within 32 counts on the second round and stops there, so a healthy cell
+costs about what it always did.
+
+The `metrics` sample reports the **believed** millivolts, not the bare ADC
+read: the hysteresis above already refused to act on an implausible drop, but
+the metrics line went straight to the ADC, so a frame that correctly kept
+rendering still told the cloud it was at 1 % and the battery graph grew a
+cliff that never happened (E1004 reported 3062 mV at 16:38 and 3942 mV
+fifteen minutes either side, 2026-08-31). When the two differ the raw sample
+is reported alongside as `batteryRawMillivolts`, so a misbehaving divider
+stays visible instead of being smoothed into silence.
+
 A pass that ends in an awake hold (a verb arrived, `keep_awake`) no longer
 renders again when the hold ends: the next panel refresh's due time is kept
 for every wait, so the follow-up pass checks in and sleeps until it. And

--- a/embedded/esp32/main/CMakeLists.txt
+++ b/embedded/esp32/main/CMakeLists.txt
@@ -20,6 +20,7 @@ idf_component_register(
         "fos_settings.c"
         "fos_tz.c"
         "fos_battery.c"
+        "fos_battery_filter.c"
         "fos_assets.c"
         "fos_assets_sd.c"
         "fos_sd_probe.c"

--- a/embedded/esp32/main/fos_battery.c
+++ b/embedded/esp32/main/fos_battery.c
@@ -1,5 +1,6 @@
 #include "fos_battery.h"
 
+#include "fos_battery_filter.h"
 #include "esp_adc/adc_cali.h"
 #include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_oneshot.h"
@@ -11,7 +12,15 @@
 
 static const char *TAG = "fos_battery";
 
-#define BATTERY_SAMPLES 16
+/* How long the divider gets to charge before the first round. The Seeed
+ * Battery_Monitor example waits 10 ms; the prod logs show whole bursts
+ * reading a third of the truth at that figure, so the first round starts
+ * later and the rounds below re-read until two agree. */
+#define BATTERY_SETTLE_MS 20
+/* Between rounds. Long enough that a still-charging divider has visibly
+ * moved by the next round, short enough that four rounds are ~30 ms — noise
+ * beside the 40-60 s render this read precedes. */
+#define BATTERY_ROUND_GAP_MS 5
 
 static bool s_present = false;
 static float s_divider = 2.0f;
@@ -93,25 +102,40 @@ void fos_battery_init(int8_t gpio, float divider, int8_t enable_gpio)
 
 bool fos_battery_present(void) { return s_present; }
 
-/* The averaged raw ADC reading with the divider switched on; -1 when no
- * sample came back. Caller holds s_lock. */
+/* The believed raw ADC reading with the divider switched on; -1 when no
+ * sample came back. Caller holds s_lock.
+ *
+ * Rounds of samples rather than one long burst, reduced by
+ * fos_battery_filter.c: the median within a round drops the odd near-zero
+ * sample, and the highest round wins because every way this read can go
+ * wrong (a divider still charging, a supply sagging under the radio, an
+ * overlapping read) pulls the number down and none pushes it up. A settled
+ * divider stops after two rounds, so the healthy case stays cheap. */
 static int sample_raw_locked(void)
 {
     if (s_enable_gpio >= 0) {
-        /* Seeed: enable, wait ~10 ms for the divider to settle, read. */
+        /* Seeed: enable, wait for the divider to settle, read. */
         gpio_set_level(s_enable_gpio, 1);
-        vTaskDelay(pdMS_TO_TICKS(10));
+        vTaskDelay(pdMS_TO_TICKS(BATTERY_SETTLE_MS));
     }
-    int raw_sum = 0, samples = 0;
-    for (int i = 0; i < BATTERY_SAMPLES; i++) {
-        int raw = 0;
-        if (adc_oneshot_read(s_adc, s_channel, &raw) == ESP_OK) {
-            raw_sum += raw;
-            samples++;
+
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    for (int round = 0; round < FOS_BATTERY_MAX_ROUNDS; round++) {
+        if (round > 0) vTaskDelay(pdMS_TO_TICKS(BATTERY_ROUND_GAP_MS));
+        int scratch[FOS_BATTERY_ROUND_SAMPLES];
+        int samples = 0;
+        for (int i = 0; i < FOS_BATTERY_ROUND_SAMPLES; i++) {
+            int raw = 0;
+            if (adc_oneshot_read(s_adc, s_channel, &raw) == ESP_OK) {
+                scratch[samples++] = raw;
+            }
         }
+        if (fos_battery_burst_add(&burst, fos_battery_median(scratch, samples))) break;
     }
+
     if (s_enable_gpio >= 0) gpio_set_level(s_enable_gpio, 0);
-    return samples == 0 ? -1 : raw_sum / samples;
+    return fos_battery_burst_value(&burst);
 }
 
 static int millivolts_from_raw(int raw)
@@ -158,6 +182,11 @@ void fos_battery_read(int *millivolts, int *percent)
     }
     if (millivolts) *millivolts = mv;
     if (percent) *percent = percent_from_millivolts(mv);
+}
+
+int fos_battery_percent_for(int millivolts)
+{
+    return percent_from_millivolts(millivolts);
 }
 
 int fos_battery_millivolts(void)

--- a/embedded/esp32/main/fos_battery.h
+++ b/embedded/esp32/main/fos_battery.h
@@ -26,14 +26,21 @@ bool fos_battery_present(void);
 /* One sampled read: the cell voltage in millivolts (after divider
  * correction; 0 when unavailable) and the charge estimate 0..100 from a
  * Li-ion discharge curve (-1 when unavailable), both from the SAME ADC
- * sample. Either out pointer may be NULL. Averages a handful of samples and
- * takes ~10 ms more on boards with an enable pin. Serialized by a mutex:
- * the render task, the HTTP server (/status), the console and the cloud
- * client all read it, and an unserialized caller switching the divider off
- * mid-sample turned a full cell into a ~1.9 V reading. Prefer one call per
- * pass over millivolts() + percent() back to back. */
+ * sample. Either out pointer may be NULL. Samples in rounds until two agree
+ * (see fos_battery_filter.h) and takes ~25-45 ms on boards with an enable
+ * pin. Serialized by a mutex: the render task, the HTTP server (/status),
+ * the console and the cloud client all read it, and an unserialized caller
+ * switching the divider off mid-sample turned a full cell into a ~1.9 V
+ * reading. Prefer one call per pass over millivolts() + percent() back to
+ * back. */
 void fos_battery_read(int *millivolts, int *percent);
 
 /* Convenience wrappers around fos_battery_read(); each one samples. */
 int fos_battery_millivolts(void);
 int fos_battery_percent(void);
+
+/* The charge estimate 0..100 for a voltage the caller already has, off the
+ * same Li-ion discharge curve fos_battery_read() uses; -1 for a voltage of
+ * 0. Lets a consumer that reports a believed reading (fos_power.h) report a
+ * percentage consistent with it instead of one from the raw sample. */
+int fos_battery_percent_for(int millivolts);

--- a/embedded/esp32/main/fos_battery_filter.c
+++ b/embedded/esp32/main/fos_battery_filter.c
@@ -1,0 +1,60 @@
+#include "fos_battery_filter.h"
+
+#include <stddef.h>
+
+/* Insertion sort: n is FOS_BATTERY_ROUND_SAMPLES, and at that size it beats
+ * anything with a call in its inner loop. */
+static void sort_ints(int *v, int n)
+{
+    for (int i = 1; i < n; i++) {
+        int key = v[i];
+        int j = i - 1;
+        while (j >= 0 && v[j] > key) {
+            v[j + 1] = v[j];
+            j--;
+        }
+        v[j + 1] = key;
+    }
+}
+
+int fos_battery_median(int *scratch, int n)
+{
+    if (scratch == NULL || n <= 0) return -1;
+    sort_ints(scratch, n);
+    return scratch[n / 2];
+}
+
+void fos_battery_burst_reset(fos_battery_burst_t *burst)
+{
+    if (burst == NULL) return;
+    burst->count = 0;
+    for (int i = 0; i < FOS_BATTERY_MAX_ROUNDS; i++) burst->rounds[i] = -1;
+}
+
+bool fos_battery_burst_add(fos_battery_burst_t *burst, int round_median)
+{
+    if (burst == NULL || round_median < 0) return false;
+    if (burst->count >= FOS_BATTERY_MAX_ROUNDS) return true;
+
+    int previous = burst->count > 0 ? burst->rounds[burst->count - 1] : -1;
+    burst->rounds[burst->count++] = round_median;
+    /* Out of rounds: stop, settled or not. The caller's loop bound says the
+     * same thing, but a reducer whose "stop" answer depends on the caller
+     * counting correctly is one refactor from sampling forever. */
+    if (burst->count >= FOS_BATTERY_MAX_ROUNDS) return true;
+    if (previous < 0) return false;
+
+    int drift = round_median - previous;
+    if (drift < 0) drift = -drift;
+    return drift <= FOS_BATTERY_SETTLED_COUNTS;
+}
+
+int fos_battery_burst_value(const fos_battery_burst_t *burst)
+{
+    if (burst == NULL) return -1;
+    int best = -1;
+    for (int i = 0; i < burst->count; i++) {
+        if (burst->rounds[i] > best) best = burst->rounds[i];
+    }
+    return best;
+}

--- a/embedded/esp32/main/fos_battery_filter.h
+++ b/embedded/esp32/main/fos_battery_filter.h
@@ -1,0 +1,71 @@
+/*
+ * Reducing one ADC burst to a believable raw count. Pure arithmetic on
+ * purpose — no IDF, no ADC — so main/tests/test_fos_battery_filter.c can
+ * argue with it on a laptop. fos_battery.c drives the GPIO and the ADC and
+ * feeds the numbers through here.
+ *
+ * Why the mean was wrong. fos_battery.c used to average 16 back-to-back
+ * samples and return that. Two different faults both land as a confident,
+ * far-too-low reading:
+ *
+ *  - A minority of samples come back near zero (the divider's enable line
+ *    settling, or another task's read overlapping ours). A mean is dragged
+ *    down in proportion: four zeros in sixteen turn a 4018 mV cell into
+ *    3013 mV. The prod logs show exactly these ratios — E1002 and E1004
+ *    reported 3062, 2558, 2036 and even 1050 mV against a true ~4000 mV,
+ *    i.e. roughly a quarter, a half, three quarters of the samples lost.
+ *  - The whole burst reads low because the divider had not finished
+ *    charging when sampling began. Sixteen samples back to back span well
+ *    under a millisecond, so they all sit at the same point on the ramp and
+ *    no amount of averaging recovers the truth.
+ *
+ * The median inside a round handles the first; sampling in rounds spread
+ * over time and keeping the HIGHEST handles the second. Taking the maximum
+ * is sound because the error is one-directional: a divider still charging,
+ * a sagging supply and an overlapping read can only pull a reading down,
+ * never push it up. fos_client.c already relied on that when it took the
+ * higher of two whole reads a moment apart; this moves the same reasoning
+ * inside a single read, where it is cheap.
+ *
+ * A burst that has settled stops early, so a healthy cell still costs about
+ * what it always did.
+ */
+#pragma once
+
+#include <stdbool.h>
+
+/* Samples per round. Odd, so the median is a real sample rather than a mean
+ * of two — a mean of the middle pair reintroduces exactly the averaging this
+ * module exists to avoid. */
+#define FOS_BATTERY_ROUND_SAMPLES 9
+/* Rounds per read, worst case. The early exit below means a settled divider
+ * pays two. */
+#define FOS_BATTERY_MAX_ROUNDS 4
+/* Two consecutive rounds within this many raw counts of each other means the
+ * divider has settled. At 12 bits over ~3.1 V with a divider of 2, one count
+ * is about 1.5 mV at the cell, so 32 counts is ~48 mV — wider than ADC noise,
+ * far narrower than the ramp this is looking for. */
+#define FOS_BATTERY_SETTLED_COUNTS 32
+
+/* The rounds of one read, newest last. */
+typedef struct {
+    int rounds[FOS_BATTERY_MAX_ROUNDS];
+    int count;
+} fos_battery_burst_t;
+
+/* The median of `n` raw samples. Sorts `scratch` in place (it is the
+ * caller's buffer, not a copy — this runs per read on a device). Returns -1
+ * when there is nothing to take a median of. */
+int fos_battery_median(int *scratch, int n);
+
+void fos_battery_burst_reset(fos_battery_burst_t *burst);
+
+/* Record one round's median. Returns true when the read can stop early:
+ * this round and the one before it agree within FOS_BATTERY_SETTLED_COUNTS,
+ * so more rounds would only repeat the same number. A round of -1 (no
+ * sample came back) is not recorded and never settles the burst. */
+bool fos_battery_burst_add(fos_battery_burst_t *burst, int round_median);
+
+/* The believed raw count for the read: the highest round recorded, or -1
+ * when no round produced a sample. */
+int fos_battery_burst_value(const fos_battery_burst_t *burst);

--- a/embedded/esp32/main/fos_client.c
+++ b/embedded/esp32/main/fos_client.c
@@ -192,8 +192,27 @@ static const char *wake_cause_name(void)
 static void log_metrics_sample(void)
 {
     char json[640];
-    int battery_pct = -1, battery_mv = 0;
-    if (fos_battery_present()) fos_battery_read(&battery_mv, &battery_pct);
+    int battery_pct = -1, battery_mv = 0, battery_raw_mv = 0;
+    if (fos_battery_present()) {
+        fos_battery_read(&battery_raw_mv, &battery_pct);
+        battery_mv = battery_raw_mv;
+        /* Report what the pass BELIEVED, not the bare sample. fos_power.h's
+         * hysteresis already refuses to act on a reading that drops
+         * implausibly far in one pass, but this line went straight to the
+         * ADC — so a frame that correctly kept rendering still told the
+         * cloud it was at 1 %, and the graph grew a cliff that never
+         * happened (E1004 reported 3062 mV at 16:38 and 3942 mV fifteen
+         * minutes later, 2026-08-31). Same test, same answer, one source of
+         * truth. The raw sample is still reported when the two differ, so a
+         * misbehaving divider stays visible rather than being smoothed into
+         * silence. */
+        int believed = s_power_state.last_good_mv;
+        if (believed >= FOS_POWER_PRESENT_MV &&
+            battery_raw_mv < believed - FOS_POWER_GLITCH_DROP_MV) {
+            battery_mv = believed;
+            battery_pct = fos_battery_percent_for(believed);
+        }
+    }
     size_t used = (size_t)snprintf(
         json, sizeof(json),
         "{\"event\":\"metrics\",\"source\":\"esp32\","
@@ -237,6 +256,10 @@ static void log_metrics_sample(void)
                                  ",\"batteryPercent\":%d,\"batteryMillivolts\":%d,\"onBattery\":%s",
                                  battery_pct, battery_mv,
                                  battery_mv >= FOS_POWER_PRESENT_MV ? "true" : "false");
+        if (battery_raw_mv != battery_mv && used < sizeof(json) - 40) {
+            used += (size_t)snprintf(json + used, sizeof(json) - used,
+                                     ",\"batteryRawMillivolts\":%d", battery_raw_mv);
+        }
     }
     if (used < sizeof(json) - 2) {
         snprintf(json + used, sizeof(json) - used, "}");

--- a/embedded/esp32/main/tests/test_fos_battery_filter.c
+++ b/embedded/esp32/main/tests/test_fos_battery_filter.c
@@ -1,0 +1,194 @@
+/*
+ * Host tests for the ADC burst reducer (fos_battery_filter.c). No IDF, no
+ * mocks: the file is pure arithmetic on purpose, so a laptop compiler can
+ * check it.
+ *
+ * Build and run (from embedded/esp32/):
+ *
+ *   cc -std=c11 -Wall -Wextra -Werror -O2 -Imain \
+ *      main/fos_battery_filter.c main/tests/test_fos_battery_filter.c \
+ *      -o /tmp/test_fos_battery_filter && /tmp/test_fos_battery_filter
+ *
+ * (backend/app/tasks/tests/test_esp32_battery_filter.py does exactly that
+ * in CI.)
+ *
+ * The cases replay the two shapes the prod logs show. Raw counts here are
+ * the 12-bit ADC's, so a ~4.0 V cell behind a divider of 2 sits near 2640:
+ *
+ *  - E1002, 2026-08-29..31: 20 of 293 on-battery samples read far below
+ *    truth, the lowest 1050 mV against a true ~4018 mV. The ratios (a
+ *    quarter, a half, three quarters) say a varying MINORITY of samples came
+ *    back near zero and the old mean averaged them in.
+ *  - E1004, same window: 44 of 396, and one pass reported 1 % at 16:38
+ *    against 74 % fifteen minutes either side — a WHOLE burst low, which is
+ *    the divider still charging and which no average can recover.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "fos_battery_filter.h"
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond, ...)                                                       \
+    do {                                                                       \
+        g_checks++;                                                            \
+        if (!(cond)) {                                                         \
+            g_failures++;                                                      \
+            printf("FAIL %s:%d: ", __func__, __LINE__);                        \
+            printf(__VA_ARGS__);                                               \
+            printf("\n");                                                      \
+        }                                                                      \
+    } while (0)
+
+/* The old reducer, kept so the tests can state what changed rather than
+ * just asserting the new numbers. */
+static int mean_of(const int *v, int n)
+{
+    int sum = 0;
+    for (int i = 0; i < n; i++) sum += v[i];
+    return n ? sum / n : -1;
+}
+
+static int median_of(const int *v, int n)
+{
+    int scratch[FOS_BATTERY_ROUND_SAMPLES];
+    memcpy(scratch, v, (size_t)n * sizeof(int));
+    return fos_battery_median(scratch, n);
+}
+
+static void test_median_ignores_a_minority_of_dropouts(void)
+{
+    /* Nine samples of a ~4018 mV cell, three of which came back at zero:
+     * the mean is the fault the prod logs show, the median is not. */
+    const int samples[FOS_BATTERY_ROUND_SAMPLES] = {2640, 2642, 0, 2639, 0,
+                                                    2641, 2640, 0, 2643};
+    CHECK(median_of(samples, 9) == 2640, "the median is the cell, not the dropouts");
+    CHECK(mean_of(samples, 9) < 1800, "the mean this replaces was dragged to %d",
+          mean_of(samples, 9));
+}
+
+static void test_median_survives_a_minority_of_spikes(void)
+{
+    const int samples[FOS_BATTERY_ROUND_SAMPLES] = {2640, 4095, 2639, 2641, 4095,
+                                                    2640, 2642, 2640, 2638};
+    CHECK(median_of(samples, 9) == 2640, "a high spike is rejected the same way");
+}
+
+static void test_median_of_nothing(void)
+{
+    int scratch[1] = {0};
+    CHECK(fos_battery_median(scratch, 0) == -1, "no samples is not a reading");
+    CHECK(fos_battery_median(NULL, 4) == -1, "no buffer is not a reading");
+}
+
+static void test_median_of_one_and_of_all_equal(void)
+{
+    int one[1] = {2640};
+    CHECK(fos_battery_median(one, 1) == 2640, "a single sample is its own median");
+    int flat[5] = {2640, 2640, 2640, 2640, 2640};
+    CHECK(fos_battery_median(flat, 5) == 2640, "a flat round is its own median");
+}
+
+static void test_settled_divider_stops_after_two_rounds(void)
+{
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    CHECK(!fos_battery_burst_add(&burst, 2640), "one round cannot agree with itself");
+    CHECK(fos_battery_burst_add(&burst, 2644), "two rounds 4 counts apart have settled");
+    CHECK(burst.count == 2, "and the read stops there");
+    CHECK(fos_battery_burst_value(&burst) == 2644, "believing the higher of the two");
+}
+
+static void test_charging_divider_climbs_and_the_highest_wins(void)
+{
+    /* The E1004 shape: the first round catches the divider a third of the
+     * way up, and it is still climbing a round later. */
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    CHECK(!fos_battery_burst_add(&burst, 700), "round 1 is far too low");
+    CHECK(!fos_battery_burst_add(&burst, 1800), "round 2 has not settled either");
+    CHECK(!fos_battery_burst_add(&burst, 2500), "round 3 still climbing");
+    CHECK(fos_battery_burst_add(&burst, 2640), "round 4 is the last one regardless");
+    CHECK(fos_battery_burst_value(&burst) == 2640,
+          "the believed reading is the top of the ramp, not its mean");
+    CHECK(mean_of(burst.rounds, burst.count) < 2000,
+          "averaging the ramp would have reported %d",
+          mean_of(burst.rounds, burst.count));
+}
+
+static void test_a_settled_low_cell_is_still_believed(void)
+{
+    /* The filter must not invent charge: a genuinely flat cell reads low in
+     * every round, and low is the answer. */
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    fos_battery_burst_add(&burst, 2050);
+    fos_battery_burst_add(&burst, 2048);
+    CHECK(fos_battery_burst_value(&burst) == 2050, "a low cell reads low");
+}
+
+static void test_dead_rounds_are_not_recorded(void)
+{
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    CHECK(!fos_battery_burst_add(&burst, -1), "a round with no samples settles nothing");
+    CHECK(burst.count == 0, "and is not recorded");
+    CHECK(fos_battery_burst_value(&burst) == -1, "a read with no rounds is no reading");
+    /* A dead round between two live ones must not make them look adjacent. */
+    fos_battery_burst_add(&burst, 2640);
+    fos_battery_burst_add(&burst, -1);
+    CHECK(burst.count == 1, "still one round");
+    CHECK(fos_battery_burst_value(&burst) == 2640, "and the live one stands");
+}
+
+static void test_burst_cannot_overrun_its_rounds(void)
+{
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    /* Never settling: every round differs by more than the tolerance. */
+    for (int i = 0; i < FOS_BATTERY_MAX_ROUNDS * 3; i++) {
+        int value = 500 + i * (FOS_BATTERY_SETTLED_COUNTS + 50);
+        bool stop = fos_battery_burst_add(&burst, value);
+        if (i >= FOS_BATTERY_MAX_ROUNDS - 1) {
+            CHECK(stop, "a full burst always stops (round %d)", i);
+        }
+    }
+    CHECK(burst.count == FOS_BATTERY_MAX_ROUNDS, "and never records more than it holds");
+}
+
+static void test_reset_clears_a_previous_read(void)
+{
+    fos_battery_burst_t burst;
+    fos_battery_burst_reset(&burst);
+    fos_battery_burst_add(&burst, 2640);
+    fos_battery_burst_reset(&burst);
+    CHECK(burst.count == 0, "reset empties the burst");
+    CHECK(fos_battery_burst_value(&burst) == -1, "and forgets the old reading");
+}
+
+static void test_null_burst_is_survivable(void)
+{
+    fos_battery_burst_reset(NULL);
+    CHECK(!fos_battery_burst_add(NULL, 2640), "no burst settles nothing");
+    CHECK(fos_battery_burst_value(NULL) == -1, "and holds no reading");
+}
+
+int main(void)
+{
+    test_median_ignores_a_minority_of_dropouts();
+    test_median_survives_a_minority_of_spikes();
+    test_median_of_nothing();
+    test_median_of_one_and_of_all_equal();
+    test_settled_divider_stops_after_two_rounds();
+    test_charging_divider_climbs_and_the_highest_wins();
+    test_a_settled_low_cell_is_still_believed();
+    test_dead_rounds_are_not_recorded();
+    test_burst_cannot_overrun_its_rounds();
+    test_reset_clears_a_previous_read();
+    test_null_burst_is_survivable();
+    printf("%s: %d checks, %d failures\n", g_failures ? "FAILED" : "ok",
+           g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## The bug

Both battery frames report wrong battery readings several times a day. Over 2026-08-29..31:

| | bogus readings | rate | worst |
|---|---|---|---|
| E1002 | 20 / 293 on-battery samples | ~7/day | **1050 mV** vs a true ~4018 mV |
| E1004 | 44 / 396 on-battery samples | ~9/day | 2036 mV vs a true ~3950 mV |

E1004 reported `batteryPercent: 1` at 16:38 on 2026-08-31 and 74 % fifteen minutes either side.

## Two causes, one mean

`fos_battery.c` averaged 16 back-to-back ADC samples. Two unrelated faults both land as a confident, far-too-low number:

1. **A minority of samples return near zero** — the divider's enable line settling, or another task's read overlapping ours. A mean is dragged down in proportion: four zeros in sixteen turn a 4018 mV cell into 3013 mV. The observed values are near-exact fractions of truth (¼, ½, ¾), which is the signature.
2. **The whole burst reads low** because the divider had not finished charging. Sixteen samples span well under a millisecond, so they all sit at the same point on the ramp and no amount of averaging recovers the truth.

## The fix

Rounds of 9 samples spread over a few milliseconds, reduced in a new pure `fos_battery_filter.c`:

- **median inside a round** → drops the dropouts (and spikes)
- **highest round across the read** → drops the ramp

The maximum is the right estimator because every way this read goes wrong — a divider still charging, a supply sagging under the radio, an overlapping read — pulls the number down and none pushes it up. `fos_client.c` already relied on exactly that when it kept the higher of two whole reads a moment apart; this moves the same reasoning inside a single read, where it is cheap. A settled divider agrees within 32 counts on the second round and stops there, so a healthy cell costs about what it always did (~25 ms vs ~10 ms, against a 40-60 s render).

## Second half: stop reporting the raw sample

`fos_power.c`'s hysteresis already refused to *act* on an implausible drop — that is why these frames kept rendering correctly through every glitch. But `log_metrics_sample()` went straight to the ADC, so the cloud got the glitch anyway and the battery graph grew cliffs that never happened.

Metrics now report the **believed** millivolts, with the raw sample alongside as `batteryRawMillivolts` when the two differ — so a genuinely misbehaving divider stays visible instead of being smoothed into silence.

## Tests

- `main/tests/test_fos_battery_filter.c` — 37 checks, pure host test, same arrangement as `fos_power.c`/`fos_wake.c`. Cases replay both prod shapes and assert what the old mean would have returned.
- `backend/app/tasks/tests/test_esp32_battery_filter.py` runs it in CI, and includes a guard that fails if an average ever returns to the read path.
- `idf.py build` clean for esp32s3, no new warnings.

## Not verified

**Hardware unverified** — neither frame has run this. The failure is intermittent (~7-9 times a day), so confirming it means watching `batteryRawMillivolts` appear without `batteryMillivolts` moving for a day or two after flashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7Mqwr5z8ewACLgUYyyTAM