### PR TITLE
Cloud: settings become an account tab; fix the rail's stuck Frame spinner

### DIFF
--- a/cloud-frontend/src/cloudConfig.ts
+++ b/cloud-frontend/src/cloudConfig.ts
@@ -24,6 +24,9 @@ interface CloudAppConfig {
   cloud_logout_url?: string
   cloud_origin?: string
   cloud_scenes_url?: string
+  /** The account's settings page (service API keys, SSH keys). Read by the
+   * shared SPA's urls.settings() (frontend/src/urls.ts), not here. */
+  cloud_settings_url?: string
   cloud_theme_cookie_domain?: string
   /** Read by livePreviewLogic straight off FRAMEOS_APP_CONFIG: the wasm
    * preview's same-origin HTTP proxy (/api/store/preview-proxy). */

--- a/cloud-frontend/src/routes.ts
+++ b/cloud-frontend/src/routes.ts
@@ -40,9 +40,16 @@ export function cloudSceneUrl(frameId: string, sceneId?: string): string {
   return sceneId ? `${path}/${encodeURIComponent(sceneId)}` : path
 }
 
-/** The account settings page (service API keys) — the SPA's `settings` scene. */
+/**
+ * The account settings page (service API keys, SSH keys). An account page,
+ * not a scene of this SPA — the path only; Next.js server code links to it
+ * through getAccountUrl("/account/settings"), which knows the split-host
+ * shortening, and the SPA reads the finished URL from the injected
+ * cloud_settings_url (frontend/src/urls.ts). The old /frames/settings scene
+ * is redirected here by the [[...path]] route.
+ */
 export function cloudSettingsUrl(): string {
-  return `${cloudRouteBasePath}/settings`
+  return '/account/settings'
 }
 
 /**

--- a/cloud-frontend/src/scenes/cloud/Cloud.tsx
+++ b/cloud-frontend/src/scenes/cloud/Cloud.tsx
@@ -11,7 +11,6 @@ import { socketLogic } from '../../../../frontend/src/scenes/socketLogic'
 import { AppsWorkspace } from '../../../../frontend/src/scenes/workspace/AppsWorkspace'
 import { FramesHome } from '../../../../frontend/src/scenes/workspace/FramesHome'
 import { SceneWorkspace } from '../../../../frontend/src/scenes/workspace/SceneWorkspace'
-import { Settings } from '../../../../frontend/src/scenes/settings/Settings'
 import { CloudFirstRunAddFrame } from '../../components/CloudFirstRunAddFrame'
 
 interface CloudSceneProps {
@@ -92,14 +91,6 @@ export function CloudAppsWorkspace({ frameId, sceneId, nodeId }: CloudSceneProps
   return (
     <CloudGate>
       <AppsWorkspace frameId={frameId} sceneId={sceneId} nodeId={nodeId} />
-    </CloudGate>
-  )
-}
-
-export function CloudSettings() {
-  return (
-    <CloudGate>
-      <Settings />
     </CloudGate>
   )
 }

--- a/cloud-frontend/src/scenes/scenes.tsx
+++ b/cloud-frontend/src/scenes/scenes.tsx
@@ -8,22 +8,22 @@ export const scenes = {
   frame: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudFrame }))),
   sceneWorkspace: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudSceneWorkspace }))),
   appsWorkspace: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudAppsWorkspace }))),
-  settings: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudSettings }))),
 }
 
 // Routes come from the shared urls module so they always match the links
 // the shared components generate. With route_base_path = '/frames' these
-// resolve to /frames, /frames/:id, /frames/:id/scenes/..., /frames/apps/...
-// and /frames/settings (the account's service API keys). kea-router takes
-// the first matching pattern, so the literal /frames/* routes come before
-// the parametric /frames/:id.
+// resolve to /frames, /frames/:id, /frames/:id/scenes/... and
+// /frames/apps/... kea-router takes the first matching pattern, so the
+// literal /frames/* routes come before the parametric /frames/:id.
 // The SPA's own login/signup scenes are deliberately absent: Next.js owns
-// auth on the cloud (apiFetch redirects to /login on 401).
+// auth on the cloud (apiFetch redirects to /login on 401). So is the
+// settings scene: the account's service API keys and SSH keys are an
+// account page (/account/settings), and urls.settings() links out to it;
+// the old /frames/settings is redirected there server-side.
 export const getRoutes = () =>
   ({
     [urls.frames()]: 'frames',
     [urls.frames() + '/']: 'frames',
-    [urls.settings()]: 'settings',
     [urls.scenes()]: 'sceneWorkspace',
     [urls.apps()]: 'appsWorkspace',
     [urls.apps(':frameId')]: 'appsWorkspace',

--- a/cloud/apps/auth-web/app/account/layout.tsx
+++ b/cloud/apps/auth-web/app/account/layout.tsx
@@ -113,6 +113,7 @@ export default async function AccountLayout({
           developer: getAccountUrl("/account/developer"),
           installs: getAccountUrl("/account/installs"),
           security: getAccountUrl("/account/security"),
+          settings: getAccountUrl("/account/settings"),
         }}
       />
       {children}

--- a/cloud/apps/auth-web/app/account/settings/page.tsx
+++ b/cloud/apps/auth-web/app/account/settings/page.tsx
@@ -1,0 +1,64 @@
+import { createDb } from "@frameos-cloud/db";
+import { AccountSettingsForm } from "../../../src/components/AccountSettingsForm";
+import { AccountSshKeys } from "../../../src/components/AccountSshKeys";
+import { storedAccountSettings } from "../../../src/lib/account-settings";
+import {
+  serviceSettingsFrom,
+  sshKeysFrom,
+} from "../../../src/lib/account-settings-form";
+import { readSession } from "../../../src/lib/session";
+
+export const metadata = { title: "Settings" };
+
+// The account's frame settings: the service API keys the apps on your
+// frames use, and the SSH public keys the SD card builder installs. These
+// used to be a scene of the /frames workspace (the shared SPA's settings
+// page in cloud mode); they are account-level facts, so they live with the
+// rest of the account. Same storage and API as before (account_settings,
+// /api/settings), so nothing a frame receives changed.
+export default async function AccountSettingsPage() {
+  const session = await readSession();
+  const accountId = session?.accountId;
+  if (!accountId) {
+    return (
+      <section className="card">
+        <p className="copy">Sign in to manage your settings.</p>
+      </section>
+    );
+  }
+  const stored = await storedAccountSettings(createDb(), accountId);
+
+  return (
+    <>
+      <section className="section-block">
+        <div className="content-header compact-header">
+          <div>
+            <h2>Service API keys</h2>
+            <p className="copy">
+              Keys the apps on your frames use — Unsplash photos, Immich
+              albums, Home Assistant sensors, OpenAI images and text. Saved
+              keys reach your cloud-managed frames on their next check-in.
+            </p>
+          </div>
+        </div>
+        <AccountSettingsForm initial={serviceSettingsFrom(stored)} />
+      </section>
+
+      <section className="section-block" id="settings-ssh">
+        <div className="content-header compact-header">
+          <div>
+            <h2>SSH keys</h2>
+            <p className="copy">
+              Public keys the SD card builder installs on new Linux frames, so
+              you can log in as root over SSH. The cloud stores public keys
+              only.
+            </p>
+          </div>
+        </div>
+        <section className="card">
+          <AccountSshKeys initialKeys={sshKeysFrom(stored)} />
+        </section>
+      </section>
+    </>
+  );
+}

--- a/cloud/apps/auth-web/app/api/settings/route.ts
+++ b/cloud/apps/auth-web/app/api/settings/route.ts
@@ -8,6 +8,7 @@ import {
 import { NextRequest, NextResponse } from "next/server";
 import {
   filterAccountSettings,
+  storedAccountSettings,
   type FilteredAccountSettings,
 } from "../../../src/lib/account-settings";
 import { recordAuditEvent } from "../../../src/lib/audit";
@@ -34,17 +35,8 @@ export const runtime = "nodejs";
 // unchanged in cloud mode: GET returns the merged {group: value} object,
 // POST replaces each posted group wholesale and returns the updated merge.
 // Which groups and fields are storable is the account-settings.ts allowlist.
-
-async function storedAccountSettings(
-  db: ReturnType<typeof createDb>,
-  accountId: string,
-): Promise<Record<string, unknown>> {
-  const rows = await db
-    .select()
-    .from(accountSettings)
-    .where(eq(accountSettings.accountId, accountId));
-  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
-}
+// The account settings page (app/account/settings) renders the same merged
+// object server-side and posts here from its form.
 
 // Tell every cloud-managed frame that holds `settings:services` to re-pull.
 // The nudge carries NO payload — the keys ride the device-authed HTTPS pull

--- a/cloud/apps/auth-web/app/frames/[[...path]]/route.test.ts
+++ b/cloud/apps/auth-web/app/frames/[[...path]]/route.test.ts
@@ -239,6 +239,28 @@ describe("frames SPA shell", () => {
     // Baked into SD images and ESP32 NVS: the deployment's public URL, never
     // the browser's address bar.
     expect(lines).toContain('cloud_origin: "https://account.frameos.net",');
+    // The SPA's settings gear links out to the account page, shortened the
+    // way every other /account/* path is on a split-host deployment.
+    expect(lines).toContain(
+      'cloud_settings_url: "https://account.frameos.net/settings",',
+    );
+  });
+
+  // The global settings were a SPA scene at /frames/settings until 2026.9;
+  // the scene editors still hold links to it with an #settings-openai
+  // fragment, which the browser carries across a fragment-less redirect.
+  it("redirects the old /frames/settings scene to the account page", async () => {
+    process.env.FRAMEOS_CLOUD_APP_URL = "https://frameos.net";
+    process.env.FRAMEOS_ACCOUNT_APP_URL = "https://account.frameos.net";
+    process.env.FRAMEOS_SCENES_APP_URL = "https://scenes.frameos.net";
+    for (const path of ["/frames/settings", "/frames/settings/"]) {
+      const response = await get(`https://account.frameos.net${path}`);
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe("https://account.frameos.net/settings");
+      expect(response.headers.get("cache-control")).toBe("no-store");
+    }
+    // Only that path: a frame that happens to be called "settings-…" is a frame.
+    expect((await get("https://account.frameos.net/frames/settings-x")).status).toBe(200);
   });
 
   it("substitutes the machine's LAN address for a localhost enrollment origin", async () => {

--- a/cloud/apps/auth-web/app/frames/[[...path]]/route.ts
+++ b/cloud/apps/auth-web/app/frames/[[...path]]/route.ts
@@ -132,6 +132,9 @@ async function appConfigLines(): Promise<string[]> {
     `cloud_frames_url: ${JSON.stringify(new URL("/frames", getAccountBaseUrl()).toString())},`,
     `cloud_logout_url: ${JSON.stringify(new URL("/api/auth/logout", getCloudBaseUrl()).toString())},`,
     `cloud_scenes_url: ${JSON.stringify(getStoreUrl())},`,
+    // The global settings (service API keys, SSH keys) are an account page;
+    // the SPA's urls.settings() links out to this finished URL.
+    `cloud_settings_url: ${JSON.stringify(getAccountUrl("/account/settings"))},`,
     `cloud_origin: ${JSON.stringify(await enrollmentOrigin(accountOrigin))},`,
     `cloud_claim_token_ttl_hours: ${Math.round(claimTokenTtlMs / (60 * 60 * 1000))},`,
     // The workspace and the account pages are two different apps sharing one
@@ -190,6 +193,19 @@ function anchorMissing(anchor: string, purpose: string) {
 // itself redirects to /login on 401 — the shell is served unauthenticated,
 // like every other static asset. See cloud-frontend/README.md.
 export async function GET(request: NextRequest) {
+  // The global settings used to be a scene of the SPA at /frames/settings;
+  // they are an account page now. Old links — and the #settings-openai
+  // anchors the scene editors pointed at — keep working: a redirect without
+  // a fragment keeps the browser's. Temporary and uncacheable on purpose,
+  // like the surface redirects in proxy.ts: a permanent redirect freezes
+  // into browser caches, and routing has changed under them before.
+  if (request.nextUrl.pathname.replace(/\/+$/, "") === "/frames/settings") {
+    return NextResponse.redirect(getAccountUrl("/account/settings"), {
+      headers: { "cache-control": "no-store" },
+      status: 307,
+    });
+  }
+
   let html: string;
   try {
     html = await readFile(

--- a/cloud/apps/auth-web/app/globals.css
+++ b/cloud/apps/auth-web/app/globals.css
@@ -479,6 +479,38 @@ html.theme-dark .button-primary {
   gap: 12px;
 }
 
+/* /account/settings: the service-key cards and the SSH key list. */
+.account-settings__fields {
+  margin-top: 14px;
+}
+
+.account-settings__hint {
+  font-size: 13px;
+}
+
+.account-settings__check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+/* A Save with nothing to save: visibly inert, not a green promise. */
+.account-settings__actions .button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.account-settings__textarea {
+  min-height: 0;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  resize: vertical;
+}
+
 /* The new-token form on /account/developer: one row — the name grows, the
    two selects and the button take what they need — over a one-line hint.
    Not .actions: that grid stretches a button to the card's full width,

--- a/cloud/apps/auth-web/app/my-scenes/new/page.tsx
+++ b/cloud/apps/auth-web/app/my-scenes/new/page.tsx
@@ -5,7 +5,6 @@ import { NewSceneWithAi } from "../../../src/components/NewSceneWithAi";
 import {
   getAccountUrl,
   getCloudBaseUrl,
-  getFramesUrl,
   getMyScenesUrl,
   getScenesBaseUrl,
   hasDatabaseUrl,
@@ -66,7 +65,7 @@ export default async function NewScenePage({
       initialPrompt={prompt}
       loginUrl={new URL("/login", getCloudBaseUrl()).toString()}
       myScenesUrl={getMyScenesUrl()}
-      settingsUrl={`${getFramesUrl()}/settings#settings-openai`}
+      settingsUrl={`${getAccountUrl("/account/settings")}#settings-openai`}
     />
   );
 }

--- a/cloud/apps/auth-web/app/s/[slug]/page.tsx
+++ b/cloud/apps/auth-web/app/s/[slug]/page.tsx
@@ -19,7 +19,6 @@ import {
   getAccountBaseUrl,
   getAccountUrl,
   getCloudBaseUrl,
-  getFramesUrl,
   getScenesBaseUrl,
   getStorePath,
   hasDatabaseUrl,
@@ -435,7 +434,7 @@ export default async function ScenePage({
         signupUrl={new URL("/signup", getCloudBaseUrl()).toString()}
         pinnedVersion={pinnedVersion ? pinnedVersion.version : null}
         sceneId={scene.id}
-        settingsUrl={`${getFramesUrl()}/settings#settings-openai`}
+        settingsUrl={`${getAccountUrl("/account/settings")}#settings-openai`}
         share={share}
         signedIn={Boolean(session?.accountId)}
         versions={info.versions}

--- a/cloud/apps/auth-web/src/components/AccountNav.tsx
+++ b/cloud/apps/auth-web/src/components/AccountNav.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 // workspace and the private scene list is a tab of the scene store.
 const sections = [
   { href: "/account/installs", key: "installs", label: "Backends" },
+  { href: "/account/settings", key: "settings", label: "Settings" },
   { href: "/account/ai", key: "ai", label: "AI usage" },
   { href: "/account/backups", key: "backups", label: "Backups" },
   { href: "/account/activity", key: "activity", label: "Activity" },

--- a/cloud/apps/auth-web/src/components/AccountSettingsForm.test.tsx
+++ b/cloud/apps/auth-web/src/components/AccountSettingsForm.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { storableAccountSettingsFields } from "../lib/account-settings";
+import {
+  serviceSettingsFrom,
+  serviceSettingsGroups,
+  sshKeysFrom,
+} from "../lib/account-settings-form";
+import { AccountSettingsForm } from "./AccountSettingsForm";
+import { AccountSshKeys } from "./AccountSshKeys";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+describe("account settings page", () => {
+  it("edits only groups and fields the cloud can store", () => {
+    for (const group of serviceSettingsGroups) {
+      const allowed = storableAccountSettingsFields.get(group.key);
+      expect(allowed, group.key).toBeDefined();
+      for (const field of group.fields) {
+        expect(allowed?.has(field.name), `${group.key}.${field.name}`).toBe(true);
+      }
+    }
+  });
+
+  it("builds every group with every field, '' when unset", () => {
+    const values = serviceSettingsFrom({
+      openAI: { apiKey: "sk-frames", chatModel: 7 },
+      unsplash: "not an object",
+    });
+    expect(values.openAI).toEqual({
+      apiKey: "sk-frames",
+      backendApiKey: "",
+      chatModel: "",
+      chatReasoningEffort: "",
+    });
+    expect(values.unsplash).toEqual({ accessKey: "" });
+    expect(Object.keys(values)).toEqual(serviceSettingsGroups.map((group) => group.key));
+  });
+
+  it("posts every service group wholesale and resets from the answer", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      // The route answers with what it stored (an extra group the form does
+      // not edit rides along, as ssh_keys does in production).
+      return jsonResponse({ ...body, ssh_keys: { keys: [] } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AccountSettingsForm
+        initial={serviceSettingsFrom({ unsplash: { accessKey: "old-key" } })}
+      />,
+    );
+    const save = screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText("Access key"), { target: { value: "new-key" } });
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+
+    await screen.findByRole("status");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/settings");
+    expect(init?.method).toBe("POST");
+    const posted = JSON.parse(String(init?.body)) as Record<string, Record<string, string>>;
+    expect(Object.keys(posted).sort()).toEqual(
+      serviceSettingsGroups.map((group) => group.key).sort(),
+    );
+    expect(posted.unsplash).toEqual({ accessKey: "new-key" });
+    // Untouched groups go along in full — POST replaces groups wholesale, so
+    // leaving one out would not "keep" it, and a missing field would clear it.
+    expect(posted.homeAssistant).toEqual({ url: "", accessToken: "" });
+    expect((save as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("shows the route's refusal and keeps the edit", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "settings_value_too_large" }, 400)),
+    );
+    render(<AccountSettingsForm initial={serviceSettingsFrom({})} />);
+    fireEvent.change(screen.getByLabelText("API key for frames"), {
+      target: { value: "sk-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect((await screen.findByRole("alert")).textContent).toMatch(/too long/);
+    expect((screen.getByLabelText("API key for frames") as HTMLInputElement).value).toBe("sk-1");
+  });
+
+  it("keeps the model settings folded unless one is set", () => {
+    const { unmount } = render(<AccountSettingsForm initial={serviceSettingsFrom({})} />);
+    expect(screen.queryByLabelText("Chat model")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Show model settings" }));
+    expect(screen.getByLabelText("Chat model")).toBeTruthy();
+    unmount();
+
+    render(
+      <AccountSettingsForm
+        initial={serviceSettingsFrom({ openAI: { chatReasoningEffort: "high" } })}
+      />,
+    );
+    expect((screen.getByLabelText("Reasoning effort") as HTMLSelectElement).value).toBe("high");
+  });
+});
+
+describe("account SSH keys", () => {
+  const line = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxhcHRvcC1rZXktZm9yLXRlc3Rz you@laptop";
+
+  it("reads the stored group and skips what is not a key", () => {
+    expect(
+      sshKeysFrom({
+        ssh_keys: {
+          keys: [
+            { id: "a", name: "Laptop", public: line, use_for_new_frames: true },
+            { id: "b", name: "Empty", public: "" },
+            "junk",
+          ],
+        },
+      }),
+    ).toEqual([{ id: "a", name: "Laptop", public: line, use_for_new_frames: true }]);
+    expect(sshKeysFrom({})).toEqual([]);
+  });
+
+  it("saves the whole list on add and renders what the server kept", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        ssh_keys: { keys: { id: string; name: string; public: string }[] };
+      };
+      return jsonResponse({ ssh_keys: body.ssh_keys });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AccountSshKeys
+        initialKeys={[{ id: "a", name: "Laptop", public: line, use_for_new_frames: true }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add SSH key" }));
+    fireEvent.change(screen.getByLabelText("Key name"), { target: { value: "Desk" } });
+    fireEvent.change(screen.getByLabelText("Public key"), {
+      target: { value: `  ${line.replace("you@laptop", "me@desk")}\n` },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add key" }));
+
+    await waitFor(() => expect(screen.getByText("Desk")).toBeTruthy());
+    const posted = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body)) as {
+      ssh_keys: { keys: { id: string; name: string; public: string; use_for_new_frames: boolean }[] };
+    };
+    expect(posted).toEqual({
+      ssh_keys: {
+        keys: [
+          { id: "a", name: "Laptop", public: line, use_for_new_frames: true },
+          {
+            id: expect.any(String),
+            name: "Desk",
+            public: line.replace("you@laptop", "me@desk"),
+            use_for_new_frames: true,
+          },
+        ],
+      },
+    });
+    expect(screen.getByText("Laptop")).toBeTruthy();
+    expect(screen.queryByLabelText("Public key")).toBeNull();
+  });
+
+  it("explains a refused key and keeps the form open", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "invalid_ssh_key" }, 400)),
+    );
+    render(<AccountSshKeys initialKeys={[]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Add SSH key" }));
+    fireEvent.change(screen.getByLabelText("Public key"), { target: { value: "nope" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add key" }));
+    expect((await screen.findByRole("alert")).textContent).toMatch(/not an OpenSSH public key/);
+    expect((screen.getByLabelText("Public key") as HTMLTextAreaElement).value).toBe("nope");
+  });
+});

--- a/cloud/apps/auth-web/src/components/AccountSettingsForm.tsx
+++ b/cloud/apps/auth-web/src/components/AccountSettingsForm.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import {
+  describeSettingsError,
+  serviceSettingsFrom,
+  serviceSettingsGroups,
+  type ServiceFieldSpec,
+  type ServiceGroupSpec,
+  type ServiceSettingsValues,
+} from "../lib/account-settings-form";
+
+// The service API keys on /account/settings. One form, one Save: the whole
+// object goes to POST /api/settings, which replaces every group wholesale
+// and answers with what it stored — the form resets from that answer, so
+// what is on screen after a save is what the database holds. Cloud-managed
+// frames are nudged to re-pull their keys by the route, not by us.
+
+function hasAdvancedValues(values: ServiceSettingsValues): boolean {
+  return serviceSettingsGroups.some((group) =>
+    group.fields.some(
+      (field) => field.advanced && (values[group.key]?.[field.name] ?? "") !== "",
+    ),
+  );
+}
+
+function FieldInput({
+  group,
+  field,
+  value,
+  onChange,
+}: {
+  group: ServiceGroupSpec;
+  field: ServiceFieldSpec;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const id = `${group.key}-${field.name}`;
+  return (
+    <div className="field">
+      <label htmlFor={id}>{field.label}</label>
+      {field.options ? (
+        <select
+          className="input"
+          id={id}
+          onChange={(event) => onChange(event.target.value)}
+          value={value}
+        >
+          {field.options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          autoComplete={field.secret ? "new-password" : "off"}
+          className="input"
+          id={id}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={field.placeholder}
+          spellCheck={false}
+          type={field.secret ? "password" : "text"}
+          value={value}
+        />
+      )}
+      {field.hint ? <p className="copy account-settings__hint">{field.hint}</p> : null}
+    </div>
+  );
+}
+
+export function AccountSettingsForm({ initial }: { initial: ServiceSettingsValues }) {
+  const [saved, setSaved] = useState(initial);
+  const [values, setValues] = useState(initial);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [justSaved, setJustSaved] = useState(false);
+  const [showModelSettings, setShowModelSettings] = useState(() => hasAdvancedValues(initial));
+  const changed = JSON.stringify(values) !== JSON.stringify(saved);
+
+  function update(group: string, field: string, value: string) {
+    setJustSaved(false);
+    setValues((current) => ({
+      ...current,
+      [group]: { ...current[group], [field]: value },
+    }));
+  }
+
+  async function save(event: React.FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    setError(undefined);
+    try {
+      const response = await fetch("/api/settings", {
+        body: JSON.stringify(values),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const payload = (await response.json().catch(() => undefined)) as
+        | (Record<string, unknown> & { error?: string })
+        | undefined;
+      if (!response.ok) {
+        setError(describeSettingsError(response.status, payload?.error));
+        return;
+      }
+      const next = serviceSettingsFrom(payload);
+      setSaved(next);
+      setValues(next);
+      setJustSaved(true);
+    } catch {
+      setError(describeSettingsError(0, undefined));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="stack-lg" onSubmit={(event) => void save(event)}>
+      {serviceSettingsGroups.map((group) => {
+        const groupValues = values[group.key] ?? {};
+        const advanced = group.fields.some((field) => field.advanced);
+        return (
+          <section className="card" id={group.id} key={group.key}>
+            <h3>{group.title}</h3>
+            {group.intro ? <p className="copy">{group.intro}</p> : null}
+            {group.introLink ? (
+              <p className="copy">
+                <a href={group.introLink.href} rel="noreferrer" target="_blank">
+                  {group.introLink.label}
+                </a>
+                {group.introLink.after}
+              </p>
+            ) : null}
+            <div className="stack account-settings__fields">
+              {group.fields
+                .filter((field) => !field.advanced || showModelSettings)
+                .map((field) => (
+                  <FieldInput
+                    field={field}
+                    group={group}
+                    key={field.name}
+                    onChange={(value) => update(group.key, field.name, value)}
+                    value={groupValues[field.name] ?? ""}
+                  />
+                ))}
+              {advanced ? (
+                <div>
+                  <button
+                    className="button button--small button--subtle"
+                    onClick={() => setShowModelSettings((current) => !current)}
+                    type="button"
+                  >
+                    {showModelSettings ? "Hide model settings" : "Show model settings"}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </section>
+        );
+      })}
+
+      {error ? (
+        <p className="notice-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {justSaved && !changed ? (
+        <p className="notice" role="status">
+          Saved. Your frames pick up the new keys on their next check-in.
+        </p>
+      ) : null}
+
+      <div className="button-row account-settings__actions">
+        <button className="button button-primary" disabled={!changed || busy} type="submit">
+          {busy ? "Saving…" : "Save"}
+        </button>
+        <button
+          className="button"
+          disabled={!changed || busy}
+          onClick={() => {
+            setValues(saved);
+            setError(undefined);
+          }}
+          type="button"
+        >
+          Reset
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/cloud/apps/auth-web/src/components/AccountSshKeys.tsx
+++ b/cloud/apps/auth-web/src/components/AccountSshKeys.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+  describeSettingsError,
+  describeSshPublicKey,
+  sshKeysFrom,
+  type SshKeyEntry,
+} from "../lib/account-settings-form";
+
+// The account's SSH public keys on /account/settings — what the SD card
+// builder installs on new Linux frames. Every change is saved on the spot
+// (the list is one settings group, `ssh_keys`, posted wholesale) and the
+// list re-renders from what the server kept: it validates each line and
+// drops anything that is not an OpenSSH public key, so what you see is what
+// the builder will write.
+
+export function AccountSshKeys({ initialKeys }: { initialKeys: SshKeyEntry[] }) {
+  const [keys, setKeys] = useState(initialKeys);
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState("");
+  const [publicKey, setPublicKey] = useState("");
+  const [useForNewFrames, setUseForNewFrames] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  async function persist(next: SshKeyEntry[]): Promise<boolean> {
+    setBusy(true);
+    setError(undefined);
+    try {
+      const response = await fetch("/api/settings", {
+        body: JSON.stringify({ ssh_keys: { keys: next } }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const payload = (await response.json().catch(() => undefined)) as
+        | (Record<string, unknown> & { error?: string })
+        | undefined;
+      if (!response.ok) {
+        setError(describeSettingsError(response.status, payload?.error));
+        return false;
+      }
+      setKeys(sshKeysFrom(payload));
+      return true;
+    } catch {
+      setError(describeSettingsError(0, undefined));
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function add(event: React.FormEvent) {
+    event.preventDefault();
+    const line = publicKey.trim().replace(/\s+/g, " ");
+    if (!line) {
+      setError("Paste the public key first.");
+      return;
+    }
+    const entry: SshKeyEntry = {
+      id: crypto.randomUUID(),
+      name: name.trim(),
+      public: line,
+      use_for_new_frames: useForNewFrames,
+    };
+    if (await persist([...keys, entry])) {
+      setAdding(false);
+      setName("");
+      setPublicKey("");
+      setUseForNewFrames(true);
+    }
+  }
+
+  async function remove(key: SshKeyEntry) {
+    const label = key.name || describeSshPublicKey(key.public);
+    if (
+      !window.confirm(
+        `Remove the SSH key "${label}"? Frames it is already installed on keep it.`,
+      )
+    ) {
+      return;
+    }
+    await persist(keys.filter((entry) => entry.id !== key.id));
+  }
+
+  async function setDefault(key: SshKeyEntry, value: boolean) {
+    await persist(
+      keys.map((entry) =>
+        entry.id === key.id ? { ...entry, use_for_new_frames: value } : entry,
+      ),
+    );
+  }
+
+  return (
+    <div className="stack">
+      {keys.length === 0 ? (
+        <p className="copy">No SSH keys yet. Add one to be able to log in to new frames over SSH.</p>
+      ) : (
+        <div className="table-scroll">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Key</th>
+                <th>New frames</th>
+                <th aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((key) => {
+                const label = key.name || "Unnamed key";
+                return (
+                  <tr key={key.id}>
+                    <td>
+                      <strong>{label}</strong>
+                    </td>
+                    <td>
+                      <code>{describeSshPublicKey(key.public)}</code>
+                    </td>
+                    <td>
+                      <label className="account-settings__check">
+                        <input
+                          aria-label={`Install ${label} on new frames by default`}
+                          checked={key.use_for_new_frames}
+                          disabled={busy}
+                          onChange={(event) => void setDefault(key, event.target.checked)}
+                          type="checkbox"
+                        />
+                        <span>by default</span>
+                      </label>
+                    </td>
+                    <td className="cell-nowrap">
+                      <button
+                        aria-label={`Remove ${label}`}
+                        className="button button--small button--subtle"
+                        disabled={busy}
+                        onClick={() => void remove(key)}
+                        title="Remove this key"
+                        type="button"
+                      >
+                        <Trash2 aria-hidden="true" size={16} />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {error ? (
+        <p className="notice-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {adding ? (
+        <form className="stack" onSubmit={(event) => void add(event)}>
+          <div className="field">
+            <label htmlFor="ssh-key-name">Key name</label>
+            <input
+              autoFocus
+              className="input"
+              id="ssh-key-name"
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Marius' laptop"
+              value={name}
+            />
+          </div>
+          <div className="field">
+            <label htmlFor="ssh-key-public">Public key</label>
+            <textarea
+              className="input account-settings__textarea"
+              id="ssh-key-public"
+              onChange={(event) => setPublicKey(event.target.value)}
+              placeholder="ssh-ed25519 AAAA… you@laptop"
+              rows={3}
+              spellCheck={false}
+              value={publicKey}
+            />
+          </div>
+          <label className="account-settings__check">
+            <input
+              checked={useForNewFrames}
+              onChange={(event) => setUseForNewFrames(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Install on new frames by default</span>
+          </label>
+          <div className="button-row">
+            <button className="button button-primary" disabled={busy} type="submit">
+              {busy ? "Saving…" : "Add key"}
+            </button>
+            <button
+              className="button"
+              disabled={busy}
+              onClick={() => {
+                setAdding(false);
+                setError(undefined);
+              }}
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div>
+          <button
+            className="button button--small"
+            disabled={busy}
+            onClick={() => setAdding(true)}
+            type="button"
+          >
+            <Plus aria-hidden="true" size={16} />
+            Add SSH key
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cloud/apps/auth-web/src/lib/account-settings-form.ts
+++ b/cloud/apps/auth-web/src/lib/account-settings-form.ts
@@ -1,0 +1,217 @@
+// What the account settings page (app/account/settings) edits, as data the
+// server page and the client components share. No React, no database: the
+// page reads the stored settings server-side and hands the components the
+// shapes built here; the components post to /api/settings and rebuild the
+// same shapes from its response.
+//
+// The group and field names are the storable ones (account-settings.ts —
+// AccountSettingsForm.test.tsx checks they stay a subset). The wire contract
+// is the backend's: GET /api/settings is the merged {group: {field: value}}
+// object, POST replaces every posted group WHOLESALE, so a group is always
+// sent with all of its fields and an empty string clears a key.
+
+export interface ServiceFieldSpec {
+  name: string;
+  label: string;
+  /** Rendered as a password input: the value is an API key or token. */
+  secret?: boolean;
+  placeholder?: string;
+  hint?: string;
+  /** Behind the group's "Show model settings" disclosure. */
+  advanced?: boolean;
+  options?: { value: string; label: string }[];
+}
+
+export interface ServiceGroupSpec {
+  /** The settings group — the key in the /api/settings object. */
+  key: string;
+  /** Anchor the scene editors link to (#settings-openai). */
+  id: string;
+  title: string;
+  intro?: string;
+  /** Text after `intro`, linked. */
+  introLink?: { href: string; label: string; after: string };
+  fields: ServiceFieldSpec[];
+}
+
+export const serviceSettingsGroups: readonly ServiceGroupSpec[] = [
+  {
+    key: "frameOS",
+    id: "settings-gallery",
+    title: "FrameOS Gallery",
+    introLink: {
+      href: "https://gallery.frameos.net/",
+      label: "Premium AI slop",
+      after: " to get you started.",
+    },
+    fields: [
+      {
+        name: "apiKey",
+        label: "API key",
+        secret: true,
+        hint: "Just use 2024 for now. We might add custom accounts in the future.",
+      },
+    ],
+  },
+  {
+    key: "openAI",
+    id: "settings-openai",
+    title: "OpenAI",
+    intro:
+      "The key for frames is used by the OpenAI apps on your frames. The AI chat key powers scene chat in the workspace; it stays on your account and is never sent to a frame.",
+    fields: [
+      { name: "apiKey", label: "API key for frames", secret: true },
+      { name: "backendApiKey", label: "API key for AI chat", secret: true },
+      {
+        name: "chatModel",
+        label: "Chat model",
+        placeholder: "gpt-5.6-terra",
+        hint: "The OpenAI model the workspace chat runs on. Leave empty for the default.",
+        advanced: true,
+      },
+      {
+        name: "chatReasoningEffort",
+        label: "Reasoning effort",
+        hint: "How much the model thinks before answering. Higher is slower and costs more; it mostly pays off on complex scene builds. Ignored by models without reasoning.",
+        advanced: true,
+        options: [
+          { value: "", label: "Default (low)" },
+          { value: "minimal", label: "Minimal" },
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High" },
+        ],
+      },
+    ],
+  },
+  {
+    key: "homeAssistant",
+    id: "settings-home-assistant",
+    title: "Home Assistant",
+    fields: [
+      { name: "url", label: "Server URL", placeholder: "http://homeassistant.local:8123" },
+      {
+        name: "accessToken",
+        label: "Access token (Profile → Long-lived access tokens)",
+        secret: true,
+      },
+    ],
+  },
+  {
+    key: "github",
+    id: "settings-github",
+    title: "GitHub",
+    fields: [{ name: "api_key", label: "API key", secret: true }],
+  },
+  {
+    key: "immich",
+    id: "settings-immich",
+    title: "Immich",
+    fields: [
+      { name: "url", label: "Server URL", placeholder: "https://immich.example.com" },
+      { name: "apiKey", label: "API key (Account settings → API keys)", secret: true },
+    ],
+  },
+  {
+    key: "unsplash",
+    id: "settings-unsplash",
+    title: "Unsplash API",
+    fields: [{ name: "accessKey", label: "Access key", secret: true }],
+  },
+];
+
+/** {group: {field: value}} — every group with every field, '' when unset. */
+export type ServiceSettingsValues = Record<string, Record<string, string>>;
+
+export function serviceSettingsFrom(
+  stored: Record<string, unknown> | undefined,
+): ServiceSettingsValues {
+  const values: ServiceSettingsValues = {};
+  for (const group of serviceSettingsGroups) {
+    const raw = stored?.[group.key];
+    const source =
+      raw && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : {};
+    values[group.key] = Object.fromEntries(
+      group.fields.map((field) => {
+        const value = source[field.name];
+        return [field.name, typeof value === "string" ? value : ""];
+      }),
+    );
+  }
+  return values;
+}
+
+export interface SshKeyEntry {
+  id: string;
+  name: string;
+  public: string;
+  use_for_new_frames: boolean;
+}
+
+/** The `ssh_keys` group as the page shows it; anything malformed is skipped. */
+export function sshKeysFrom(
+  stored: Record<string, unknown> | undefined,
+): SshKeyEntry[] {
+  const group = stored?.ssh_keys;
+  const raw =
+    group && typeof group === "object" && !Array.isArray(group)
+      ? (group as { keys?: unknown }).keys
+      : undefined;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const keys: SshKeyEntry[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+    const { id, name, public: publicKey, use_for_new_frames } = entry as Record<string, unknown>;
+    if (typeof id !== "string" || !id || typeof publicKey !== "string" || !publicKey) {
+      continue;
+    }
+    keys.push({
+      id,
+      name: typeof name === "string" ? name : "",
+      public: publicKey,
+      use_for_new_frames: use_for_new_frames === true,
+    });
+  }
+  return keys;
+}
+
+/** "ed25519 · …3kQd · you@laptop" — enough to tell two keys apart in a list. */
+export function describeSshPublicKey(line: string): string {
+  const [type, base64, ...rest] = line.trim().split(/\s+/);
+  if (!type || !base64) {
+    return "no public key";
+  }
+  const kind = type
+    .replace(/^ssh-|^sk-ssh-|@openssh\.com$/g, "")
+    .replace("ecdsa-sha2-", "ecdsa ");
+  const tail = base64.replace(/=+$/, "").slice(-8);
+  const comment = rest.join(" ");
+  return comment ? `${kind} · …${tail} · ${comment}` : `${kind} · …${tail}`;
+}
+
+/** What to tell the user when /api/settings refuses a save. */
+export function describeSettingsError(
+  status: number,
+  error: string | undefined,
+): string {
+  switch (error) {
+    case "invalid_ssh_key":
+      return "That is not an OpenSSH public key. It looks like: ssh-ed25519 AAAA… you@laptop";
+    case "invalid_settings":
+      return "That could not be saved as it is. Check the values and try again.";
+    case "settings_value_too_large":
+      return "One of the values is too long to be a key or a URL.";
+    case "login_required":
+      return "Your session expired. Reload the page and sign in again.";
+    default:
+      return status === 429
+        ? "Too many attempts. Wait a few minutes and try again."
+        : "Something went wrong. Try again in a moment.";
+  }
+}

--- a/cloud/apps/auth-web/src/lib/account-settings.ts
+++ b/cloud/apps/auth-web/src/lib/account-settings.ts
@@ -7,7 +7,22 @@
 // form knows (SSH keys, build environment, deploy defaults, PostHog, ...) is
 // backend-only and never reaches the database here.
 
+import { eq } from "drizzle-orm";
+import { accountSettings, type createDb } from "@frameos-cloud/db";
 import { previewSettingsGroups } from "./preview-settings";
+
+// Everything stored for the account, as the merged {group: value} object
+// GET /api/settings answers with and the account settings page renders.
+export async function storedAccountSettings(
+  db: ReturnType<typeof createDb>,
+  accountId: string,
+): Promise<Record<string, unknown>> {
+  const rows = await db
+    .select()
+    .from(accountSettings)
+    .where(eq(accountSettings.accountId, accountId));
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
 
 // Generous for API tokens and URLs; anything longer is not a credential.
 export const maxAccountSettingValueLength = 4096;

--- a/cloud/apps/auth-web/src/lib/surfaces.test.ts
+++ b/cloud/apps/auth-web/src/lib/surfaces.test.ts
@@ -57,6 +57,7 @@ describe("surface routing", () => {
       ["/account/installs", "/backends"],
       ["/account/frames", "/frames"],
       ["/account/ai", "/ai"],
+      ["/account/settings", "/settings"],
       ["/account/backups", "/backups"],
       ["/account/activity", "/activity"],
       ["/account/developer", "/developer"],
@@ -140,6 +141,7 @@ describe("surface routing", () => {
     for (const [external, internal] of [
       ["/backends", "/account/installs"],
       ["/ai", "/account/ai"],
+      ["/settings", "/account/settings"],
       ["/backups", "/account/backups"],
       ["/activity", "/account/activity"],
       ["/security", "/account/security"],
@@ -193,6 +195,10 @@ describe("surface routing", () => {
     expectRoute("https://cloud.frameos.net/developer", {
       kind: "rewrite",
       url: "https://cloud.frameos.net/account/developer",
+    });
+    expectRoute("https://cloud.frameos.net/settings", {
+      kind: "rewrite",
+      url: "https://cloud.frameos.net/account/settings",
     });
     // Full-form paths serve directly instead of redirect-looping.
     for (const path of [

--- a/cloud/apps/auth-web/src/lib/surfaces.ts
+++ b/cloud/apps/auth-web/src/lib/surfaces.ts
@@ -31,6 +31,7 @@ const accountPagePrefixes = [
 const accountSectionRewrites = new Map([
   ["/backends", "/account/installs"],
   ["/ai", "/account/ai"],
+  ["/settings", "/account/settings"],
   ["/backups", "/account/backups"],
   ["/activity", "/account/activity"],
   ["/security", "/account/security"],

--- a/cloud/apps/auth-web/src/test/shared-spa/cloud-frames-routes.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/cloud-frames-routes.test.ts
@@ -64,15 +64,23 @@ describe("cloud SPA route helpers", () => {
     expect(cloudFrameUrl("abc", "settings")).toBe(fromSpa);
   });
 
-  it("agrees with the SPA's own urls.settings()", () => {
-    expect(cloudSettingsUrl()).toBe("/frames/settings");
+  // The global settings are an account page, not a SPA scene. The SPA links
+  // out to the server-injected URL (it may be another origin, and shortens
+  // on a split-host deployment) and falls back to the account path when the
+  // shell was served without injection.
+  it("links urls.settings() out to the account settings page", () => {
+    expect(cloudSettingsUrl()).toBe("/account/settings");
     expect(cloudSettingsUrl()).toBe(withCloudSpaConfig(() => urls.settings()));
+    (window as unknown as { FRAMEOS_APP_CONFIG?: unknown }).FRAMEOS_APP_CONFIG = {
+      cloudMode: true,
+      cloud_settings_url: "https://account.example/settings",
+      route_base_path: cloudRouteBasePath,
+    };
+    expect(urls.settings()).toBe("https://account.example/settings");
   });
 
-  it("registers the account settings scene at /frames/settings", async () => {
-    // The page 404'd client-side before the scene was registered: urls
-    // helpers linked to /frames/settings but the SPA's route table had no
-    // entry. The specifier is a variable ON PURPOSE: scenes.tsx transitively
+  it("has no settings scene in the cloud SPA any more", async () => {
+    // The specifier is a variable ON PURPOSE: scenes.tsx transitively
     // imports the whole React SPA, and a static (or literal-dynamic) import
     // would drag all of it into this app's stricter tsc program — vitest
     // resolves the runtime import fine either way.
@@ -82,8 +90,37 @@ describe("cloud SPA route helpers", () => {
       scenes: Record<string, unknown>;
     };
     const routes = withCloudSpaConfig(() => getRoutes());
-    expect(routes[cloudSettingsUrl()]).toBe("settings");
-    expect(scenes).toHaveProperty("settings");
+    expect(Object.values(routes)).not.toContain("settings");
+    expect(scenes).not.toHaveProperty("settings");
+  });
+
+  // The shared SPA has its OWN sceneLogic and route table
+  // (frontend/src/scenes/scenes.tsx), and the workspace shell reads THAT one
+  // to decide which rail button is pending — not the wrapper's. With
+  // /frames/:id registered first it reported "frame" for /frames/apps, and
+  // the Frame button span forever on the apps page.
+  it("orders the shared SPA's route table for the cloud mount too", async () => {
+    // Same variable-specifier trick as above; absolute so vitest resolves it
+    // from the file system rather than from the project root.
+    const scenesModulePath = new URL(
+      "../../../../../../frontend/src/scenes/scenes.tsx",
+      import.meta.url,
+    ).pathname;
+    const { getRoutes } = (await import(scenesModulePath)) as {
+      getRoutes: () => Record<string, string>;
+    };
+    const routes = withCloudSpaConfig(() => getRoutes());
+    const paths = Object.keys(routes);
+    const frameIndex = paths.indexOf("/frames/:id");
+    expect(frameIndex).toBeGreaterThan(-1);
+    for (const literal of ["/frames/apps", "/frames/apps/:frameId", "/frames/scenes", "/frames/:frameId/scenes"]) {
+      expect(paths.indexOf(literal)).toBeGreaterThan(-1);
+      expect(paths.indexOf(literal)).toBeLessThan(frameIndex);
+    }
+    expect(paths.indexOf("/frames/:frameId/scenes/:sceneId")).toBeLessThan(paths.indexOf("/frames/:id/:tool"));
+    // Not registered on the cloud at all: it would be "/account/settings",
+    // which is not under the SPA's mount.
+    expect(Object.values(routes)).not.toContain("settings");
   });
 
   it("rewrites the pre-2026.8 doubled-segment URLs", () => {
@@ -92,6 +129,7 @@ describe("cloud SPA route helpers", () => {
     expect(legacyCloudPathRedirect("/frames/scenes/abc")).toBe("/frames/abc/scenes");
     expect(legacyCloudPathRedirect("/frames/abc")).toBeNull();
     expect(legacyCloudPathRedirect("/frames/apps/system/x")).toBeNull();
+    // /frames/settings is redirected server-side by the [[...path]] route.
     expect(legacyCloudPathRedirect("/frames/settings")).toBeNull();
   });
 
@@ -106,7 +144,7 @@ describe("cloud SPA route helpers", () => {
     const paths = Object.keys(withCloudSpaConfig(() => getRoutes()));
     const frameIndex = paths.indexOf("/frames/:id");
     expect(frameIndex).toBeGreaterThan(-1);
-    for (const literal of ["/frames/settings", "/frames/apps", "/frames/apps/:frameId", "/frames/scenes"]) {
+    for (const literal of ["/frames/apps", "/frames/apps/:frameId", "/frames/scenes"]) {
       expect(paths.indexOf(literal)).toBeGreaterThan(-1);
       expect(paths.indexOf(literal)).toBeLessThan(frameIndex);
     }

--- a/frontend/src/scenes/scenes.tsx
+++ b/frontend/src/scenes/scenes.tsx
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react'
 import { urls } from '../urls'
 import { getRouteBasePath } from '../utils/getBasePath'
 import { isInFrameAdminMode } from '../utils/frameAdmin'
+import { isCloudMode } from '../utils/cloudMode'
 
 export type SceneComponent = ComponentType<Record<string, any>>
 
@@ -70,12 +71,23 @@ export function preloadSceneComponent(scene: LoadableSceneKey): void {
   void loadSceneComponent(scene).catch(() => {})
 }
 
+// kea-router takes the FIRST pattern that matches, so the literal routes are
+// registered before the parametric /frames/:id ones. Self-hosted that is
+// moot (/settings and /frames/:id never overlap), but on the cloud the SPA is
+// mounted AT /frames, and /frames/:id would swallow /frames/apps and
+// /frames/:frameId/scenes: sceneLogic then reported scene "frame" on the apps
+// page, and the shell's rail — which compares that scene with the mode the
+// rendered page passed it — showed the Frame button as forever pending.
+//
+// The settings scene is not registered at all where it never renders: on the
+// cloud the settings page is an account page (urls.settings() links out to
+// it), and in frame-admin mode urls.settings() IS a frame tool path
+// (/frames/<id>/settings) that the frame scene renders.
 export const getRoutes = () =>
   ({
     ...(getRouteBasePath() ? { [getRouteBasePath() + '/']: 'frames' } : {}),
     [urls.frames()]: isInFrameAdminMode() ? 'frame' : 'frames',
-    [urls.frame(':id')]: 'frame',
-    [urls.frame(':id', ':tool')]: 'frame',
+    ...(isInFrameAdminMode() || isCloudMode() ? {} : { [urls.settings()]: 'settings' }),
     [urls.scenes()]: 'sceneWorkspace',
     [urls.scenes(':frameId')]: 'sceneWorkspace',
     [urls.scenes(':frameId', ':sceneId')]: 'sceneWorkspace',
@@ -83,8 +95,9 @@ export const getRoutes = () =>
     [urls.apps(':frameId')]: 'appsWorkspace',
     [urls.apps(':frameId', ':sceneId')]: 'appsWorkspace',
     [urls.apps(':frameId', ':sceneId', ':nodeId')]: 'appsWorkspace',
-    [urls.settings()]: 'settings',
     [urls.login()]: 'login',
     [urls.signup()]: 'signup',
     [urls.setupUnavailable()]: 'setupUnavailable',
-  } as const)
+    [urls.frame(':id')]: 'frame',
+    [urls.frame(':id', ':tool')]: 'frame',
+  }) as const

--- a/frontend/src/scenes/workspace/AccountSettingsRailLink.tsx
+++ b/frontend/src/scenes/workspace/AccountSettingsRailLink.tsx
@@ -1,0 +1,19 @@
+import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { urls } from '../../urls'
+
+// The rail's gear on the cloud. The global settings there are an account
+// page, not a scene of this SPA, so this is a plain link that leaves the
+// workspace — no router push, no pending spinner, never "active". Drawn by
+// both the ready shell (FrameosShell) and its loading placeholder
+// (WorkspaceRouteLoading), which must stay pixel-identical.
+export function AccountSettingsRailLink(): JSX.Element {
+  return (
+    <a
+      href={urls.settings()}
+      title="Account settings"
+      className="frameos-nav-button flex h-12 w-12 items-center justify-center rounded-xl text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+    >
+      <Cog6ToothIcon className="h-8 w-8" />
+    </a>
+  )
+}

--- a/frontend/src/scenes/workspace/FrameosShell.tsx
+++ b/frontend/src/scenes/workspace/FrameosShell.tsx
@@ -32,6 +32,7 @@ import {
   workspaceLogic,
 } from './workspaceLogic'
 import { workspaceModeForScene, type WorkspaceMode } from './workspaceModes'
+import { AccountSettingsRailLink } from './AccountSettingsRailLink'
 import { framesModel } from '../../models/framesModel'
 import { frameHost } from '../../decorators/frame'
 import { frameLogic } from '../frame/frameLogic'
@@ -612,19 +613,23 @@ export function FrameosShell({
           >
             {theme === 'dark' ? <SunIcon className="h-7 w-7" /> : <MoonIcon className="h-7 w-7" />}
           </button>
-          <NavButton
-            active={activeMode === 'settings'}
-            current={mode === 'settings'}
-            href={urls.settings()}
-            pending={pendingMode === 'settings'}
-            preloadScene="settings"
-            sidebarOpen={secondarySidebarOpen}
-            title={secondarySidebarOpen && mode === 'settings' ? 'Hide settings panel' : 'Settings'}
-            onActiveClick={toggleSecondarySidebar}
-            onInactiveClick={prepareFirstLevelNavigation}
-          >
-            <Cog6ToothIcon className="h-8 w-8" />
-          </NavButton>
+          {isCloudMode() ? (
+            <AccountSettingsRailLink />
+          ) : (
+            <NavButton
+              active={activeMode === 'settings'}
+              current={mode === 'settings'}
+              href={urls.settings()}
+              pending={pendingMode === 'settings'}
+              preloadScene="settings"
+              sidebarOpen={secondarySidebarOpen}
+              title={secondarySidebarOpen && mode === 'settings' ? 'Hide settings panel' : 'Settings'}
+              onActiveClick={toggleSecondarySidebar}
+              onInactiveClick={prepareFirstLevelNavigation}
+            >
+              <Cog6ToothIcon className="h-8 w-8" />
+            </NavButton>
+          )}
         </div>
         <div
           className={clsx(

--- a/frontend/src/scenes/workspace/WorkspaceRouteLoading.tsx
+++ b/frontend/src/scenes/workspace/WorkspaceRouteLoading.tsx
@@ -29,6 +29,7 @@ import {
   workspaceLogic,
 } from './workspaceLogic'
 import { workspaceModeForSceneOrFrames, type WorkspaceMode } from './workspaceModes'
+import { AccountSettingsRailLink } from './AccountSettingsRailLink'
 
 function LoadingNavButton({
   active,
@@ -318,17 +319,21 @@ export function WorkspaceRouteLoading({ scene }: { scene: string | null }): JSX.
           >
             {theme === 'dark' ? <SunIcon className="h-7 w-7" /> : <MoonIcon className="h-7 w-7" />}
           </button>
-          <LoadingNavButton
-            active={mode === 'settings'}
-            href={urls.settings()}
-            pending={spinnerMode === 'settings'}
-            preloadScene="settings"
-            sidebarOpen={secondarySidebarOpen}
-            title={secondarySidebarOpen && mode === 'settings' ? 'Hide settings panel' : 'Settings'}
-            onActiveClick={toggleSecondarySidebar}
-          >
-            <Cog6ToothIcon className="h-8 w-8" />
-          </LoadingNavButton>
+          {isCloudMode() ? (
+            <AccountSettingsRailLink />
+          ) : (
+            <LoadingNavButton
+              active={mode === 'settings'}
+              href={urls.settings()}
+              pending={spinnerMode === 'settings'}
+              preloadScene="settings"
+              sidebarOpen={secondarySidebarOpen}
+              title={secondarySidebarOpen && mode === 'settings' ? 'Hide settings panel' : 'Settings'}
+              onActiveClick={toggleSecondarySidebar}
+            >
+              <Cog6ToothIcon className="h-8 w-8" />
+            </LoadingNavButton>
+          )}
         </div>
         <div
           className={clsx(

--- a/frontend/src/scenes/workspace/workspaceLogic.tsx
+++ b/frontend/src/scenes/workspace/workspaceLogic.tsx
@@ -2080,7 +2080,7 @@ export const workspaceLogic = kea<workspaceLogicType>([
       [framesPath]: rootRouteHandler,
       [`${framesPath.replace(/\/$/, '')}/`]: rootRouteHandler,
       // Literal paths before /frames/:id — on the cloud that pattern would
-      // otherwise swallow /frames/apps and /frames/settings.
+      // otherwise swallow /frames/apps (same rule in scenes.tsx getRoutes).
       [urls.scenes(':frameId')]: applySceneOrAppRoute,
       [urls.scenes(':frameId', ':sceneId')]: applySceneOrAppRoute,
       [urls.apps(':frameId')]: applySceneOrAppRoute,

--- a/frontend/src/scenes/workspace/workspaceSurfaces.ts
+++ b/frontend/src/scenes/workspace/workspaceSurfaces.ts
@@ -230,9 +230,11 @@ export const allowedFrameSettingsSections: Record<WorkspaceMode, readonly string
  * the per-frame settings panel above. `null` means "everything the page
  * renders": the backend owns all of it, and the on-device admin never mounts
  * this page at all (urls.settings() routes it to the frame's own settings
- * panel instead). The cloud keeps only the service API keys scenes use —
- * there is no local account, deploy host, SSH, build environment, font
- * store, backend PostHog or backend system info to configure.
+ * panel instead). The cloud does not mount it either any more: its service
+ * API keys and SSH keys are an account page
+ * (cloud/apps/auth-web/app/account/settings), and urls.settings() links out
+ * to it. The cloud list below is the subset that page carries, kept so the
+ * shared component's mode contract stays complete.
  */
 export const allowedGlobalSettingsSections: Record<WorkspaceMode, readonly string[] | null> = {
   backend: null,

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -28,6 +28,18 @@ function scenesUrl(frameId?: FrameId, sceneId?: string): string {
   return getRouteBasePath() + '/scenes' + (frameId ? '/' + frameId : '') + (frameId && sceneId ? '/' + sceneId : '')
 }
 
+// On the cloud the global settings (service API keys, SSH keys) are a tab of
+// the account pages, not a scene of this SPA. The finished URL is injected
+// by the server (cloud/apps/auth-web/app/frames/[[...path]]/route.ts —
+// cloud_settings_url) because the account surface may live on another origin
+// and shortens /account/* on a split-host deployment; the fallback is only
+// for a shell served without injection.
+function cloudAccountSettingsUrl(): string {
+  const injected =
+    typeof window !== 'undefined' ? (window as any).FRAMEOS_APP_CONFIG?.cloud_settings_url : undefined
+  return typeof injected === 'string' && injected ? injected : '/account/settings'
+}
+
 function frameControlUrl(tool?: string): string {
   return frameUrl(getFrameControlFrameId(), tool)
 }
@@ -51,7 +63,12 @@ export const urls = {
     (frameId && sceneId && nodeId ? '/' + nodeId : ''),
   systemApps: (keyword?: string | null) =>
     getRouteBasePath() + '/apps/system' + (keyword ? '/' + encodeURIComponent(keyword) : ''),
-  settings: () => (isInFrameAdminMode() ? frameControlUrl('settings') : getRouteBasePath() + '/settings'),
+  settings: () =>
+    isInFrameAdminMode()
+      ? frameControlUrl('settings')
+      : isCloudMode()
+        ? cloudAccountSettingsUrl()
+        : getRouteBasePath() + '/settings',
   login: () => getRouteBasePath() + '/login',
   logout: () => getRouteBasePath() + '/logout',
   signup: () => getRouteBasePath() + '/signup',


### PR DESCRIPTION
## The bug

On `cloud.frameos.net/frames/settings` (and `/frames/apps`) the sidebar's **Frame** button was active and spinning forever.

The workspace shell decides which rail button is pending by comparing the mode the rendered page passed it with the scene reported by the **shared** SPA's `sceneLogic` (`frontend/src/scenes/sceneLogic`), not the cloud wrapper's. The shared route table registered `/frames/:id` before the literal routes; with the cloud SPA mounted at `/frames`, kea-router (first match wins) resolved `/frames/settings` and `/frames/apps` as a frame named "settings"/"apps". Mode ≠ scene → spinner.

**Fix:** literal routes precede `/frames/:id` in `frontend/src/scenes/scenes.tsx`, plus a test in `cloud-frames-routes.test.ts` that runs the shared table under the cloud config.

## Settings move under Account

Per Marius: the frame API key settings belong on the account page, not in `/frames`.

- New **Settings** tab: `app/account/settings/page.tsx` with `AccountSettingsForm` (six service groups, one Save that posts every group in full — `POST /api/settings` replaces groups wholesale) and `AccountSshKeys` (saves the whole `ssh_keys` list on every change, re-renders from the server's answer). Pure specs/helpers in `src/lib/account-settings-form.ts`; a test asserts the form's fields ⊆ `storableAccountSettingsFields`.
- Same storage and API as before; nothing a frame receives changed. Secrets render as password inputs (the API returns keys in clear).
- Anchors kept (`#settings-openai`, `#settings-ssh`, …); the scene editors' settings links point at the account page.
- `/frames/settings` → 307 (no-store) to the account page; the fragment survives.
- `surfaces.ts` gets the `/settings` clean-path rewrite row (the thing `/ai` shipped without).
- SPA: `urls.settings()` in cloud mode returns the server-injected `cloud_settings_url`; the rail gear is a plain link (`AccountSettingsRailLink`, drawn by both the ready shell and the loading placeholder). The cloud wrapper's `settings` scene is removed.

## Verification

- auth-web: full vitest suite (147 files) green, eslint clean, `tsc --noEmit` clean (it typechecks the shared SPA too); frontend `tsc` clean. cloud-frontend's own `tsc` has 4 errors identical on main.
- Local dev server: `/frames/apps` shows no spinner and the gear links out; `/frames/settings#settings-openai` redirects onto the OpenAI card; a save + revert round-trip stored and cleared a value while leaving an untouched key in the same group intact.

Follow-up (not in this PR): the shared `Settings.tsx` cloud-mode branches and `allowedGlobalSettingsSections.cloud` are now unreachable and can be trimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTqmjYcU6eXG6CzXgcULec
