### PR TITLE
Cloud: leave battery-misreads out of Next's type check

### DIFF
--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -56,6 +56,13 @@
     "src/test/shared-spa/cloud-scene-persist-equality.test.ts",
     "src/test/shared-spa/scene-origin.test.ts",
     "src/test/shared-spa/embedded-editor-scene-sanitize.test.ts",
+    // Same story from the other direction: it imports metricsLogic directly
+    // for the metric-card hash helpers, and metricsLogic builds RebootMarker
+    // objects with optional fields spelled as `undefined` — legal under the
+    // frontend's tsconfig, not under this one's exactOptionalPropertyTypes.
+    // Nothing else in auth-web reaches that module. Vitest still runs it;
+    // only tsc leaves it out.
+    "src/test/shared-spa/battery-misreads.test.ts",
     // The widest graph of the lot: it mounts the whole FrameSettings panel,
     // which reaches the colour picker and every device-settings component
     // behind it. Vitest still runs it; only tsc leaves it out.

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -46,6 +46,10 @@ export default tseslint.config(
       // Same exclusion, same reason: sanitizeIncomingScenes is a thin wrapper
       // over that same sanitizeScene.
       "**/src/test/shared-spa/embedded-editor-scene-sanitize.test.ts",
+      // Same exclusion, same reason from the other direction: it imports
+      // metricsLogic, whose RebootMarker literals spell optional fields as
+      // `undefined`.
+      "**/src/test/shared-spa/battery-misreads.test.ts",
       // Same exclusion, same reason, widest graph of the lot: mounts the
       // whole FrameSettings panel and the colour picker behind it.
       "**/src/test/shared-spa/cloud-frame-settings-panel.test.tsx",


### PR DESCRIPTION
`main` is red. [Run 33540379793](https://github.com/FrameOS/frameos/actions/runs/33540379793)
on `225ddc9a` fails `verify` → `@frameos-cloud/auth-web#build`:

```
✓ Compiled successfully in 35.0s
  Running TypeScript ...
Failed to type check.

../../../frontend/src/scenes/frame/panels/Metrics/metricsLogic.ts:199:3
Type error: Type '{ timestamp: Date; logId: string | undefined; ... }' is not
assignable to type 'RebootMarker' with 'exactOptionalPropertyTypes: true'.
  Types of property 'logId' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
```

`metricsLogic.ts` builds a `RebootMarker` with its optional fields spelled as
`undefined`. That is legal under the frontend's tsconfig and not under
auth-web's, which sets `exactOptionalPropertyTypes`.

It only reaches auth-web's type check at all because `6865b1f6` added
`src/test/shared-spa/battery-misreads.test.ts`, which imports `metricsLogic`
for the metric-card hash helpers. Nothing else in `cloud/` imports that module
(`git grep metricsLogic -- cloud/` finds only comments and this test), and the
last green `main` run — `6e923c1c` at 15:53 — predates the commit.

So it is the same trap the ten entries above it in `tsconfig.json` already
document, and it gets the same fix.

**The fix is a pair, and it is easy to half-do.** `tsconfig.json`'s `exclude`
keeps `tsc` off the file; `cloud/eslint.config.mjs`'s `ignores` keeps typed
linting off it too. Doing only the first turns the build error into

```
0:0  error  Parsing error: .../battery-misreads.test.ts was not found by the
project service. Consider either including it in the tsconfig.json or
including it in allowDefaultProject
```

which is what the first push of this PR did. The two lists are otherwise
identical, entry for entry. Vitest still runs the test either way.

The better long-term fix is to widen `RebootMarker`'s optional fields to
`string | undefined`, or to omit the keys rather than assign `undefined` — that
belongs with whoever owns the type. This is the unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8vRETZAR2GHjYPydppFPA
