### PR TITLE
Cloud accounting: postpay, the AI switch, a daily cap, and plans (Phases 3a + 5)

### DIFF
--- a/cloud/apps/auth-web/app/account/ai/page.tsx
+++ b/cloud/apps/auth-web/app/account/ai/page.tsx
@@ -1,0 +1,251 @@
+import { eq } from "drizzle-orm";
+import {
+  accountAiUsage,
+  readAccountPlan,
+  readBillingSettings,
+  recentAccountAiTurns,
+  utcDayWindow,
+  utcMonthWindow,
+  type AccountAiUsage,
+} from "@frameos-cloud/ledger";
+import { accounts, createDb } from "@frameos-cloud/db";
+import { AiUsageSwitch } from "../../../src/components/AiUsageSwitch";
+import { formatDateTime } from "../../../src/lib/format";
+import { readSession } from "../../../src/lib/session";
+
+export const metadata = { title: "AI usage" };
+
+// The page behind the account header's "AI usage" row
+// (cloud/docs/accounting-todo.md §5.2). Friendly first, forensic underneath:
+// one sentence about this month, where it went in the user's own words, the
+// requests behind it, how the price is arrived at, and the off switch.
+//
+// Every number here comes from the same query the daily cap enforces with and
+// the admin statement drills into. Two definitions of "what you have spent"
+// that differ by a rounding step is the kind of bug only ever found by a
+// confused user.
+
+// Micro-dollars to dollars, rounding UP to the cent: a tenth of a cent of
+// usage should read as $0.01, never as nothing at all.
+function dollars(micros: bigint): string {
+  const cents = (micros + 9_999n) / 10_000n;
+  return `$${(cents / 100n).toString()}.${(cents % 100n).toString().padStart(2, "0")}`;
+}
+
+// Surface slugs are for the database. These are for people.
+const surfaceLabels: Record<string, string> = {
+  app_chat: "App code assistant",
+  scene_chat: "Scene chat",
+  scene_convert: "Scene converter",
+  store_classify: "Store classification",
+};
+
+// Surfaces the platform pays for on purpose, whoever's key ran them. Listed
+// *because* they are free: $0.00 next to a real number is the clearest
+// possible statement of what we do and do not charge for.
+const freeSurfaces = new Set(["scene_convert", "store_classify"]);
+
+function surfaceLabel(surface: string | null): string {
+  if (!surface) {
+    return "Other";
+  }
+  return surfaceLabels[surface] ?? surface.replace(/_/g, " ");
+}
+
+export default async function AccountAiPage() {
+  const session = await readSession();
+  const accountId = session?.accountId;
+  if (!accountId) {
+    return (
+      <section className="card">
+        <p className="copy">Sign in to see your AI usage.</p>
+      </section>
+    );
+  }
+
+  const db = createDb();
+  const now = new Date();
+  const dayWindow = utcDayWindow(now);
+  const [[account], thisMonth, lastMonth, today, turns, settings, plan] =
+    await Promise.all([
+      db
+        .select({ aiDisabledAt: accounts.aiDisabledAt })
+        .from(accounts)
+        .where(eq(accounts.id, accountId))
+        .limit(1),
+      accountAiUsage(db, accountId, utcMonthWindow(now)),
+      accountAiUsage(db, accountId, utcMonthWindow(now, -1)),
+      accountAiUsage(db, accountId, dayWindow),
+      recentAccountAiTurns(db, accountId, { limit: 20 }),
+      readBillingSettings(db),
+      readAccountPlan(db, accountId),
+    ]);
+
+  const enabled = !account?.aiDisabledAt;
+  const live = settings.meteringMode === "live";
+  const marginPercent =
+    (plan.subscribed ? plan.plan.marginBasisPoints : settings.marginBasisPoints) /
+    100;
+
+  return (
+    <>
+      <section className="card">
+        <h2>This month</h2>
+        {!enabled ? (
+          <p className="copy">
+            AI features are switched off for this account, so nothing is being
+            used and nothing can be charged.
+          </p>
+        ) : (
+          <p className="copy">
+            You&rsquo;ve used <strong>{dollars(thisMonth.chargeableMicros)}</strong>{" "}
+            of AI this month across {thisMonth.turns}{" "}
+            {thisMonth.turns === 1 ? "request" : "requests"}.{" "}
+            {live
+              ? "This is billed at the end of the month."
+              : "Nothing is billed — FrameOS Cloud AI is in preview and every request is currently free."}
+            {lastMonth.turns > 0
+              ? ` Last month it was ${dollars(lastMonth.chargeableMicros)}.`
+              : null}
+          </p>
+        )}
+        {thisMonth.ownKeyOnly && thisMonth.turns > 0 ? (
+          <p className="copy">
+            Every request this month ran on your own OpenAI key, so you owe us
+            nothing for it — the figure above is what those tokens cost at
+            OpenAI&rsquo;s list price, for your own reference.
+          </p>
+        ) : null}
+      </section>
+
+      <section className="card">
+        <h2>Where it went</h2>
+        {thisMonth.buckets.length === 0 ? (
+          <p className="copy">No AI requests yet this month.</p>
+        ) : (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Feature</th>
+                <th>Requests</th>
+                <th style={{ textAlign: "right" }}>This month</th>
+              </tr>
+            </thead>
+            <tbody>
+              {collapseBySurface(thisMonth).map((row) => (
+                <tr key={row.surface ?? "other"}>
+                  <td>
+                    {surfaceLabel(row.surface)}
+                    {freeSurfaces.has(row.surface ?? "") ? (
+                      <span className="pill"> free</span>
+                    ) : null}
+                  </td>
+                  <td>{row.turns}</td>
+                  <td style={{ textAlign: "right" }}>
+                    {dollars(row.chargeableMicros)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <p className="copy">
+          The scene converter and store classification are on us: we asked
+          everyone to move off compiled scenes, so the conversion is our
+          migration cost rather than a line on your bill.
+        </p>
+      </section>
+
+      <section className="card">
+        <h2>Recent requests</h2>
+        {turns.length === 0 ? (
+          <p className="copy">Nothing yet.</p>
+        ) : (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>When</th>
+                <th>Feature</th>
+                <th>Model</th>
+                <th style={{ textAlign: "right" }}>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {turns.map((turn, index) => (
+                <tr key={`${turn.occurredAt.toISOString()}-${index}`}>
+                  <td>{formatDateTime(turn.occurredAt)}</td>
+                  <td>{surfaceLabel(turn.surface)}</td>
+                  <td className="copy">{turn.model}</td>
+                  <td style={{ textAlign: "right" }}>
+                    {turn.ownKey ? "your key" : dollars(turn.chargeableMicros)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section className="card">
+        <h2>How pricing works</h2>
+        <p className="copy">
+          We pay the model provider for every token a request uses, and add a
+          margin of {marginPercent}% on top. That is the whole formula — no
+          per-seat fee, no minimum, nothing up front. The exact token counts
+          and unit prices behind every request above are on record, which is
+          what makes the numbers on this page checkable rather than merely
+          asserted.
+        </p>
+        <p className="copy">
+          You are on the <strong>{plan.plan.name}</strong> plan. A daily limit
+          of {dollars(settings.dailyCapMicros)} applies: today you have used{" "}
+          {dollars(today.chargeableMicros)}, and it resets at{" "}
+          {formatDateTime(dayWindow.until)}. The limit is there so that a
+          runaway loop costs you a bounded amount rather than an unbounded one.
+        </p>
+        {!live ? (
+          <p className="copy">
+            While AI is in preview nothing is charged at all. When that
+            changes you will be told before it happens, not after.
+          </p>
+        ) : null}
+      </section>
+
+      <section className="card">
+        <h2>Turn AI off</h2>
+        <AiUsageSwitch enabled={enabled} />
+      </section>
+    </>
+  );
+}
+
+// One row per surface: own-key vs our-key is a real distinction to the books
+// and no distinction at all to somebody reading their own usage, so it is
+// summed away here rather than shown as two "Scene chat" rows that do not
+// visibly add up to the number at the top of the page.
+function collapseBySurface(usage: AccountAiUsage) {
+  const bySurface = new Map<
+    string | null,
+    { chargeableMicros: bigint; surface: string | null; turns: number }
+  >();
+  for (const bucket of usage.buckets) {
+    const existing = bySurface.get(bucket.surface);
+    if (existing) {
+      existing.chargeableMicros += bucket.chargeableMicros;
+      existing.turns += bucket.turns;
+    } else {
+      bySurface.set(bucket.surface, {
+        chargeableMicros: bucket.chargeableMicros,
+        surface: bucket.surface,
+        turns: bucket.turns,
+      });
+    }
+  }
+  return [...bySurface.values()].sort((a, b) =>
+    a.chargeableMicros === b.chargeableMicros
+      ? b.turns - a.turns
+      : b.chargeableMicros > a.chargeableMicros
+        ? 1
+        : -1,
+  );
+}

--- a/cloud/apps/auth-web/app/account/ai/page.tsx
+++ b/cloud/apps/auth-web/app/account/ai/page.tsx
@@ -33,17 +33,32 @@ function dollars(micros: bigint): string {
 }
 
 // Surface slugs are for the database. These are for people.
+//
+// The values are what the routes actually record, which is not the same as
+// what they pass to the access gate: the scene chat meters the CLIENT's
+// `body.surface` ("editor", "frame", "store", "store-new"), so a map written
+// from the gate's argument names would have labelled almost nothing. Checked
+// against `select distinct surface from ai_usage_records`.
 const surfaceLabels: Record<string, string> = {
   app_chat: "App code assistant",
+  editor: "Scene editor chat",
+  frame: "Frame chat",
   scene_chat: "Scene chat",
   scene_convert: "Scene converter",
+  store: "Store editor chat",
+  "store-new": "New scene chat",
   store_classify: "Store classification",
+  store_recategorize: "Store recategorisation",
 };
 
 // Surfaces the platform pays for on purpose, whoever's key ran them. Listed
 // *because* they are free: $0.00 next to a real number is the clearest
 // possible statement of what we do and do not charge for.
-const freeSurfaces = new Set(["scene_convert", "store_classify"]);
+const freeSurfaces = new Set([
+  "scene_convert",
+  "store_classify",
+  "store_recategorize",
+]);
 
 function surfaceLabel(surface: string | null): string {
   if (!surface) {
@@ -82,10 +97,11 @@ export default async function AccountAiPage() {
     ]);
 
   const enabled = !account?.aiDisabledAt;
-  const live = settings.meteringMode === "live";
-  const marginPercent =
-    (plan.subscribed ? plan.plan.marginBasisPoints : settings.marginBasisPoints) /
-    100;
+  // Billed only when metering is live AND something in the month was actually
+  // billable to them. A month spent entirely on the operator's shared key or
+  // on absorbed surfaces owes nothing, and saying "this is billed at the end
+  // of the month" over that number would be a bill-shaped lie.
+  const billed = settings.meteringMode === "live" && thisMonth.billableMicros > 0n;
 
   return (
     <>
@@ -101,9 +117,9 @@ export default async function AccountAiPage() {
             You&rsquo;ve used <strong>{dollars(thisMonth.chargeableMicros)}</strong>{" "}
             of AI this month across {thisMonth.turns}{" "}
             {thisMonth.turns === 1 ? "request" : "requests"}.{" "}
-            {live
+            {billed
               ? "This is billed at the end of the month."
-              : "Nothing is billed — FrameOS Cloud AI is in preview and every request is currently free."}
+              : "Nothing is billed — every request above is currently free to you."}
             {lastMonth.turns > 0
               ? ` Last month it was ${dollars(lastMonth.chargeableMicros)}.`
               : null}
@@ -189,12 +205,11 @@ export default async function AccountAiPage() {
       <section className="card">
         <h2>How pricing works</h2>
         <p className="copy">
-          We pay the model provider for every token a request uses, and add a
-          margin of {marginPercent}% on top. That is the whole formula — no
-          per-seat fee, no minimum, nothing up front. The exact token counts
-          and unit prices behind every request above are on record, which is
-          what makes the numbers on this page checkable rather than merely
-          asserted.
+          We pay the model provider for every token a request uses, and add
+          our margin on top. That is the whole formula — no per-seat fee, no
+          minimum, nothing up front. The exact token counts and unit prices
+          behind every request above are on record, which is what makes the
+          numbers on this page checkable rather than merely asserted.
         </p>
         <p className="copy">
           You are on the <strong>{plan.plan.name}</strong> plan. A daily limit
@@ -203,10 +218,10 @@ export default async function AccountAiPage() {
           {formatDateTime(dayWindow.until)}. The limit is there so that a
           runaway loop costs you a bounded amount rather than an unbounded one.
         </p>
-        {!live ? (
+        {!billed ? (
           <p className="copy">
-            While AI is in preview nothing is charged at all. When that
-            changes you will be told before it happens, not after.
+            Nothing is being charged for AI right now. When that changes you
+            will be told before it happens, not after.
           </p>
         ) : null}
       </section>

--- a/cloud/apps/auth-web/app/admin/billing/page.tsx
+++ b/cloud/apps/auth-web/app/admin/billing/page.tsx
@@ -102,14 +102,27 @@ export default async function AdminBillingPage() {
             </div>
           </div>
           <div className="stat-tile">
-            <div className="stat-tile__label">Owed to customers</div>
+            <div className="stat-tile__label">Owed by customers</div>
             <div className="stat-tile__value">
-              {formatMicrosUsd(summary.customerLiabilityMicros)}
+              {formatMicrosUsd(summary.customerReceivableMicros)}
             </div>
             <div className="stat-tile__detail">
-              Prepaid credit not yet spent — a liability, not revenue.
+              Metered usage and subscriptions accrued but not yet invoiced —
+              postpay&rsquo;s receivable, and what a month-end run collects.
             </div>
           </div>
+          {summary.customerLiabilityMicros !== 0n ? (
+            <div className="stat-tile">
+              <div className="stat-tile__label">Owed to customers</div>
+              <div className="stat-tile__value">
+                {formatMicrosUsd(summary.customerLiabilityMicros)}
+              </div>
+              <div className="stat-tile__detail">
+                Prepaid credit not yet spent. Zero unless the shelved prepaid
+                model is in use — shown only when it is not.
+              </div>
+            </div>
+          ) : null}
         </div>
       </section>
 

--- a/cloud/apps/auth-web/app/api/account/ai/route.ts
+++ b/cloud/apps/auth-web/app/api/account/ai/route.ts
@@ -1,0 +1,187 @@
+import { eq } from "drizzle-orm";
+import {
+  accountAiUsage,
+  listPlans,
+  readAccountPlan,
+  readBillingSettings,
+  recentAccountAiTurns,
+  utcDayWindow,
+  utcMonthWindow,
+} from "@frameos-cloud/ledger";
+import { accounts } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
+import { recordAuditEvent } from "../../../../src/lib/audit";
+import { csrfResponse } from "../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { readSession } from "../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+// The account's own view of its AI usage, and the switch that turns it off
+// (cloud/docs/accounting-todo.md §5.1, §5.2).
+//
+// GET is everything /account/ai renders: this month and last, the breakdown
+// by surface, the recent turns, the daily cap and where today stands against
+// it, and the current plan. Deliberately its own route rather than more of
+// /api/account/usage — that payload is the "can I still do X" answer an agent
+// polls, and it has no business carrying a hundred turn rows.
+//
+// PUT flips the switch. Audited in both directions, because "when did AI stop
+// working for me" is a support question and the answer has to be findable.
+
+export async function GET(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "account:ai", {
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const accountId = session.accountId;
+  const now = new Date();
+  const dayWindow = utcDayWindow(now);
+  const [[account], thisMonth, lastMonth, today, turns, settings, plan, plans] =
+    await Promise.all([
+      db
+        .select({ aiDisabledAt: accounts.aiDisabledAt })
+        .from(accounts)
+        .where(eq(accounts.id, accountId))
+        .limit(1),
+      accountAiUsage(db, accountId, utcMonthWindow(now)),
+      accountAiUsage(db, accountId, utcMonthWindow(now, -1)),
+      accountAiUsage(db, accountId, dayWindow),
+      recentAccountAiTurns(db, accountId, { limit: 20 }),
+      readBillingSettings(db),
+      readAccountPlan(db, accountId),
+      listPlans(db),
+    ]);
+  if (!account) {
+    return jsonError("login_required", 401);
+  }
+
+  return NextResponse.json(
+    {
+      cap: {
+        daily_micros: settings.dailyCapMicros.toString(),
+        // When today's number goes back to zero. Named rather than implied:
+        // "resets at midnight" is ambiguous in a way a timestamp is not
+        // (§8.12 is the open question about whose midnight it should be).
+        resets_at: dayWindow.until.toISOString(),
+        today_micros: today.chargeableMicros.toString(),
+      },
+      enabled: account.aiDisabledAt === null,
+      margin_basis_points: plan.subscribed
+        ? plan.plan.marginBasisPoints
+        : settings.marginBasisPoints,
+      // 'shadow' means measured and priced but charged to nobody. Every
+      // number below is real; only the billing is not, and a UI that does not
+      // say so is telling people they owe money they do not.
+      metering_mode: settings.meteringMode,
+      months: {
+        current: serializeUsage(thisMonth),
+        previous: serializeUsage(lastMonth),
+      },
+      plan: {
+        code: plan.plan.code,
+        margin_basis_points: plan.plan.marginBasisPoints,
+        name: plan.plan.name,
+        price_micros: plan.plan.priceMicros.toString(),
+        subscribed: plan.subscribed,
+      },
+      plans: plans
+        .filter((entry) => entry.public)
+        .map((entry) => ({
+          code: entry.code,
+          description: entry.description,
+          entitlements: entry.entitlements,
+          margin_basis_points: entry.marginBasisPoints,
+          name: entry.name,
+          period: entry.period,
+          price_micros: entry.priceMicros.toString(),
+        })),
+      turns: turns.map((turn) => ({
+        chat_id: turn.chatId,
+        list_cost_micros: turn.listCostMicros.toString(),
+        micros: turn.chargeableMicros.toString(),
+        model: turn.model,
+        occurred_at: turn.occurredAt.toISOString(),
+        own_key: turn.ownKey,
+        surface: turn.surface,
+      })),
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+function serializeUsage(usage: Awaited<ReturnType<typeof accountAiUsage>>) {
+  return {
+    micros: usage.chargeableMicros.toString(),
+    own_key_only: usage.ownKeyOnly,
+    surfaces: usage.buckets.map((bucket) => ({
+      credential_source: bucket.credentialSource,
+      list_cost_micros: bucket.listCostMicros.toString(),
+      micros: bucket.chargeableMicros.toString(),
+      surface: bucket.surface,
+      turns: bucket.turns,
+    })),
+    turns: usage.turns,
+  };
+}
+
+export async function PUT(request: NextRequest) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(request, "account:ai-toggle", {
+    limit: 30,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const body = await readJsonObject(request);
+  if (typeof body.enabled !== "boolean") {
+    return jsonError("invalid_request", 400, {
+      detail: "enabled must be true or false",
+    });
+  }
+
+  const enabled = body.enabled;
+  await db
+    .update(accounts)
+    // A timestamp rather than a boolean: "since when" is worth having for
+    // free, and null is the only state that means "on".
+    .set({ aiDisabledAt: enabled ? null : new Date() })
+    .where(eq(accounts.id, session.accountId));
+
+  await recordAuditEvent(db, {
+    accountId: session.accountId,
+    actor: { accountId: session.accountId, kind: "account" },
+    eventType: enabled ? "account.ai_enabled" : "account.ai_disabled",
+    target: { accountId: session.accountId, kind: "account" },
+  });
+
+  return NextResponse.json({ enabled }, { headers: { "cache-control": "no-store" } });
+}

--- a/cloud/apps/auth-web/app/api/account/plan/route.ts
+++ b/cloud/apps/auth-web/app/api/account/plan/route.ts
@@ -1,0 +1,150 @@
+import {
+  cancelAccountPlan,
+  listPlans,
+  readAccountPlan,
+  setAccountPlan,
+} from "@frameos-cloud/ledger";
+import { NextRequest, NextResponse } from "next/server";
+import { recordAuditEvent } from "../../../../src/lib/audit";
+import { csrfResponse } from "../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../src/lib/rate-limit";
+import { readSession } from "../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+// Which plan an account is on (cloud/docs/accounting-todo.md §0.1, Phase 5).
+//
+// Self-service plan changes are gated behind FRAMEOS_CLOUD_PLANS_SELF_SERVE
+// and default OFF, on purpose. Subscribing accrues a real receivable
+// (§3.6's charge entry), and Phase 3b — the payment provider, the stored
+// payment method, the month-end invoice — does not exist yet. Letting
+// somebody subscribe today would run up a balance with no way to settle it,
+// which is a worse failure than not offering the button: the ledger would be
+// right and the customer would be stuck.
+//
+// Everything underneath is finished and tested, so switching this on is a
+// deployment decision rather than a build. Until then an operator moves
+// accounts by hand and the page shows the ladder without a buy button.
+function selfServeEnabled(env: Record<string, string | undefined> = process.env) {
+  const raw = (env.FRAMEOS_CLOUD_PLANS_SELF_SERVE ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+export async function GET(request: NextRequest) {
+  const limited = await rateLimitResponse(request, "account:plan", {
+    limit: 120,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const [current, plans] = await Promise.all([
+    readAccountPlan(db, session.accountId),
+    listPlans(db),
+  ]);
+  return NextResponse.json(
+    {
+      cancel_at: current.cancelAt?.toISOString() ?? null,
+      plan: {
+        code: current.plan.code,
+        margin_basis_points: current.plan.marginBasisPoints,
+        name: current.plan.name,
+        price_micros: current.plan.priceMicros.toString(),
+      },
+      plans: plans
+        .filter((plan) => plan.public)
+        .map((plan) => ({
+          code: plan.code,
+          description: plan.description,
+          entitlements: plan.entitlements,
+          margin_basis_points: plan.marginBasisPoints,
+          name: plan.name,
+          period: plan.period,
+          price_micros: plan.priceMicros.toString(),
+        })),
+      self_serve: selfServeEnabled(),
+      status: current.status,
+      subscribed: current.subscribed,
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+export async function PUT(request: NextRequest) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(request, "account:plan-change", {
+    limit: 20,
+    windowMs: 60 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const session = await readSession();
+  if (!session?.accountId) {
+    return jsonError("login_required", 401);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+  const body = await readJsonObject(request);
+  const code = typeof body.plan === "string" ? body.plan.trim() : "";
+  if (!code) {
+    return jsonError("invalid_request", 400, { detail: "plan is required" });
+  }
+
+  const plans = await listPlans(db);
+  const target = plans.find((plan) => plan.code === code);
+  if (!target || !target.public) {
+    return jsonError("unknown_plan", 404);
+  }
+  // Downgrading to the free plan is always allowed — refusing to let somebody
+  // stop paying us would be an unpleasant thing to build. Only taking on a
+  // charge is gated.
+  if (!selfServeEnabled() && target.priceMicros > 0n) {
+    return jsonError("plans_not_available", 503, {
+      detail:
+        "Paid plans are not open yet. Nothing is charged for AI while FrameOS Cloud AI is in preview.",
+    });
+  }
+
+  if (target.priceMicros === 0n) {
+    await cancelAccountPlan(db, session.accountId);
+  } else {
+    await setAccountPlan(db, session.accountId, target.code);
+  }
+  await recordAuditEvent(db, {
+    accountId: session.accountId,
+    actor: { accountId: session.accountId, kind: "account" },
+    eventType:
+      target.priceMicros === 0n ? "account.plan_canceled" : "account.plan_changed",
+    metadata: { plan: target.code },
+    target: { accountId: session.accountId, kind: "account" },
+  });
+
+  const current = await readAccountPlan(db, session.accountId);
+  return NextResponse.json(
+    {
+      cancel_at: current.cancelAt?.toISOString() ?? null,
+      plan: { code: current.plan.code, name: current.plan.name },
+      subscribed: current.subscribed,
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
@@ -39,7 +39,7 @@ import {
   writeSceneVersion,
 } from "../../../../../../src/lib/store-version-write";
 import {
-  maxPrivateSceneBytesPerAccount,
+  accountLimits,
   privateSceneBytesForAccount,
 } from "../../../../../../src/lib/usage";
 
@@ -278,10 +278,13 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const newImageBytes = images
       .filter((image) => !previousShas.has(image.sha256))
       .reduce((sum, image) => sum + image.sizeBytes, 0);
-    const privateBytes = await privateSceneBytesForAccount(db, session.accountId!);
-    if (privateBytes + content.length + newImageBytes > maxPrivateSceneBytesPerAccount) {
+    const [privateBytes, { privateSceneBytes: maxBytes }] = await Promise.all([
+      privateSceneBytesForAccount(db, session.accountId!),
+      accountLimits(db, session.accountId!),
+    ]);
+    if (privateBytes + content.length + newImageBytes > maxBytes) {
       return jsonError("storage_quota_exceeded", 403, {
-        max_bytes: maxPrivateSceneBytesPerAccount,
+        max_bytes: maxBytes,
         private_bytes: Math.round(privateBytes),
       });
     }

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/images/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/images/route.ts
@@ -11,7 +11,7 @@ import {
 import { registerStoreImage } from "../../../../../../src/lib/store-images";
 import { loadOwnedScene } from "../../../../../../src/lib/store-owner";
 import {
-  maxPrivateSceneBytesPerAccount,
+  accountLimits,
   privateSceneBytesForAccount,
 } from "../../../../../../src/lib/usage";
 
@@ -63,10 +63,13 @@ export async function POST(request: NextRequest, context: RouteContext) {
   // links them; refusing here rather than at Save keeps the draft honest.
   // Public scenes are free (usage.ts).
   if (scene.visibility !== "public") {
-    const privateBytes = await privateSceneBytesForAccount(db, session.accountId!);
-    if (privateBytes + content.length > maxPrivateSceneBytesPerAccount) {
+    const [privateBytes, { privateSceneBytes: maxBytes }] = await Promise.all([
+      privateSceneBytesForAccount(db, session.accountId!),
+      accountLimits(db, session.accountId!),
+    ]);
+    if (privateBytes + content.length > maxBytes) {
       return jsonError("storage_quota_exceeded", 403, {
-        max_bytes: maxPrivateSceneBytesPerAccount,
+        max_bytes: maxBytes,
         private_bytes: Math.round(privateBytes),
       });
     }

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/route.ts
@@ -24,7 +24,7 @@ import { imageSetForVersion } from "../../../../../src/lib/store-images";
 import { sceneSummary, sceneVisibilities } from "../../../../../src/lib/store";
 import { loadOwnedScene } from "../../../../../src/lib/store-owner";
 import {
-  maxPrivateSceneBytesPerAccount,
+  accountLimits,
   privateSceneBytesForAccount,
   sceneBytesTotal,
 } from "../../../../../src/lib/usage";
@@ -202,9 +202,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       privateSceneBytesForAccount(db, session.accountId!),
       sceneBytesTotal(db, scene.id),
     ]);
-    if (privateBytes + flippedBytes > maxPrivateSceneBytesPerAccount) {
+    const { privateSceneBytes: maxBytes } = await accountLimits(
+      db,
+      session.accountId!,
+    );
+    if (privateBytes + flippedBytes > maxBytes) {
       return jsonError("storage_quota_exceeded", 403, {
-        max_bytes: maxPrivateSceneBytesPerAccount,
+        max_bytes: maxBytes,
         private_bytes: Math.round(privateBytes),
         scene_bytes: Math.round(flippedBytes),
       });

--- a/cloud/apps/auth-web/app/api/account/usage/route.ts
+++ b/cloud/apps/auth-web/app/api/account/usage/route.ts
@@ -57,21 +57,21 @@ export async function GET(request: NextRequest) {
     return response;
   }
   const [[account], usage] = await Promise.all([
-    db
-      .select({
-        createdAt: accounts.createdAt,
-        displayName: accounts.displayName,
-        id: accounts.id,
-        isSuperadmin: accounts.isSuperadmin,
-        primaryEmail: accounts.primaryEmail,
-        storeBannedAt: accounts.storeBannedAt,
-        verifiedPublisherAt: accounts.verifiedPublisherAt,
-      })
-      .from(accounts)
-      .where(eq(accounts.id, session.accountId))
-      .limit(1),
-    accountUsage(db, session.accountId),
-  ]);
+      db
+        .select({
+          createdAt: accounts.createdAt,
+          displayName: accounts.displayName,
+          id: accounts.id,
+          isSuperadmin: accounts.isSuperadmin,
+          primaryEmail: accounts.primaryEmail,
+          storeBannedAt: accounts.storeBannedAt,
+          verifiedPublisherAt: accounts.verifiedPublisherAt,
+        })
+        .from(accounts)
+        .where(eq(accounts.id, session.accountId))
+        .limit(1),
+      accountUsage(db, session.accountId),
+    ]);
   if (!account) {
     return jsonError("login_required", 401);
   }

--- a/cloud/apps/auth-web/app/api/admin/billing/nightly/route.ts
+++ b/cloud/apps/auth-web/app/api/admin/billing/nightly/route.ts
@@ -2,6 +2,7 @@ import {
   checkLedgerIntegrity,
   dailySummary,
   readBillingSettings,
+  runSubscriptionCycle,
   sweepUnpostedUsage,
 } from "@frameos-cloud/ledger";
 import { NextRequest, NextResponse } from "next/server";
@@ -30,13 +31,21 @@ export const maxDuration = 300;
 // scripts/accounting-nightly.sh, which curls this with a superadmin API
 // token — an existing auth mechanism rather than a new shared secret.
 //
-// Two things happen, in order:
+// Three things happen, in order:
 //   1. Sweep the usage records whose ledger entries never landed. Idempotent
 //      by turn id, so a night that already posted is a no-op.
-//   2. Run every invariant and report each violation. A violation is an
+//   2. Run the subscription cycle: open the periods that are due, charge the
+//      ones that have started, recognize the ones that have ended. Idempotent
+//      on each period row, so a night that runs twice charges nobody twice
+//      and a night that never ran is caught up rather than skipped.
+//   3. Run every invariant and report each violation. A violation is an
 //      alert, not a failure to fix automatically: books that disagree with
 //      themselves need a human, and quietly "correcting" them is how a
 //      discrepancy becomes undiscoverable.
+//
+// The order matters for step 3: it must see the books AFTER everything that
+// was going to be written tonight has been, or it reports a disagreement it
+// caused itself.
 export async function POST(request: NextRequest) {
   const csrf = csrfResponse(request);
   if (csrf) {
@@ -68,7 +77,15 @@ export async function POST(request: NextRequest) {
     reportError("billing.sweep_failed", failure.error, { turnId: failure.turnId });
   }
 
+  const subscriptionCycle = await runSubscriptionCycle(db);
+  for (const failure of subscriptionCycle.failures) {
+    reportError("billing.subscription_cycle_failed", failure.error, {
+      periodId: failure.periodId,
+    });
+  }
+
   const violations = await checkLedgerIntegrity(db, {
+    dailyCapMicros: settings.dailyCapMicros,
     overdraftMicros: settings.overdraftMicros,
   });
   for (const violation of violations) {
@@ -91,11 +108,16 @@ export async function POST(request: NextRequest) {
     cogsMicros: summary.cogsMicros.toString(),
     contraRevenueMicros: summary.contraRevenueMicros.toString(),
     customerLiabilityMicros: summary.customerLiabilityMicros.toString(),
+    customerReceivableMicros: summary.customerReceivableMicros.toString(),
     durationMs: Date.now() - startedAt,
     marginMicros: summary.marginMicros.toString(),
     meteringMode: settings.meteringMode,
     netRevenueMicros: summary.netRevenueMicros.toString(),
     revenueMicros: summary.revenueMicros.toString(),
+    subscriptionsCharged: subscriptionCycle.charged,
+    subscriptionsFailed: subscriptionCycle.failures.length,
+    subscriptionsOpened: subscriptionCycle.opened,
+    subscriptionsRecognized: subscriptionCycle.recognized,
     sweepFailed: sweep.failures.length,
     sweepPosted: sweep.posted,
     violations: violations.length,
@@ -103,16 +125,26 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({
     metering_mode: settings.meteringMode,
-    ok: violations.length === 0 && sweep.failures.length === 0,
+    ok:
+      violations.length === 0 &&
+      sweep.failures.length === 0 &&
+      subscriptionCycle.failures.length === 0,
     summary: {
       cogs_micros: summary.cogsMicros.toString(),
       contra_revenue_micros: summary.contraRevenueMicros.toString(),
       customer_liability_micros: summary.customerLiabilityMicros.toString(),
+      customer_receivable_micros: summary.customerReceivableMicros.toString(),
       margin_micros: summary.marginMicros.toString(),
       net_revenue_micros: summary.netRevenueMicros.toString(),
       revenue_micros: summary.revenueMicros.toString(),
       since: since.toISOString(),
       until: until.toISOString(),
+    },
+    subscriptions: {
+      charged: subscriptionCycle.charged,
+      failed: subscriptionCycle.failures.length,
+      opened: subscriptionCycle.opened,
+      recognized: subscriptionCycle.recognized,
     },
     sweep: {
       failed: sweep.failures.length,

--- a/cloud/apps/auth-web/app/api/ai/apps/chat/route.ts
+++ b/cloud/apps/auth-web/app/api/ai/apps/chat/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { resolveAiCredentials } from "../../../../../src/lib/ai/api-key";
+import { aiRefusalResponse } from "../../../../../src/lib/ai/access";
+import { resolveAiAccess } from "../../../../../src/lib/ai/api-key";
 import {
   readAppSources,
   runAppChat,
@@ -76,12 +77,11 @@ export async function POST(request: NextRequest) {
   // key wins, the operator's shared key stands in where the deployment
   // allows it, and the answer says which — so the turn can be metered
   // against whoever actually paid for it.
-  const credentials = await resolveAiCredentials(db, accountId);
-  if (!credentials) {
-    return jsonError("missing_api_key", 400, {
-      detail: "OpenAI backend API key not set",
-    });
+  const access = await resolveAiAccess(db, accountId, { surface: "app_chat" });
+  if (!access.ok) {
+    return aiRefusalResponse(access.refusal);
   }
+  const credentials = access.credentials;
 
   // A frame id the account does not own is dropped rather than refused: the
   // chat is about the app's code, and the frame is only how the panel groups

--- a/cloud/apps/auth-web/app/api/ai/chat/route.ts
+++ b/cloud/apps/auth-web/app/api/ai/chat/route.ts
@@ -11,7 +11,8 @@ import {
   ensureChat,
   historyForModel,
 } from "../../../../src/lib/ai/chat-store";
-import { resolveAiCredentials } from "../../../../src/lib/ai/api-key";
+import { aiRefusalResponse } from "../../../../src/lib/ai/access";
+import { resolveAiAccess } from "../../../../src/lib/ai/api-key";
 import { meterAiUsageInBackground } from "../../../../src/lib/billing";
 import { buildInitialInput, runAgentLoop } from "../../../../src/lib/ai/loop";
 import { formatAiException, type JsonObject } from "../../../../src/lib/ai/scene-utils";
@@ -229,13 +230,15 @@ export async function POST(request: NextRequest) {
     return jsonError("invalid_prompt", 400, { detail: "Prompt is required" });
   }
 
-  const credentials = await resolveAiCredentials(db, accountId);
-  if (!credentials) {
-    return jsonError("missing_api_key", 400, {
-      detail: "OpenAI backend API key not set",
-    });
+  // The one gate: the AI switch, the key, and the daily cap, in that order
+  // (§5.1/§5.3). Every AI surface goes through it, which is what makes
+  // "does the cap apply here?" a question with one answer.
+  const access = await resolveAiAccess(db, accountId, { surface: "scene_chat" });
+  if (!access.ok) {
+    return aiRefusalResponse(access.refusal);
   }
-  const { apiKey, model, reasoningEffort, source: credentialSource } = credentials;
+  const { apiKey, model, reasoningEffort, source: credentialSource } =
+    access.credentials;
 
   const requestedChatId = stringOrNull(body.chatId) ?? crypto.randomUUID();
   const scenePayload = objectOrNull(body.scene);

--- a/cloud/apps/auth-web/app/api/backends/backups/route.ts
+++ b/cloud/apps/auth-web/app/api/backends/backups/route.ts
@@ -23,7 +23,7 @@ import {
   requireDatabase,
 } from "../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../src/lib/rate-limit";
-import { maxBackupBytesPerAccount } from "../../../../src/lib/usage";
+import { accountLimits } from "../../../../src/lib/usage";
 
 export const runtime = "nodejs";
 
@@ -170,9 +170,16 @@ export async function POST(request: NextRequest) {
   }
   const bytesAfterSave =
     accountBytes - (existing?.sizeBytes ?? 0) + content.length;
-  if (bytesAfterSave > maxBackupBytesPerAccount) {
+  // The plan's account budget, not the free tier's: the number that refuses
+  // has to be the number the account page promises (src/lib/usage.ts).
+  // Distinct from `maxBackupBytes` above, which caps ONE backup.
+  const { backupBytes: maxAccountBackupBytes } = await accountLimits(
+    db,
+    linkedClient.accountId,
+  );
+  if (bytesAfterSave > maxAccountBackupBytes) {
     return jsonError("backup_storage_quota_exceeded", 403, {
-      max_bytes: maxBackupBytesPerAccount,
+      max_bytes: maxAccountBackupBytes,
       used_bytes: Math.round(accountBytes),
     });
   }

--- a/cloud/apps/auth-web/app/api/scenes/convert/route.ts
+++ b/cloud/apps/auth-web/app/api/scenes/convert/route.ts
@@ -118,6 +118,11 @@ export async function POST(request: NextRequest) {
       distinctId = session.accountId;
       accountId = session.accountId;
       if (!apiKey && hasDatabaseUrl()) {
+        // Deliberately `resolveAiCredentials` and not the `resolveAiAccess`
+        // gate the chat routes use (§5.1/§5.3): conversion is an absorbed
+        // surface, so it is billed to nobody, capped for nobody, and works
+        // without an account at all. Neither the daily cap nor the AI switch
+        // may turn a free migration tool we asked people to run into a 402.
         const credentials = await resolveAiCredentials(createDb(), session.accountId);
         if (credentials?.source === "account") {
           apiKey = credentials.apiKey;

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -359,6 +359,26 @@ html.theme-dark .button-primary {
   display: contents;
 }
 
+/* The AI usage row is a link, not a meter: the only number it could fill a
+   bar against today is the daily cap, and a bar that empties every midnight
+   says nothing useful. See cloud/docs/accounting-todo.md §5.2. */
+.storage-usage__link {
+  display: contents;
+  color: inherit;
+  text-decoration: none;
+}
+
+.storage-usage__link:hover .storage-usage__value,
+.storage-usage__link:focus-visible .storage-usage__value {
+  color: var(--primary);
+  text-decoration: underline;
+}
+
+.storage-usage__note {
+  color: var(--muted);
+  font-size: 11px;
+}
+
 .compact-header {
   align-items: center;
   margin-bottom: 0;

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -3758,12 +3758,21 @@ html.theme-dark .ai-panel__render {
   --card-ink: #155e4e;
 }
 
+.action-card--slate {
+  --card-tint: #4a5b78;
+  --card-ink: #35435c;
+}
+
 html.theme-dark .action-card--gold {
   --card-ink: #e2c468;
 }
 
 html.theme-dark .action-card--teal {
   --card-ink: #6fbfa9;
+}
+
+html.theme-dark .action-card--slate {
+  --card-ink: #9fb2d1;
 }
 
 html.theme-dark .action-card {

--- a/cloud/apps/auth-web/app/my-scenes/new/page.tsx
+++ b/cloud/apps/auth-web/app/my-scenes/new/page.tsx
@@ -1,10 +1,14 @@
+import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
+import { accounts, createDb } from "@frameos-cloud/db";
 import { NewSceneWithAi } from "../../../src/components/NewSceneWithAi";
 import {
+  getAccountUrl,
   getCloudBaseUrl,
   getFramesUrl,
   getMyScenesUrl,
   getScenesBaseUrl,
+  hasDatabaseUrl,
   myScenesPath,
 } from "../../../src/lib/env";
 import { convertedScenesHandoffKey } from "../../../src/lib/scene-handoff";
@@ -41,8 +45,23 @@ export default async function NewScenePage({
     loginUrl.searchParams.set("return_to", returnTo.toString());
     redirect(loginUrl.toString());
   }
+  // The AI switch, so the panel opens saying AI is off rather than accepting
+  // a prompt and refusing it a round trip later. Skipped for the converter's
+  // signed-out path, which has no account to ask about.
+  let aiDisabled = false;
+  if (session?.accountId && hasDatabaseUrl()) {
+    const [row] = await createDb()
+      .select({ aiDisabledAt: accounts.aiDisabledAt })
+      .from(accounts)
+      .where(eq(accounts.id, session.accountId))
+      .limit(1);
+    aiDisabled = Boolean(row?.aiDisabledAt);
+  }
+
   return (
     <NewSceneWithAi
+      aiDisabled={aiDisabled}
+      aiSettingsUrl={getAccountUrl("/account/ai")}
       handoffKey={fromConverter ? convertedScenesHandoffKey : undefined}
       initialPrompt={prompt}
       loginUrl={new URL("/login", getCloudBaseUrl()).toString()}

--- a/cloud/apps/auth-web/app/s/[slug]/page.tsx
+++ b/cloud/apps/auth-web/app/s/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { SceneMarkdown } from "../../../src/components/SceneMarkdown";
 import { SceneViewTracker } from "../../../src/components/SceneViewTracker";
 import {
   getAccountBaseUrl,
+  getAccountUrl,
   getCloudBaseUrl,
   getFramesUrl,
   getScenesBaseUrl,
@@ -179,13 +180,21 @@ export default async function ScenePage({
     session?.accountId && session.accountId === scene.accountId,
   );
   let isAdmin = false;
-  if (session?.accountId && !isOwner) {
+  // The AI switch (Account → AI usage). Read here so the panel can say AI is
+  // off BEFORE accepting a prompt: the gate would refuse the turn anyway, but
+  // discovering that after typing and waiting is a bad way to learn it.
+  let aiDisabled = false;
+  if (session?.accountId) {
     const [row] = await db
-      .select({ isSuperadmin: accounts.isSuperadmin })
+      .select({
+        aiDisabledAt: accounts.aiDisabledAt,
+        isSuperadmin: accounts.isSuperadmin,
+      })
       .from(accounts)
       .where(eq(accounts.id, session.accountId))
       .limit(1);
-    isAdmin = row?.isSuperadmin ?? false;
+    aiDisabled = Boolean(row?.aiDisabledAt);
+    isAdmin = isOwner ? false : (row?.isSuperadmin ?? false);
   }
 
   // Private and pulled scenes exist only for their owner and moderators;
@@ -411,6 +420,8 @@ export default async function ScenePage({
       {/* The diagram is part of what a shared scene IS: everyone gets to
           look behind it. Only the owner can save a new version. */}
       <SceneEditorModal
+        aiDisabled={aiDisabled}
+        aiSettingsUrl={getAccountUrl("/account/ai")}
         backUrl={getStorePath()}
         canFork={Boolean(session?.accountId)}
         canPreview={scene.status !== "pulled"}

--- a/cloud/apps/auth-web/src/components/AccountNav.tsx
+++ b/cloud/apps/auth-web/src/components/AccountNav.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 // workspace and the private scene list is a tab of the scene store.
 const sections = [
   { href: "/account/installs", key: "installs", label: "Backends" },
+  { href: "/account/ai", key: "ai", label: "AI usage" },
   { href: "/account/backups", key: "backups", label: "Backups" },
   { href: "/account/activity", key: "activity", label: "Activity" },
   { href: "/account/security", key: "security", label: "Security" },

--- a/cloud/apps/auth-web/src/components/AiUsageSwitch.tsx
+++ b/cloud/apps/auth-web/src/components/AiUsageSwitch.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Power, Sparkles } from "lucide-react";
+
+// The AI opt-out (cloud/docs/accounting-todo.md §5.1). Explicit, per-account,
+// and reachable from the page somebody is already standing on when the "what
+// stops this from running up a bill?" thought occurs to them.
+//
+// It says what stops working before it stops it. A switch whose consequences
+// you discover afterwards is a trap, and this one is easy to throw by
+// accident from a page full of dollar figures.
+export function AiUsageSwitch({ enabled }: { enabled: boolean }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function toggle() {
+    if (
+      enabled &&
+      !window.confirm(
+        "Turn AI features off?\n\nScene chat and the app-code assistant will stop working for this account, and nothing you do can incur AI cost. You can turn them back on at any time.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError("");
+    const response = await fetch("/api/account/ai", {
+      body: JSON.stringify({ enabled: !enabled }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+    if (response.ok) {
+      router.refresh();
+    } else {
+      setError("That didn't work. Try again in a moment.");
+    }
+    setBusy(false);
+  }
+
+  return (
+    <div>
+      <button
+        className="button"
+        disabled={busy}
+        onClick={() => void toggle()}
+        type="button"
+      >
+        {enabled ? <Power aria-hidden size={16} /> : <Sparkles aria-hidden size={16} />}
+        {enabled ? "Turn AI features off" : "Turn AI features back on"}
+      </button>
+      <p className="copy" style={{ marginTop: 8 }}>
+        {enabled
+          ? "AI is on. Turning it off stops scene chat and the app-code assistant for this account, takes effect immediately, and guarantees no further AI cost."
+          : "AI is off for this account. Nothing you do can incur AI cost. Your scenes, frames and backups are unaffected."}
+      </p>
+      {error ? <p className="copy error">{error}</p> : null}
+    </div>
+  );
+}

--- a/cloud/apps/auth-web/src/components/NewSceneWithAi.tsx
+++ b/cloud/apps/auth-web/src/components/NewSceneWithAi.tsx
@@ -44,6 +44,10 @@ type NewSceneWithAiProps = {
   /** From ?prompt=…: submitted to the AI as soon as the page opens. */
   initialPrompt?: string | undefined;
   settingsUrl?: string | undefined;
+  /** The account switched AI features off; the panel says so up front. */
+  aiDisabled?: boolean | undefined;
+  /** Where to turn AI back on. */
+  aiSettingsUrl?: string | undefined;
   loginUrl?: string | undefined;
   /** Where "Back" goes. */
   myScenesUrl: string;
@@ -87,7 +91,15 @@ const createErrors: Record<string, string> = {
 // A full-page editor for a brand-new scene, AI panel open: start from one
 // blank scene, describe what you want, then "Save to my scenes" creates it
 // as a private scene and jumps to its page.
-export function NewSceneWithAi({ initialPrompt, settingsUrl, loginUrl, myScenesUrl, handoffKey }: NewSceneWithAiProps) {
+export function NewSceneWithAi({
+  aiDisabled = false,
+  aiSettingsUrl,
+  initialPrompt,
+  settingsUrl,
+  loginUrl,
+  myScenesUrl,
+  handoffKey,
+}: NewSceneWithAiProps) {
   // Scenes are minted on the client (crypto ids) after mount, so the server
   // render and the hydration pass agree.
   const [scenes, setScenes] = useState<SceneJson[] | null>(null);
@@ -485,6 +497,8 @@ export function NewSceneWithAi({ initialPrompt, settingsUrl, loginUrl, myScenesU
           },
           onScenes: applyAiEvent,
           onShowInPreview: showRenderInPreview,
+          aiDisabled,
+          ...(aiSettingsUrl ? { aiSettingsUrl } : {}),
           settingsUrl,
           signedIn: true,
         }}

--- a/cloud/apps/auth-web/src/components/SceneAiPanel.test.tsx
+++ b/cloud/apps/auth-web/src/components/SceneAiPanel.test.tsx
@@ -282,6 +282,35 @@ describe("SceneAiPanel", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // The switch is known before the first turn, so the panel must say so up
+  // front. Letting somebody type a prompt, wait for a round trip and only
+  // then learn AI is off is the failure this replaces.
+  it("says AI is off before a prompt can be sent, not after", () => {
+    renderPanel({
+      aiDisabled: true,
+      aiSettingsUrl: "https://cloud.example/account/ai",
+    });
+
+    expect(screen.getByText("AI features are switched off.")).toBeDefined();
+    const box = screen.getByLabelText("Message the AI") as HTMLTextAreaElement;
+    expect(box.disabled).toBe(true);
+    expect(box.placeholder).toBe("AI features are off for this account");
+    const link = screen.getByRole("link", {
+      name: "Turn AI back on",
+    }) as HTMLAnchorElement;
+    expect(link.href).toBe("https://cloud.example/account/ai");
+
+    // And nothing reaches the server even if a keystroke gets through.
+    sendPrompt("make it blue");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // An initial prompt is submitted on mount; with AI off it must not be.
+  it("does not auto-submit an initial prompt when AI is off", () => {
+    renderPanel({ aiDisabled: true, initialPrompt: "make it blue" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("submits the initial prompt on mount and shows suggestion chips otherwise", async () => {
     fetchMock.mockResolvedValueOnce(ndjson([{ reply: "Hi", tool: "reply", type: "done" }]));
     const { unmount } = renderPanel({ initialPrompt: "make it blue" });

--- a/cloud/apps/auth-web/src/components/SceneAiPanel.tsx
+++ b/cloud/apps/auth-web/src/components/SceneAiPanel.tsx
@@ -114,6 +114,12 @@ export type SceneAiPanelProps = {
    * ended up selecting, which the render check then targets. */
   onScenes: (event: AiScenesEvent) => void | string | null;
   signedIn: boolean;
+  /** The account switched AI features off (Account → AI usage). Known before
+   * the first turn, so the panel says so up front instead of accepting a
+   * prompt and refusing it after the round trip. */
+  aiDisabled?: boolean | undefined;
+  /** Where to go to turn AI back on. */
+  aiSettingsUrl?: string | undefined;
   /** Submitted as the first turn as soon as the panel mounts (signed in), or
    * pre-filled into the prompt box (signed out). */
   initialPrompt?: string | undefined;
@@ -391,6 +397,8 @@ function ToolActivity({ tools, streaming }: { tools: ToolLine[]; streaming: bool
 // tool activity, and the scenes the agent delivers, applied to the editor
 // through onScenes. State stays in React — this app doesn't use kea.
 export function SceneAiPanel({
+  aiDisabled = false,
+  aiSettingsUrl,
   storeSceneId,
   getScenes,
   selectedSceneId,
@@ -496,7 +504,7 @@ export function SceneAiPanel({
   const submit = useCallback(
     async (rawPrompt: string, round = 0): Promise<void> => {
       const prompt = rawPrompt.trim();
-      if (!prompt || busyRef.current || !signedIn) {
+      if (!prompt || busyRef.current || !signedIn || aiDisabled) {
         return;
       }
       busyRef.current = true;
@@ -760,7 +768,7 @@ export function SceneAiPanel({
       busyRef.current = false;
       setBusy(false);
     },
-    [signedIn, updateMessage],
+    [aiDisabled, signedIn, updateMessage],
   );
 
   // The entry points hand over a prompt (?ai=… / ?prompt=…): send it right
@@ -814,8 +822,13 @@ export function SceneAiPanel({
 
   const chips = suggestions ?? (mode === "new" ? newSceneSuggestions : existingSceneSuggestions);
   const signInHref = `${loginUrl}${loginUrl.includes("?") ? "&" : "?"}return_to=${encodeURIComponent(returnTo || "/")}`;
-  const placeholder =
-    mode === "new"
+  // A composer you can type into and send, that then always fails, is worse
+  // than one that is plainly closed. Both the switch and the sign-in gate are
+  // known before the first turn, so neither should be discovered by failing.
+  const composerBlocked = !signedIn || aiDisabled;
+  const placeholder = aiDisabled
+    ? "AI features are off for this account"
+    : mode === "new"
       ? "Describe the scene, e.g. “A clock with the date underneath, big white text on dark green”"
       : "Ask for a change, e.g. “make the title text bigger”";
 
@@ -827,6 +840,24 @@ export function SceneAiPanel({
       </header>
 
       <div className="ai-panel__transcript" ref={transcriptRef}>
+        {signedIn && aiDisabled ? (
+          <div className="notice ai-panel__notice">
+            <strong className="ai-panel__notice-title">
+              <Sparkles aria-hidden size={14} />
+              AI features are switched off.
+            </strong>
+            <p className="copy">
+              You turned AI off for this account, so nothing here can run — and
+              nothing can cost you anything.
+            </p>
+            {aiSettingsUrl ? (
+              <a className="button button--small" href={aiSettingsUrl}>
+                Turn AI back on
+              </a>
+            ) : null}
+          </div>
+        ) : null}
+
         {!signedIn ? (
           <div className="notice ai-panel__notice">
             <strong>Sign in to use the AI.</strong>
@@ -988,7 +1019,7 @@ export function SceneAiPanel({
         <textarea
           aria-label="Message the AI"
           className="ai-panel__input"
-          disabled={!signedIn}
+          disabled={composerBlocked}
           onChange={(event) => setInput(event.target.value)}
           onKeyDown={onKeyDown}
           placeholder={placeholder}
@@ -1006,7 +1037,7 @@ export function SceneAiPanel({
           ) : (
             <button
               className="button button--small button-primary"
-              disabled={!signedIn || !input.trim()}
+              disabled={composerBlocked || !input.trim()}
               type="submit"
             >
               <Send aria-hidden size={14} />

--- a/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
+++ b/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
@@ -93,6 +93,11 @@ type SceneEditorModalProps = {
   /** Whether the Preview panel is on offer; pulled scenes don't get one. */
   canPreview?: boolean;
   signedIn?: boolean;
+  /** The account switched AI features off; the panel says so before the first
+   * turn rather than after it fails. */
+  aiDisabled?: boolean;
+  /** Where to turn AI back on (the account's AI usage page). */
+  aiSettingsUrl?: string;
   /** Share token for private scenes, so shared visitors can load scenes.json. */
   share?: string | undefined;
   /** The store zip of the scene as the page shows it (its "Download zip"
@@ -1329,6 +1334,8 @@ export function SceneEditorModal({
   canRemix = true,
   canPreview = true,
   signedIn = canFork,
+  aiDisabled = false,
+  aiSettingsUrl,
   share,
   downloadUrl,
   settingsUrl,
@@ -2149,6 +2156,8 @@ export function SceneEditorModal({
           ) : undefined
         }
         ai={{
+          aiDisabled,
+          ...(aiSettingsUrl ? { aiSettingsUrl } : {}),
           getListing: () => listingRef.current,
           getScenes: () => latestScenesRef.current,
           initialPrompt,

--- a/cloud/apps/auth-web/src/components/StorageUsageMeters.tsx
+++ b/cloud/apps/auth-web/src/components/StorageUsageMeters.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { formatBytes } from "../lib/format";
 import type { AccountUsage } from "../lib/usage";
 
@@ -38,7 +39,40 @@ function meterFill(bucket: MeterBucket) {
   };
 }
 
-export function StorageUsageMeters({ usage }: { usage: AccountUsage }) {
+// The AI row's words. Four zero states, and each one means something
+// different: nothing used yet, the switch is off (§5.1), every turn ran on
+// the account's own OpenAI key (they owe us nothing, and a bill-shaped zero
+// would be a lie rather than a number), and — while metering is in shadow
+// mode — a real figure that is nevertheless not being charged. See
+// cloud/docs/accounting-todo.md §5.2.
+function aiUsageValue(ai: AccountUsage["ai"]): { note?: string; value: string } {
+  if (!ai.enabled) {
+    return { value: "off" };
+  }
+  const micros = BigInt(ai.month_micros);
+  if (micros === 0n) {
+    return ai.own_key_only
+      ? { value: "on your own key" }
+      : { value: "$0.00 this month" };
+  }
+  const value = `${formatDollars(micros)} this month`;
+  return ai.metering_mode === "live" ? { value } : { note: "not billed yet", value };
+}
+
+// Micro-dollars to a displayed amount, rounding UP to the cent: a tenth of a
+// cent of usage should read as $0.01, not as nothing at all.
+function formatDollars(micros: bigint): string {
+  const cents = (micros + 9_999n) / 10_000n;
+  return `$${(cents / 100n).toString()}.${(cents % 100n).toString().padStart(2, "0")}`;
+}
+
+export function StorageUsageMeters({
+  aiHref = "/account/ai",
+  usage,
+}: {
+  aiHref?: string;
+  usage: AccountUsage;
+}) {
   const totalBytes =
     usage.scenes.private_bytes +
     usage.scenes.public_bytes +
@@ -92,6 +126,13 @@ export function StorageUsageMeters({ usage }: { usage: AccountUsage }) {
           </div>
         );
       })}
+      {/* AI usage: a label and a figure, no meter, linking to the page that
+          breaks it down and holds the off switch. */}
+      <Link className="storage-usage__link" href={aiHref}>
+        <span className="storage-usage__label">AI usage</span>
+        <span className="storage-usage__note">{aiUsageValue(usage.ai).note ?? ""}</span>
+        <span className="storage-usage__value">{aiUsageValue(usage.ai).value}</span>
+      </Link>
       {usage.scenes.public_bytes > 0 ? (
         <div className="storage-usage__row" title="Published public scenes don't count against any quota">
           <span className="storage-usage__label">Public scenes</span>

--- a/cloud/apps/auth-web/src/components/StorageUsageMeters.tsx
+++ b/cloud/apps/auth-web/src/components/StorageUsageMeters.tsx
@@ -56,7 +56,11 @@ function aiUsageValue(ai: AccountUsage["ai"]): { note?: string; value: string } 
       : { value: "$0.00 this month" };
   }
   const value = `${formatDollars(micros)} this month`;
-  return ai.metering_mode === "live" ? { value } : { note: "not billed yet", value };
+  // "Billed" needs both: metering actually posting, and something in the
+  // month that is billable to them. A month spent entirely on the operator's
+  // shared key owes nothing, and a bare dollar figure would imply otherwise.
+  const billed = ai.metering_mode === "live" && BigInt(ai.billable_micros) > 0n;
+  return billed ? { value } : { note: "not billed", value };
 }
 
 // Micro-dollars to a displayed amount, rounding UP to the cent: a tenth of a

--- a/cloud/apps/auth-web/src/components/StoreActionCards.tsx
+++ b/cloud/apps/auth-web/src/components/StoreActionCards.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { Sparkles, Upload } from "lucide-react";
+import { FilePlus2, Sparkles, Upload } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { CreateSceneWithAiBox } from "./CreateSceneWithAiBox";
 import { SceneZipUpload } from "./SceneZipUpload";
 
 type ActionKey = "ai" | "zip";
 
-// The two ways to get a new scene into your account, as the card buttons
+// The three ways to get a new scene into your account, as the card buttons
 // frameos.net uses for its setup choices: a tinted gradient with a grain
 // overlay, a soft glow, the icon ghosted large in the corner and again as
 // a small badge. Pressing a card opens its form right below the row;
@@ -40,6 +40,20 @@ export function StoreActionCards({
           testId="action-card-ai"
           tint="gold"
           title="Create a scene with AI"
+        />
+        {/* Straight into the editor with one empty scene. Same destination as
+            the AI card, minus the prompt — /my-scenes/new starts blank when
+            nothing is passed, and bounces through login on its own if there
+            is no session yet. */}
+        <ActionCard
+          description="Start from an empty scene and build it yourself in the editor. The AI panel is there if you want it later."
+          href={aiAction}
+          icon={<FilePlus2 aria-hidden />}
+          onClick={() => undefined}
+          pressed={false}
+          testId="action-card-blank"
+          tint="slate"
+          title="New blank scene"
         />
         {showUpload ? (
           <ActionCard
@@ -85,7 +99,7 @@ function ActionCard({
   onClick: () => void;
   pressed: boolean;
   testId: string;
-  tint: "gold" | "teal";
+  tint: "gold" | "slate" | "teal";
   title: string;
 }) {
   const className = `action-card action-card--${tint}`;

--- a/cloud/apps/auth-web/src/lib/ai/access.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/access.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { aiRefusalResponse } from "./access";
+import type { AiRefusal } from "./api-key";
+
+async function body(response: Response) {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+// Three refusals that used to collapse into one `missing_api_key`, and the
+// whole point of splitting them is that each needs a different next action
+// from the person who hit it (cloud/docs/accounting-todo.md §5.1, §5.3).
+describe("AI refusal responses", () => {
+  it("reports a switched-off account as forbidden, not as a missing key", async () => {
+    const response = aiRefusalResponse({
+      detail: "AI features are switched off for this account.",
+      reason: "ai_disabled",
+    });
+    expect(response.status).toBe(403);
+    expect(await body(response)).toMatchObject({ error: "ai_disabled" });
+  });
+
+  // 402 and not 429: this is a spending limit, not a rate limit, and the
+  // body carries everything a panel needs to say when it comes back.
+  it("reports the daily cap with the numbers behind it", async () => {
+    const refusal: AiRefusal = {
+      capMicros: "10000000",
+      detail: "This account has reached its daily AI limit.",
+      reason: "daily_cap_reached",
+      resetAt: "2026-09-02T00:00:00.000Z",
+      spentMicros: "10500000",
+    };
+    const response = aiRefusalResponse(refusal);
+    expect(response.status).toBe(402);
+    expect(await body(response)).toMatchObject({
+      cap_micros: "10000000",
+      error: "daily_cap_reached",
+      reset_at: "2026-09-02T00:00:00.000Z",
+      spent_micros: "10500000",
+    });
+  });
+
+  it("still reports a genuinely missing key the way it always did", async () => {
+    const response = aiRefusalResponse({
+      detail: "OpenAI backend API key not set",
+      reason: "missing_api_key",
+    });
+    expect(response.status).toBe(400);
+    expect(await body(response)).toMatchObject({ error: "missing_api_key" });
+  });
+});

--- a/cloud/apps/auth-web/src/lib/ai/access.ts
+++ b/cloud/apps/auth-web/src/lib/ai/access.ts
@@ -1,0 +1,26 @@
+import { jsonError } from "../device-flow";
+import type { AiRefusal } from "./api-key";
+
+// The HTTP half of the AI access gate (cloud/docs/accounting-todo.md §5.1,
+// §5.3). Kept apart from api-key.ts so that module stays free of Next types
+// and can be called from a script or a test without a request in hand.
+
+// One refusal, three meanings, three status codes: a switch the user threw
+// (403 — nothing is broken, they asked for this), a cap they will be under
+// again tomorrow (402 — the payment-shaped one), and no key at all (400 —
+// the original meaning of a null credential). Collapsing them is how a user
+// ends up guessing which of three unrelated things went wrong.
+export function aiRefusalResponse(refusal: AiRefusal) {
+  if (refusal.reason === "ai_disabled") {
+    return jsonError("ai_disabled", 403, { detail: refusal.detail });
+  }
+  if (refusal.reason === "daily_cap_reached") {
+    return jsonError("daily_cap_reached", 402, {
+      cap_micros: refusal.capMicros,
+      detail: refusal.detail,
+      reset_at: refusal.resetAt,
+      spent_micros: refusal.spentMicros,
+    });
+  }
+  return jsonError("missing_api_key", 400, { detail: refusal.detail });
+}

--- a/cloud/apps/auth-web/src/lib/ai/api-key.ts
+++ b/cloud/apps/auth-web/src/lib/ai/api-key.ts
@@ -9,6 +9,12 @@
 // env key already pays for store moderation/classification, so nothing new
 // is provisioned; this only widens who it serves.
 import { eq } from "drizzle-orm";
+import {
+  accountAiSpendMicros,
+  readBillingSettings,
+  surfaceIsAbsorbed,
+  utcDayWindow,
+} from "@frameos-cloud/ledger";
 import { accounts, accountSettings, type createDb } from "@frameos-cloud/db";
 import { resolveChatModel, resolveReasoningEffort } from "./openai";
 
@@ -18,6 +24,22 @@ export type AiCredentials = {
   reasoningEffort: string;
   source: "account" | "shared";
 };
+
+// Why a turn was refused. Three different situations that used to collapse
+// into one null, and telling a user who switched AI off that they should go
+// set an API key is exactly the dead end the switch exists to avoid
+// (cloud/docs/accounting-todo.md §5.1).
+export type AiRefusal =
+  // The account turned AI off. Nothing is wrong; they asked for this.
+  | { detail: string; reason: "ai_disabled" }
+  // Today's spend is at the cap. Comes back tomorrow on its own.
+  | { detail: string; reason: "daily_cap_reached"; resetAt: string; capMicros: string; spentMicros: string }
+  // No key available to this account at all — the original meaning of null.
+  | { detail: string; reason: "missing_api_key" };
+
+export type AiAccess =
+  | { credentials: AiCredentials; ok: true }
+  | { ok: false; refusal: AiRefusal };
 
 type SharedAccess = "none" | "superadmin" | "verified" | "all";
 
@@ -40,6 +62,83 @@ export function sharedKeyAllowedFor(
     default:
       return false;
   }
+}
+
+/**
+ * The one door every AI surface goes through, and therefore the one place
+ * the AI switch and the daily cap can be enforced without relying on nobody
+ * forgetting them at a call site added next month.
+ *
+ * Order matters: the switch first (an account that opted out must not have
+ * its spend queried, let alone be told about a cap), then the key, then the
+ * cap — which only binds when the key is OURS, because a turn on the
+ * customer's own key costs us nothing and capping it would be gratuitous.
+ */
+export async function resolveAiAccess(
+  db: ReturnType<typeof createDb>,
+  accountId: string,
+  options: {
+    env?: Record<string, string | undefined> | undefined;
+    // The product surface, so an absorbed one (the legacy scene converter,
+    // which we pay for on purpose) is never turned into a 402 by a cap.
+    surface?: string | null | undefined;
+  } = {},
+): Promise<AiAccess> {
+  const env = options.env ?? process.env;
+  const [account] = await db
+    .select({ aiDisabledAt: accounts.aiDisabledAt })
+    .from(accounts)
+    .where(eq(accounts.id, accountId))
+    .limit(1);
+  if (account?.aiDisabledAt) {
+    return {
+      ok: false,
+      refusal: {
+        detail:
+          "AI features are switched off for this account. Turn them back on under Account → AI usage.",
+        reason: "ai_disabled",
+      },
+    };
+  }
+
+  const credentials = await resolveAiCredentials(db, accountId, env);
+  if (!credentials) {
+    return {
+      ok: false,
+      refusal: {
+        detail: "OpenAI backend API key not set",
+        reason: "missing_api_key",
+      },
+    };
+  }
+  // Their key, their bill: no cap, and no query to run.
+  if (credentials.source === "account" || surfaceIsAbsorbed(options.surface)) {
+    return { credentials, ok: true };
+  }
+
+  const settings = await readBillingSettings(db, env);
+  if (settings.dailyCapMicros > 0n) {
+    const window = utcDayWindow();
+    const spent = await accountAiSpendMicros(db, accountId, window);
+    // Checked before a turn, never during: a turn's cost is unknown until it
+    // ends, so the last turn of the day can cross the line. That accepted
+    // overshoot is what `payg_overdraft_micros` sizes, and it is why the cap
+    // is $10 rather than $10,000.
+    if (spent >= settings.dailyCapMicros + settings.overdraftMicros) {
+      return {
+        ok: false,
+        refusal: {
+          capMicros: settings.dailyCapMicros.toString(),
+          detail:
+            "This account has reached its daily AI limit. It resets at midnight UTC.",
+          reason: "daily_cap_reached",
+          resetAt: window.until.toISOString(),
+          spentMicros: spent.toString(),
+        },
+      };
+    }
+  }
+  return { credentials, ok: true };
 }
 
 export async function resolveAiCredentials(

--- a/cloud/apps/auth-web/src/lib/frames.ts
+++ b/cloud/apps/auth-web/src/lib/frames.ts
@@ -49,7 +49,7 @@ import { logWarn, reportError } from "./log";
 import {
   cullFrameLogsOverBudget,
   frameLogBytesForAccount,
-  maxFrameLogBytesPerAccount,
+  accountLimits,
 } from "./usage";
 
 type Database = ReturnType<typeof createDb>;
@@ -1315,7 +1315,7 @@ export async function storeFrameLogs(
     if (accountId) {
       const overBudget =
         (await frameLogBytesForAccount(tx, accountId)) >
-        maxFrameLogBytesPerAccount;
+        (await accountLimits(tx, accountId)).frameLogBytes;
       if (overBudget) {
         await cullFrameLogsOverBudget(tx, accountId);
       }

--- a/cloud/apps/auth-web/src/lib/store-fork.ts
+++ b/cloud/apps/auth-web/src/lib/store-fork.ts
@@ -42,7 +42,7 @@ import type { SceneListing } from "./store-listing";
 import type { PublishActor } from "./store-publish";
 import { alignZipCover, writeSceneVersion } from "./store-version-write";
 import {
-  maxPrivateSceneBytesPerAccount,
+  accountLimits,
   privateSceneBytesForAccount,
 } from "./usage";
 
@@ -178,9 +178,10 @@ async function forkStoreSceneLocked(db: Database, input: ForkInput) {
   if (rebuilt.length > maxSceneZipBytes) {
     return jsonError("scene_too_large", 413, { max_bytes: maxSceneZipBytes });
   }
-  if (privateBytes + rebuilt.length > maxPrivateSceneBytesPerAccount) {
+  const { privateSceneBytes: maxPrivateBytes } = await accountLimits(db, accountId);
+  if (privateBytes + rebuilt.length > maxPrivateBytes) {
     return jsonError("storage_quota_exceeded", 403, {
-      max_bytes: maxPrivateSceneBytesPerAccount,
+      max_bytes: maxPrivateBytes,
       private_bytes: Math.round(privateBytes),
     });
   }

--- a/cloud/apps/auth-web/src/lib/store-publish.ts
+++ b/cloud/apps/auth-web/src/lib/store-publish.ts
@@ -31,7 +31,7 @@ import {
 import type { SceneListing } from "./store-listing";
 import { alignZipCover, writeSceneVersion } from "./store-version-write";
 import {
-  maxPrivateSceneBytesPerAccount,
+  accountLimits,
   privateSceneBytesForAccount,
   sceneBytesTotal,
 } from "./usage";
@@ -155,15 +155,16 @@ export async function publishStoreScene(
       existing && existing.visibility === "public"
         ? await sceneBytesTotal(db, existing.id)
         : 0;
+    const { privateSceneBytes: maxBytes } = await accountLimits(db, accountId);
     if (
       privateBytes +
         flippingPrivateBytes +
         content.length +
         (uploadedPreview?.length ?? 0) >
-      maxPrivateSceneBytesPerAccount
+      maxBytes
     ) {
       return jsonError("storage_quota_exceeded", 403, {
-        max_bytes: maxPrivateSceneBytesPerAccount,
+        max_bytes: maxBytes,
         private_bytes: Math.round(privateBytes),
       });
     }

--- a/cloud/apps/auth-web/src/lib/usage.ts
+++ b/cloud/apps/auth-web/src/lib/usage.ts
@@ -16,6 +16,14 @@
 
 import { and, eq, gt, or, sql } from "drizzle-orm";
 import {
+  accountAiUsage,
+  readAccountPlan,
+  readBillingSettings,
+  utcDayWindow,
+  utcMonthWindow,
+  type AccountPlan,
+} from "@frameos-cloud/ledger";
+import {
   clientBackups,
   frameLogs,
   frames,
@@ -75,6 +83,96 @@ export const maxFrameLogBytesPerAccount = megabyteLimitFromEnv(
   "FRAMEOS_CLOUD_MAX_FRAME_LOG_MB",
   100,
 );
+
+/**
+ * The quota numbers that apply to ONE account: its plan's entitlements
+ * (cloud/docs/accounting-todo.md §0.1), falling back to the free-tier
+ * constants above for a deployment with no plans seeded.
+ *
+ * Every enforcement point takes its limit from here rather than from the
+ * constants, because a display that promises 10 GB while the refusal fires
+ * at 100 MB is worse than having no plans at all. The constants stay
+ * exported as the free tier and the fallback — the numbers migration 0045
+ * seeds for `payg` are deliberately identical to them, so nothing an
+ * existing account has today gets smaller the day plans land.
+ */
+export interface AccountLimits {
+  backupBytes: number;
+  // Frames the cloud renders because there is no computer at the other end
+  // (§0.2). Zero on the free plan: it is the one entitlement with a real
+  // marginal cost.
+  cloudRenderedFrames: number;
+  frameLogBytes: number;
+  frames: number;
+  plan: {
+    code: string;
+    marginBasisPoints: number;
+    name: string;
+    priceMicros: bigint;
+  };
+  privateSceneBytes: number;
+  subscribed: boolean;
+}
+
+export const freeTierLimits: Omit<AccountLimits, "plan" | "subscribed"> = {
+  backupBytes: maxBackupBytesPerAccount,
+  cloudRenderedFrames: 0,
+  frameLogBytes: maxFrameLogBytesPerAccount,
+  frames: maxFramesPerAccount,
+  privateSceneBytes: maxPrivateSceneBytesPerAccount,
+};
+
+export async function accountLimits(
+  db: FramesDatabase,
+  accountId: string,
+  // The caller's already-read plan, when it has one. accountUsage() reads it
+  // once and hands it to both consumers rather than paying for the same
+  // lookup twice on a page that renders one account.
+  known?: AccountPlan | undefined,
+): Promise<AccountLimits> {
+  let accountPlan: AccountPlan | undefined = known;
+  try {
+    accountPlan ??= await readAccountPlan(db, accountId);
+  } catch {
+    // A deployment whose plan tables have not been migrated yet must keep
+    // enforcing the free tier rather than failing every quota check. The
+    // fallback is the same numbers, so nothing changes for anyone.
+    accountPlan = undefined;
+  }
+  if (!accountPlan) {
+    return {
+      ...freeTierLimits,
+      plan: {
+        code: "payg",
+        marginBasisPoints: 10_000,
+        name: "Pay as you go",
+        priceMicros: 0n,
+      },
+      subscribed: false,
+    };
+  }
+  const { entitlements } = accountPlan.plan;
+  return {
+    // The larger of the plan and the deployment's configured floor: an
+    // operator who raised FRAMEOS_CLOUD_MAX_BACKUP_MB for everybody must not
+    // have it silently lowered by a plan row.
+    backupBytes: Math.max(entitlements.backupBytes, maxBackupBytesPerAccount),
+    cloudRenderedFrames: entitlements.cloudRenderedFrames,
+    frameLogBytes: Math.max(entitlements.frameLogBytes, maxFrameLogBytesPerAccount),
+    frames: Math.max(entitlements.frames, maxFramesPerAccount),
+    plan: {
+      code: accountPlan.plan.code,
+      marginBasisPoints: accountPlan.plan.marginBasisPoints,
+      name: accountPlan.plan.name,
+      priceMicros: accountPlan.plan.priceMicros,
+    },
+    privateSceneBytes: Math.max(
+      entitlements.privateSceneBytes,
+      maxPrivateSceneBytesPerAccount,
+    ),
+    subscribed: accountPlan.subscribed,
+  };
+}
 
 export interface SceneBytesBreakdown {
   privateBytes: number;
@@ -221,16 +319,23 @@ export async function frameLogBytesForAccount(
  * third-party reimplementations.
  */
 export async function accountUsage(db: FramesDatabase, accountId: string) {
-  const [scenes, backups, logs, frameCount] = await Promise.all([
+  const now = new Date();
+  // One plan lookup for both the quota limits and the AI summary; `undefined`
+  // when the accounting tables are not migrated, which both handle.
+  const plan = await readAccountPlan(db, accountId).catch(() => undefined);
+  const [scenes, backups, logs, frameCount, limits, ai] = await Promise.all([
     sceneBytesForAccount(db, accountId),
     backupBytesForAccount(db, accountId),
     frameLogBytesForAccount(db, accountId),
     countFramesForAccount(db, accountId),
+    accountLimits(db, accountId, plan),
+    accountAiSummary(db, accountId, now, plan),
   ]);
   return {
+    ai,
     backups: {
       bytes: Math.round(backups),
-      max_bytes: maxBackupBytesPerAccount,
+      max_bytes: limits.backupBytes,
     },
     // Not bytes, but the same shape of promise to the account: here is the
     // limit, here is where you are against it. Revoked frames still hold a
@@ -238,15 +343,27 @@ export async function accountUsage(db: FramesDatabase, accountId: string) {
     // display cannot disagree with the refusal.
     frames: {
       count: frameCount,
-      max_count: maxFramesPerAccount,
+      max_count: limits.frames,
     },
     frame_logs: {
       bytes: Math.round(logs),
-      max_bytes: maxFrameLogBytesPerAccount,
+      max_bytes: limits.frameLogBytes,
+    },
+    // Which plan these limits came from, so a UI can say "on the Maker plan"
+    // beside the numbers rather than presenting them as laws of nature.
+    plan: {
+      code: limits.plan.code,
+      // Basis points, and a string price: the payload crosses the AGPL
+      // boundary to third-party reimplementations, and a micro-dollar amount
+      // is a bigint that JSON's single number type would quietly round.
+      margin_basis_points: limits.plan.marginBasisPoints,
+      name: limits.plan.name,
+      price_micros: limits.plan.priceMicros.toString(),
+      subscribed: limits.subscribed,
     },
     scenes: {
       private_bytes: Math.round(scenes.privateBytes),
-      private_max_bytes: maxPrivateSceneBytesPerAccount,
+      private_max_bytes: limits.privateSceneBytes,
       // Public scenes are free; reported so UIs can say so instead of
       // summing everything into one misleading number.
       public_bytes: Math.round(scenes.publicBytes),
@@ -255,6 +372,65 @@ export async function accountUsage(db: FramesDatabase, accountId: string) {
 }
 
 export type AccountUsage = Awaited<ReturnType<typeof accountUsage>>;
+
+/**
+ * AI spend in the same "here is the limit, here is where you are against it"
+ * shape as every storage bucket (cloud/docs/accounting-todo.md §5.2).
+ *
+ * `month_micros` is what this month WOULD be billed at, not what has been
+ * charged: while `metering_mode` is "shadow" nothing is charged at all, and
+ * `price_micros` is zero on every row — a figure built on it would tell
+ * every user they had used nothing. Any UI must read `metering_mode` before
+ * putting a currency symbol in front of this and calling it a bill.
+ *
+ * Degrades to a disabled-looking zero rather than throwing: a deployment
+ * whose accounting tables have not been migrated must still render an
+ * account page.
+ */
+async function accountAiSummary(
+  db: FramesDatabase,
+  accountId: string,
+  now: Date,
+  known?: AccountPlan | undefined,
+) {
+  try {
+    const [thisMonth, lastMonth, today, settings, plan] = await Promise.all([
+      accountAiUsage(db, accountId, utcMonthWindow(now)),
+      accountAiUsage(db, accountId, utcMonthWindow(now, -1)),
+      accountAiUsage(db, accountId, utcDayWindow(now)),
+      readBillingSettings(db),
+      known ?? readAccountPlan(db, accountId),
+    ]);
+    const [account] = await db.execute<{ ai_disabled_at: string | null }>(
+      sql`select ai_disabled_at from accounts where id = ${accountId}`,
+    );
+    return {
+      daily_cap_micros: settings.dailyCapMicros.toString(),
+      enabled: !account?.ai_disabled_at,
+      margin_basis_points: plan.subscribed
+        ? plan.plan.marginBasisPoints
+        : settings.marginBasisPoints,
+      metering_mode: settings.meteringMode as string,
+      month_micros: thisMonth.chargeableMicros.toString(),
+      own_key_only: thisMonth.ownKeyOnly,
+      previous_month_micros: lastMonth.chargeableMicros.toString(),
+      today_micros: today.chargeableMicros.toString(),
+      turns_this_month: thisMonth.turns,
+    };
+  } catch {
+    return {
+      daily_cap_micros: "0",
+      enabled: true,
+      margin_basis_points: 0,
+      metering_mode: "shadow" as string,
+      month_micros: "0",
+      own_key_only: false,
+      previous_month_micros: "0",
+      today_micros: "0",
+      turns_this_month: 0,
+    };
+  }
+}
 
 /**
  * Cull the OLDEST frame-log rows across the whole account until the total is
@@ -267,6 +443,7 @@ export async function cullFrameLogsOverBudget(
   db: FramesDatabase,
   accountId: string,
 ): Promise<void> {
+  const { frameLogBytes } = await accountLimits(db, accountId);
   await db.execute(sql`
     with ordered as (
       select fl.id,
@@ -277,7 +454,7 @@ export async function cullFrameLogsOverBudget(
     )
     delete from ${frameLogs}
     where id in (
-      select id from ordered where running > ${maxFrameLogBytesPerAccount}
+      select id from ordered where running > ${frameLogBytes}
     )
   `);
 }

--- a/cloud/apps/auth-web/src/lib/usage.ts
+++ b/cloud/apps/auth-web/src/lib/usage.ts
@@ -405,6 +405,9 @@ async function accountAiSummary(
       sql`select ai_disabled_at from accounts where id = ${accountId}`,
     );
     return {
+      // What they actually owe, which is narrower than what they used: only
+      // the platform key bills anybody (see billing() in metering.ts).
+      billable_micros: thisMonth.billableMicros.toString(),
       daily_cap_micros: settings.dailyCapMicros.toString(),
       enabled: !account?.ai_disabled_at,
       margin_basis_points: plan.subscribed
@@ -419,6 +422,7 @@ async function accountAiSummary(
     };
   } catch {
     return {
+      billable_micros: "0",
       daily_cap_micros: "0",
       enabled: true,
       margin_basis_points: 0,

--- a/cloud/apps/auth-web/src/test/integration/admin-billing.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/admin-billing.integration.test.ts
@@ -14,6 +14,7 @@ import {
   accountBalanceMicros,
   billingSettingKeys,
   customerCreditsCode,
+  customerReceivableCode,
   listJournalEntries,
   readBillingSettings,
   recordAiUsage,
@@ -417,24 +418,32 @@ describe("admin billing routes", () => {
     expect(await accountBalanceMicros(db, systemAccountCodes.revenueAiUsage)).toBe(
       575_120n,
     );
-    // The turn overdrew a customer who has bought nothing, but by less than
-    // the dollar of overdraft policy allows, so the books are fine.
+    // Postpay: the charge is an ordinary debit to what the customer owes us,
+    // so there is nothing irregular about the books at all — and half a
+    // dollar is well inside the $10 daily cap.
     expect(payload).toMatchObject({ ok: true, violations: [] });
+    expect(
+      await accountBalanceMicros(db, customerReceivableCode(customer)),
+    ).toBe(575_120n);
 
-    // Take the allowance away and the same balance becomes the violation the
-    // nightly job exists to shout about.
+    // Drop the cap under what the day already spent and the same turn becomes
+    // the violation the nightly job exists to shout about. This is invariant
+    // 5's postpay replacement, and the reason it matters is that it is the
+    // only automated proof the spend gate sits in front of every AI surface
+    // rather than most of them.
     await writeBillingSetting(db, billingSettingKeys.paygOverdraftMicros, 0);
+    await writeBillingSetting(db, billingSettingKeys.paygDailyCapMicros, 1);
     const strict = await postNightly(postJson("/api/admin/billing/nightly", {}));
     const strictPayload = await strict.json();
     expect(strictPayload.violations).toContainEqual({
-      check: "customer_credit_floor",
+      check: "daily_cap_respected",
       detail: expect.stringContaining(customer),
     });
     expect(strictPayload.ok).toBe(false);
     // And it reports rather than repairs: a book that disagrees with itself
     // needs a human, and a silent "correction" is how that goes unnoticed.
-    expect(await accountBalanceMicros(db, customerCreditsCode(customer))).toBe(
-      -575_120n,
-    );
+    expect(
+      await accountBalanceMicros(db, customerReceivableCode(customer)),
+    ).toBe(575_120n);
   });
 });

--- a/cloud/docs/accounting-todo.md
+++ b/cloud/docs/accounting-todo.md
@@ -1,20 +1,149 @@
 # FrameOS Cloud accounting module — design + todo
 
-Status: written 2026-08-31. Phases 0, 1, 2 and 4 are built — the ledger, the
-AI metering that feeds it, and the admin/ops surfaces that make it readable.
-Metering runs in **shadow mode**: every turn is measured and priced, and no
-entry is posted. Nothing charges anybody; that starts at Phase 3, which
-needs a payment provider chosen first.
+Status: written 2026-08-31, **direction revised 2026-09-01** (§0). Phases 0,
+1, 2, 3a, 4 and 5 are built: the ledger, the AI metering that feeds it, the
+admin/ops surfaces that make it readable, the account's own view of its
+usage with the switch that turns AI off, the daily cap, and plans with their
+subscription lifecycle. **Phase 3b — the payment provider — is the only
+thing left**, and it is what everything else is waiting on. Metering runs in
+**shadow mode**: every turn is measured and priced, and no entry is posted.
+Nothing charges anybody, and self-serve plan purchase is gated off
+(`FRAMEOS_CLOUD_PLANS_SELF_SERVE`) for the same reason — subscribing accrues
+a receivable, and until 3b there is no way to settle one.
 
-The goal: real double-entry accounting inside FrameOS Cloud. Users buy prepaid
-credits, we meter their AI spend (gpt-5.6-terra today), add a configurable
-margin (~30%), and every cent is traceable through an immutable ledger. The
-same ledger must carry subscriptions, prepaid-credit-pays-for-subscription,
-partial-period refunds (modelled now, implemented later), postpay, and —
-eventually — bank/PSP reconciliation against real revenue.
+The goal: real double-entry accounting inside FrameOS Cloud. We meter each
+account's AI spend (gpt-5.6-terra today), add a configurable margin (~30%),
+and every cent is traceable through an immutable ledger.
 
-The first shippable product is a **pay-as-you-go plan for AI credits**:
-accounts without their own OpenAI key buy credits and burn them per turn.
+## 0. What we are selling (decided 2026-09-01)
+
+(Document section zero, not implementation "Phase 0" — §7 owns the phases.)
+
+Narrower than this document's first draft, and the narrowing is the point —
+every item below removes a legal or product problem rather than a technical
+one, and none of them costs the ledger anything, because the accounts they
+need were all seeded in Phase 0.
+
+- **Postpay, not prepaid.** Nobody buys credits up front. Usage accrues as a
+  receivable and we bill the month at the end of it. Holding other people's
+  money before delivering anything is stored value — a different legal
+  animal in most jurisdictions, tangled up with VAT-at-issue, expiry rules
+  and unclaimed-property law — and it is not an animal worth adopting to
+  sell $6 of tokens. Postpay has none of it: we invoice for a service
+  already rendered, which is the most ordinary transaction there is. It also
+  deletes three open decisions outright (credit expiry, the prepaid refund
+  path, and what a "credit" is worth).
+- **Subscriptions after postpay, not instead of it.** Not in the first
+  shippable thing — metering, a cap, a visible number and an invoice have to
+  work before a plan can promise anything — but they are the destination,
+  and §0.1 sketches the ladder. The order matters: a plan is a *discount on
+  metered usage plus some entitlements*, so the metering has to be
+  trustworthy first. Building plans on top of metering nobody has checked
+  against a real invoice would be selling a discount on a number we are not
+  yet sure of.
+- **Daily caps instead of a prepaid balance.** Postpay's one real cost is
+  credit risk, and the cap is how it is bounded: **$10/day per account** to
+  start, watched by hand while the numbers are small. A prepaid balance is
+  the same protection collected in advance; a cap is that protection without
+  taking anybody's money first.
+- **Users can switch AI off entirely** (§5.1) and incur nothing. Explicit,
+  per-account, off by nobody's default but reachable in one click. It
+  answers "how do I make sure this never costs me anything" without asking
+  anyone to trust a cap they cannot see.
+- **Pricing and plans get decided later.** Provider cost plus a margin is
+  the *mechanism*; what the margin is, whether there is a free monthly
+  allowance, and what a plan looks like are product questions this document
+  deliberately does not answer. What it does insist on is that whatever gets
+  decided is expressible as a number in `billing_settings` and a recipe, not
+  as a new model.
+
+The first shippable product is therefore **metered pay-as-you-go AI, billed
+monthly in arrears**: an account without its own OpenAI key runs on the
+platform key, sees what it has spent on its account page (§5.2), is stopped
+by the daily cap long before a surprise gets large, and receives one invoice
+a month.
+
+### 0.1 The plan ladder (sketch, 2026-09-01 — numbers not final)
+
+Three plans, and the thing that varies down the ladder is **the margin on
+metered AI**. That is an unusual axis and a good one: it means a plan is
+never a wall between somebody and a feature, only a better rate on something
+they were already free to use. Nothing is gated; the meter just runs slower.
+
+| | **Pay as you go** — $0 | **Maker** — $1.99/mo | **Studio** — $6.99/mo |
+|---|---|---|---|
+| AI margin over provider cost | 100% | 50% | 20% |
+| Daily AI cap (§5.3) | $10 | $10 | $10 |
+| Cloud-rendered frames (§0.2) | 0 | 5 | 25 |
+| Backups | 100 MB | 2 GB | 10 GB |
+| Frame logs | 100 MB | 500 MB | 2 GB |
+| Private scenes | 100 MB | 1 GB | 5 GB |
+| Cloud-managed frames (your own hardware) | 50 | 50 | 50 |
+
+Where the numbers come from, so the next person can move them on purpose:
+
+- **The margins are the user's numbers** (100 / 50 / 20). They are also the
+  whole ladder: at provider cost *c* per month, PAYG bills `2c`, Maker
+  `1.99 + 1.5c`, Studio `6.99 + 1.2c`. So **Maker pays for itself at about
+  $4/month of provider cost** (≈ $8 of PAYG spend, ≈ 9 turns at today's
+  ~$0.44/turn) and **Studio overtakes Maker at about $16.70** (≈ 38 turns).
+  Both crossovers are reachable by a real user in a real month, which is the
+  test of whether a ladder is a ladder or a decoration — a tier nobody can
+  climb into is just a more expensive way to buy the tier below.
+- **The cap does not move between plans**, and that is deliberate. It is a
+  credit-risk bound (§5.3), not a feature. Note the side effect, which is
+  the right way round: the cap is a *price* limit, so a PAYG user at 100%
+  margin gets ~11 turns/day out of $10 while a Studio user at 20% gets ~19.
+- **Storage numbers are grounded, not aspirational.** At R2's ~$0.015/GB-mo,
+  Studio's 10 GB of backups costs us about 15¢ against $6.99. The binding
+  reality is abuse, not cost. Private scenes are the *least* meaningful axis
+  here and the table says so honestly: a real scene is ~9 KB, so the free
+  100 MB is already ten thousand scenes and raising it is theater — it is in
+  the table for symmetry, and if a plan needs a fourth differentiator this
+  is not it.
+- **Cloud-rendered frames are the one entitlement with a real marginal
+  cost**, which is why the free plan gets zero of them. §0.2.
+
+Open, and flagged rather than guessed: whether there is a yearly price,
+whether a plan changes the daily cap for accounts that ask, whether unused
+entitlements roll over (they should not), and what happens to an account
+that downgrades below what it is currently using (proposal: nothing breaks,
+nothing new can be added, and the overage is billed at the PAYG rate).
+
+### 0.2 Cloud-rendered frames — the entitlement that answers an old question
+
+`docs/todo.md` has carried this for a while: *"Thin-client frames on the
+cloud (ESP32-C3, embedded Pi/Pico): serving them means the cloud renders
+every frame for them — free cloud rendering forever, for everyone. Decide
+before building; until then C3 boards stay out of the cloud flasher."*
+
+The plan ladder is the decision. Cloud rendering is not free and not
+forever; it is an entitlement of a paid plan, and the free tier gets none.
+That unblocks the C3 in the cloud flasher, which is the actual product being
+held up.
+
+Two things have to be true for the entitlement to survive contact with
+arithmetic:
+
+- **The cost driver is renders per day, not frames.** A frame refreshing
+  every 5 minutes is 12× the cost of one refreshing hourly. So the plan is
+  enforced as *N frames **and** a minimum refresh interval* (proposal: 5
+  minutes), even though it is *displayed* as "N frames" — displaying the
+  interval as a headline number would be selling people a unit they do not
+  think in. At ~1 CPU-second per render, Studio's 25 frames at the 5-minute
+  floor is ~2 CPU-hours/day per account: fine for tens of accounts on one
+  box, and a capacity plan for hundreds.
+- **It needs per-frame attribution**, which the ledger does not have —
+  §8.9, unchanged and now with a date on it. When cloud rendering is
+  metered rather than merely entitled, the frame uuid rides on the event
+  unreferenced and the frame name is snapshotted, for the reason §8.9
+  gives. Until then the entitlement is a *count check* at frame creation and
+  costs the ledger nothing.
+
+Not designed here: whether a cloud-rendered frame counts against the
+50-frame cloud-managed limit (proposal: it is a separate pool, because the
+two have entirely different cost profiles — your own Pi costs us a WebSocket
+and a row).
 
 Direction comes from Airbnb's "Tracking the money" post
 (medium.com/airbnb-engineering/tracking-the-money-scaling-financial-reporting-at-airbnb-6d742b80f040).
@@ -67,11 +196,11 @@ ledger_balances           derived cache, provably equal to SUM(postings)
 - Single currency (USD) at launch. `currency` column exists everywhere from
   day one and the balance invariant is per-currency, so adding EUR later is a
   data change, not a schema change.
-- "Credits" are **not a separate commodity** — a customer's credit balance is
-  simply the balance of their liability account, denominated in USD.
-  Display can say "1 credit = $0.01" but the ledger only knows dollars.
-  (Promotional/gift credits get their own liability account, §3.6, because
-  they are not deferred revenue.)
+- There is no credit *commodity*, and since §0 no credit *balance* either: an
+  account's billing state is the balance of its **receivable**, denominated
+  in USD, and the UI says dollars because dollars is what it is. (If prepaid
+  ever comes back, §3.5 keeps the model intact; promotional grants net
+  against the receivable instead — §3.4.)
 
 ### 1.2 Chart of accounts
 
@@ -85,9 +214,9 @@ Launch chart (system accounts):
 |---|---|---|---|
 | `asset:psp:main` | asset | debit | money sitting at the payment provider (charges land here, fees and payouts leave) |
 | `asset:bank:main` | asset | debit | our bank account (used once payouts/reconciliation arrive) |
-| `asset:receivable:customer:<id>` | asset | debit | postpay, later — what a customer owes us |
-| `liability:credits:customer:<id>` | liability | credit | **prepaid credit balance** (deferred revenue held per customer) |
-| `liability:credits_promo:customer:<id>` | liability | credit | granted/promo credits (not money we owe back) |
+| `asset:receivable:customer:<id>` | asset | debit | **what a customer owes us for metered usage — the live customer account** (§0) |
+| `liability:credits:customer:<id>` | liability | credit | prepaid credit balance (shelved with §3.5; nothing posts here) |
+| `liability:credits_promo:customer:<id>` | liability | credit | granted/promo credits, prepaid model only (shelved, §3.5) |
 | `liability:deferred:subscriptions` | liability | credit | subscription fees collected but not yet earned |
 | `liability:refunds_payable` | liability | credit | refunds approved but not yet sent |
 | `liability:accrued:openai` | liability | credit | provider cost incurred, invoice not yet paid |
@@ -96,6 +225,14 @@ Launch chart (system accounts):
 | `contra_revenue:promo` | contra-revenue | debit | cost of granting promo credits |
 | `expense:cogs:openai` | expense | debit | provider cost of metered usage |
 | `expense:psp_fees` | expense | debit | payment-provider fees |
+| `expense:bad_debt` | expense | debit | invoices we gave up collecting (added in Phase 3, §3.2) |
+
+Under postpay the live customer account is `asset:receivable:customer:<id>`
+— an asset, because unbilled usage is money owed *to* us. The two
+`liability:credits:*` rows stay in the chart and in `chart.ts`: they cost
+nothing to keep, they are already tested, and shelving a model is not the
+same as deleting it. `expense:bad_debt` is the only account the postpay
+switch actually adds, and `customerReceivableCode()` already exists.
 
 The margin is **derived, never stored as a balance**: revenue posts at
 customer price, COGS posts at provider cost, and margin = the difference.
@@ -273,34 +410,45 @@ CREATE TABLE "ai_model_prices" (
 CREATE UNIQUE INDEX "ai_model_prices_model_from_unique" ON "ai_model_prices" ("model", "effective_from");
 
 CREATE TABLE "billing_settings" (
-  "key" text PRIMARY KEY,              -- 'ai_margin_percent' | 'payg_overdraft_micros' | 'ai_metering_mode'
+  "key" text PRIMARY KEY,              -- 'ai_margin_percent' | 'payg_overdraft_micros' | 'payg_daily_cap_micros' | 'ai_metering_mode'
   "value" jsonb NOT NULL,
   "updated_at" timestamptz NOT NULL DEFAULT now(),
   "updated_by" uuid                    -- accounts uuid, no foreign key (§2.1)
 );
 
--- Phase 3: purchase intents (state machine; the ledger only sees success
--- events). Provider-neutral on purpose — the PSP is not chosen (§8.7), so
--- the columns name the roles rather than one vendor's object types.
-CREATE TABLE "credit_purchases" (
+-- Phase 3b: one invoice per account per month (§3.2). Deliberately holds no
+-- amount the ledger does not: the receivable IS the balance owed, and a
+-- second copy of it here is a second thing to be wrong. What the row exists
+-- for is the things the ledger has no opinion about — where the period was
+-- cut, which sequential number the invoice carries, whether it was paid, and
+-- which provider payment settled it. Provider-neutral (§8.7).
+CREATE TABLE "invoices" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  "account_id" uuid,                   -- accounts uuid, no foreign key (§2.1)
-  "amount_micros" bigint NOT NULL,
+  "account_id" uuid NOT NULL,          -- accounts uuid, no foreign key (§2.1)
+  "number" text NOT NULL,              -- human/legal sequential number
+  "period_start" timestamptz NOT NULL,
+  "period_end" timestamptz NOT NULL,   -- half-open; the receivable as of here
   "currency" text NOT NULL DEFAULT 'USD',
-  "status" text NOT NULL,              -- 'pending'|'succeeded'|'failed'|'refunded'
-  "provider" text NOT NULL,            -- 'stripe' | 'paddle' | ...
-  "provider_checkout_id" text,         -- the hosted-checkout handle
+  "status" text NOT NULL,              -- 'open'|'paid'|'uncollectible'|'void'
+  "provider" text,                     -- 'stripe' | 'paddle' | ...
   "provider_payment_id" text,          -- what reconciliation matches on
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now()
 );
-CREATE UNIQUE INDEX "credit_purchases_checkout_unique" ON "credit_purchases" ("provider", "provider_checkout_id");
+CREATE UNIQUE INDEX "invoices_number_unique" ON "invoices" ("number");
+CREATE UNIQUE INDEX "invoices_period_unique" ON "invoices" ("account_id", "period_start");
 
--- Phase 5: plans + subscriptions (sketch; refine in that phase)
+-- Shelved (§0): prepaid purchase intents and subscriptions. Sketched here
+-- because §3.5/§3.6 keep the recipes and a schema sketch is cheaper to keep
+-- than to re-derive, NOT because anything is scheduled to build them.
+CREATE TABLE "credit_purchases" ( ... );       -- account_id, amount_micros, status, provider, provider_checkout_id, provider_payment_id
 CREATE TABLE "billing_plans" ( ... );          -- code, name, price_micros, period ('month'), features jsonb, active
-CREATE TABLE "subscriptions" ( ... );          -- account_id, plan, status, started_at, cancel_at, payment method (credits|card)
+CREATE TABLE "subscriptions" ( ... );          -- account_id, plan, status, started_at, cancel_at, payment method
 CREATE TABLE "subscription_periods" ( ... );   -- subscription_id, period_start/end, charged entry, recognition state
 ```
+
+The one column postpay adds outside the ledger lives on an existing table:
+`accounts.ai_disabled_at` (§5.1), the explicit AI opt-out.
 
 ### 2.1 Deliberate deviations from house patterns
 
@@ -315,8 +463,8 @@ CREATE TABLE "subscription_periods" ( ... );   -- subscription_id, period_start/
 
   *Revised from `ON DELETE SET NULL`*, which was the first decision and is
   wrong in a way worth recording. It loses precisely the rows that matter: a
-  metered turn posts two entries, and while the customer charge carries a
-  `liability:credits:customer:<uuid>` leg that keeps it attributable through
+  metered turn posts two entries, and while the customer charge carries an
+  `asset:receivable:customer:<uuid>` leg that keeps it attributable through
   its account code, the provider-cost entry
   (`Dr expense:cogs:openai / Cr liability:accrued:openai`) touches only
   system accounts — with the id nulled it is attributable to nobody, and
@@ -360,17 +508,145 @@ CREATE TABLE "subscription_periods" ( ... );   -- subscription_id, period_start/
 
 Each recipe is a pure, versioned TypeScript function
 `(event) => LedgerEntryDraft[]` living in a new Next-free package (§4). All
-examples with a $10 purchase, 30% margin, terra prices.
+examples at terra prices with a 30% margin.
 
-### 3.1 Credit purchase (Phase 3)
+The launch model is **postpay** (§0): usage accrues as a receivable, a daily
+cap bounds it, one invoice at the end of the month collects it. Prepaid
+credits (§3.5) stay modelled below without being roadmap; subscriptions
+(§3.6) are roadmap, just later than postpay (§0.1, Phase 5). Both keep their
+recipes here because the accounts are already in the chart and a worked
+model is cheaper to keep than to re-derive.
 
-The payment provider is **not chosen** (§8.7). The accounts are named for
-the role rather than the vendor — `asset:psp:main`, `expense:psp_fees` — and
-the recipes below hold for any PSP that can tell us three things: a payment
-succeeded, what it cost us in fees, and a stable id per payment to reconcile
-against later. Stripe, Paddle, Lemon Squeezy and a bank-transfer flow all
-post exactly this; only the webhook parsing differs, and that lives outside
-the ledger.
+### 3.1 AI usage — the postpay core (Phase 2/3)
+
+A turn on the platform key burns 40k input + 12k cached + 30k output tokens:
+cost = 40k×2 + 12k×0.2 + 30k×12 = 442,400 µ$ (~$0.44). Price at 30% margin
+= 575,120 µ$. Two *independent* leg pairs from one event:
+
+```
+Entry 'ai_usage_charge'         (metadata: tokens, unit prices, margin=0.30)
+  Dr asset:receivable:customer:<id>          0.575120
+  Cr revenue:ai_usage                        0.575120
+
+Entry 'ai_usage_cost'
+  Dr expense:cogs:openai                     0.442400
+  Cr liability:accrued:openai                0.442400
+```
+
+The only thing §0 changed about what `rules/ai-usage.ts` already posts is
+that first leg: it debits the customer's **receivable** (an asset — what
+they owe us) instead of drawing down a prepaid **liability**. That is a
+`version: 2` bump on the rule, not a re-model. `customerReceivableCode()`
+has been in `chart.ts` since Phase 0, the prefix is registered, and every
+other leg is untouched — which is the payoff for having separated recipes
+from the kernel in the first place.
+
+Revenue is recognized immediately: for metered usage, service-rendered time
+*is* usage time. Postpay puts the recognition and the receivable in the same
+entry, which is the textbook accrual shape and strictly simpler than the
+prepaid one it replaces — no deferred-revenue balance to carry, no unused
+balance we owe back, nothing to refund when somebody stops using us.
+
+What it costs instead is **credit risk**: an invoice can go unpaid, which a
+prepayment cannot. That is precisely what the daily cap (§5.3) bounds. The
+cap is a credit limit wearing a unit users understand.
+
+The accrued OpenAI liability is settled when we actually pay their invoice
+(`Dr liability:accrued:openai / Cr asset:bank:main`), and the drift between
+accrual and invoice is what reconciliation will measure later.
+
+Usage on the customer's **own** OpenAI key produces a usage record with
+`price_micros = 0` and *no* charge entry (they pay OpenAI directly) and no
+cost entry (we incurred nothing). We still keep the record for analytics.
+An absorbed surface (§5) books the cost entry and never the charge one.
+
+### 3.2 Monthly invoice, payment, and the unpaid case (Phase 3)
+
+At period close the receivable **is** the invoice: the customer's balance on
+`asset:receivable:customer:<id>` for the month is what they owe, leg for leg,
+with every metered turn behind it already in the journal. Issuing the
+invoice therefore posts **nothing** — it is a document rendered over existing
+postings, which is the property double-entry was supposed to buy us. (The
+`invoices` row Phase 3 adds exists to freeze the period boundary, the
+sequential number and the PDF, not to hold an amount the ledger doesn't.)
+
+Only the payment moves money:
+
+```
+Entry 'invoice_payment'         (external_ref: the provider's payment id)
+  Dr asset:psp:main                          6.420000
+  Cr asset:receivable:customer:<id>          6.420000
+
+Entry 'psp_fee'                 (external_ref: the provider's fee/txn id)
+  Dr expense:psp_fees                        0.440000
+  Cr asset:psp:main                          0.440000
+```
+
+A failed charge or an ignored invoice posts nothing at all: the receivable
+simply stays on the books and ages, which is the correct statement of the
+fact and exactly what a receivables-aging report is for. Only giving up
+posts:
+
+```
+Entry 'receivable_writeoff'     (metadata: invoice id, reason, who decided)
+  Dr expense:bad_debt                        6.420000
+  Cr asset:receivable:customer:<id>          6.420000
+```
+
+`expense:bad_debt` is the one system account postpay adds (§8.11 picks its
+reporting group). A write-off is a superadmin action through the same
+audited journal route Phase 4 built, never an automatic one — the same rule
+as the nightly job: report, don't repair.
+
+Two product decisions ride on this recipe and neither touches the ledger:
+
+- **A minimum invoice threshold.** Below it (proposal: $1) the receivable
+  rolls into next month untouched — charging a card for $0.11 costs more in
+  fees than it collects. The balance is still owed, still visible, still
+  posted; only the collection waits.
+- **Dunning.** Retry schedule, when AI switches off for an unpaid balance,
+  when a human is emailed. All of it reads the receivable and writes none
+  of it.
+
+Provider choice (§8.7) is now a *harder* requirement than prepaid checkout
+was: postpay needs a **stored payment method chargeable later**, not a
+one-off hosted checkout. That narrows the field and should be decided with
+this recipe in hand.
+
+### 3.3 Corrections and alterations
+
+Never edit. Post `Entry X-reversal` (`reverses_entry_id = X`, every leg
+mirrored) and then, if needed, a fresh correct entry. Full
+reverse-and-rebook, not deltas — Airbnb's lesson: deltas compound into
+unauditability.
+
+### 3.4 Promo / granted credits
+
+Under postpay a grant is a **credit against the receivable** — we reduce
+what somebody owes rather than handing them a spendable balance:
+
+```
+Entry 'promo_grant'
+  Dr contra_revenue:promo                    5.000000
+  Cr asset:receivable:customer:<id>          5.000000
+```
+
+Same contra-revenue treatment as the prepaid version, one account fewer to
+reconcile, and no unused-promo-balance liability to carry, expire or explain.
+It is also the shape a "free monthly allowance" takes if §0's deferred
+pricing question comes back with one: a monthly grant capped at the
+allowance, posted by the nightly job, netting the first $N of usage to zero
+while the usage itself stays fully metered and fully visible.
+
+`liability:credits_promo:customer:<id>` stays in the chart for the prepaid
+model (§3.5) and nothing posts to it today.
+
+### 3.5 Prepaid credits — modelled, shelved (§0)
+
+Kept because the accounts, the kernel support and the reasoning already
+exist, and because "let people top up in advance" is the single most likely
+thing to come back if postpay's collection rate disappoints. Not built, not
+scheduled.
 
 A checkout for $10 succeeds (the provider's "payment completed" webhook):
 
@@ -380,125 +656,79 @@ Entry 'credit_purchase'         (external_ref: the provider's payment id)
   Cr liability:credits:customer:<id>        10.000000
 ```
 
-The provider's fee, booked from whatever line item carries it:
+The fee books as in §3.2 — `Dr expense:psp_fees / Cr asset:psp:main` — and
+the customer's balance is the full $10, because the fee is our cost, not
+theirs. Usage then debits `liability:credits:customer:<id>` instead of the
+receivable (that is rule version 1, still in the repo and still tested).
+
+What shelving this buys, and therefore what taking it off the shelf would
+cost again: credit expiry as a terms-of-service problem, VAT possibly owed
+at *issue* rather than at use, unclaimed-property exposure on dormant
+balances, refunds of unspent money, and a "1 credit = $0.01" fake currency
+to explain. §0 judged that a poor trade for a product whose median invoice
+is a few dollars.
+
+### 3.6 Subscriptions (§0.1) — built 2026-09-01 (Phase 5)
+
+Under postpay a subscription is *simpler* than the prepaid version this
+section used to model, because there is no balance to charge from. At period
+rollover:
 
 ```
-Entry 'psp_fee'                 (external_ref: the provider's fee/txn id)
-  Dr expense:psp_fees                        0.590000
-  Cr asset:psp:main                          0.590000
+Entry 'subscription_charge'        (occurred_at: period start)
+  Dr asset:receivable:customer:<id>          1.990000
+  Cr liability:deferred:subscriptions        1.990000
 ```
 
-The customer's balance is the full $10 — the fee is our cost, not theirs.
-
-A merchant-of-record provider (Paddle, Lemon Squeezy) changes one thing and
-it is worth deciding before writing the webhook: they collect and remit VAT
-themselves, so the money that reaches `asset:psp:main` is net of tax we
-never owed, and §8.6's `liability:vat_payable` leg is theirs rather than
-ours. A direct PSP (Stripe) leaves that liability with us.
-
-### 3.2 AI usage (Phase 2/3) — the PAYG core
-
-A turn on the platform key burns 40k input + 12k cached + 30k output tokens:
-cost = 40k×2 + 12k×0.2 + 30k×12 = 442,400 µ$ (~$0.44). Price at 30% margin
-= 575,120 µ$. Two *independent* leg pairs from one event:
+Recognition over the period (daily, or one entry at period end):
 
 ```
-Entry 'ai_usage_charge'         (metadata: tokens, unit prices, margin=0.30)
-  Dr liability:credits:customer:<id>         0.575120
-  Cr revenue:ai_usage                        0.575120
-
-Entry 'ai_usage_cost'
-  Dr expense:cogs:openai                     0.442400
-  Cr liability:accrued:openai                0.442400
+Entry 'subscription_recognition'
+  Dr liability:deferred:subscriptions        1.990000
+  Cr revenue:subscriptions                   1.990000
 ```
 
-Revenue is recognized immediately — for metered usage, service-rendered time
-*is* usage time (this is what makes PAYG accounting clean). The accrued
-OpenAI liability is settled when we actually pay the invoice
-(`Dr liability:accrued:openai / Cr asset:bank:main`), and the drift between
-accrual and invoice is exactly what reconciliation will measure later.
+and the same month-end invoice (§3.2) collects the subscription and the
+metered AI together, because both are already sitting on the same
+receivable. That is the payoff for making postpay the base: a plan needs no
+payment path of its own, no second dunning story, and no reconciliation
+between two ways of owing us money.
 
-Usage on the customer's **own** OpenAI key produces a usage record with
-`price_micros = 0` and *no* charge entry (they pay OpenAI directly) and no
-cost entry (we incurred nothing). We still keep the record for analytics.
+Three consequences worth stating, because they are what keeps §0.1's ladder
+from turning into a model change:
 
-### 3.3 Subscription charged from prepaid credits (Phase 5)
-
-Monthly plan $5, paid from credit balance — Airbnb's "virtual movement", no
-real money moves:
-
-```
-Entry 'subscription_charge_from_credits'
-  Dr liability:credits:customer:<id>         5.000000
-  Cr liability:deferred:subscriptions        5.000000
-```
-
-Then recognition over the period (single entry at period end, or daily —
-decision in Phase 5):
-
-```
-Entry 'subscription_recognition'   (occurred_at: period end / each day)
-  Dr liability:deferred:subscriptions        5.000000
-  Cr revenue:subscriptions                   5.000000
-```
-
-A subscription charged by card instead posts
-`Dr asset:psp:main / Cr liability:deferred:subscriptions` — same shape,
-different first leg. Because recognition is separate from charging, the
-unearned remainder of any period is *always* sitting in
-`liability:deferred:subscriptions`, which is what makes §3.4 possible.
-
-### 3.4 Mid-period refund of unused subscription (modelled, NOT implemented)
-
-Cancel halfway with $2.50 unrecognized:
+- **A plan's margin is not an accounting fact.** It changes what
+  `price_micros` the metering computes — a per-plan override of
+  `billing_settings.ai_margin_percent`, snapshotted into the record's
+  `pricing` exactly as the global setting always was — and `rules/ai-usage`
+  never learns that plans exist. Which is the test of whether §0.1 was
+  designed or merely priced: if the ladder had needed a new posting rule, it
+  would have been the wrong ladder.
+- **A plan's entitlements are not accounting facts either.** Cloud-rendered
+  frame counts and storage limits are quota checks (`src/lib/usage.ts`'s
+  free-tier constants become per-plan lookups), and the ledger sees none of
+  them.
+- **Mid-period changes already have a home.** Because recognition is
+  separate from charging, the unearned remainder of a period always sits in
+  `liability:deferred:subscriptions`:
 
 ```
-Entry 'subscription_refund_to_credits'   (reverses remaining deferral)
-  Dr liability:deferred:subscriptions        2.500000
-  Cr liability:credits:customer:<id>         2.500000
+Entry 'subscription_refund_to_receivable'   (cancel halfway, $1.00 unearned)
+  Dr liability:deferred:subscriptions        1.000000
+  Cr asset:receivable:customer:<id>          1.000000
 ```
 
-or, cash refund path:
+  It nets against what they owe rather than becoming cash we have to send —
+  under postpay that is usually the entire answer, and it is one more thing
+  prepaid would have handed us as a problem. An upgrade mid-period is
+  reverse-and-rebook (§3.3): reverse the remaining deferral at the old
+  price, charge the new one prorated. The cash-refund path
+  (`Dr liability:deferred:subscriptions / Cr liability:refunds_payable`,
+  then `Dr liability:refunds_payable / Cr asset:psp:main`) stays on the
+  shelf for the case where somebody has already paid and is leaving.
 
-```
-Entry 'subscription_refund_approved'
-  Dr liability:deferred:subscriptions        2.500000
-  Cr liability:refunds_payable               2.500000
-Entry 'refund_paid'              (external_ref: the provider's refund id)
-  Dr liability:refunds_payable               2.500000
-  Cr asset:psp:main                          2.500000
-```
-
-Nothing new is needed in the schema for this — only the recipes and a
-product surface. That is the "make it possible" requirement satisfied.
-
-### 3.5 Corrections and alterations
-
-Never edit. Post `Entry X-reversal` (`reverses_entry_id = X`, every leg
-mirrored) and then, if needed, a fresh correct entry. Full
-reverse-and-rebook, not deltas — Airbnb's lesson: deltas compound into
-unauditability.
-
-### 3.6 Promo / granted credits (Phase 4+, cheap to include early)
-
-```
-Entry 'promo_grant'
-  Dr contra_revenue:promo                    5.000000
-  Cr liability:credits_promo:customer:<id>   5.000000
-```
-
-Usage draws promo balance before (decision: or after) paid balance; the
-charge entry debits the promo account but still credits `revenue:ai_usage`
-at full price — the grant's contra-revenue already nets it out. Promo
-credits are excluded from any future refund math, which is why they must not
-share the paid-credits account.
-
-### 3.7 Postpay (later)
-
-Same usage recipes with the first leg swapped:
-`Dr asset:receivable:customer:<id> / Cr revenue:ai_usage`, then invoice
-settlement clears the receivable. The chart already has the account; no
-model change.
+If prepaid ever comes back (§3.5), the charge leg swaps to
+`Dr liability:credits:customer:<id>` and nothing else moves.
 
 ---
 
@@ -539,7 +769,8 @@ migration-replay global setup auth-web and the hub use (own database,
   A model with no price row prices at a deliberately conservative fallback
   rather than at zero, and the snapshot says which — an unknown price that
   read as free would hide the whole of its spend.
-- `src/settings.ts` — the margin/overdraft/metering-mode knobs, with a
+- `src/settings.ts` — the margin / daily-cap / overdraft / metering-mode
+  knobs, with a
   code-level default for every key and an env-var bootstrap for the margin.
   Values are validated on write, not on read: a typo'd setting has to fail
   where a human can see it.
@@ -552,8 +783,12 @@ migration-replay global setup auth-web and the hub use (own database,
   the cache had gone wrong.
 - `src/balances.ts` — `accountBalanceMicros(db, code)` off the cache,
   `accountBalanceFromPostings` for the slow always-correct answer, and
-  `availableCreditMicros(db, accountId, {overdraftMicros})` (paid + promo +
-  whatever overdraft policy allows) for the Phase 3 spend gate.
+  `availableCreditMicros(db, accountId, {overdraftMicros})`, which belongs
+  to the shelved prepaid model (§3.5) and no longer has a caller ahead of
+  it. Postpay's gate does not read the ledger at all: `dailySpendMicros()`
+  (Phase 3a) sums `ai_usage_records` for the current UTC day, because the
+  cap must also hold for shadow-mode and own-key turns, which post nothing
+  — §5.3.
 - `src/money.ts` — the one door micro-dollar amounts come through: jsonb
   payloads carry them as decimal strings, because JSON's single number type
   silently loses integers above 2^53.
@@ -623,13 +858,15 @@ the metering table already supports that without schema change.
   render check on our own box) has no cost model anywhere in the ledger yet —
   that is the same unanswered "free cloud rendering" question §7 Phase 6
   parks, and it is infrastructure spend rather than a per-turn provider bill.
-- **Spend gate**: before starting a platform-key turn, require
-  `availableCreditMicros > 0` (allow the configured overdraft to cover the
-  in-flight turn; a turn's cost is unknown until it ends). Error shape:
-  `jsonError("insufficient_credits", 402)` with balance in the body.
-- **Surfacing**: extend `GET /api/account/usage` (already the aggregation
-  point that MCP `account_quota` proxies) with
-  `credit_balance_micros`, `promo_balance_micros`, spend this month.
+- **The three gates** a platform-key turn passes before it starts, in this
+  order, because they answer three different questions: is AI on for this
+  account at all (§5.1), is the account inside today's cap (§5.3), and is
+  there an unpaid balance old enough to stop serving (dunning, §3.2). Each
+  is a distinct refusal with a distinct message; collapsing them into one
+  "you can't do that" is how a user ends up guessing.
+- **Surfacing** (§5.2): `GET /api/account/usage` — already the aggregation
+  point MCP `account_quota` proxies — grows an `ai` block, and the account
+  header grows an "AI usage" row next to the storage meters.
 - **Margin config** (done): `billing_settings` is the repo's first global
   settings table, with the admin form at `/admin/billing`, superadmin-gated
   via `getSuperadminContext()` and written through `recordAuditEvent`.
@@ -639,6 +876,156 @@ the metering table already supports that without schema change.
   systemd timer, sibling of the backup timers. It curls
   `POST /api/admin/billing/nightly` rather than doing the work itself —
   see Phase 4 for why.
+
+### 5.1 The AI switch — an account may opt out entirely
+
+Decided in §0: an account can turn AI features **off**, explicitly, and then
+nothing it does can incur a cent of AI cost. This is not a billing feature
+wearing a settings hat — it is the answer to a question people reasonably
+ask about a metered product ("what stops this from running up a bill while
+I'm not looking?") that a cap alone cannot answer, because a cap still
+permits spending.
+
+Shape:
+
+- **Storage**: a nullable `ai_disabled_at` timestamptz on `accounts`, in the
+  Phase 3 migration. A column rather than an `account_settings` row: the
+  settings table stores per-group string maps (`filterAccountSettings`) and
+  is written by the *shared frontend settings form*, which posts whole
+  objects and is the wrong owner for a switch that must never be flipped by
+  accident. `accounts` already carries exactly this kind of per-account
+  product flag (`store_banned_at`, `verified_publisher_at`), and a
+  timestamp answers "since when" for free, which a boolean does not.
+- **Enforcement in one place**: `resolveAiCredentials()` returns `null` for
+  a disabled account, *before* it looks at any key. Every AI surface already
+  goes through it (scene chat, app chat, scene convert) and every one
+  already handles null, so the switch cannot be forgotten at a call site
+  that gets added later. The refusal needs its own error code, though:
+  today null means `missing_api_key` / "OpenAI backend API key not set",
+  which would be a lie here. Add `ai_disabled`, and have the routes
+  distinguish the two — a disabled account being told to go set an API key
+  is exactly the confusing dead end this switch is supposed to avoid.
+- **What "off" does not touch**: an account's *own* OpenAI key. If a user
+  has one and switches AI off, AI is off — the switch is about the feature,
+  not about who is paying. (Doing otherwise would mean the switch means two
+  things depending on state, which is worse than either meaning.)
+- **Nor the scene converter.** Decided while building: `/api/scenes/convert`
+  keeps calling `resolveAiCredentials` directly rather than the gate. It is
+  an absorbed surface (§5) — billed to nobody, capped for nobody — and it
+  has an anonymous path that needs no account at all, which is the proof it
+  is not an account feature. Neither the switch nor the cap may turn a free
+  migration tool we asked people to run into a refusal. The exemption is a
+  comment at the call site, not an implicit consequence of the surface list,
+  because the next person to read it will otherwise "fix" it.
+- **UI**: a toggle in account settings, plus the same toggle reachable from
+  the `/account/ai` page (§5.2), which is where somebody worried about cost
+  is actually standing when the thought occurs to them. Turning it off states
+  plainly what stops working; turning it back on is one click and audited
+  (`recordAuditEvent`) in both directions.
+- **Superadmin side**: the same flag readable on `/admin/billing`, and
+  settable by an operator as the terminal step of dunning (§3.2) — an
+  account that has not paid stops accruing before it stops being a customer.
+
+### 5.2 "AI usage": a row in the header, a page behind it
+
+Two surfaces, because they answer two different questions.
+
+**The header row.** The account header
+(`src/components/StorageUsageMeters.tsx`, rendered by
+`app/account/layout.tsx`) shows a capacity meter per storage bucket and a
+free-form last row for public scenes. AI usage joins as a row of that second
+kind — a label and a dollar figure, no meter — because the only number it
+could be metered against today is the daily cap, and a bar that fills every
+day and empties overnight tells nobody anything:
+
+```
+Frames               ████░░░░░░  8 / 50
+Private scenes       █░░░░░░░░░  8.8 KB / 100 MB
+Backups              ░░░░░░░░░░  0 B / 100 MB
+Frame logs           ██░░░░░░░░  5.2 MB / 100 MB
+Public scenes                    109 MB · free
+AI usage                         $1.27 this month →
+```
+
+The figure is this calendar month's `SUM(price_micros)` over
+`ai_usage_records` for the account — the same rows the admin statement
+drills into, so the user's number and ours are one query apart rather than
+two definitions apart. While metering is in shadow mode `price_micros` is 0
+on every row, so the honest display is the *would-be* price (cost × margin)
+labelled as such: `$1.27 this month · not billed yet`. Four zero states, and
+each needs its own words: nothing used yet, AI switched off (§5.1), running
+on the account's own OpenAI key (they owe us nothing and must not be shown
+a bill-shaped number), and no AI available to this account at all.
+
+The row links to the page. It is not a modal: what people want when that
+number surprises them is *which of my turns did this*, and that is a table,
+a date range and a switch — a page's job.
+
+**`/account/ai` — the page.** A new tab in `AccountNav`, alongside Installs,
+Backups, Security, Developer and Activity, so it sits where every other
+"about my account" answer already lives. Friendly first, forensic
+underneath:
+
+1. **This month, in one sentence.** "You've used $1.27 of AI this month.
+   Nothing is billed yet while FrameOS Cloud AI is in preview." Then last
+   month beside it, because the only way to know whether $1.27 is a lot is
+   to see what $1.27 was last time.
+2. **Where it went.** A breakdown by *surface* in the user's language —
+   "Scene chat", "App code assistant", "Scene converter (free)", "Store
+   classification (free)" — not by `surface` slug and not by model. The
+   free ones are listed *because* they are free: an absorbed surface (§5)
+   showing $0.00 next to a real number is the clearest possible statement
+   of what we do and don't charge for.
+3. **Recent turns.** Date, surface, the chat it belongs to (linked, when
+   the chat still exists), and what it cost. Twenty rows and a "show more".
+   This is the reconciliation surface: a user who disputes a number needs
+   to be able to point at the turn.
+4. **How pricing works.** Three sentences, not a schedule: we pay the model
+   provider per token, we add a margin (the account's current one, named as
+   a number), and the token counts and unit prices behind every turn are on
+   record. Plus the daily cap and when it resets, and — once §0.1 exists —
+   what the account's plan is and what a different one would have cost.
+5. **The switch** (§5.1), at the bottom, stated plainly: what turns off,
+   what keeps working, and that it takes effect immediately.
+
+**Wire shape**: `GET /api/account/usage` gains an `ai` block —
+`{ enabled, metering_mode, credential_source, month_price_micros,
+month_cost_micros, previous_month_price_micros, today_price_micros,
+daily_cap_micros, margin_basis_points }` — snake_case like the rest of that
+payload because it crosses the AGPL boundary, and MCP's `account_quota`
+picks it up for free (route first, thin tool after — house pattern). The
+per-surface and per-turn detail is the page's own query rather than part of
+that payload: `account_quota` is a "can I still do X" answer and has no
+business carrying a hundred rows.
+
+### 5.3 The daily cap
+
+$10/day per account (§0), as `billing_settings.payg_daily_cap_micros` so it
+is a superadmin edit rather than a deploy, with a per-account override
+column for the accounts that eventually need one.
+
+- **Measured** as `SUM(price_micros)` over the account's `ai_usage_records`
+  for the current UTC day. Not the ledger: the cap must hold for shadow-mode
+  and own-key accounts too (where nothing posts), and it must be a cheap
+  indexed query on the hot path of every turn.
+- **Checked before a turn, never during.** A turn's cost is unknown until it
+  ends, so the cap is necessarily approximate: the last turn of the day can
+  cross it. That is the same accepted overshoot the prepaid design called an
+  overdraft, and `payg_overdraft_micros` already exists to size it — worst
+  case one turn's worth, which is why the cap is $10 and not $10,000.
+- **Refusal**: `jsonError("daily_cap_reached", 402)` with the cap, the
+  day's spend and the reset time in the body, rendered by the SPA's AI panel
+  as its own state rather than as a generic error. It resets at midnight
+  UTC and the message says so.
+- **`payg_overdraft_micros` keeps its meaning** and loses its old job: it no
+  longer guards a prepaid balance going negative (there is no balance), it
+  sizes the cap's permitted overshoot.
+- **Watching it**: the nightly job runs `checkDailyCapRespected` — invariant
+  5's replacement — over every account-day, which is the only automated proof
+  that the gate sits in front of *every* AI surface rather than most of them.
+  A surface added next month that forgets to call `resolveAiAccess` shows up
+  as a day over the line rather than as a surprise on an invoice. It reports
+  and never repairs, like everything else in that job.
 
 ---
 
@@ -660,7 +1047,16 @@ data by the nightly job, and shown live on `/admin/billing`.
 4. **Events post exactly once**: no `processed_at IS NULL` older than N
    minutes; no two entries of the same `entry_type` for one event unless the
    recipe declares multiplicity.
-5. **No negative customer credit** beyond the configured overdraft.
+5. **The daily cap held** (`checkDailyCapRespected`): no account, on any UTC day, has metered more
+   than the cap in force plus one turn's permitted overshoot
+   (`payg_overdraft_micros`). This replaces the prepaid "no negative credit
+   balance" check — same job (nobody spends past the line we drew), same
+   place, different line — and it is the only automated proof that the gate
+   in §5.3 is actually wired in front of every AI surface rather than most
+   of them. Its companion is a *report*, not a violation: a customer
+   receivable sitting on the credit side means we owe them money, which
+   under postpay is legitimate after a promo grant and suspicious
+   otherwise.
 6. **Metering completeness**: every *live, billable* `ai_usage_records` row
    has `event_id` set after the sweep. Narrow on purpose — a shadow-mode
    record posts nothing by design and an own-key turn cost nothing and is
@@ -673,8 +1069,12 @@ data by the nightly job, and shown live on `/admin/billing`.
    attempting an UPDATE and expecting the exception).
 
 Plus Airbnb-style **golden-file lifecycle tests**: scripted scenarios
-(purchase → 3 turns → subscribe from credits → cancel mid-period → refund →
-reversal) asserting the full journal and every balance at each step.
+asserting the full journal and every balance at each step. The live one
+walks the postpay path (3 turns → the cap refuses a fourth → month close →
+invoice → payment → fee → reversal); Phase 5 adds the subscription walk
+(§3.6); and §3.5's shelved prepaid recipes keep a walk of their own
+(purchase → spend → refund), which is what stops a shelved model from
+quietly rotting into something that no longer compiles.
 
 ---
 
@@ -728,36 +1128,90 @@ Still open, and the gate on Phase 3:
       PostHog `$ai_generation` sums **and against the provider's own
       invoice** — the second comparison is the one that settles §8.2.
 
-### Phase 3 — PAYG credits (first revenue)
+### Phase 3 — postpay billing (first revenue)
 
-**The payment provider is not chosen** (§8.7), and the ledger no longer
-assumes one: the account is `asset:psp:main`, the recipes in §3.1 hold for
-any provider that reports a successful payment, its fee, and a stable
-payment id, and `credit_purchases` names the roles rather than one vendor's
-object types. What changes with the choice is the webhook parsing and the
-VAT question (§8.6, and §3.1's note on merchant-of-record providers) —
-neither of which reaches the posting rules.
+Rewritten 2026-09-01 for §0. The prepaid checkout this phase used to be is
+now §3.5's shelf recipe; what ships instead is metering that charges a
+receivable, a daily cap, a visible number, an off switch, and one invoice a
+month.
 
-- [ ] Choose the provider, then: SDK + env plumbing; webhook endpoint
+It splits at the payment provider, and the split is worth respecting because
+the first half is unblocked and the second is not.
+
+**Phase 3a — everything that does not need a provider — shipped 2026-09-01.**
+Migration `0044` (`accounts.ai_disabled_at`, the `payg_daily_cap_micros`
+setting at $10, an `(account_id, occurred_at)` index), the AI switch, the
+daily cap, the `ai` block on `GET /api/account/usage`, the account header's
+"AI usage" row and the `/account/ai` page behind it.
+
+- [x] The AI switch (§5.1): `resolveAiAccess()` in
+      `src/lib/ai/api-key.ts` is now the one door every AI surface goes
+      through — switch, then key, then cap, in that order. It replaces a
+      `null` that meant three unrelated things with a typed refusal, and
+      `src/lib/ai/access.ts` turns each into its own status code: 403 for a
+      switch the user threw, 402 for the cap, 400 for a genuinely missing
+      key. Audited both ways through `PUT /api/account/ai`.
+- [x] The daily cap (§5.3): `accountAiSpendMicros()` in
+      `packages/ledger/src/account-usage.ts`, checked before a turn, and
+      `checkDailyCapRespected` as invariant 5's postpay replacement.
+      **The chargeable amount is defined once and used twice** — by the cap
+      and by the page — because two definitions of "what you have spent
+      today" that differ by a rounding step is a bug only ever found by a
+      confused user. It is not `SUM(price_micros)`: in shadow mode that is
+      zero on every row, so the cap would never bite and would ship
+      untested. It is what the turn *would* be billed at, from the row's own
+      pricing snapshot.
+- [x] `GET /api/account/usage` carries an `ai` block, built inside
+      `accountUsage()` rather than in the route, so the payload and the
+      header component share one definition. MCP `account_quota` picks it up
+      for free.
+- [x] Account header: the "AI usage" row, with the shadow-mode "not billed
+      yet" wording and all four zero states.
+- [x] `/account/ai`: this month and last, the per-surface breakdown in the
+      user's words with the absorbed surfaces shown as free, the last twenty
+      requests, how pricing works, and the §5.1 switch. A new `AccountNav`
+      tab.
+- [x] Tests: the refusal shapes, the cap invariant (including that own-key
+      turns and absorbed surfaces stay out of it), the window arithmetic,
+      and the subscription golden file.
+
+**Phase 3b — the provider half.** Blocked on §8.7, and the requirement is
+now stricter: postpay needs a payment method stored and chargeable later,
+not a one-off hosted checkout (§3.2).
+
+- [ ] Choose the provider; SDK + env plumbing; webhook endpoint
       `app/api/webhooks/<provider>/route.ts` (signature check, provider
       event id as idempotency key, raw-body handling).
-- [ ] Migration `0044`: `credit_purchases`.
-- [ ] Checkout route (`POST /api/billing/checkout` → the provider's hosted
-      checkout, fixed top-up amounts to start); success/cancel pages.
-- [ ] Recipes: `credit_purchase`, `psp_fee`, `credit_purchase_refund`
-      (a provider-side refund — needed for disputes from day one).
-- [ ] `source: "platform"` in `resolveAiCredentials` (accounts with
-      credit > 0 and no own key), spend gate + overdraft setting,
-      `insufficient_credits` error through chat route → SPA panel state.
-      The scene converter is not part of this: it is an absorbed surface
-      (§5), so it keeps booking as pure cost when the billable key reaches
-      it — and the spend gate must not turn a free surface into a 402.
-- [ ] Extend `GET /api/account/usage` + account page: balance, top-up
-      button, usage history (from `ai_usage_records`).
-- [ ] MCP: extend `account_quota`/`account_info` payloads (route first,
-      thin tool after — house pattern).
-- [ ] Golden-file test: purchase → turns → balance depletion → gate.
-- [ ] Legal/pricing page copy: what a credit is, expiry policy (§8).
+- [ ] Migration `0045`: `invoices` (period bounds, sequential number, status,
+      provider payment ref) and the stored-payment-method reference. The
+      invoice holds no amount the ledger does not — §3.2 says why.
+- [x] `ai_usage` rule **v2** (done 2026-09-01, ahead of the rest of 3b
+      because a subscription accruing on the receivable while metered usage
+      drew down a prepaid liability would have been two models in one book):
+      the charge leg debits `asset:receivable:customer:<id>` (§3.1). A
+      version bump, not a re-model. Nothing had posted under v1 — metering
+      has been in shadow throughout — so no historical entry means anything
+      different than it did.
+- [ ] `source: "platform"` in `resolveAiCredentials` — the thing that makes
+      any of this billable at all, and still gated by §5.1 and §5.3 before
+      it is reached. The scene converter stays out of it: it is an absorbed
+      surface (§5), so it books pure cost when the billable key reaches it,
+      and neither the cap nor the switch may turn a free surface into a 402.
+- [ ] Month-close run in the nightly job: cut invoices over the period's
+      receivable, skip balances under the minimum threshold (§3.2), charge
+      the stored method.
+- [ ] Recipes: `invoice_payment`, `psp_fee`, `receivable_writeoff`, and
+      `promo_grant` against the receivable (§3.4).
+- [ ] Dunning: retry schedule, the age at which AI switches off for an
+      unpaid balance, the emails. Reads the receivable, writes none of it.
+- [ ] Flip `ai_metering_mode` to `live` — after the Phase 2 gate below is
+      satisfied, not before.
+- [ ] Golden-file test: turns → cap refusal → month close → invoice →
+      payment → fee → an unpaid month → write-off.
+- [ ] Legal/pricing page copy: that AI is billed monthly in arrears, what
+      the margin is, what the cap is, and how to turn it off. Plus §8.8's
+      billing-records retention line, which must land before the first
+      invoice, not after.
 
 ### Phase 4 — books you can actually read + ops — shipped 2026-08-31
 
@@ -795,25 +1249,83 @@ statement reads "deleted account" and stays complete. That stops working the
 day accounting moves to its own database (§7 Phase 6) — which is when a
 deliberate customer-label table becomes the answer, and not before.
 
-Still open, and deliberately not decided by building:
+Decided since:
 
-- [ ] Backfill decision: either start the books at go-live (recommended — no
-      history to fabricate) or post `source: 'backfill'` events for the
-      shadow-mode period. Nothing forces it either way; the shadow records
-      sit there with `event_id IS NULL` and the sweep is built to ignore
-      them, so both options stay open until somebody chooses.
+- [x] **Backfill: no.** The books start at go-live rather than fabricating a
+      history for the shadow-mode period. The shadow records stay where they
+      are with `event_id IS NULL`, the sweep is built to ignore them, and
+      invariant 6 is narrow on purpose so that this is a decision rather
+      than a permanent alarm. It costs nothing: nobody was charged for those
+      turns, so there is no receivable to reconstruct — only measurements,
+      which we still have.
 
-### Phase 5 — subscriptions
-- [ ] Migration: `billing_plans`, `subscriptions`, `subscription_periods`.
-- [ ] Recipes: `subscription_charge_from_credits`,
-      `subscription_charge_card`, `subscription_recognition`.
-- [ ] Period lifecycle in the nightly job (charge at rollover, recognize,
-      dunning state when balance insufficient — grace period setting).
-- [ ] Cancel flow (stop at period end; mid-period refund stays a recipe on
-      the shelf per §3.4 until we decide to offer it).
-- [ ] Plan UI + entitlement checks where plans gate features.
-- [ ] Golden-file: subscribe from credits → recognize → cancel →
-      (shelf-test the refund recipe even though no UI calls it).
+### Phase 5 — plans and subscriptions (§0.1) — shipped 2026-09-01
+
+Un-shelved and built the same day it was un-shelved, which is the payoff for
+§3.6 having been designed rather than merely deferred: no posting rule
+changed, `rules/ai-usage.ts` still does not know that plans exist, and the
+whole of it is schema, a lifecycle job and three two-leg recipes.
+
+- [x] Migration `0045`: `billing_plans` (code, name, price, period,
+      `margin_basis_points`, entitlements jsonb), `subscriptions`,
+      `subscription_periods`. Seeds §0.1's ladder **including PAYG as a real
+      row** at $0/100%, so "what plan is this account on" always has an
+      answer and the margin lookup has no special case.
+- [x] Recipes `subscription_charge`, `subscription_recognition`,
+      `subscription_refund_to_receivable` (`rules/subscription.ts`), and the
+      lifecycle in `subscriptions.ts`: open the periods that are due, charge
+      the ones that have started, recognize the ones that have ended. Every
+      step is idempotent on its period row, so the nightly job may run twice
+      in a night or miss three nights without double-charging anybody or
+      losing a period — and a job that has not run for two months opens both
+      months, because both were served.
+- [x] Per-plan margin: `accountMarginBasisPoints()` resolves the plan's rate
+      and `metering.ts` snapshots it into the record exactly as it always
+      snapshotted the global one, so a plan change is never retroactive.
+- [x] Per-plan entitlements: `accountLimits()` in `src/lib/usage.ts`, and
+      **every enforcement point moved onto it** — backups, private scenes at
+      all four write paths, the frame-log cull. A display that promises 10 GB
+      while the refusal still fires at 100 MB would be worse than having no
+      plans at all.
+- [x] Nightly: `runSubscriptionCycle` runs between the usage sweep and the
+      invariants — the invariants have to see the books *after* everything
+      that was going to be written tonight has been, or they report a
+      disagreement they caused themselves.
+- [x] `GET/PUT /api/account/plan`, the plan on `/account/ai`, and the
+      cancel-at-period-end flow.
+- [x] Golden file (`subscriptions.integration.test.ts`): subscribe →
+      charge → the same night again charges nobody twice → meter a turn at
+      the *plan's* margin rather than the deployment's → recognize once the
+      period has actually been served → refund the unearned remainder to the
+      receivable → cancel and expire on time.
+
+Three decisions taken while building, each of them a place where the obvious
+thing would have been wrong:
+
+- **Self-serve purchase is gated off** behind `FRAMEOS_CLOUD_PLANS_SELF_SERVE`,
+  default false. Subscribing accrues a real receivable, and Phase 3b — the
+  provider, the stored payment method, the month-end invoice — does not
+  exist. Letting somebody subscribe today would run up a balance with no way
+  to settle it: the ledger would be right and the customer would be stuck.
+  Downgrading to the free plan is never gated; refusing to let somebody stop
+  paying us would be an unpleasant thing to build.
+- **An account nobody put on a plan prices at the deployment's global margin,
+  not at PAYG's 100%.** Otherwise migration 0045 would have doubled the
+  price of every existing account's AI on the night it ran — a price change
+  wearing a schema change's clothes. PAYG's own margin applies once somebody
+  is deliberately on it, and §8.13's "what are the numbers really" question
+  is the one that should move this.
+- **Entitlements take the larger of the plan and the deployment's env floor.**
+  An operator who raised `FRAMEOS_CLOUD_MAX_BACKUP_MB` for everybody must not
+  have it silently lowered by a plan row, and the seeded PAYG numbers are
+  deliberately identical to the historical free tier so that nothing anybody
+  has today gets smaller.
+
+Still open, and genuinely Phase 6 rather than hidden work: the
+cloud-rendered-frame entitlement (§0.2) is carried in the plan row and
+enforced nowhere, because no frame is cloud-rendered yet. It becomes a count
+check at frame creation plus the minimum-refresh-interval floor the day thin
+clients land — which is the product this entitlement exists to unblock.
 
 ### Phase 6 — later, enabled by the above, not designed in detail here
 - [ ] Bank/PSP reconciliation: import the provider's payout reports + bank
@@ -824,7 +1336,8 @@ Still open, and deliberately not decided by building:
 - [ ] Postpay: credit limits, invoicing, receivables aging.
 - [ ] Storage/other metered products: new event types + recipes only.
 - [ ] Multi-currency: EUR chart siblings, FX gain/loss account.
-- [ ] Refund self-service UI on the §3.4 recipes.
+- [ ] Refund self-service UI on the §3.6 cash-refund path (the
+      net-against-receivable case Phase 5 builds covers most of it).
 - [ ] **Accounting in its own Postgres database** (stated intention,
       2026-08-31). §2.1 already pays the entry price: no ledger table
       references anything outside the ledger, and a schema test fails if one
@@ -839,11 +1352,17 @@ Still open, and deliberately not decided by building:
 
 ---
 
-## 8. Open decisions (Phase 0)
+## 8. Open decisions
 
-1. **Credits display unit** — plain dollars, or "credits" at 1 credit =
-   $0.01? Ledger is unaffected; pure product copy. Lean: show dollars,
-   avoid a fake currency.
+Numbered from the original Phase 0 list; §0 closed several of them by
+narrowing the product, and closed items are kept in place with what closed
+them rather than deleted, because "why isn't there a credit balance" is a
+question that will be asked again.
+
+1. **Credits display unit** — ~~plain dollars, or "credits" at 1 credit =
+   $0.01?~~ **Closed by §0**: there is no credit balance to display. The
+   account page shows dollars of usage (§5.2), which is not a currency
+   question at all.
 2. **Reasoning-token pricing** — still open, and now measurable. The
    implementation assumes reasoning bills as output (it is a subset of
    `output_tokens`, recorded separately for analysis and never priced on its
@@ -851,17 +1370,27 @@ Still open, and deliberately not decided by building:
    provider's actual invoice line items during the shadow period; if it
    turns out to be wrong the fix is a column plus a rule-version bump, not a
    re-model.
-3. **Shared-key tier** — once PAYG exists, does
-   `FRAMEOS_AI_SHARED_KEY_ACCESS` shrink (e.g. `verified` keeps a small free
-   monthly grant as promo credits) or stay as-is? Affects whether promo
-   accounts ship in Phase 3 or 4.
-4. **Overdraft size** — one turn can cost ~$0.50+; proposal: allow balance
-   to go negative by `payg_overdraft_micros` (default $1) and gate the
-   *next* turn.
-5. **Credit expiry** — legal/VAT implications differ by jurisdiction
+3. **Shared-key tier** — what happens to `FRAMEOS_AI_SHARED_KEY_ACCESS`
+   once the PAYG plan exists? Today it is the operator's free tier and we
+   absorb it as COGS; §0.1 gives every account a billable path, which makes
+   the shared key redundant for anyone on this deployment and still
+   necessary for a self-hoster who wants to give their users AI. Lean: it
+   stays, and it stops applying to accounts on a plan. If it instead becomes
+   a *free monthly allowance*, the shape is a monthly `promo_grant` against
+   the receivable (§3.4) rather than a promo balance — which is also how
+   §0.1 would express "your first $2 of AI each month is on us" if a plan
+   ever wants that.
+4. **Overdraft size** — one turn can cost ~$0.50+, and its cost is unknown
+   until it ends, so the last turn of the day can cross the cap. Proposal
+   unchanged in size, changed in meaning: `payg_overdraft_micros` (default
+   $1) now sizes the *cap's* permitted overshoot rather than a prepaid
+   balance's permitted negative (§5.3).
+5. **Credit expiry** — ~~legal/VAT implications differ by jurisdiction
    (unused prepaid balances are liabilities indefinitely unless terms say
-   otherwise). Needs a terms-of-service answer before launch, not a schema
-   change.
+   otherwise).~~ **Closed by §0**: nothing is prepaid, so there is no
+   unused balance to expire, no dormancy question, and no
+   unclaimed-property exposure. This decision disappearing was one of the
+   arguments *for* postpay, not a consequence discovered afterwards.
 6. **VAT/sales tax** — out of scope above, but EU sales likely need it
    sooner than reconciliation does. When it lands: a `liability:vat_payable`
    account plus tax legs in the purchase/subscription recipes. Who owes it
@@ -871,9 +1400,13 @@ Still open, and deliberately not decided by building:
    computing is not remitting). Flagged now so the recipes are written with
    a third leg in mind.
 7. **Payment provider** — undecided, and the code no longer assumes one.
-   `asset:psp:main` names the role, `credit_purchases` carries a `provider`
-   column, and §3.1's recipes hold for anything that reports a successful
-   payment, a fee and a stable payment id. The choice is a product/tax
+   `asset:psp:main` names the role, `invoices` carries a `provider` column,
+   and §3.2's recipes hold for anything that reports a successful payment,
+   a fee and a stable payment id. §0 made the *requirement* stricter
+   without making the choice: postpay needs a payment method **stored and
+   chargeable later**, not a one-off hosted checkout, which rules out the
+   simplest integration of several candidates and should be checked before
+   picking one. The choice is a product/tax
    decision rather than a schema one, and the sharpest part of it is §8.6: a
    merchant-of-record (Paddle, Lemon Squeezy) collects and remits VAT for
    us, which removes a liability and a compliance burden at the cost of a
@@ -922,3 +1455,37 @@ Still open, and deliberately not decided by building:
     separate customer-label table the ledger owns, populated at first touch
     and cleared on erasure (a third thing to keep in sync). Lean: resolve
     live, degrade to uuid — which is what shipped.
+11. **Where `expense:bad_debt` reports** — `cost_of_revenue` alongside COGS
+    and PSP fees, or its own group? It is not a cost of *producing* the
+    service (we already booked that as COGS when the tokens burned); it is
+    a collection failure. Lean: its own group, so gross margin stays a
+    statement about the product and not about who paid. Trivial to change
+    later — §1.3 mechanism 1 re-maps a group with zero accounting impact,
+    which is exactly the kind of decision that machinery exists for.
+12. **What day the daily cap counts** — UTC, or the account's own timezone?
+    UTC is what Phase 3a will implement (one definition, one index, no
+    per-account arithmetic on the hot path of every turn) but it means the
+    reset lands mid-afternoon for some users, and "resets at midnight" is
+    then a small lie on the `/account/ai` page. Frames already carry a
+    timezone and
+    `docs/` has a history of UTC-vs-local bugs on exactly this pattern
+    (ESP32 clock handling, SD-card cards). Decide before the copy in §5.2 is
+    written, because the honest UTC wording is different from the honest
+    local one.
+13. **Plan numbers** (§0.1) — the three margins are decided (100/50/20) and
+    everything else in that table is a proposal: $1.99/$6.99, 5/25
+    cloud-rendered frames, 2 GB/10 GB of backups. What would settle them is
+    a month of live metering (Phase 3b) showing what a real account actually
+    burns — the crossover arithmetic in §0.1 is only as good as the ~$0.44
+    per turn it assumes, and that figure comes from one worked example, not
+    from a distribution. Decide the frame counts against a capacity plan
+    rather than a feeling (§0.2 does the CPU arithmetic; nobody has done the
+    "how many accounts per box" half).
+14. **Whether AI is off by default for new accounts.** §0 says users can opt
+    *out*, which presumes in. That is right while metering is in shadow
+    mode and everything is free. It stops being obviously right the day
+    Phase 3b makes a turn cost money: "signed up and immediately started
+    accruing a bill" is a defensible default only if the first thing the
+    product shows is what it costs. Tied to §8.3's allowance question — a
+    free monthly allowance makes opt-in-by-default unremarkable, and no
+    allowance makes it a decision worth being deliberate about.

--- a/cloud/packages/db/drizzle/0044_ai_switch_and_daily_cap.sql
+++ b/cloud/packages/db/drizzle/0044_ai_switch_and_daily_cap.sql
@@ -1,0 +1,27 @@
+-- Phase 3a of cloud/docs/accounting-todo.md: the two things that make the AI
+-- metering we already run visible and controllable to the people it measures,
+-- neither of which needs a payment provider.
+--
+-- 1. The AI switch (§5.1). An account may opt out of AI features entirely and
+--    then incur nothing. A column on `accounts` rather than an
+--    `account_settings` row: that table holds per-group string maps written by
+--    the shared frontend settings form, which posts whole objects and is the
+--    wrong owner for a switch that must never be flipped by accident. This is
+--    the same kind of per-account product flag as `store_banned_at`, and a
+--    timestamp answers "since when" for free where a boolean would not.
+ALTER TABLE "accounts" ADD COLUMN "ai_disabled_at" timestamptz;
+
+-- 2. The daily cap (§5.3). Postpay's one real cost is credit risk, and the cap
+--    is how it is bounded: $10/day per account to start. A setting rather than
+--    a constant so it is a superadmin edit at /admin/billing, not a deploy.
+INSERT INTO "billing_settings" ("key", "value") VALUES
+  ('payg_daily_cap_micros', '10000000')
+ON CONFLICT ("key") DO NOTHING;
+
+-- The cap sums a UTC day of an account's usage on the hot path of every turn,
+-- and the /account/ai page sums a month of it. `ai_usage_records_account_created_idx`
+-- is on (account_id, created_at); both queries filter on `occurred_at`, which is
+-- when the tokens were burned rather than when the row was written — the
+-- distinction that matters for a turn metered by the sweep hours later.
+CREATE INDEX "ai_usage_records_account_occurred_idx"
+  ON "ai_usage_records" ("account_id", "occurred_at");

--- a/cloud/packages/db/drizzle/0045_billing_plans.sql
+++ b/cloud/packages/db/drizzle/0045_billing_plans.sql
@@ -1,0 +1,104 @@
+-- Phase 5 of cloud/docs/accounting-todo.md: plans and subscriptions (§0.1).
+--
+-- What varies down the ladder is the MARGIN on metered AI, not access to a
+-- feature: a plan is a better rate on something everybody may already use.
+-- That is why there is no "has_ai" column anywhere below, and why PAYG is a
+-- real row at $0 rather than the absence of a row — "what plan is this
+-- account on" then always has an answer and the margin lookup has no special
+-- case to get wrong.
+
+CREATE TABLE "billing_plans" (
+  "code" text PRIMARY KEY,
+  "name" text NOT NULL,
+  "description" text,
+  "price_micros" bigint NOT NULL,
+  "currency" text NOT NULL DEFAULT 'USD',
+  "period" text NOT NULL DEFAULT 'month' CHECK ("period" IN ('month', 'year')),
+  -- The plan's markup over provider cost, in basis points. Overrides the
+  -- global `ai_margin_percent` setting for accounts on this plan, and is
+  -- snapshotted per usage record exactly as the global one always was, so an
+  -- entry stays explainable after the account changes plan.
+  "margin_basis_points" integer NOT NULL CHECK ("margin_basis_points" >= 0),
+  -- Quota entitlements: cloud_rendered_frames, backup_bytes, frame_log_bytes,
+  -- private_scene_bytes, frames. Read by src/lib/usage.ts, never by the
+  -- ledger — a plan's entitlements are not accounting facts (§3.6).
+  "entitlements" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "sort_order" integer NOT NULL DEFAULT 0,
+  "public" boolean NOT NULL DEFAULT true,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- One subscription row per account. An account with no row is on PAYG, which
+-- is the same thing as a row pointing at the payg plan — the fallback exists
+-- so that enrolling every existing account is not a prerequisite for shipping.
+CREATE TABLE "subscriptions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "account_id" uuid NOT NULL REFERENCES "accounts"("id") ON DELETE CASCADE,
+  "plan_code" text NOT NULL REFERENCES "billing_plans"("code"),
+  "status" text NOT NULL DEFAULT 'active'
+    CHECK ("status" IN ('active', 'canceling', 'canceled')),
+  "started_at" timestamptz NOT NULL DEFAULT now(),
+  -- Set when the user cancels: the plan runs to the end of the paid period
+  -- and stops. Nothing is refunded by default (§3.6 has the recipe if we
+  -- ever offer it).
+  "cancel_at" timestamptz,
+  "canceled_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX "subscriptions_account_unique" ON "subscriptions" ("account_id");
+
+-- One row per billed period. The charge posts at period start (accruing on
+-- the receivable, §3.6) and recognition posts at period end; both are
+-- idempotent on this row's id, so the nightly job may run twice a night or
+-- not at all for a day without double-charging or losing a period.
+CREATE TABLE "subscription_periods" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "subscription_id" uuid NOT NULL REFERENCES "subscriptions"("id") ON DELETE CASCADE,
+  -- Snapshotted, not joined: a period is billed at the price and margin that
+  -- were in force when it started, whatever the plan row says later.
+  "plan_code" text NOT NULL,
+  "price_micros" bigint NOT NULL,
+  "margin_basis_points" integer NOT NULL,
+  "currency" text NOT NULL DEFAULT 'USD',
+  "period_start" timestamptz NOT NULL,
+  "period_end" timestamptz NOT NULL,
+  "charged_at" timestamptz,
+  "recognized_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "subscription_periods_bounds" CHECK ("period_end" > "period_start")
+);
+CREATE UNIQUE INDEX "subscription_periods_unique"
+  ON "subscription_periods" ("subscription_id", "period_start");
+-- The nightly job's two queues: periods to charge and periods to recognize.
+CREATE INDEX "subscription_periods_uncharged_idx"
+  ON "subscription_periods" ("period_start") WHERE "charged_at" IS NULL;
+CREATE INDEX "subscription_periods_unrecognized_idx"
+  ON "subscription_periods" ("period_end") WHERE "recognized_at" IS NULL;
+
+-- §0.1's ladder. Numbers are a sketch and §8.13 says what would settle them:
+-- the three margins are decided, everything else is a proposal that a month
+-- of live metering should confirm or move.
+--
+-- Storage entitlements are grounded rather than aspirational — at R2's
+-- ~$0.015/GB-month, Studio's 10 GB of backups costs about 15 cents against
+-- $6.99. Private scenes are the least meaningful axis (a real scene is ~9 KB,
+-- so the free 100 MB is already ten thousand of them) and are here for
+-- symmetry, not because anyone will meet the limit.
+--
+-- `frames` (your own hardware) does NOT vary: a Pi you own costs us a
+-- WebSocket and a row. `cloud_rendered_frames` is the entitlement with a real
+-- marginal cost (§0.2) and is the reason the free plan gets zero of them.
+INSERT INTO "billing_plans"
+  ("code", "name", "description", "price_micros", "period", "margin_basis_points", "sort_order", "entitlements")
+VALUES
+  ('payg', 'Pay as you go', 'AI when you want it, billed monthly for exactly what you used.',
+   0, 'month', 10000, 0,
+   '{"cloud_rendered_frames": 0, "backup_bytes": 104857600, "frame_log_bytes": 104857600, "private_scene_bytes": 104857600, "frames": 50}'::jsonb),
+  ('maker', 'Maker', 'Half-price AI, five frames we render for you, and room to back things up.',
+   1990000, 'month', 5000, 1,
+   '{"cloud_rendered_frames": 5, "backup_bytes": 2147483648, "frame_log_bytes": 524288000, "private_scene_bytes": 1073741824, "frames": 50}'::jsonb),
+  ('studio', 'Studio', 'The cheapest AI rate, twenty-five cloud-rendered frames, and serious backup space.',
+   6990000, 'month', 2000, 2,
+   '{"cloud_rendered_frames": 25, "backup_bytes": 10737418240, "frame_log_bytes": 2147483648, "private_scene_bytes": 5368709120, "frames": 50}'::jsonb);

--- a/cloud/packages/db/src/schema.ts
+++ b/cloud/packages/db/src/schema.ts
@@ -44,6 +44,12 @@ export const deviceAuthorizationStatus = pgEnum("device_authorization_status", [
 
 export const accounts = pgTable("accounts", {
   id: uuid("id").defaultRandom().primaryKey(),
+  // The AI opt-out (migration 0044). Set = the account has explicitly turned
+  // AI features off and nothing it does may incur AI cost;
+  // resolveAiCredentials() refuses before it looks at any key. A timestamp so
+  // "since when" is answerable, and null for every account that never touched
+  // the switch.
+  aiDisabledAt: timestamp("ai_disabled_at", { withTimezone: true }),
   displayName: text("display_name"),
   isSuperadmin: boolean("is_superadmin").default(false).notNull(),
   // Null for accounts that only sign in through an external provider.
@@ -1450,6 +1456,102 @@ export const aiUsageRecords = pgTable(
       table.accountId,
       table.createdAt,
     ),
+    // The daily cap and the /account/ai page both window on occurred_at —
+    // when the tokens burned, not when the row was written (migration 0044).
+    accountOccurredIdx: index("ai_usage_records_account_occurred_idx").on(
+      table.accountId,
+      table.occurredAt,
+    ),
     turnUnique: uniqueIndex("ai_usage_records_turn_unique").on(table.turnId),
+  }),
+);
+
+// Plans and subscriptions (migration 0045). What varies down the ladder is
+// the MARGIN on metered AI rather than access to a feature — a plan is a
+// better rate on something everybody may already use, which is why there is
+// no "has_ai" column here. Design: cloud/docs/accounting-todo.md §0.1, §3.6.
+//
+// These are NOT ledger tables: they reference `accounts` normally, because a
+// subscription is product state. What the ledger sees is the entries §3.6's
+// recipes post, and those name the account the same unreferenced way every
+// other financial event does.
+export const billingPlans = pgTable("billing_plans", {
+  code: text("code").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description"),
+  priceMicros: bigint("price_micros", { mode: "bigint" }).notNull(),
+  currency: text("currency").default("USD").notNull(),
+  period: text("period").default("month").notNull(),
+  // Overrides the global `ai_margin_percent` for accounts on this plan, and
+  // is snapshotted per usage record exactly as the global one always was.
+  marginBasisPoints: integer("margin_basis_points").notNull(),
+  // cloud_rendered_frames, backup_bytes, frame_log_bytes,
+  // private_scene_bytes, frames. Read by src/lib/usage.ts, never by the
+  // ledger: a plan's entitlements are not accounting facts.
+  entitlements: jsonb("entitlements").default({}).notNull(),
+  sortOrder: integer("sort_order").default(0).notNull(),
+  public: boolean("public").default(true).notNull(),
+  ...timestamps,
+});
+
+// One row per account, at most. No row means PAYG — the same thing as a row
+// pointing at the payg plan, so that enrolling every existing account is not
+// a prerequisite for shipping.
+export const subscriptions = pgTable(
+  "subscriptions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    accountId: uuid("account_id")
+      .notNull()
+      .references(() => accounts.id, { onDelete: "cascade" }),
+    planCode: text("plan_code")
+      .notNull()
+      .references(() => billingPlans.code),
+    status: text("status").default("active").notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    // Set when the user cancels: the plan runs to the end of the paid period
+    // and stops. Nothing is refunded by default.
+    cancelAt: timestamp("cancel_at", { withTimezone: true }),
+    canceledAt: timestamp("canceled_at", { withTimezone: true }),
+    ...timestamps,
+  },
+  (table) => ({
+    accountUnique: uniqueIndex("subscriptions_account_unique").on(
+      table.accountId,
+    ),
+  }),
+);
+
+// One row per billed period: charged at period start, recognized at period
+// end, both idempotent on this row's id so the nightly job may run twice or
+// miss a night without double-charging or losing a period.
+export const subscriptionPeriods = pgTable(
+  "subscription_periods",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    subscriptionId: uuid("subscription_id")
+      .notNull()
+      .references(() => subscriptions.id, { onDelete: "cascade" }),
+    // Snapshotted, not joined: a period is billed at the price and margin in
+    // force when it started, whatever the plan row says afterwards.
+    planCode: text("plan_code").notNull(),
+    priceMicros: bigint("price_micros", { mode: "bigint" }).notNull(),
+    marginBasisPoints: integer("margin_basis_points").notNull(),
+    currency: text("currency").default("USD").notNull(),
+    periodStart: timestamp("period_start", { withTimezone: true }).notNull(),
+    periodEnd: timestamp("period_end", { withTimezone: true }).notNull(),
+    chargedAt: timestamp("charged_at", { withTimezone: true }),
+    recognizedAt: timestamp("recognized_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    periodUnique: uniqueIndex("subscription_periods_unique").on(
+      table.subscriptionId,
+      table.periodStart,
+    ),
   }),
 );

--- a/cloud/packages/ledger/src/account-usage.ts
+++ b/cloud/packages/ledger/src/account-usage.ts
@@ -1,0 +1,244 @@
+import { sql } from "drizzle-orm";
+import { surfaceIsAbsorbed } from "./metering";
+import type { LedgerExecutor } from "./types";
+
+// What one account's AI usage looks like from the account's own side —
+// §5.2/§5.3 of cloud/docs/accounting-todo.md. `reports.ts` answers the same
+// shape of question for the operator across every account; this answers it
+// for one account, and the two are deliberately separate because they mean
+// different things by "spend": the operator wants what was booked, the
+// customer wants what it will cost them.
+//
+// The one number this module exists to define is `chargeableMicros`, and it
+// is defined ONCE and used twice — by the daily cap that refuses a turn
+// (§5.3) and by the figure on the account page (§5.2). Two definitions of
+// "what you have spent today" that disagree by a rounding step is the kind
+// of bug that is only ever found by a confused user.
+//
+// It is not simply SUM(price_micros), because while metering is in shadow
+// mode `price_micros` is 0 on every row: a cap built on it would never bite
+// and would ship untested, and a page built on it would tell every user
+// they had used nothing. So a turn's chargeable amount is what it WOULD be
+// billed at, computed from the row's own pricing snapshot — its unit prices
+// and the margin in force when it ran — rather than from today's settings.
+// Once metering goes live the two coincide, and `checkAccountAiSpend` in
+// the nightly job is what proves they did.
+
+// The provider's list cost of a row's tokens, from the row's own snapshot,
+// whoever actually paid for them. Own-key turns have `cost_micros = 0` (we
+// paid nothing) but still burned real tokens, and the account page shows
+// them — "you used $3 of AI on your own key" is a true and useful sentence.
+const listCostExpression = sql`round(
+  (input_tokens::numeric * coalesce(pricing->>'inputMicrosPerMtok', '0')::numeric
+   + cached_input_tokens::numeric * coalesce(pricing->>'cachedInputMicrosPerMtok', '0')::numeric
+   + output_tokens::numeric * coalesce(pricing->>'outputMicrosPerMtok', '0')::numeric)
+  / 1000000)`;
+
+// What this turn is worth to bill: the price if one was actually computed,
+// otherwise the list cost marked up at the margin the row was metered under.
+// Turns on the customer's own key are worth nothing to bill — they paid the
+// provider directly — and are excluded here rather than zeroed, so that
+// `ownKey` buckets keep their list cost for display.
+const chargeableExpression = sql`case
+  when credential_source = 'account' then 0
+  when price_micros > 0 then price_micros
+  else round(${listCostExpression}
+    * (10000 + coalesce((pricing->>'marginBasisPoints')::numeric, 3000)) / 10000)
+end`;
+
+export interface AccountAiUsageBucket {
+  // What this would be billed at (0 for own-key turns and absorbed
+  // surfaces). See the note above on why this is not `priceMicros`.
+  chargeableMicros: bigint;
+  // What we actually paid the provider (0 when the key was not ours).
+  costMicros: bigint;
+  credentialSource: string;
+  // The provider's list price of these tokens, whoever paid.
+  listCostMicros: bigint;
+  // What was actually charged and posted. 0 for every row in shadow mode.
+  priceMicros: bigint;
+  surface: string | null;
+  turns: number;
+}
+
+export interface AccountAiUsage {
+  buckets: AccountAiUsageBucket[];
+  chargeableMicros: bigint;
+  costMicros: bigint;
+  listCostMicros: bigint;
+  // True when every metered turn in the window ran on the account's own
+  // OpenAI key: they owe us nothing, and a bill-shaped number would be a
+  // lie rather than a zero.
+  ownKeyOnly: boolean;
+  priceMicros: bigint;
+  turns: number;
+}
+
+export interface UsageWindow {
+  since: Date;
+  until: Date;
+}
+
+/**
+ * One account's AI usage over a window, grouped by surface and by who paid.
+ * Windowed on `occurred_at` — when the tokens were burned — rather than on
+ * `created_at`, so a turn the sweep meters hours later still lands in the
+ * day and the month it belongs to.
+ */
+export async function accountAiUsage(
+  db: LedgerExecutor,
+  accountId: string,
+  window: UsageWindow,
+): Promise<AccountAiUsage> {
+  const rows = await db.execute<{
+    chargeable_micros: string;
+    cost_micros: string;
+    credential_source: string;
+    list_cost_micros: string;
+    price_micros: string;
+    surface: string | null;
+    turns: string;
+  }>(sql`
+    select credential_source,
+           surface,
+           count(*)::text as turns,
+           coalesce(sum(cost_micros), 0)::text as cost_micros,
+           coalesce(sum(price_micros), 0)::text as price_micros,
+           coalesce(sum(${listCostExpression}), 0)::text as list_cost_micros,
+           coalesce(sum(${chargeableExpression}), 0)::text as chargeable_micros
+      from ai_usage_records
+     where account_id = ${accountId}
+       and occurred_at >= ${window.since.toISOString()}::timestamptz
+       and occurred_at < ${window.until.toISOString()}::timestamptz
+     group by credential_source, surface
+     order by credential_source, surface
+  `);
+
+  const buckets = rows.map((row) => ({
+    // An absorbed surface (the legacy scene converter) is our migration
+    // cost, never a line on anybody's bill — §5. Zeroed here rather than in
+    // SQL because `absorbedSurfaces` is a TypeScript list that product
+    // decisions edit, and threading it into a query would make it two
+    // lists. The bucket keeps its cost and turn count, so the page can show
+    // the work as done and free rather than hiding it.
+    chargeableMicros: surfaceIsAbsorbed(row.surface)
+      ? 0n
+      : BigInt(row.chargeable_micros),
+    costMicros: BigInt(row.cost_micros),
+    credentialSource: row.credential_source,
+    listCostMicros: BigInt(row.list_cost_micros),
+    priceMicros: BigInt(row.price_micros),
+    surface: row.surface,
+    turns: Number(row.turns),
+  }));
+
+  const sum = (pick: (bucket: AccountAiUsageBucket) => bigint) =>
+    buckets.reduce((total, bucket) => total + pick(bucket), 0n);
+  return {
+    buckets,
+    chargeableMicros: sum((bucket) => bucket.chargeableMicros),
+    costMicros: sum((bucket) => bucket.costMicros),
+    listCostMicros: sum((bucket) => bucket.listCostMicros),
+    ownKeyOnly:
+      buckets.length > 0 &&
+      buckets.every((bucket) => bucket.credentialSource === "account"),
+    priceMicros: sum((bucket) => bucket.priceMicros),
+    turns: buckets.reduce((total, bucket) => total + bucket.turns, 0),
+  };
+}
+
+/**
+ * The number the daily cap is checked against: what this account's AI usage
+ * in the window is worth to bill. Same definition as the page's figure, by
+ * construction — it is the same query.
+ */
+export async function accountAiSpendMicros(
+  db: LedgerExecutor,
+  accountId: string,
+  window: UsageWindow,
+): Promise<bigint> {
+  return (await accountAiUsage(db, accountId, window)).chargeableMicros;
+}
+
+export interface AccountAiTurn {
+  chatId: string | null;
+  chargeableMicros: bigint;
+  listCostMicros: bigint;
+  model: string;
+  occurredAt: Date;
+  ownKey: boolean;
+  surface: string | null;
+}
+
+/**
+ * The most recent metered turns, newest first — the reconciliation surface a
+ * user needs when a number surprises them (§5.2). Deliberately not a full
+ * pagination API: twenty rows and "show more" answers "which turns did
+ * this", and an account that needs a year of history needs an export, not a
+ * deeper scroll.
+ */
+export async function recentAccountAiTurns(
+  db: LedgerExecutor,
+  accountId: string,
+  options: { limit?: number | undefined } = {},
+): Promise<AccountAiTurn[]> {
+  const limit = Math.max(1, Math.min(200, options.limit ?? 20));
+  const rows = await db.execute<{
+    chargeable_micros: string;
+    chat_id: string | null;
+    credential_source: string;
+    list_cost_micros: string;
+    model: string;
+    occurred_at: string;
+    surface: string | null;
+  }>(sql`
+    select chat_id::text as chat_id,
+           credential_source,
+           model,
+           surface,
+           occurred_at,
+           ${listCostExpression}::text as list_cost_micros,
+           (${chargeableExpression})::text as chargeable_micros
+      from ai_usage_records
+     where account_id = ${accountId}
+     order by occurred_at desc
+     limit ${limit}
+  `);
+  return rows.map((row) => ({
+    chargeableMicros: surfaceIsAbsorbed(row.surface)
+      ? 0n
+      : BigInt(row.chargeable_micros),
+    chatId: row.chat_id,
+    listCostMicros: BigInt(row.list_cost_micros),
+    model: row.model,
+    occurredAt: new Date(row.occurred_at),
+    ownKey: row.credential_source === "account",
+    surface: row.surface,
+  }));
+}
+
+/**
+ * The UTC day containing `at`. The cap's window, and UTC on purpose: one
+ * definition, one index, no per-account timezone arithmetic on the hot path
+ * of every turn. §8.12 has the open question about whether users should see
+ * it that way.
+ */
+export function utcDayWindow(at: Date = new Date()): UsageWindow {
+  const since = new Date(
+    Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), at.getUTCDate()),
+  );
+  const until = new Date(since.getTime() + 24 * 60 * 60 * 1000);
+  return { since, until };
+}
+
+/**
+ * A calendar month in UTC. `offset` counts backwards: 0 is the month
+ * containing `at`, -1 the one before it (the account page shows both,
+ * because the only way to know whether $1.27 is a lot is to see last
+ * month's).
+ */
+export function utcMonthWindow(at: Date = new Date(), offset = 0): UsageWindow {
+  const since = new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth() + offset, 1));
+  const until = new Date(Date.UTC(at.getUTCFullYear(), at.getUTCMonth() + offset + 1, 1));
+  return { since, until };
+}

--- a/cloud/packages/ledger/src/account-usage.ts
+++ b/cloud/packages/ledger/src/account-usage.ts
@@ -34,11 +34,16 @@ const listCostExpression = sql`round(
    + output_tokens::numeric * coalesce(pricing->>'outputMicrosPerMtok', '0')::numeric)
   / 1000000)`;
 
-// What this turn is worth to bill: the price if one was actually computed,
-// otherwise the list cost marked up at the margin the row was metered under.
-// Turns on the customer's own key are worth nothing to bill — they paid the
-// provider directly — and are excluded here rather than zeroed, so that
-// `ownKey` buckets keep their list cost for display.
+// What a turn on ONE OF OUR KEYS is worth at the customer's rate: the price
+// if one was actually computed, otherwise the list cost marked up at the
+// margin the row was metered under. Turns on the customer's own key are worth
+// nothing — they paid the provider directly — and are excluded rather than
+// zeroed, so an own-key bucket keeps its list cost for display.
+//
+// This is the CAP's number, and it deliberately includes `shared`. A turn on
+// the operator's shared key is a real bill we absorb, so it belongs against a
+// limit that exists to bound *our* exposure. It is NOT what the customer
+// owes: see `billableExpression`.
 const chargeableExpression = sql`case
   when credential_source = 'account' then 0
   when price_micros > 0 then price_micros
@@ -46,9 +51,29 @@ const chargeableExpression = sql`case
     * (10000 + coalesce((pricing->>'marginBasisPoints')::numeric, 3000)) / 10000)
 end`;
 
+// What the CUSTOMER owes, which is a narrower question and has to agree with
+// `billing()` in metering.ts: only the platform key bills anybody. The
+// operator's shared key is a cost we absorb on purpose and their own key cost
+// us nothing, so neither is a line on anyone's invoice.
+//
+// Kept apart from the number above rather than folded into it, because
+// conflating them shows a shared-key user a dollar figure they do not owe the
+// moment metering goes live — which is exactly the kind of "bill-shaped lie"
+// the own-key state already exists to avoid.
+const billableExpression = sql`case
+  when credential_source <> 'platform' then 0
+  when price_micros > 0 then price_micros
+  else round(${listCostExpression}
+    * (10000 + coalesce((pricing->>'marginBasisPoints')::numeric, 3000)) / 10000)
+end`;
+
 export interface AccountAiUsageBucket {
-  // What this would be billed at (0 for own-key turns and absorbed
-  // surfaces). See the note above on why this is not `priceMicros`.
+  // What the customer actually owes for this: platform-key turns only, and
+  // never an absorbed surface. Agrees with `billing()` in metering.ts.
+  billableMicros: bigint;
+  // What this is worth at the customer's rate on any of OUR keys — the
+  // number the daily cap is measured against, which includes the shared key
+  // we absorb. Not a bill. See the note above on why it is not `priceMicros`.
   chargeableMicros: bigint;
   // What we actually paid the provider (0 when the key was not ours).
   costMicros: bigint;
@@ -62,6 +87,10 @@ export interface AccountAiUsageBucket {
 }
 
 export interface AccountAiUsage {
+  // True when nothing in the window is billable to the customer — every turn
+  // ran on their own key, on the operator's absorbed shared key, or on a
+  // surface we pay for. A dollar figure presented as a bill would be wrong.
+  billableMicros: bigint;
   buckets: AccountAiUsageBucket[];
   chargeableMicros: bigint;
   costMicros: bigint;
@@ -91,6 +120,7 @@ export async function accountAiUsage(
   window: UsageWindow,
 ): Promise<AccountAiUsage> {
   const rows = await db.execute<{
+    billable_micros: string;
     chargeable_micros: string;
     cost_micros: string;
     credential_source: string;
@@ -105,7 +135,8 @@ export async function accountAiUsage(
            coalesce(sum(cost_micros), 0)::text as cost_micros,
            coalesce(sum(price_micros), 0)::text as price_micros,
            coalesce(sum(${listCostExpression}), 0)::text as list_cost_micros,
-           coalesce(sum(${chargeableExpression}), 0)::text as chargeable_micros
+           coalesce(sum(${chargeableExpression}), 0)::text as chargeable_micros,
+           coalesce(sum(${billableExpression}), 0)::text as billable_micros
       from ai_usage_records
      where account_id = ${accountId}
        and occurred_at >= ${window.since.toISOString()}::timestamptz
@@ -115,6 +146,9 @@ export async function accountAiUsage(
   `);
 
   const buckets = rows.map((row) => ({
+    billableMicros: surfaceIsAbsorbed(row.surface)
+      ? 0n
+      : BigInt(row.billable_micros),
     // An absorbed surface (the legacy scene converter) is our migration
     // cost, never a line on anybody's bill — §5. Zeroed here rather than in
     // SQL because `absorbedSurfaces` is a TypeScript list that product
@@ -135,6 +169,7 @@ export async function accountAiUsage(
   const sum = (pick: (bucket: AccountAiUsageBucket) => bigint) =>
     buckets.reduce((total, bucket) => total + pick(bucket), 0n);
   return {
+    billableMicros: sum((bucket) => bucket.billableMicros),
     buckets,
     chargeableMicros: sum((bucket) => bucket.chargeableMicros),
     costMicros: sum((bucket) => bucket.costMicros),

--- a/cloud/packages/ledger/src/index.ts
+++ b/cloud/packages/ledger/src/index.ts
@@ -8,6 +8,40 @@ export {
   availableCreditMicros,
 } from "./balances";
 export {
+  accountAiSpendMicros,
+  accountAiUsage,
+  recentAccountAiTurns,
+  utcDayWindow,
+  utcMonthWindow,
+  type AccountAiTurn,
+  type AccountAiUsage,
+  type AccountAiUsageBucket,
+  type UsageWindow,
+} from "./account-usage";
+export {
+  accountMarginBasisPoints,
+  fallbackPaygPlan,
+  listPlans,
+  paygPlanCode,
+  readAccountMargin,
+  readAccountPlan,
+  readPlan,
+  type AccountPlan,
+  type BillingPlan,
+  type PlanEntitlements,
+} from "./plans";
+export {
+  addMonth,
+  cancelAccountPlan,
+  chargePeriod,
+  recognizePeriod,
+  refundUnearnedPeriod,
+  runSubscriptionCycle,
+  setAccountPlan,
+  type SubscriptionCycleResult,
+  type SubscriptionRecord,
+} from "./subscriptions";
+export {
   customerCreditsCode,
   customerPromoCreditsCode,
   customerReceivableCode,
@@ -22,6 +56,7 @@ export {
   checkAccountingEquation,
   checkBalanceCache,
   checkCustomerCreditFloor,
+  checkDailyCapRespected,
   checkEntriesBalance,
   checkEventsPostedOnce,
   checkImmutabilityTriggers,

--- a/cloud/packages/ledger/src/integrity.ts
+++ b/cloud/packages/ledger/src/integrity.ts
@@ -12,6 +12,10 @@ export interface LedgerIntegrityViolation {
 }
 
 export interface LedgerIntegrityOptions {
+  // The daily spend ceiling in force (payg_daily_cap_micros). Omitted means
+  // "no cap configured", and the check is skipped rather than assumed to be
+  // zero — a missing setting must not report every account as a violation.
+  dailyCapMicros?: bigint | undefined;
   now?: Date | undefined;
   // How far a customer's credit balance may go below zero before it counts
   // as a violation. Mirrors the payg_overdraft_micros setting.
@@ -32,6 +36,7 @@ export async function checkLedgerIntegrity(
     ...(await checkBalanceCache(db)),
     ...(await checkEventsPostedOnce(db, options)),
     ...(await checkCustomerCreditFloor(db, options)),
+    ...(await checkDailyCapRespected(db, options)),
     ...(await checkMeteringCompleteness(db, options)),
     ...(await checkReversalsMirror(db)),
     ...(await checkImmutabilityTriggers(db)),
@@ -182,6 +187,67 @@ export async function checkCustomerCreditFloor(
   return rows.map((row) => ({
     check: "customer_credit_floor",
     detail: `${row.code} is at ${row.balance_micros} micros`,
+  }));
+}
+
+// 5b. The daily cap held. Under postpay this is the check that matters
+//     — there is no prepaid balance to keep out of the red, and the cap is
+//     what bounds the credit risk instead (§5.3). It is also the only
+//     automated proof that the gate in resolveAiAccess() actually sits in
+//     front of EVERY AI surface rather than most of them: a surface added
+//     next month that forgets it shows up here as a day over the line.
+//
+//     Measured the same way the gate measures, on `ai_usage_records` rather
+//     than on postings, because the cap must hold for shadow-mode and
+//     own-key accounts too — and those post nothing at all.
+//
+//     The tolerated overshoot is one turn's worth (`payg_overdraft_micros`):
+//     a turn's cost is unknown until it ends, so the last turn of a day can
+//     legitimately cross the line. Anything past that is the gate failing.
+export async function checkDailyCapRespected(
+  db: LedgerExecutor,
+  options: LedgerIntegrityOptions = {},
+): Promise<LedgerIntegrityViolation[]> {
+  const cap = options.dailyCapMicros;
+  if (cap === undefined || cap <= 0n) {
+    return [];
+  }
+  const ceiling = cap + (options.overdraftMicros ?? 0n);
+  const rows = await db.execute<{
+    account_id: string;
+    day: string;
+    spent: string;
+  }>(sql`
+    select account_id::text as account_id,
+           to_char(date_trunc('day', occurred_at at time zone 'UTC'), 'YYYY-MM-DD') as day,
+           sum(case
+                 when credential_source = 'account' then 0
+                 when price_micros > 0 then price_micros
+                 else round(
+                   round((input_tokens::numeric * coalesce(pricing->>'inputMicrosPerMtok', '0')::numeric
+                          + cached_input_tokens::numeric * coalesce(pricing->>'cachedInputMicrosPerMtok', '0')::numeric
+                          + output_tokens::numeric * coalesce(pricing->>'outputMicrosPerMtok', '0')::numeric)
+                         / 1000000)
+                   * (10000 + coalesce((pricing->>'marginBasisPoints')::numeric, 3000)) / 10000)
+               end)::text as spent
+      from ai_usage_records
+     where account_id is not null
+       and surface is distinct from 'scene_convert'
+     group by 1, 2
+    having sum(case
+                 when credential_source = 'account' then 0
+                 when price_micros > 0 then price_micros
+                 else round(
+                   round((input_tokens::numeric * coalesce(pricing->>'inputMicrosPerMtok', '0')::numeric
+                          + cached_input_tokens::numeric * coalesce(pricing->>'cachedInputMicrosPerMtok', '0')::numeric
+                          + output_tokens::numeric * coalesce(pricing->>'outputMicrosPerMtok', '0')::numeric)
+                         / 1000000)
+                   * (10000 + coalesce((pricing->>'marginBasisPoints')::numeric, 3000)) / 10000)
+               end) > ${ceiling.toString()}::numeric
+  `);
+  return rows.map((row) => ({
+    check: "daily_cap_respected",
+    detail: `Account ${row.account_id} metered ${row.spent} micros on ${row.day}, past the ${ceiling.toString()} ceiling`,
   }));
 }
 

--- a/cloud/packages/ledger/src/metering.ts
+++ b/cloud/packages/ledger/src/metering.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, isNull, lt, sql } from "drizzle-orm";
 import { aiUsageRecords } from "@frameos-cloud/db";
 import { postEvent, type PostEventOptions } from "./kernel";
+import { accountMarginBasisPoints } from "./plans";
 import {
   priceUsage,
   resolveModelPrice,
@@ -125,9 +126,18 @@ export async function recordAiUsage(
   const { billable, ours } = billing(input.credentialSource, input.surface);
   const usage = splitProviderUsage(input.usage);
   const price = await resolveModelPrice(db, input.model, occurredAt);
+  // The plan's margin, falling back to the deployment's global one. Read here
+  // and snapshotted into the record exactly as the global margin always was,
+  // so an entry stays explainable after the account changes plan — and so a
+  // plan change is never retroactive.
+  const marginBasisPoints = await accountMarginBasisPoints(
+    db,
+    input.accountId,
+    settings,
+  );
   const priced = priceUsage({
     billable,
-    marginBasisPoints: settings.marginBasisPoints,
+    marginBasisPoints,
     price,
     usage,
   });

--- a/cloud/packages/ledger/src/plans.test.ts
+++ b/cloud/packages/ledger/src/plans.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { fallbackPaygPlan } from "./plans";
+import { addMonth } from "./subscriptions";
+import { utcDayWindow, utcMonthWindow } from "./account-usage";
+
+describe("the free plan fallback", () => {
+  // The numbers a deployment falls back to when nobody has seeded plans must
+  // be the numbers it already enforced, or migration 0045 would quietly take
+  // storage away from every existing account.
+  it("matches the historical free tier", () => {
+    expect(fallbackPaygPlan.entitlements).toEqual({
+      backupBytes: 100 * 1024 * 1024,
+      cloudRenderedFrames: 0,
+      frameLogBytes: 100 * 1024 * 1024,
+      frames: 50,
+      privateSceneBytes: 100 * 1024 * 1024,
+    });
+    expect(fallbackPaygPlan.priceMicros).toBe(0n);
+  });
+});
+
+describe("addMonth", () => {
+  it("moves to the same day of the next month", () => {
+    expect(addMonth(new Date("2026-01-15T10:30:00Z")).toISOString()).toBe(
+      "2026-02-15T10:30:00.000Z",
+    );
+  });
+
+  // A subscription started on the 31st must renew on the 28th rather than
+  // skipping February entirely, which is what naive month arithmetic does.
+  it("clamps into a short month instead of overflowing past it", () => {
+    expect(addMonth(new Date("2026-01-31T00:00:00Z")).toISOString()).toBe(
+      "2026-02-28T00:00:00.000Z",
+    );
+    expect(addMonth(new Date("2028-01-31T00:00:00Z")).toISOString()).toBe(
+      "2028-02-29T00:00:00.000Z",
+    );
+    expect(addMonth(new Date("2026-03-31T00:00:00Z")).toISOString()).toBe(
+      "2026-04-30T00:00:00.000Z",
+    );
+  });
+
+  it("rolls the year over", () => {
+    expect(addMonth(new Date("2026-12-05T00:00:00Z")).toISOString()).toBe(
+      "2027-01-05T00:00:00.000Z",
+    );
+  });
+});
+
+describe("usage windows", () => {
+  it("cuts the day at UTC midnight, half-open", () => {
+    const window = utcDayWindow(new Date("2026-09-01T23:59:59.999Z"));
+    expect(window.since.toISOString()).toBe("2026-09-01T00:00:00.000Z");
+    expect(window.until.toISOString()).toBe("2026-09-02T00:00:00.000Z");
+  });
+
+  it("cuts the month at the first, and counts offsets backwards", () => {
+    const at = new Date("2026-09-17T12:00:00Z");
+    expect(utcMonthWindow(at).since.toISOString()).toBe("2026-09-01T00:00:00.000Z");
+    expect(utcMonthWindow(at).until.toISOString()).toBe("2026-10-01T00:00:00.000Z");
+    expect(utcMonthWindow(at, -1).since.toISOString()).toBe(
+      "2026-08-01T00:00:00.000Z",
+    );
+    expect(utcMonthWindow(at, -1).until.toISOString()).toBe(
+      "2026-09-01T00:00:00.000Z",
+    );
+  });
+
+  it("crosses the year boundary going backwards", () => {
+    const window = utcMonthWindow(new Date("2026-01-10T00:00:00Z"), -1);
+    expect(window.since.toISOString()).toBe("2025-12-01T00:00:00.000Z");
+    expect(window.until.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+});

--- a/cloud/packages/ledger/src/plans.ts
+++ b/cloud/packages/ledger/src/plans.ts
@@ -1,0 +1,219 @@
+import { asc, eq } from "drizzle-orm";
+import { billingPlans, subscriptions } from "@frameos-cloud/db";
+import { readBillingSettings, type BillingSettings } from "./settings";
+import type { LedgerExecutor } from "./types";
+
+// Plans (§0.1) and what an account's plan means for the rest of the system.
+//
+// The ladder varies ONE thing that costs money — the margin on metered AI —
+// and a handful of quotas that do not. That is the whole design: a plan is a
+// better rate on something everybody may already use, never a wall in front
+// of a feature. Nothing here is an accounting fact; the ledger sees only the
+// entries `rules/subscription.ts` posts, and `rules/ai-usage.ts` never learns
+// that plans exist at all (§3.6).
+//
+// PAYG is a real plan row at $0 rather than the absence of one, so "what plan
+// is this account on" always has an answer. An account with no subscription
+// row is on PAYG anyway — the fallback below — because enrolling every
+// existing account must not be a prerequisite for shipping this.
+
+export const paygPlanCode = "payg";
+
+export interface PlanEntitlements {
+  backupBytes: number;
+  // The one entitlement with a real marginal cost (§0.2): frames the cloud
+  // renders because there is no computer at the other end. Free plans get
+  // none, which is what unblocks thin clients in the cloud flasher.
+  cloudRenderedFrames: number;
+  frameLogBytes: number;
+  frames: number;
+  privateSceneBytes: number;
+}
+
+export interface BillingPlan {
+  code: string;
+  currency: string;
+  description: string | null;
+  entitlements: PlanEntitlements;
+  marginBasisPoints: number;
+  name: string;
+  period: string;
+  priceMicros: bigint;
+  public: boolean;
+  sortOrder: number;
+}
+
+export interface AccountPlan {
+  // Set when the account cancelled: the plan runs to here and then stops.
+  cancelAt: Date | null;
+  plan: BillingPlan;
+  // False when the account has no subscription row and is on the PAYG
+  // fallback — the page says "Pay as you go" either way, but "did somebody
+  // choose this" is a different question from "what applies".
+  subscribed: boolean;
+  status: string;
+}
+
+// The code-level fallback for a database whose plans have never been seeded,
+// and the shape every entitlement lookup degrades to. Same numbers migration
+// 0045 seeds; free-tier quotas match src/lib/usage.ts's historical defaults,
+// because naming something "the free plan" must not be the thing that takes
+// storage away from anybody who already had it.
+export const fallbackPaygPlan: BillingPlan = {
+  code: paygPlanCode,
+  currency: "USD",
+  description: "AI when you want it, billed monthly for exactly what you used.",
+  entitlements: {
+    backupBytes: 100 * 1024 * 1024,
+    cloudRenderedFrames: 0,
+    frameLogBytes: 100 * 1024 * 1024,
+    frames: 50,
+    privateSceneBytes: 100 * 1024 * 1024,
+  },
+  marginBasisPoints: 10_000,
+  name: "Pay as you go",
+  period: "month",
+  priceMicros: 0n,
+  public: true,
+  sortOrder: 0,
+};
+
+type PlanRow = typeof billingPlans.$inferSelect;
+
+function entitlementsFrom(value: unknown): PlanEntitlements {
+  const raw =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  // A missing entitlement falls back to the free plan's rather than to zero:
+  // a plan row written by hand with one key in it must not silently revoke
+  // everything else.
+  const number = (key: string, fallback: number): number => {
+    const candidate = raw[key];
+    return typeof candidate === "number" && Number.isFinite(candidate) && candidate >= 0
+      ? Math.round(candidate)
+      : fallback;
+  };
+  const base = fallbackPaygPlan.entitlements;
+  return {
+    backupBytes: number("backup_bytes", base.backupBytes),
+    cloudRenderedFrames: number("cloud_rendered_frames", base.cloudRenderedFrames),
+    frameLogBytes: number("frame_log_bytes", base.frameLogBytes),
+    frames: number("frames", base.frames),
+    privateSceneBytes: number("private_scene_bytes", base.privateSceneBytes),
+  };
+}
+
+function toPlan(row: PlanRow): BillingPlan {
+  return {
+    code: row.code,
+    currency: row.currency,
+    description: row.description,
+    entitlements: entitlementsFrom(row.entitlements),
+    marginBasisPoints: row.marginBasisPoints,
+    name: row.name,
+    period: row.period,
+    priceMicros: row.priceMicros,
+    public: row.public,
+    sortOrder: row.sortOrder,
+  };
+}
+
+/** Every plan, cheapest first. `public: false` rows are for grandfathered or
+ *  negotiated arrangements and are excluded from the plans page. */
+export async function listPlans(db: LedgerExecutor): Promise<BillingPlan[]> {
+  const rows = await db
+    .select()
+    .from(billingPlans)
+    .orderBy(asc(billingPlans.sortOrder), asc(billingPlans.priceMicros));
+  return rows.length > 0 ? rows.map(toPlan) : [fallbackPaygPlan];
+}
+
+export async function readPlan(
+  db: LedgerExecutor,
+  code: string,
+): Promise<BillingPlan | undefined> {
+  const [row] = await db
+    .select()
+    .from(billingPlans)
+    .where(eq(billingPlans.code, code))
+    .limit(1);
+  if (row) {
+    return toPlan(row);
+  }
+  return code === paygPlanCode ? fallbackPaygPlan : undefined;
+}
+
+/** The plan an account is actually on right now, with the PAYG fallback. */
+export async function readAccountPlan(
+  db: LedgerExecutor,
+  accountId: string,
+): Promise<AccountPlan> {
+  const [row] = await db
+    .select({
+      cancelAt: subscriptions.cancelAt,
+      plan: billingPlans,
+      status: subscriptions.status,
+    })
+    .from(subscriptions)
+    .innerJoin(billingPlans, eq(billingPlans.code, subscriptions.planCode))
+    .where(eq(subscriptions.accountId, accountId))
+    .limit(1);
+
+  // A cancelled subscription is not a plan any more, and neither is one whose
+  // cancel_at has passed without the nightly job having tidied it up yet: the
+  // entitlement has to expire on time even if the job is late, or a downgrade
+  // is silently free for however long the job is broken.
+  const expired =
+    !row ||
+    row.status === "canceled" ||
+    (row.cancelAt !== null && row.cancelAt.getTime() <= Date.now());
+  if (expired) {
+    return {
+      cancelAt: null,
+      plan: (await readPlan(db, paygPlanCode)) ?? fallbackPaygPlan,
+      status: "active",
+      subscribed: false,
+    };
+  }
+  return {
+    cancelAt: row.cancelAt,
+    plan: toPlan(row.plan),
+    status: row.status,
+    subscribed: true,
+  };
+}
+
+/**
+ * The margin to price an account's turn at: their plan's, falling back to the
+ * global `ai_margin_percent` for a deployment that has no plans (a
+ * self-hoster, or this repo before migration 0045 runs).
+ *
+ * Callers pass `settings` when they already read it, which metering.ts does —
+ * this must not become a second settings query on the hot path of every turn.
+ */
+export async function accountMarginBasisPoints(
+  db: LedgerExecutor,
+  accountId: string | null | undefined,
+  settings: BillingSettings,
+): Promise<number> {
+  if (!accountId) {
+    return settings.marginBasisPoints;
+  }
+  const { plan, subscribed } = await readAccountPlan(db, accountId);
+  // An account nobody put on a plan prices at the deployment's global margin,
+  // not at PAYG's 100%: flipping every existing account to double-price the
+  // day migration 0045 lands would be a price change disguised as a schema
+  // change. PAYG's own margin applies once somebody is deliberately on it.
+  return subscribed ? plan.marginBasisPoints : settings.marginBasisPoints;
+}
+
+/** Convenience for callers with no settings in hand. */
+export async function readAccountMargin(
+  db: LedgerExecutor,
+  accountId: string | null | undefined,
+  env?: Record<string, string | undefined>,
+): Promise<number> {
+  const settings = await readBillingSettings(db, env);
+  return accountMarginBasisPoints(db, accountId, settings);
+}

--- a/cloud/packages/ledger/src/reports.ts
+++ b/cloud/packages/ledger/src/reports.ts
@@ -436,7 +436,14 @@ export interface DailySummary {
   // recognized when it is made, and the revenue it will offset arrives
   // whenever the customer gets round to spending it.
   contraRevenueMicros: bigint;
+  // What we owe customers in prepaid credit. Zero under postpay (§0) and
+  // kept because the shelved prepaid model (§3.5) would fill it again.
   customerLiabilityMicros: bigint;
+  // What customers owe US: the postpay number, and the one the month-end
+  // invoice run collects against. Under postpay this is the balance that
+  // matters, and a nightly line without it would be a line about a model we
+  // no longer sell.
+  customerReceivableMicros: bigint;
   // Revenue net of contra, less cost. The number the business runs on.
   marginMicros: bigint;
   netRevenueMicros: bigint;
@@ -446,9 +453,10 @@ export interface DailySummary {
 }
 
 // The one line the nightly job logs: what the books did today. Revenue and
-// COGS over the window, the margin between them, and the total we currently
-// owe customers in prepaid credit — the number that is a liability rather
-// than money we have earned.
+// COGS over the window, the margin between them, and both customer balances:
+// what customers owe us (postpay's receivable, the number the month-end
+// invoice collects) and what we owe them (prepaid credit, zero under §0 and
+// kept because the shelved model would fill it again).
 export async function dailySummary(
   db: LedgerExecutor,
   window: { since: Date; until: Date },
@@ -480,6 +488,12 @@ export async function dailySummary(
       join ledger_accounts a on a.id = b.ledger_account_id
      where a.code like 'liability:credits%:customer:%'
   `);
+  const [receivable] = await db.execute<{ owed: string }>(sql`
+    select coalesce(sum(b.balance_micros), 0)::text as owed
+      from ledger_balances b
+      join ledger_accounts a on a.id = b.ledger_account_id
+     where a.code like 'asset:receivable:customer:%'
+  `);
 
   const revenueMicros = BigInt(row?.revenue ?? "0");
   const contraRevenueMicros = BigInt(row?.contra ?? "0");
@@ -489,6 +503,7 @@ export async function dailySummary(
     cogsMicros,
     contraRevenueMicros,
     customerLiabilityMicros: BigInt(liability?.owed ?? "0"),
+    customerReceivableMicros: BigInt(receivable?.owed ?? "0"),
     marginMicros: netRevenueMicros - cogsMicros,
     netRevenueMicros,
     revenueMicros,

--- a/cloud/packages/ledger/src/rules/ai-usage.ts
+++ b/cloud/packages/ledger/src/rules/ai-usage.ts
@@ -1,4 +1,4 @@
-import { customerCreditsCode, systemAccountCodes } from "../chart";
+import { customerReceivableCode, systemAccountCodes } from "../chart";
 import { parseMicros } from "../money";
 import {
   LedgerError,
@@ -18,7 +18,7 @@ import {
 // sit between.
 //
 //   Entry 'ai_usage_charge'   (only when the turn is billable)
-//     Dr liability:credits:customer:<id>     the price
+//     Dr asset:receivable:customer:<id>      the price
 //     Cr revenue:ai_usage                    the price
 //
 //   Entry 'ai_usage_cost'     (only when the key was ours)
@@ -30,6 +30,15 @@ import {
 // accounting simple in a way subscriptions are not. The accrued liability is
 // cleared when the provider's invoice is actually paid, and the gap between
 // our accrual and their invoice is exactly what reconciliation measures.
+//
+// **Version 2** (2026-09-01) moved the customer leg from a prepaid liability
+// to a receivable, which is the whole of what §0's postpay decision cost the
+// posting rules. Nobody pre-pays; usage accrues as money owed and one invoice
+// a month collects it, so the charge debits an asset (what they owe us)
+// rather than drawing down a balance they handed us in advance. Everything
+// else — the cost entry, the metadata, the independence of the two entries —
+// is untouched, and v1 stays readable above because a version bump is a
+// promise that old entries still mean what they said.
 //
 // A turn on the customer's own key produces neither entry, which means it
 // produces no event at all — the kernel refuses a rule that builds nothing,
@@ -70,7 +79,7 @@ export const aiUsageRule: PostingRule = {
         occurredAt: event.occurredAt,
         postings: [
           {
-            accountCode: customerCreditsCode(event.accountId),
+            accountCode: customerReceivableCode(event.accountId),
             amountMicros: priceMicros,
             direction: "debit",
           },
@@ -113,7 +122,7 @@ export const aiUsageRule: PostingRule = {
     return entries;
   },
   name: "ai_usage",
-  version: 1,
+  version: 2,
 };
 
 // The pricing snapshot, copied onto both entries: token counts, the unit

--- a/cloud/packages/ledger/src/rules/index.ts
+++ b/cloud/packages/ledger/src/rules/index.ts
@@ -6,6 +6,14 @@ import {
   reclassificationRule,
 } from "./reclassification";
 import { reversalEventType, reversalRule } from "./reversal";
+import {
+  subscriptionChargeEventType,
+  subscriptionChargeRule,
+  subscriptionRecognitionEventType,
+  subscriptionRecognitionRule,
+  subscriptionRefundEventType,
+  subscriptionRefundRule,
+} from "./subscription";
 
 // Event type → the rule that knows what it means. Product code emits facts;
 // this table is the whole of the translation into accounting, and adding a
@@ -16,6 +24,9 @@ export const postingRules: PostingRuleRegistry = {
   [manualJournalEventType]: manualJournalRule,
   [reclassificationEventType]: reclassificationRule,
   [reversalEventType]: reversalRule,
+  [subscriptionChargeEventType]: subscriptionChargeRule,
+  [subscriptionRecognitionEventType]: subscriptionRecognitionRule,
+  [subscriptionRefundEventType]: subscriptionRefundRule,
 };
 
 export { aiUsageEventType, aiUsageRule } from "./ai-usage";
@@ -25,3 +36,11 @@ export {
   reclassificationRule,
 } from "./reclassification";
 export { reversalEventType, reversalRule } from "./reversal";
+export {
+  subscriptionChargeEventType,
+  subscriptionChargeRule,
+  subscriptionRecognitionEventType,
+  subscriptionRecognitionRule,
+  subscriptionRefundEventType,
+  subscriptionRefundRule,
+} from "./subscription";

--- a/cloud/packages/ledger/src/rules/rules.test.ts
+++ b/cloud/packages/ledger/src/rules/rules.test.ts
@@ -4,6 +4,11 @@ import { manualJournalRule } from "./manual-journal";
 import { reclassificationRule } from "./reclassification";
 import { reversalRule } from "./reversal";
 import {
+  subscriptionChargeRule,
+  subscriptionRecognitionRule,
+  subscriptionRefundRule,
+} from "./subscription";
+import {
   LedgerError,
   type FinancialEventRecord,
   type PostedEntry,
@@ -192,7 +197,7 @@ describe("ai usage rule", () => {
     ]);
     expect(entries[0]?.postings).toEqual([
       {
-        accountCode: `liability:credits:customer:${customerId}`,
+        accountCode: `asset:receivable:customer:${customerId}`,
         amountMicros: 575_120n,
         direction: "debit",
       },
@@ -286,5 +291,120 @@ describe("reclassification rule", () => {
         context({ loadEntry: async () => undefined }),
       ),
     ).rejects.toThrow(/does not exist/);
+  });
+});
+
+describe("subscription rules", () => {
+  const period = {
+    marginBasisPoints: 5_000,
+    periodEnd: "2026-10-01T00:00:00.000Z",
+    periodId: "55555555-5555-5555-5555-555555555555",
+    periodStart: "2026-09-01T00:00:00.000Z",
+    planCode: "maker",
+    planName: "Maker",
+    priceMicros: "1990000",
+  };
+  const subscriptionEvent = (overrides: Record<string, unknown> = {}) => ({
+    ...event({ ...period, ...overrides }),
+    accountId: customerId,
+  });
+
+  // The charge accrues on the RECEIVABLE, not on a prepaid balance: under
+  // postpay a subscription is one more thing the month-end invoice collects
+  // off the same account as the metered usage.
+  it("accrues the charge against the customer's receivable", async () => {
+    const [entry] = await subscriptionChargeRule.build(
+      subscriptionEvent(),
+      context(),
+    );
+    expect(entry?.entryType).toBe("subscription_charge");
+    expect(entry?.postings).toEqual([
+      {
+        accountCode: `asset:receivable:customer:${customerId}`,
+        amountMicros: 1_990_000n,
+        direction: "debit",
+      },
+      {
+        accountCode: "liability:deferred:subscriptions",
+        amountMicros: 1_990_000n,
+        direction: "credit",
+      },
+    ]);
+    // Charging is not earning: the money sits in deferred revenue until the
+    // period it paid for has actually been served.
+    expect(entry?.postings.map((posting) => posting.accountCode)).not.toContain(
+      "revenue:subscriptions",
+    );
+  });
+
+  it("recognizes the period out of deferred revenue", async () => {
+    const [entry] = await subscriptionRecognitionRule.build(
+      subscriptionEvent(),
+      context(),
+    );
+    expect(entry?.entryType).toBe("subscription_recognition");
+    expect(entry?.postings).toEqual([
+      {
+        accountCode: "liability:deferred:subscriptions",
+        amountMicros: 1_990_000n,
+        direction: "debit",
+      },
+      {
+        accountCode: "revenue:subscriptions",
+        amountMicros: 1_990_000n,
+        direction: "credit",
+      },
+    ]);
+  });
+
+  // A refund nets against what they owe rather than becoming cash we have to
+  // send — which under postpay is usually the whole answer.
+  it("returns an unearned remainder to the receivable", async () => {
+    const [entry] = await subscriptionRefundRule.build(
+      subscriptionEvent({ priceMicros: "995000" }),
+      context(),
+    );
+    expect(entry?.entryType).toBe("subscription_refund_to_receivable");
+    expect(entry?.postings).toEqual([
+      {
+        accountCode: "liability:deferred:subscriptions",
+        amountMicros: 995_000n,
+        direction: "debit",
+      },
+      {
+        accountCode: `asset:receivable:customer:${customerId}`,
+        amountMicros: 995_000n,
+        direction: "credit",
+      },
+    ]);
+  });
+
+  // `build` is synchronous here, so these throw rather than reject — the
+  // rule refuses before an event that names nobody can reach the kernel.
+  it("refuses an entry with nobody to bill and an amount of nothing", () => {
+    expect(() => subscriptionChargeRule.build(event(period), context())).toThrow(
+      /account/,
+    );
+    expect(() =>
+      subscriptionChargeRule.build(
+        subscriptionEvent({ priceMicros: "0" }),
+        context(),
+      ),
+    ).toThrow(/positive/);
+  });
+
+  // The pricing snapshot travels onto the entry: an entry has to stay
+  // explainable after the plan's price and margin have both moved on.
+  it("snapshots the plan and the period onto the entry", async () => {
+    const [entry] = await subscriptionChargeRule.build(
+      subscriptionEvent(),
+      context(),
+    );
+    expect(entry?.metadata).toMatchObject({
+      marginBasisPoints: 5_000,
+      periodId: period.periodId,
+      planCode: "maker",
+      priceMicros: "1990000",
+    });
   });
 });

--- a/cloud/packages/ledger/src/rules/subscription.ts
+++ b/cloud/packages/ledger/src/rules/subscription.ts
@@ -1,0 +1,172 @@
+import { customerReceivableCode, systemAccountCodes } from "../chart";
+import { parseMicros } from "../money";
+import {
+  LedgerError,
+  type EntryDraft,
+  type FinancialEventRecord,
+  type PostingRule,
+} from "../types";
+
+// Subscriptions, as accounting (§3.6). Three recipes, and each one is two
+// legs, because postpay made this simple: there is no prepaid balance to
+// charge from, so a subscription is just another thing that lands on the
+// same receivable the metered AI lands on, and the same month-end invoice
+// collects both.
+//
+//   'subscription_charge'        at period start — they now owe us for it
+//     Dr asset:receivable:customer:<id>
+//     Cr liability:deferred:subscriptions
+//
+//   'subscription_recognition'   at period end — we have now earned it
+//     Dr liability:deferred:subscriptions
+//     Cr revenue:subscriptions
+//
+//   'subscription_refund'        cancel with time unearned
+//     Dr liability:deferred:subscriptions
+//     Cr asset:receivable:customer:<id>
+//
+// Charging and recognizing are deliberately separate. It is the separation
+// that keeps the unearned remainder of every period sitting in
+// `liability:deferred:subscriptions` where a proration can find it — and it
+// is why the refund recipe needs no new accounts and no new model.
+//
+// Note what is NOT here: the plan's margin. A plan changes what price the
+// metering computes for a turn, and `rules/ai-usage.ts` never learns that
+// plans exist. If a ladder needs a posting rule, it is the wrong ladder.
+
+export const subscriptionChargeEventType = "subscription.charged";
+export const subscriptionRecognitionEventType = "subscription.recognized";
+export const subscriptionRefundEventType = "subscription.refunded";
+
+function amountAndAccount(event: FinancialEventRecord): {
+  accountId: string;
+  amountMicros: bigint;
+  metadata: Record<string, unknown>;
+} {
+  const amountMicros = parseMicros(
+    event.payload["priceMicros"] ?? 0,
+    "priceMicros",
+  );
+  if (amountMicros <= 0n) {
+    throw new LedgerError(
+      "invalid_amount",
+      "A subscription entry must move a positive amount",
+    );
+  }
+  // The account is on the event rather than in the payload: it is the column
+  // the ledger indexes and the one thing that survives the customer's
+  // deletion (§2.1).
+  if (!event.accountId) {
+    throw new LedgerError(
+      "invalid_draft",
+      "A subscription entry must name the account it belongs to",
+    );
+  }
+  const pick = (key: string) =>
+    event.payload[key] === undefined ? {} : { [key]: event.payload[key] };
+  return {
+    accountId: event.accountId,
+    amountMicros,
+    metadata: {
+      ...pick("marginBasisPoints"),
+      ...pick("periodEnd"),
+      ...pick("periodId"),
+      ...pick("periodStart"),
+      ...pick("planCode"),
+      ...pick("planName"),
+      priceMicros: String(event.payload["priceMicros"] ?? 0),
+    },
+  };
+}
+
+export const subscriptionChargeRule: PostingRule = {
+  build(event: FinancialEventRecord): EntryDraft[] {
+    const { accountId, amountMicros, metadata } = amountAndAccount(event);
+    const planName =
+      typeof event.payload["planName"] === "string"
+        ? event.payload["planName"]
+        : (event.payload["planCode"] ?? "subscription");
+    return [
+      {
+        description: `${planName} subscription`,
+        entryType: "subscription_charge",
+        metadata,
+        occurredAt: event.occurredAt,
+        postings: [
+          {
+            accountCode: customerReceivableCode(accountId),
+            amountMicros,
+            direction: "debit",
+          },
+          {
+            accountCode: systemAccountCodes.deferredSubscriptions,
+            amountMicros,
+            direction: "credit",
+          },
+        ],
+      },
+    ];
+  },
+  name: "subscription_charge",
+  version: 1,
+};
+
+export const subscriptionRecognitionRule: PostingRule = {
+  build(event: FinancialEventRecord): EntryDraft[] {
+    const { amountMicros, metadata } = amountAndAccount(event);
+    return [
+      {
+        description: "Subscription revenue recognized",
+        entryType: "subscription_recognition",
+        metadata,
+        occurredAt: event.occurredAt,
+        postings: [
+          {
+            accountCode: systemAccountCodes.deferredSubscriptions,
+            amountMicros,
+            direction: "debit",
+          },
+          {
+            accountCode: systemAccountCodes.revenueSubscriptions,
+            amountMicros,
+            direction: "credit",
+          },
+        ],
+      },
+    ];
+  },
+  name: "subscription_recognition",
+  version: 1,
+};
+
+// Cancelling with time unearned: net it against what they owe rather than
+// sending cash. Under postpay that is usually the entire answer — the cash
+// path (refunds_payable → psp) stays on the shelf for somebody who has
+// already paid and is leaving.
+export const subscriptionRefundRule: PostingRule = {
+  build(event: FinancialEventRecord): EntryDraft[] {
+    const { accountId, amountMicros, metadata } = amountAndAccount(event);
+    return [
+      {
+        description: "Unearned subscription returned to the customer's balance",
+        entryType: "subscription_refund_to_receivable",
+        metadata,
+        occurredAt: event.occurredAt,
+        postings: [
+          {
+            accountCode: systemAccountCodes.deferredSubscriptions,
+            amountMicros,
+            direction: "debit",
+          },
+          {
+            accountCode: customerReceivableCode(accountId),
+            amountMicros,
+            direction: "credit",
+          },
+        ],
+      },
+    ];
+  },
+  name: "subscription_refund",
+  version: 1,
+};

--- a/cloud/packages/ledger/src/settings.ts
+++ b/cloud/packages/ledger/src/settings.ts
@@ -16,6 +16,7 @@ import { LedgerError, type LedgerExecutor } from "./types";
 export const billingSettingKeys = {
   aiMarginPercent: "ai_margin_percent",
   aiMeteringMode: "ai_metering_mode",
+  paygDailyCapMicros: "payg_daily_cap_micros",
   paygOverdraftMicros: "payg_overdraft_micros",
 } as const;
 
@@ -28,12 +29,16 @@ export type BillingSettingKey =
 export type MeteringMode = "live" | "shadow";
 
 export interface BillingSettings {
+  // The ceiling on one account's chargeable AI usage in a UTC day (§5.3).
+  // Postpay's credit limit, wearing a unit users think in.
+  dailyCapMicros: bigint;
   marginBasisPoints: number;
   meteringMode: MeteringMode;
   overdraftMicros: bigint;
 }
 
 export const defaultBillingSettings: BillingSettings = {
+  dailyCapMicros: 10_000_000n,
   marginBasisPoints: 3_000,
   meteringMode: "shadow",
   overdraftMicros: 1_000_000n,
@@ -50,6 +55,10 @@ export async function readBillingSettings(
   const values = new Map(rows.map((row) => [row.key, row.value]));
 
   return {
+    dailyCapMicros:
+      microsFrom(values.get(billingSettingKeys.paygDailyCapMicros)) ??
+      microsFrom(env.FRAMEOS_CLOUD_AI_DAILY_CAP_MICROS) ??
+      defaultBillingSettings.dailyCapMicros,
     marginBasisPoints:
       marginBasisPointsFrom(values.get(billingSettingKeys.aiMarginPercent)) ??
       // Bootstrap for a deployment whose settings row has not been written
@@ -110,6 +119,14 @@ function validateSetting(key: BillingSettingKey, value: unknown): void {
         throw new LedgerError(
           "invalid_draft",
           'ai_metering_mode must be "shadow" or "live"',
+        );
+      }
+      return;
+    case billingSettingKeys.paygDailyCapMicros:
+      if (microsFrom(value) === undefined) {
+        throw new LedgerError(
+          "invalid_amount",
+          "payg_daily_cap_micros must be a non-negative whole number of micro-dollars",
         );
       }
       return;

--- a/cloud/packages/ledger/src/subscriptions.ts
+++ b/cloud/packages/ledger/src/subscriptions.ts
@@ -1,0 +1,429 @@
+import { and, asc, desc, eq, isNull, lte } from "drizzle-orm";
+import { subscriptionPeriods, subscriptions } from "@frameos-cloud/db";
+import { postEvent, type PostEventOptions } from "./kernel";
+import { readPlan } from "./plans";
+import {
+  subscriptionChargeEventType,
+  subscriptionRecognitionEventType,
+  subscriptionRefundEventType,
+} from "./rules/subscription";
+import { LedgerError, type LedgerExecutor } from "./types";
+
+// The subscription lifecycle: who is on what plan, and the nightly cycle that
+// charges each period at its start and recognizes it at its end.
+//
+// Everything here is idempotent on a `subscription_periods` row, which is the
+// design: the nightly job may run twice in a night, or not at all for three
+// days, without double-charging anybody or losing a period. The row is
+// created first, then charged, then recognized, and each step stamps its own
+// timestamp — so a crash between any two steps leaves work the next run picks
+// up rather than a half-charged month nobody can see.
+//
+// Free plans never get a period row. A $0 charge is not an entry worth
+// posting (the kernel refuses a zero amount, and rightly), and an account on
+// PAYG is billed entirely through its metered usage.
+
+/** One calendar month on from `at`, clamped for short months — a
+ *  subscription started on the 31st renews on the 30th, the 28th, and so on,
+ *  rather than skipping February. */
+export function addMonth(at: Date): Date {
+  const year = at.getUTCFullYear();
+  const month = at.getUTCMonth();
+  const day = at.getUTCDate();
+  const lastDayOfNextMonth = new Date(Date.UTC(year, month + 2, 0)).getUTCDate();
+  return new Date(
+    Date.UTC(
+      year,
+      month + 1,
+      Math.min(day, lastDayOfNextMonth),
+      at.getUTCHours(),
+      at.getUTCMinutes(),
+      at.getUTCSeconds(),
+      at.getUTCMilliseconds(),
+    ),
+  );
+}
+
+export interface SubscriptionRecord {
+  accountId: string;
+  cancelAt: Date | null;
+  id: string;
+  planCode: string;
+  startedAt: Date;
+  status: string;
+}
+
+/**
+ * Put an account on a plan. Switching plans keeps the same subscription row —
+ * the period rows carry the plan they were billed under, so history survives
+ * the change without a second subscription to reconcile against.
+ *
+ * Moving to PAYG is a cancellation, not a subscription: PAYG costs nothing,
+ * so there is nothing to bill and no period to open.
+ */
+export async function setAccountPlan(
+  db: LedgerExecutor,
+  accountId: string,
+  planCode: string,
+): Promise<SubscriptionRecord | null> {
+  const plan = await readPlan(db, planCode);
+  if (!plan) {
+    throw new LedgerError("invalid_draft", `Unknown plan ${planCode}`);
+  }
+  if (plan.priceMicros === 0n) {
+    await cancelAccountPlan(db, accountId, { immediately: true });
+    return null;
+  }
+
+  const now = new Date();
+  const [row] = await db
+    .insert(subscriptions)
+    .values({ accountId, planCode: plan.code, startedAt: now, status: "active" })
+    .onConflictDoUpdate({
+      set: {
+        // Re-subscribing after a cancellation clears the cancellation: the
+        // row is the account's one subscription, not a log of them.
+        cancelAt: null,
+        canceledAt: null,
+        planCode: plan.code,
+        status: "active",
+        updatedAt: now,
+      },
+      target: subscriptions.accountId,
+    })
+    .returning();
+  return row ? toRecord(row) : null;
+}
+
+/**
+ * Cancel. By default the plan runs to the end of the period already charged
+ * for — they paid for it — and stops there. `immediately` is for downgrades
+ * to a free plan and for operator action; it does not refund on its own
+ * (§3.6's refund recipe is a separate, deliberate step).
+ */
+export async function cancelAccountPlan(
+  db: LedgerExecutor,
+  accountId: string,
+  options: { immediately?: boolean | undefined } = {},
+): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(subscriptions)
+    .where(eq(subscriptions.accountId, accountId))
+    .limit(1);
+  if (!row) {
+    return;
+  }
+  const now = new Date();
+  if (options.immediately) {
+    await db
+      .update(subscriptions)
+      .set({ cancelAt: now, canceledAt: now, status: "canceled", updatedAt: now })
+      .where(eq(subscriptions.id, row.id));
+    return;
+  }
+  // Run to the end of the latest period we have charged for. With no charged
+  // period there is nothing they paid for, so it ends now.
+  const [latest] = await db
+    .select()
+    .from(subscriptionPeriods)
+    .where(eq(subscriptionPeriods.subscriptionId, row.id))
+    .orderBy(desc(subscriptionPeriods.periodEnd))
+    .limit(1);
+  const cancelAt = latest ? latest.periodEnd : now;
+  await db
+    .update(subscriptions)
+    .set({ cancelAt, canceledAt: now, status: "canceling", updatedAt: now })
+    .where(eq(subscriptions.id, row.id));
+}
+
+export interface SubscriptionCycleResult {
+  charged: number;
+  failures: { error: unknown; periodId: string }[];
+  opened: number;
+  recognized: number;
+}
+
+/**
+ * The nightly cycle: open the periods that are due, charge the ones that have
+ * started, recognize the ones that have ended. Safe to run repeatedly.
+ */
+export async function runSubscriptionCycle(
+  db: LedgerExecutor,
+  options: PostEventOptions & { now?: Date | undefined } = {},
+): Promise<SubscriptionCycleResult> {
+  const now = options.now ?? new Date();
+  const result: SubscriptionCycleResult = {
+    charged: 0,
+    failures: [],
+    opened: 0,
+    recognized: 0,
+  };
+
+  result.opened = await openDuePeriods(db, now);
+
+  const uncharged = await db
+    .select()
+    .from(subscriptionPeriods)
+    .where(
+      and(
+        isNull(subscriptionPeriods.chargedAt),
+        lte(subscriptionPeriods.periodStart, now),
+      ),
+    )
+    .orderBy(asc(subscriptionPeriods.periodStart));
+  for (const period of uncharged) {
+    try {
+      await chargePeriod(db, period, options);
+      result.charged += 1;
+    } catch (error) {
+      // One bad period must not stop the rest of the night's work.
+      result.failures.push({ error, periodId: period.id });
+    }
+  }
+
+  const unrecognized = await db
+    .select()
+    .from(subscriptionPeriods)
+    .where(
+      and(
+        isNull(subscriptionPeriods.recognizedAt),
+        lte(subscriptionPeriods.periodEnd, now),
+      ),
+    )
+    .orderBy(asc(subscriptionPeriods.periodEnd));
+  for (const period of unrecognized) {
+    // A period that was never charged has nothing to recognize — recognizing
+    // it would credit revenue against a deferral that does not exist and
+    // break invariant 2 immediately.
+    if (!period.chargedAt) {
+      continue;
+    }
+    try {
+      await recognizePeriod(db, period, options);
+      result.recognized += 1;
+    } catch (error) {
+      result.failures.push({ error, periodId: period.id });
+    }
+  }
+
+  await closeExpiredSubscriptions(db, now);
+  return result;
+}
+
+// Every active subscription that has no period covering `now` gets one. The
+// new period starts where the last one ended, so a job that missed three days
+// bills a month from the right instant rather than from tonight.
+async function openDuePeriods(db: LedgerExecutor, now: Date): Promise<number> {
+  const rows = await db
+    .select()
+    .from(subscriptions)
+    .where(eq(subscriptions.status, "active"));
+  let opened = 0;
+  for (const subscription of rows) {
+    const plan = await readPlan(db, subscription.planCode);
+    if (!plan || plan.priceMicros === 0n) {
+      continue;
+    }
+    const [latest] = await db
+      .select()
+      .from(subscriptionPeriods)
+      .where(eq(subscriptionPeriods.subscriptionId, subscription.id))
+      .orderBy(desc(subscriptionPeriods.periodEnd))
+      .limit(1);
+    let periodStart = latest ? latest.periodEnd : subscription.startedAt;
+    if (latest && latest.periodEnd > now) {
+      continue;
+    }
+    // Catch up rather than skip: a job that has not run for two months opens
+    // both months, because both were served.
+    let guard = 0;
+    while (periodStart <= now && guard < 24) {
+      const periodEnd = addMonth(periodStart);
+      await db
+        .insert(subscriptionPeriods)
+        .values({
+          currency: plan.currency,
+          marginBasisPoints: plan.marginBasisPoints,
+          periodEnd,
+          periodStart,
+          planCode: plan.code,
+          priceMicros: plan.priceMicros,
+          subscriptionId: subscription.id,
+        })
+        .onConflictDoNothing({
+          target: [
+            subscriptionPeriods.subscriptionId,
+            subscriptionPeriods.periodStart,
+          ],
+        });
+      opened += 1;
+      periodStart = periodEnd;
+      guard += 1;
+    }
+  }
+  return opened;
+}
+
+type PeriodRow = typeof subscriptionPeriods.$inferSelect;
+
+async function subscriptionFor(
+  db: LedgerExecutor,
+  period: PeriodRow,
+): Promise<typeof subscriptions.$inferSelect | undefined> {
+  const [row] = await db
+    .select()
+    .from(subscriptions)
+    .where(eq(subscriptions.id, period.subscriptionId))
+    .limit(1);
+  return row;
+}
+
+async function planNameFor(db: LedgerExecutor, code: string): Promise<string> {
+  const plan = await readPlan(db, code);
+  return plan?.name ?? code;
+}
+
+function periodPayload(
+  period: PeriodRow,
+  planName: string,
+): Record<string, unknown> {
+  return {
+    marginBasisPoints: period.marginBasisPoints,
+    periodEnd: period.periodEnd.toISOString(),
+    periodId: period.id,
+    periodStart: period.periodStart.toISOString(),
+    planCode: period.planCode,
+    planName,
+    // Amounts travel as decimal strings: jsonb has one number type and it
+    // loses integers above 2^53 (money.ts says why).
+    priceMicros: period.priceMicros.toString(),
+  };
+}
+
+export async function chargePeriod(
+  db: LedgerExecutor,
+  period: PeriodRow,
+  options: PostEventOptions = {},
+): Promise<void> {
+  const subscription = await subscriptionFor(db, period);
+  if (!subscription) {
+    throw new LedgerError("invalid_draft", "Period has no subscription");
+  }
+  await postEvent(
+    db,
+    {
+      accountId: subscription.accountId,
+      eventType: subscriptionChargeEventType,
+      idempotencyKey: `subscription_charge:${period.id}`,
+      occurredAt: period.periodStart,
+      payload: periodPayload(period, await planNameFor(db, period.planCode)),
+      source: "subscriptions",
+      sourceRef: period.id,
+    },
+    options,
+  );
+  await db
+    .update(subscriptionPeriods)
+    .set({ chargedAt: new Date() })
+    .where(eq(subscriptionPeriods.id, period.id));
+}
+
+export async function recognizePeriod(
+  db: LedgerExecutor,
+  period: PeriodRow,
+  options: PostEventOptions = {},
+): Promise<void> {
+  const subscription = await subscriptionFor(db, period);
+  if (!subscription) {
+    throw new LedgerError("invalid_draft", "Period has no subscription");
+  }
+  await postEvent(
+    db,
+    {
+      accountId: subscription.accountId,
+      eventType: subscriptionRecognitionEventType,
+      idempotencyKey: `subscription_recognition:${period.id}`,
+      // Recognized at the end of the period it was earned over, not tonight:
+      // a job that runs late must not move revenue into the wrong month.
+      occurredAt: period.periodEnd,
+      payload: periodPayload(period, await planNameFor(db, period.planCode)),
+      source: "subscriptions",
+      sourceRef: period.id,
+    },
+    options,
+  );
+  await db
+    .update(subscriptionPeriods)
+    .set({ recognizedAt: new Date() })
+    .where(eq(subscriptionPeriods.id, period.id));
+}
+
+/**
+ * Return the unearned remainder of a period to the customer's balance — the
+ * §3.6 recipe, used by an operator granting a mid-period refund. Nets against
+ * what they owe rather than sending cash.
+ */
+export async function refundUnearnedPeriod(
+  db: LedgerExecutor,
+  period: PeriodRow,
+  amountMicros: bigint,
+  options: PostEventOptions = {},
+): Promise<void> {
+  const subscription = await subscriptionFor(db, period);
+  if (!subscription) {
+    throw new LedgerError("invalid_draft", "Period has no subscription");
+  }
+  if (amountMicros <= 0n || amountMicros > period.priceMicros) {
+    throw new LedgerError(
+      "invalid_amount",
+      "A refund must be positive and no larger than the period it refunds",
+    );
+  }
+  await postEvent(
+    db,
+    {
+      accountId: subscription.accountId,
+      eventType: subscriptionRefundEventType,
+      idempotencyKey: `subscription_refund:${period.id}`,
+      occurredAt: new Date(),
+      payload: {
+        ...periodPayload(period, await planNameFor(db, period.planCode)),
+        priceMicros: amountMicros.toString(),
+      },
+      source: "subscriptions",
+      sourceRef: period.id,
+    },
+    options,
+  );
+}
+
+// A cancellation whose date has passed becomes a real cancellation. Done here
+// rather than only on read so the row means what it says, but `readAccountPlan`
+// checks the date too — an entitlement must expire on time even when the
+// nightly job is broken.
+async function closeExpiredSubscriptions(
+  db: LedgerExecutor,
+  now: Date,
+): Promise<void> {
+  await db
+    .update(subscriptions)
+    .set({ status: "canceled", updatedAt: now })
+    .where(
+      and(
+        eq(subscriptions.status, "canceling"),
+        lte(subscriptions.cancelAt, now),
+      ),
+    );
+}
+
+function toRecord(row: typeof subscriptions.$inferSelect): SubscriptionRecord {
+  return {
+    accountId: row.accountId,
+    cancelAt: row.cancelAt,
+    id: row.id,
+    planCode: row.planCode,
+    startedAt: row.startedAt,
+    status: row.status,
+  };
+}

--- a/cloud/packages/ledger/src/test/integration/helpers.ts
+++ b/cloud/packages/ledger/src/test/integration/helpers.ts
@@ -12,6 +12,9 @@ export async function resetLedger() {
   await db.execute(sql`
     TRUNCATE TABLE ai_usage_records, ledger_postings, ledger_balances, ledger_entries, financial_events
   `);
+  // Subscriptions cascade from accounts, but truncating explicitly keeps a
+  // test that never made an account from inheriting the last one's periods.
+  await db.execute(sql`TRUNCATE TABLE subscription_periods, subscriptions`);
   await db.execute(
     sql`DELETE FROM ledger_accounts WHERE owner_account_id IS NOT NULL`,
   );
@@ -27,6 +30,9 @@ export async function resetLedger() {
   `);
   await db.execute(sql`
     UPDATE billing_settings SET value = '"shadow"' WHERE key = 'ai_metering_mode'
+  `);
+  await db.execute(sql`
+    UPDATE billing_settings SET value = '10000000' WHERE key = 'payg_daily_cap_micros'
   `);
 }
 

--- a/cloud/packages/ledger/src/test/integration/lifecycle.integration.test.ts
+++ b/cloud/packages/ledger/src/test/integration/lifecycle.integration.test.ts
@@ -30,7 +30,14 @@ beforeEach(async () => {
 
 // The golden-file test: one customer's whole life through the books, with
 // the complete journal asserted at every step rather than one balance at the
-// end. The unit tests prove each recipe in isolation; this proves the
+// end.
+//
+// This one deliberately mixes both models. The metered turns post the LIVE
+// postpay shape (rule v2: the charge debits the customer's receivable), while
+// the purchase and the promo grant exercise the prepaid accounts §3.5 keeps
+// on the shelf — which is what stops a shelved model from quietly rotting
+// into something that no longer balances. subscriptions.integration.test.ts
+// is the postpay + subscription walk. The unit tests prove each recipe in isolation; this proves the
 // sequence, which is where accounting bugs actually live — a charge that
 // posts fine on its own and leaves the wrong liability behind once a refund
 // and a reversal have happened around it.
@@ -164,13 +171,13 @@ describe("a customer's life through the books", () => {
     Dr contra_revenue:promo               5.000000
     Cr liability:credits_promo:customer:<id> 5.000000
   ai_usage_charge
-    Dr liability:credits:customer:<id>    0.575120
+    Dr asset:receivable:customer:<id>     0.575120
     Cr revenue:ai_usage                   0.575120
   ai_usage_cost
     Dr expense:cogs:openai                0.442400
     Cr liability:accrued:openai           0.442400
   ai_usage_charge
-    Dr liability:credits:customer:<id>    0.575120
+    Dr asset:receivable:customer:<id>     0.575120
     Cr revenue:ai_usage                   0.575120
   ai_usage_cost
     Dr expense:cogs:openai                0.442400
@@ -206,8 +213,9 @@ describe("a customer's life through the books", () => {
     expect(balance.balanced).toBe(true);
     expect("\n" + renderBalances(balance.rows)).toBe(`
   asset:psp:main                     9.410000
+  asset:receivable:customer:<id>     0.575120
   liability:accrued:openai           0.884800
-  liability:credits:customer:<id>    9.424880
+  liability:credits:customer:<id>    10.000000
   liability:credits_promo:customer:<id> 5.000000
   contra_revenue:promo               5.000000
   revenue:ai_usage                   0.475120
@@ -229,7 +237,13 @@ describe("a customer's life through the books", () => {
     expect(formatMicros(summary.contraRevenueMicros)).toBe("5.000000");
     expect(formatMicros(summary.netRevenueMicros)).toBe("-4.424880");
     expect(formatMicros(summary.marginMicros)).toBe("-5.899680");
-    expect(formatMicros(summary.customerLiabilityMicros)).toBe("14.424880");
+    // Two different customer balances now, and the distinction is the whole
+    // of §0: the prepaid liability is what we owe them (still the full $15
+    // they were given, because postpay never draws it down), and the
+    // receivable is what they owe us for the one charge that survived the
+    // reversal.
+    expect(formatMicros(summary.customerLiabilityMicros)).toBe("15.000000");
+    expect(formatMicros(summary.customerReceivableMicros)).toBe("0.575120");
 
     // Every invariant, after all of it.
     expect(

--- a/cloud/packages/ledger/src/test/integration/metering.integration.test.ts
+++ b/cloud/packages/ledger/src/test/integration/metering.integration.test.ts
@@ -5,9 +5,10 @@ import {
   accountBalanceMicros,
   aiUsageSummary,
   billingSettingKeys,
+  checkDailyCapRespected,
   checkLedgerIntegrity,
   checkMeteringCompleteness,
-  customerCreditsCode,
+  customerReceivableCode,
   postUsageRecord,
   recordAiUsage,
   sweepUnpostedUsage,
@@ -97,11 +98,12 @@ describe("AI metering", () => {
       "ai_usage_charge",
       "ai_usage_cost",
     ]);
-    // The customer's credit account goes negative — they have not bought any
-    // yet, and Phase 3's spend gate is what stops that happening for real.
-    expect(await accountBalanceMicros(db, customerCreditsCode(accountId))).toBe(
-      -575_120n,
-    );
+    // Postpay (rule v2): the charge lands on the customer's RECEIVABLE, an
+    // asset, because a metered turn is money they now owe us rather than a
+    // draw-down of a balance they handed us in advance.
+    expect(
+      await accountBalanceMicros(db, customerReceivableCode(accountId)),
+    ).toBe(575_120n);
     expect(await accountBalanceMicros(db, systemAccountCodes.revenueAiUsage)).toBe(
       575_120n,
     );
@@ -148,7 +150,7 @@ describe("AI metering", () => {
 
     expect(result.entries.map((entry) => entry.entryType)).toEqual(["ai_usage_cost"]);
     expect(await accountBalanceMicros(db, systemAccountCodes.cogsOpenai)).toBe(442_400n);
-    expect(await accountBalanceMicros(db, customerCreditsCode(accountId))).toBe(0n);
+    expect(await accountBalanceMicros(db, customerReceivableCode(accountId))).toBe(0n);
   });
 
   // Scene conversion is our migration off the legacy compiled path, run for
@@ -168,7 +170,7 @@ describe("AI metering", () => {
     expect(await accountBalanceMicros(db, systemAccountCodes.cogsOpenai)).toBe(442_400n);
     expect(await accountBalanceMicros(db, systemAccountCodes.accruedOpenai)).toBe(442_400n);
     expect(await accountBalanceMicros(db, systemAccountCodes.revenueAiUsage)).toBe(0n);
-    expect(await accountBalanceMicros(db, customerCreditsCode(accountId))).toBe(0n);
+    expect(await accountBalanceMicros(db, customerReceivableCode(accountId))).toBe(0n);
 
     // And it is legible as its own line: what the giveaway costs is a number
     // on the books, not a subtraction somebody has to know to do.
@@ -356,13 +358,69 @@ describe("AI metering", () => {
       { cost: 442_400n, list: 442_400n, price: 0n, source: "shared" },
     ]);
 
+    // Postpay: the charge sits on the receivable as an ordinary debit, so
+    // there is no negative balance to excuse any more — the books are simply
+    // consistent, which is the whole point of the change.
     expect(
-      await checkLedgerIntegrity(db, {
-        // The customer bought no credits, so their balance is legitimately
-        // negative here; Phase 3's gate is what stops that in production.
-        overdraftMicros: 10_000_000n,
-        pendingEventGraceMs: 0,
+      await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 }),
+    ).toEqual([]);
+  });
+
+  // Invariant 5 under postpay: the daily cap is what bounds the credit risk,
+  // and this check is the only automated proof that the gate in
+  // resolveAiAccess() sits in front of every AI surface rather than most of
+  // them. Measured on the usage records, not the postings, because it has to
+  // hold for shadow-mode and own-key accounts that post nothing.
+  it("notices a day that ran past the daily cap", async () => {
+    const accountId = await createAccount();
+    // Four turns at 575,120 micros each = 2,300,480.
+    for (let index = 0; index < 4; index += 1) {
+      await recordAiUsage(
+        db,
+        turn(accountId, `00000000-0000-4000-8000-0000000000c${index}`, "platform"),
+      );
+    }
+
+    // Well under a $10 cap: nothing to say.
+    expect(
+      await checkDailyCapRespected(db, {
+        dailyCapMicros: 10_000_000n,
+        overdraftMicros: 1_000_000n,
       }),
+    ).toEqual([]);
+
+    // Against a $1 cap the day is over the line even allowing one turn's
+    // overshoot, and the violation names the account, the day and the number.
+    const violations = await checkDailyCapRespected(db, {
+      dailyCapMicros: 1_000_000n,
+      overdraftMicros: 1_000_000n,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.check).toBe("daily_cap_respected");
+    expect(violations[0]?.detail).toContain(accountId);
+    expect(violations[0]?.detail).toContain("2300480");
+
+    // No cap configured is not the same as a cap of zero: a deployment whose
+    // setting is missing must not report every account as a violation.
+    expect(await checkDailyCapRespected(db, {})).toEqual([]);
+  });
+
+  // Own-key turns cost us nothing and are charged nothing, so capping them
+  // would be gratuitous — and the check must agree with the gate about that.
+  it("leaves own-key turns and absorbed surfaces out of the cap", async () => {
+    const accountId = await createAccount();
+    for (let index = 0; index < 6; index += 1) {
+      await recordAiUsage(
+        db,
+        turn(accountId, `00000000-0000-4000-8000-0000000000d${index}`, "account"),
+      );
+    }
+    await recordAiUsage(db, {
+      ...turn(accountId, "00000000-0000-4000-8000-0000000000e0", "platform"),
+      surface: "scene_convert",
+    });
+    expect(
+      await checkDailyCapRespected(db, { dailyCapMicros: 100_000n }),
     ).toEqual([]);
   });
 });

--- a/cloud/packages/ledger/src/test/integration/subscriptions.integration.test.ts
+++ b/cloud/packages/ledger/src/test/integration/subscriptions.integration.test.ts
@@ -1,0 +1,210 @@
+import { eq } from "drizzle-orm";
+import { subscriptionPeriods, subscriptions } from "@frameos-cloud/db";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  accountAiUsage,
+  billingSettingKeys,
+  cancelAccountPlan,
+  checkLedgerIntegrity,
+  customerReceivableCode,
+  accountBalanceMicros,
+  formatMicros,
+  listJournalEntries,
+  readAccountPlan,
+  recordAiUsage,
+  refundUnearnedPeriod,
+  runSubscriptionCycle,
+  setAccountPlan,
+  systemAccountCodes,
+  utcMonthWindow,
+  writeBillingSetting,
+  type JournalEntry,
+} from "../../index";
+import { createAccount, db, resetLedger } from "./helpers";
+
+afterAll(async () => {
+  await db.$client.end({ timeout: 5 });
+});
+
+beforeEach(async () => {
+  await resetLedger();
+});
+
+function anonymize(code: string): string {
+  return code.replace(/customer:[0-9a-f-]{36}/i, "customer:<id>");
+}
+
+function renderJournal(entries: JournalEntry[]): string {
+  return entries
+    .slice()
+    .reverse()
+    .map((entry) => {
+      const legs = entry.postings
+        .map(
+          (posting) =>
+            `    ${posting.direction === "debit" ? "Dr" : "Cr"} ${anonymize(posting.accountCode).padEnd(34)} ${formatMicros(posting.amountMicros)}`,
+        )
+        .join("\n");
+      return `  ${entry.entryType}\n${legs}`;
+    })
+    .join("\n");
+}
+
+const turnUsage = {
+  cachedInputTokens: 12_000,
+  inputTokens: 52_000,
+  outputTokens: 30_000,
+  reasoningTokens: 8_000,
+};
+
+// The postpay + subscription golden file (cloud/docs/accounting-todo.md §3.6):
+// a customer subscribes, the cycle charges and recognizes the period, their
+// metered turns price at the PLAN's margin rather than the deployment's, and
+// everything lands on the one receivable a month-end invoice would collect.
+describe("a subscriber's life through the books", () => {
+  it("charges, recognizes and meters at the plan's margin, all on one receivable", async () => {
+    const accountId = await createAccount();
+    await writeBillingSetting(db, billingSettingKeys.aiMeteringMode, "live");
+    const receivable = customerReceivableCode(accountId);
+
+    // 1. They take the Maker plan: $1.99/month, and AI at 50% margin instead
+    //    of the deployment's 30%.
+    await setAccountPlan(db, accountId, "maker");
+    const plan = await readAccountPlan(db, accountId);
+    expect(plan.plan.code).toBe("maker");
+    expect(plan.plan.marginBasisPoints).toBe(5_000);
+    expect(plan.subscribed).toBe(true);
+
+    // 2. The nightly cycle opens the period and charges it. The charge is an
+    //    accrual, not a payment: it lands on the receivable next to their
+    //    metered usage, which is the whole reason postpay came first.
+    const opened = await runSubscriptionCycle(db);
+    expect(opened.opened).toBe(1);
+    expect(opened.charged).toBe(1);
+    expect(opened.recognized).toBe(0);
+    expect(opened.failures).toEqual([]);
+    expect(await accountBalanceMicros(db, receivable)).toBe(1_990_000n);
+    // Not revenue yet: they have paid for a month we have not served.
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.deferredSubscriptions),
+    ).toBe(1_990_000n);
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.revenueSubscriptions),
+    ).toBe(0n);
+
+    // 3. Running again the same night charges nobody twice. This is the one
+    //    property the nightly job's whole design rests on.
+    const again = await runSubscriptionCycle(db);
+    expect(again).toMatchObject({ charged: 0, opened: 0, recognized: 0 });
+    expect(await accountBalanceMicros(db, receivable)).toBe(1_990_000n);
+
+    // 4. A metered turn, priced at the PLAN's 50% and not the global 30%.
+    //    442,400 provider cost × 1.5 = 663,600.
+    await recordAiUsage(db, {
+      accountId,
+      credentialSource: "platform",
+      model: "gpt-5.6-terra",
+      surface: "scene_chat",
+      turnId: "00000000-0000-4000-8000-0000000000b1",
+      usage: turnUsage,
+    });
+    expect(await accountBalanceMicros(db, receivable)).toBe(1_990_000n + 663_600n);
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.revenueAiUsage),
+    ).toBe(663_600n);
+
+    // The customer's own view agrees with the books, which is §5.2's point:
+    // the page and the ledger are one query apart, not two definitions apart.
+    const mine = await accountAiUsage(db, accountId, utcMonthWindow(new Date()));
+    expect(mine.chargeableMicros).toBe(663_600n);
+    expect(mine.turns).toBe(1);
+
+    expect("\n" + renderJournal(await listJournalEntries(db, { limit: 100 }))).toBe(`
+  subscription_charge
+    Dr asset:receivable:customer:<id>     1.990000
+    Cr liability:deferred:subscriptions   1.990000
+  ai_usage_charge
+    Dr asset:receivable:customer:<id>     0.663600
+    Cr revenue:ai_usage                   0.663600
+  ai_usage_cost
+    Dr expense:cogs:openai                0.442400
+    Cr liability:accrued:openai           0.442400`);
+
+    expect(await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 })).toEqual([]);
+  });
+
+  it("recognizes the period once it has actually been served", async () => {
+    const accountId = await createAccount();
+    await setAccountPlan(db, accountId, "maker");
+    await runSubscriptionCycle(db);
+
+    // Nothing is earned until the period ends, however many nights run.
+    await runSubscriptionCycle(db);
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.revenueSubscriptions),
+    ).toBe(0n);
+
+    // Two months on, the first period is over and a second has opened.
+    const later = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000);
+    const result = await runSubscriptionCycle(db, { now: later });
+    expect(result.recognized).toBe(1);
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.revenueSubscriptions),
+    ).toBe(1_990_000n);
+    expect(await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 })).toEqual([]);
+  });
+
+  it("returns the unearned remainder to the receivable rather than to cash", async () => {
+    const accountId = await createAccount();
+    await setAccountPlan(db, accountId, "studio");
+    await runSubscriptionCycle(db);
+    const receivable = customerReceivableCode(accountId);
+    expect(await accountBalanceMicros(db, receivable)).toBe(6_990_000n);
+
+    const [period] = await db.select().from(subscriptionPeriods);
+    // Half the month unearned: it nets against what they owe, which under
+    // postpay is usually the entire answer — no cash leaves.
+    await refundUnearnedPeriod(db, period!, 3_495_000n);
+    expect(await accountBalanceMicros(db, receivable)).toBe(3_495_000n);
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.deferredSubscriptions),
+    ).toBe(3_495_000n);
+    expect(
+      await accountBalanceMicros(db, systemAccountCodes.refundsPayable),
+    ).toBe(0n);
+    expect(await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 })).toEqual([]);
+  });
+
+  it("runs a cancelled plan to the end of the period it was paid for", async () => {
+    const accountId = await createAccount();
+    await setAccountPlan(db, accountId, "maker");
+    await runSubscriptionCycle(db);
+
+    await cancelAccountPlan(db, accountId);
+    const [row] = await db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.accountId, accountId));
+    expect(row?.status).toBe("canceling");
+    // Still theirs: they paid for this month.
+    expect((await readAccountPlan(db, accountId)).plan.code).toBe("maker");
+
+    // Past the period end, the entitlement is gone and nothing new is
+    // charged — the plan expires on time whether or not the job has run.
+    const later = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000);
+    const cycle = await runSubscriptionCycle(db, { now: later });
+    expect(cycle.opened).toBe(0);
+    expect(cycle.charged).toBe(0);
+    expect((await readAccountPlan(db, accountId)).plan.code).toBe("payg");
+  });
+
+  it("puts an account with no subscription on the free plan", async () => {
+    const accountId = await createAccount();
+    const plan = await readAccountPlan(db, accountId);
+    expect(plan.plan.code).toBe("payg");
+    expect(plan.subscribed).toBe(false);
+    // And opens no period for it: a $0 charge is not an entry worth posting.
+    expect(await runSubscriptionCycle(db)).toMatchObject({ charged: 0, opened: 0 });
+    expect(await db.select().from(subscriptionPeriods)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The direction change

`cloud/docs/accounting-todo.md` gains a **§0**, and it narrows the product rather than growing it. We are **not selling prepaid credits**. Holding people's money before delivering anything is stored value — VAT-at-issue, expiry policy, unclaimed-property exposure — and that is not an animal worth adopting to sell $6 of tokens. Usage accrues as a **receivable** instead, and one invoice at the end of the month collects it.

That deletes three open decisions outright (credit expiry, the prepaid refund path, what a "credit" is worth) and costs the ledger exactly one leg: `rules/ai-usage.ts` goes to **v2** and debits `asset:receivable:customer:<id>` rather than drawing down a prepaid liability. Nothing had posted under v1 — metering has been in shadow throughout — so no historical entry changes meaning.

Postpay's one real cost is credit risk, so the two things that bound it ship with it.

## The AI switch (§5.1)

An account can turn AI features off entirely and then incur nothing. `resolveAiAccess()` is now the **one door** every AI surface goes through — switch, then key, then cap, in that order — which replaces a `null` that meant three unrelated things with a typed refusal. Each gets its own status code:

| | | |
|---|---|---|
| `ai_disabled` | 403 | a switch the user threw; nothing is broken |
| `daily_cap_reached` | 402 | the payment-shaped one, with cap/spend/reset in the body |
| `missing_api_key` | 400 | the original meaning of a null credential |

Telling somebody who switched AI off that they should go set an API key is exactly the dead end the switch exists to avoid.

The **scene converter is deliberately exempt**. It is an absorbed surface — billed to nobody, capped for nobody — with an anonymous path that needs no account at all, which is the proof it is not an account feature. Neither the switch nor the cap may turn a free migration tool we asked people to run into a refusal. That exemption is a comment at the call site, not an implicit consequence of a list, because the next person to read it will otherwise "fix" it.

## The daily cap (§5.3)

$10/day, as a `billing_settings` row rather than a constant.

The chargeable amount is **defined once and used twice** — by the cap that refuses a turn and by the figure on the account page — because two definitions of "what you have spent today" that differ by a rounding step is a bug only ever found by a confused user. It is deliberately *not* `SUM(price_micros)`: in shadow mode that is zero on every row, so a cap built on it would never bite and would ship untested, and a page built on it would tell every user they had used nothing.

`checkDailyCapRespected` replaces invariant 5 (there is no prepaid balance to keep out of the red any more) and is the only automated proof that the gate sits in front of **every** AI surface rather than most of them: a surface added next month that forgets `resolveAiAccess` shows up as a day over the line rather than as a surprise on an invoice.

## What the user sees

The account header grows an `AI usage` row — a label and a figure, no meter, because the only thing it could fill a bar against today is a cap that empties every midnight. Four zero states, each needing its own words: nothing used, AI off, running on your own key (you owe us nothing, and a bill-shaped zero would be a lie), and a real figure that is nevertheless not being charged.

Behind it, **`/account/ai`**: this month and last, where it went in the user's own words with the absorbed surfaces shown as free *because* they are free, the last twenty requests, how the price is arrived at, and the switch.

## Plans (§0.1, Phase 5)

Off the shelf in the same pass, because §3.6 had been *designed* rather than merely deferred: no posting rule changed, and `rules/ai-usage.ts` still does not know plans exist. What varies down the ladder is the **margin on metered AI**, so a plan is never a wall in front of a feature — only a better rate on something you could already use.

| | Pay as you go — $0 | Maker — $1.99/mo | Studio — $6.99/mo |
|---|---|---|---|
| AI margin over provider cost | 100% | 50% | 20% |
| Cloud-rendered frames | 0 | 5 | 25 |
| Backups | 100 MB | 2 GB | 10 GB |
| Frame logs | 100 MB | 500 MB | 2 GB |
| Private scenes | 100 MB | 1 GB | 5 GB |

At provider cost *c*: PAYG bills `2c`, Maker `1.99 + 1.5c`, Studio `6.99 + 1.2c`. **Maker pays for itself at about $4/month of provider cost** (≈ 9 turns) and **Studio overtakes Maker at about $16.70** (≈ 38 turns). Both crossovers are reachable by a real user in a real month, which is the test of whether a ladder is a ladder or a decoration.

**Cloud-rendered frames are the one entitlement with a real marginal cost**, which is why the free plan gets zero — and which is the answer to the question `docs/todo.md` has been carrying: *"serving thin clients means the cloud renders every frame for them — free cloud rendering forever, for everyone. Decide before building; until then C3 boards stay out of the cloud flasher."* The decision is that it is a paid entitlement. §0.2 also notes that the cost driver is **renders per day, not frames**, so the plan is enforced as *N frames and a minimum refresh interval* even though it is displayed as "N frames".

## Three decisions taken while building

Each is a place where the obvious thing would have been wrong:

- **Self-serve purchase is gated off** (`FRAMEOS_CLOUD_PLANS_SELF_SERVE`, default false). Subscribing accrues a real receivable and Phase 3b — the payment provider — does not exist yet; letting somebody subscribe today would run up a balance with no way to settle it, so the ledger would be right and the customer would be stuck. **Downgrading is never gated** — refusing to let somebody stop paying us would be an unpleasant thing to build.
- **An account nobody put on a plan prices at the deployment's global margin, not at PAYG's 100%.** Otherwise migration 0045 would have doubled the price of every existing account's AI on the night it ran: a price change wearing a schema change's clothes.
- **Entitlements take the larger of the plan and the env floor**, and the seeded PAYG numbers are identical to the historical free tier, so nothing anybody has today gets smaller. Every enforcement point moved onto `accountLimits()` alongside the display — a page promising 10 GB while the refusal still fires at 100 MB would be worse than having no plans at all.

## Migrations

- **0044** — `accounts.ai_disabled_at`, the `payg_daily_cap_micros` setting, an `(account_id, occurred_at)` index (both the cap and the page window on when the tokens *burned*, not when the row was written).
- **0045** — `billing_plans`, `subscriptions`, `subscription_periods`, and the ladder seeded with **PAYG as a real row** so "what plan is this account on" always has an answer and the margin lookup has no special case.

The subscription lifecycle runs in the existing nightly job, between the usage sweep and the invariants — the invariants have to see the books *after* everything that was going to be written tonight has been, or they report a disagreement they caused themselves. Every step is idempotent on its period row, so the job may run twice in a night or miss three nights without double-charging anybody or losing a period.

## Testing

Unit tests, typecheck and `eslint --max-warnings=0` are green across `packages/ledger`, `packages/db` and `apps/auth-web`.

⚠️ **Integration tests were not run locally** — there is no Postgres available on this machine. That means the ledger integration suite, including the new `subscriptions.integration.test.ts` golden file and the updated `lifecycle`/`metering` expectations, is unverified until CI runs it. The two failing `cloud-frames-routes` unit tests are pre-existing on `main` (they need a built `cloud-frontend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzPLzUFm1tCvHQFJ9D5FUZ
