### PR TITLE
Cloud accounting: the pre-Phase-3b design changes (§9.3, migration 0047)

### DIFF
--- a/cloud/apps/auth-web/app/account/ai/page.tsx
+++ b/cloud/apps/auth-web/app/account/ai/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@frameos-cloud/ledger";
 import { accounts, createDb } from "@frameos-cloud/db";
 import { AiUsageSwitch } from "../../../src/components/AiUsageSwitch";
+import { resolveAiCredentials } from "../../../src/lib/ai/api-key";
 import { formatDateTime } from "../../../src/lib/format";
 import { readSession } from "../../../src/lib/session";
 
@@ -80,7 +81,7 @@ export default async function AccountAiPage() {
   const now = new Date();
   const dayWindow = utcDayWindow(now);
   const receivable = customerReceivableCode(accountId);
-  const [[account], thisMonth, lastMonth, today, turns, settings, plan, owed, statement] =
+  const [[account], thisMonth, lastMonth, today, turns, settings, plan, owed, statement, credentials] =
     await Promise.all([
       db
         .select({ aiDisabledAt: accounts.aiDisabledAt })
@@ -95,9 +96,14 @@ export default async function AccountAiPage() {
       readAccountPlan(db, accountId),
       accountBalanceMicros(db, receivable),
       customerStatement(db, receivable, { limit: 1000 }),
+      // Which key the next turn runs on decides which daily limit applies,
+      // and whose money it guards (§5.3).
+      resolveAiCredentials(db, accountId),
     ]);
   // ONE margin definition, the same one metering prices with (plans.ts).
   const marginBasisPoints = await accountMarginBasisPoints(db, accountId, settings);
+  const sharedKey = credentials?.source === "shared";
+  const dailyCapMicros = sharedKey ? settings.sharedKeyDailyCapMicros : settings.dailyCapMicros;
 
   const enabled = !account?.aiDisabledAt;
   // The statement lines that are not metered turns: subscription charges,
@@ -265,11 +271,29 @@ export default async function AccountAiPage() {
         <p className="copy">
           You are on the <strong>{plan.plan.name}</strong> plan
           {plan.nextPlanCode ? ` (moving to ${plan.nextPlanCode} at the next renewal)` : ""}
-          {plan.cancelAt ? ` (ends ${formatDateTime(plan.cancelAt)})` : ""}. A daily limit
-          of {dollars(settings.dailyCapMicros)} applies: today you have used{" "}
-          {dollars(today.chargeableMicros)}, and it resets at{" "}
-          {formatDateTime(dayWindow.until)}. The limit is there so that a
-          runaway loop costs you a bounded amount rather than an unbounded one.
+          {plan.cancelAt ? ` (ends ${formatDateTime(plan.cancelAt)})` : ""}.
+          {plan.plan.priceMicros > 0n
+            ? " The plan fee is billed at the start of each period, in advance; AI usage is billed at the end of the month, for what was actually used."
+            : ""}{" "}
+          {sharedKey ? (
+            <>
+              Your requests run on the operator&rsquo;s shared key, which comes
+              with a free daily allowance of {dollars(dailyCapMicros)}: today
+              you have used {dollars(today.chargeableMicros)} of it, and it
+              resets at {formatDateTime(dayWindow.until)}. That allowance is
+              the operator&rsquo;s budget, not a bill — nothing on it is ever
+              charged to you. Add your own OpenAI key under Settings to use AI
+              without it.
+            </>
+          ) : (
+            <>
+              A daily limit of {dollars(dailyCapMicros)} applies: today you
+              have used {dollars(today.chargeableMicros)}, and it resets at{" "}
+              {formatDateTime(dayWindow.until)}. The limit is there so that a
+              runaway loop costs you a bounded amount rather than an unbounded
+              one.
+            </>
+          )}
         </p>
         {!billed ? (
           <p className="copy">

--- a/cloud/apps/auth-web/app/admin/billing/customers/page.tsx
+++ b/cloud/apps/auth-web/app/admin/billing/customers/page.tsx
@@ -1,14 +1,21 @@
 import Link from "next/link";
-import { aiUsageRecords, createDb, ledgerAccounts } from "@frameos-cloud/db";
+import { accounts, aiUsageRecords, createDb, ledgerAccounts } from "@frameos-cloud/db";
 import {
   customerCreditsCode,
   customerPromoCreditsCode,
+  customerReceivableCode,
   customerStatement,
+  listPlans,
+  readAccountPlan,
 } from "@frameos-cloud/ledger";
 import { desc, eq, isNotNull } from "drizzle-orm";
 import { AdminNav } from "../../../../src/components/AdminNav";
 import { AppShell } from "../../../../src/components/AppShell";
 import { BillingNav } from "../../../../src/components/BillingNav";
+import {
+  CustomerAiSwitch,
+  CustomerPlanForm,
+} from "../../../../src/components/CustomerBillingControls";
 import { requireSuperadmin } from "../../../../src/lib/admin-page";
 import {
   describeCustomer,
@@ -24,8 +31,14 @@ type PageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-// One customer's credit account, oldest first, with a running balance: the
-// view support needs when somebody asks where their credit went.
+// One customer's books, oldest first, with a running balance: the view
+// support needs when somebody asks what they owe and why. Under postpay
+// that is the receivable (§3.1); the prepaid and promo statements are the
+// shelved model (§3.5) and only appear if something ever posted to them.
+//
+// It is also where the operator's two hands on an account live (§5.1
+// "Superadmin side", §9.3): the AI switch — dunning's terminal step — and
+// the plan, for the arrangements no self-serve button covers.
 //
 // The name at the top is resolved live from `accounts` and degrades to the
 // bare uuid when nothing matches. That is not a gap to fix — the ledger
@@ -50,8 +63,9 @@ export default async function AdminBillingCustomersPage({ searchParams }: PagePr
     [...known.map((row) => row.ownerAccountId), accountId],
   );
 
-  const [paid, promo, usage] = accountId
+  const [receivable, paid, promo, usage, plan, plans, [account]] = accountId
     ? await Promise.all([
+        customerStatement(db, customerReceivableCode(accountId)),
         customerStatement(db, customerCreditsCode(accountId)),
         customerStatement(db, customerPromoCreditsCode(accountId)),
         db
@@ -60,8 +74,15 @@ export default async function AdminBillingCustomersPage({ searchParams }: PagePr
           .where(eq(aiUsageRecords.accountId, accountId))
           .orderBy(desc(aiUsageRecords.createdAt))
           .limit(50),
+        readAccountPlan(db, accountId),
+        listPlans(db),
+        db
+          .select({ aiDisabledAt: accounts.aiDisabledAt, id: accounts.id })
+          .from(accounts)
+          .where(eq(accounts.id, accountId))
+          .limit(1),
       ])
-    : [null, null, []];
+    : [null, null, null, [], null, [], []];
 
   return (
     // noCapture: this page is one customer's email and their spending.
@@ -69,8 +90,9 @@ export default async function AdminBillingCustomersPage({ searchParams }: PagePr
       <div className="content-header">
         <div>
           <p className="copy">
-            A customer&apos;s prepaid balance, entry by entry, and the metered
-            turns behind it.
+            What a customer owes, entry by entry, the metered turns behind
+            it, and the operator&apos;s controls: their plan and their AI
+            switch.
           </p>
         </div>
       </div>
@@ -120,9 +142,15 @@ export default async function AdminBillingCustomersPage({ searchParams }: PagePr
               </Link>
             </p>
             {[
+              { statement: receivable, title: "Owed to us" },
               { statement: paid, title: "Prepaid credit" },
               { statement: promo, title: "Granted credit" },
-            ].map(({ statement, title }) => (
+            ]
+              // The prepaid statements are the shelved model (§3.5): shown
+              // only when something once posted there, so the page does
+              // not open with two "nothing has ever posted" cards.
+              .filter(({ statement, title }) => title === "Owed to us" || (statement?.lines.length ?? 0) > 0)
+              .map(({ statement, title }) => (
               <div key={title}>
                 <h3>
                   {title}: {formatMicrosUsd(statement?.closingBalanceMicros ?? 0n)}
@@ -166,6 +194,53 @@ export default async function AdminBillingCustomersPage({ searchParams }: PagePr
               </div>
             ))}
           </section>
+
+          {account ? (
+            <section className="section-block">
+              <h2>Plan and AI switch</h2>
+              <p className="section-description">
+                On the <strong>{plan?.plan.name ?? "Pay as you go"}</strong> plan
+                {plan?.subscribed ? "" : " (no subscription row — the default)"}
+                {plan?.nextPlanCode ? `, moving to ${plan.nextPlanCode} at the rollover` : ""}
+                {plan?.cancelAt ? `, ends ${formatDateTime(plan.cancelAt)}` : ""}.
+                Both actions below are audited with the reason given;{" "}
+                <Link href={`/admin/users?q=${encodeURIComponent(describeCustomer(labels.get(accountId), accountId))}`}>
+                  the activity feed
+                </Link>{" "}
+                is where to read them back.
+              </p>
+              <section className="card">
+                <h3>Plan</h3>
+                <CustomerPlanForm
+                  accountId={accountId}
+                  currentCode={plan?.plan.code ?? "payg"}
+                  plans={plans.map((entry) => ({
+                    code: entry.code,
+                    name: entry.name,
+                    priceMicros: entry.priceMicros.toString(),
+                    public: entry.public,
+                  }))}
+                  subscribed={plan?.subscribed ?? false}
+                />
+              </section>
+              <section className="card">
+                <h3>AI switch</h3>
+                <CustomerAiSwitch
+                  accountId={accountId}
+                  disabledAt={account.aiDisabledAt?.toISOString() ?? null}
+                />
+              </section>
+            </section>
+          ) : (
+            <section className="section-block">
+              <section className="card">
+                <p>
+                  No account row: this customer was erased. Their books stay;
+                  there is no plan or switch left to operate.
+                </p>
+              </section>
+            </section>
+          )}
 
           <section className="section-block">
             <h2>Metered turns</h2>

--- a/cloud/apps/auth-web/app/admin/billing/page.tsx
+++ b/cloud/apps/auth-web/app/admin/billing/page.tsx
@@ -55,6 +55,7 @@ export default async function AdminBillingPage() {
     checkLedgerIntegrity(db, {
       dailyCapMicros: settings.dailyCapMicros,
       overdraftMicros: settings.overdraftMicros,
+      sharedKeyDailyCapMicros: settings.sharedKeyDailyCapMicros,
     }),
     dailySummary(db, window),
     aiUsageSummary(db, window),
@@ -347,6 +348,7 @@ export default async function AdminBillingPage() {
               dailyCapMicros: settings.dailyCapMicros.toString(),
               meteringMode: settings.meteringMode,
               overdraftMicros: settings.overdraftMicros.toString(),
+              sharedKeyDailyCapMicros: settings.sharedKeyDailyCapMicros.toString(),
             }}
           />
         </section>

--- a/cloud/apps/auth-web/app/api/account/ai/route.ts
+++ b/cloud/apps/auth-web/app/api/account/ai/route.ts
@@ -20,6 +20,7 @@ import {
   readJsonObject,
   requireDatabase,
 } from "../../../../src/lib/device-flow";
+import { resolveAiCredentials } from "../../../../src/lib/ai/api-key";
 import { rateLimitResponse } from "../../../../src/lib/rate-limit";
 import { readSession } from "../../../../src/lib/session";
 
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
   const accountId = session.accountId;
   const now = new Date();
   const dayWindow = utcDayWindow(now);
-  const [[account], thisMonth, lastMonth, today, turns, settings, plan, plans, owed] =
+  const [[account], thisMonth, lastMonth, today, turns, settings, plan, plans, owed, credentials] =
     await Promise.all([
       db
         .select({ aiDisabledAt: accounts.aiDisabledAt })
@@ -74,6 +75,9 @@ export async function GET(request: NextRequest) {
       // month-end invoice collects and the only number that includes a
       // subscription charge, a credit or a reversal (§9.2 item 11).
       accountBalanceMicros(db, customerReceivableCode(accountId)),
+      // Which key the next turn would run on decides which cap applies to
+      // it (§5.3): the shared key has its own, smaller, "our money" cap.
+      resolveAiCredentials(db, accountId),
     ]);
   if (!account) {
     return jsonError("login_required", 401);
@@ -81,11 +85,18 @@ export async function GET(request: NextRequest) {
   // ONE definition of the margin (plans.ts): the same function metering
   // prices with, so the page cannot name a rate the meter does not use.
   const marginBasisPoints = await accountMarginBasisPoints(db, accountId, settings);
+  const allowance = credentials?.source === "shared" ? "shared" : "billable";
 
   return NextResponse.json(
     {
       cap: {
-        daily_micros: settings.dailyCapMicros.toString(),
+        // "shared": the operator's free allowance on the shared key, not a
+        // limit on anything the account owes. "billable": their own.
+        allowance,
+        daily_micros: (allowance === "shared"
+          ? settings.sharedKeyDailyCapMicros
+          : settings.dailyCapMicros
+        ).toString(),
         // When today's number goes back to zero. Named rather than implied:
         // "resets at midnight" is ambiguous in a way a timestamp is not
         // (§8.12 is the open question about whose midnight it should be).

--- a/cloud/apps/auth-web/app/api/admin/billing/customers/[accountId]/ai/route.ts
+++ b/cloud/apps/auth-web/app/api/admin/billing/customers/[accountId]/ai/route.ts
@@ -1,0 +1,98 @@
+import { eq } from "drizzle-orm";
+import { accounts } from "@frameos-cloud/db";
+import { NextRequest, NextResponse } from "next/server";
+import { getSuperadminContext } from "../../../../../../../src/lib/admin";
+import { recordAuditEvent } from "../../../../../../../src/lib/audit";
+import { isAccountUuid } from "../../../../../../../src/lib/billing-admin";
+import { csrfResponse } from "../../../../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../../../../src/lib/rate-limit";
+import { readSession } from "../../../../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ accountId: string }> };
+
+// The operator's side of the AI switch (cloud/docs/accounting-todo.md §5.1,
+// built for §9.3). The same `accounts.ai_disabled_at` the account flips for
+// itself on /account/ai — one flag, two hands on it — and the terminal step
+// of dunning (§3.2): an account that has not paid stops accruing before it
+// stops being a customer.
+//
+// A reason is required, like every hand-posted journal entry. "Why is AI
+// off for me" is a support question, and the answer has to be findable in
+// the audit trail rather than in somebody's memory. The account's own
+// switch has no reason field because the account is the reason.
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(request, "admin:billing-customer-ai", {
+    limit: 60,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const admin = await getSuperadminContext();
+  if (admin.kind !== "ok") {
+    return jsonError(
+      admin.kind === "forbidden" ? "forbidden" : "unauthenticated",
+      admin.kind === "forbidden" ? 403 : 401,
+    );
+  }
+  const { accountId } = await context.params;
+  if (!isAccountUuid(accountId)) {
+    return jsonError("not_found", 404);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+
+  const body = await readJsonObject(request);
+  if (typeof body.enabled !== "boolean") {
+    return jsonError("invalid_request", 400, {
+      detail: "enabled must be true or false",
+    });
+  }
+  const reason = typeof body.reason === "string" ? body.reason.trim() : "";
+  if (!reason) {
+    return jsonError("reason_required", 400, {
+      detail: "Say why — it is what the account will be told if they ask.",
+    });
+  }
+
+  const enabled = body.enabled;
+  const [updated] = await db
+    .update(accounts)
+    .set({ aiDisabledAt: enabled ? null : new Date(), updatedAt: new Date() })
+    .where(eq(accounts.id, accountId))
+    .returning({ aiDisabledAt: accounts.aiDisabledAt, id: accounts.id });
+  if (!updated) {
+    return jsonError("not_found", 404);
+  }
+
+  const session = await readSession();
+  await recordAuditEvent(db, {
+    accountId,
+    actor: {
+      accountId: admin.accountId,
+      kind: "superadmin",
+      providerSubject: session?.providerSubject,
+    },
+    eventType: enabled ? "admin.ai_enabled" : "admin.ai_disabled",
+    metadata: { reason },
+    target: { accountId, kind: "account" },
+  });
+
+  return NextResponse.json(
+    { ai_disabled_at: updated.aiDisabledAt?.toISOString() ?? null, enabled },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/cloud/apps/auth-web/app/api/admin/billing/customers/[accountId]/plan/route.ts
+++ b/cloud/apps/auth-web/app/api/admin/billing/customers/[accountId]/plan/route.ts
@@ -1,0 +1,143 @@
+import { eq } from "drizzle-orm";
+import { accounts } from "@frameos-cloud/db";
+import {
+  cancelAccountPlan,
+  LedgerError,
+  readAccountPlan,
+  readPlan,
+  setAccountPlan,
+} from "@frameos-cloud/ledger";
+import { NextRequest, NextResponse } from "next/server";
+import { getSuperadminContext } from "../../../../../../../src/lib/admin";
+import { recordAuditEvent } from "../../../../../../../src/lib/audit";
+import { isAccountUuid } from "../../../../../../../src/lib/billing-admin";
+import { csrfResponse } from "../../../../../../../src/lib/csrf";
+import {
+  jsonError,
+  readJsonObject,
+  requireDatabase,
+} from "../../../../../../../src/lib/device-flow";
+import { rateLimitResponse } from "../../../../../../../src/lib/rate-limit";
+import { readSession } from "../../../../../../../src/lib/session";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ accountId: string }> };
+
+// Putting an account on a plan by hand (cloud/docs/accounting-todo.md §9.3:
+// "an operator moves accounts by hand" had no route). Same lifecycle the
+// self-serve route drives — first period opened and charged now, upgrades
+// prorated, downgrades at the rollover — with two operator-only differences:
+//
+//  - non-public plans are allowed. `billing_plans.public = false` rows exist
+//    precisely for grandfathered or negotiated arrangements, and the only
+//    way onto one is this route;
+//  - self-serve gating does not apply. The FRAMEOS_CLOUD_PLANS_SELF_SERVE
+//    switch exists because a customer subscribing runs up a receivable
+//    Phase 3b cannot yet settle; an operator doing it on purpose, with a
+//    reason on record, is the exception that switch was written around.
+//
+// Moving to the free plan is a cancellation: run-to-period-end by default
+// (they owe for the period already charged and keep it), or `immediately`
+// for the dunning case. Neither refunds on its own — §3.6's refund is a
+// separate, deliberate act on the journal page.
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const csrf = csrfResponse(request);
+  if (csrf) {
+    return csrf;
+  }
+  const limited = await rateLimitResponse(request, "admin:billing-customer-plan", {
+    limit: 60,
+    windowMs: 15 * 60 * 1000,
+  });
+  if (limited) {
+    return limited;
+  }
+  const admin = await getSuperadminContext();
+  if (admin.kind !== "ok") {
+    return jsonError(
+      admin.kind === "forbidden" ? "forbidden" : "unauthenticated",
+      admin.kind === "forbidden" ? 403 : 401,
+    );
+  }
+  const { accountId } = await context.params;
+  if (!isAccountUuid(accountId)) {
+    return jsonError("not_found", 404);
+  }
+  const { db, response } = requireDatabase();
+  if (!db) {
+    return response;
+  }
+
+  const body = await readJsonObject(request);
+  const code = typeof body.plan === "string" ? body.plan.trim() : "";
+  if (!code) {
+    return jsonError("invalid_request", 400, { detail: "plan is required" });
+  }
+  const reason = typeof body.reason === "string" ? body.reason.trim() : "";
+  if (!reason) {
+    return jsonError("reason_required", 400, {
+      detail: "Say why — a plan change by hand is a fact the books will ask about.",
+    });
+  }
+  const immediately = body.immediately === true;
+
+  // The account must exist: a subscription row for a uuid nobody has is a
+  // receivable nobody will ever pay, and the ledger would not notice.
+  const [account] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(eq(accounts.id, accountId))
+    .limit(1);
+  if (!account) {
+    return jsonError("not_found", 404);
+  }
+  const target = await readPlan(db, code);
+  if (!target) {
+    return jsonError("unknown_plan", 404);
+  }
+
+  const before = await readAccountPlan(db, accountId);
+  try {
+    if (target.priceMicros === 0n) {
+      await cancelAccountPlan(db, accountId, { immediately });
+    } else {
+      await setAccountPlan(db, accountId, target.code);
+    }
+  } catch (error) {
+    if (error instanceof LedgerError) {
+      return jsonError(error.code, 400, { detail: error.message });
+    }
+    throw error;
+  }
+  const after = await readAccountPlan(db, accountId);
+
+  const session = await readSession();
+  await recordAuditEvent(db, {
+    accountId,
+    actor: {
+      accountId: admin.accountId,
+      kind: "superadmin",
+      providerSubject: session?.providerSubject,
+    },
+    eventType:
+      target.priceMicros === 0n ? "admin.plan_canceled" : "admin.plan_changed",
+    metadata: {
+      from: before.subscribed ? before.plan.code : null,
+      immediately,
+      plan: target.code,
+      reason,
+    },
+    target: { accountId, kind: "account" },
+  });
+
+  return NextResponse.json(
+    {
+      cancel_at: after.cancelAt?.toISOString() ?? null,
+      next_plan_code: after.nextPlanCode,
+      plan: { code: after.plan.code, name: after.plan.name },
+      subscribed: after.subscribed,
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/cloud/apps/auth-web/app/api/admin/billing/nightly/route.ts
+++ b/cloud/apps/auth-web/app/api/admin/billing/nightly/route.ts
@@ -35,9 +35,11 @@ export const maxDuration = 300;
 //   1. Sweep the usage records whose ledger entries never landed. Idempotent
 //      by turn id, so a night that already posted is a no-op.
 //   2. Run the subscription cycle: open the periods that are due, charge the
-//      ones that have started, recognize the ones that have ended. Idempotent
-//      on each period row, so a night that runs twice charges nobody twice
-//      and a night that never ran is caught up rather than skipped.
+//      ones that have started, earn what the running ones have served so
+//      far (daily recognition, §3.6), and close out the ones that have
+//      ended. Idempotent on each period row, so a night that runs twice
+//      charges nobody twice and a night that never ran is caught up rather
+//      than skipped.
 //   3. Run every invariant and report each violation. A violation is an
 //      alert, not a failure to fix automatically: books that disagree with
 //      themselves need a human, and quietly "correcting" them is how a
@@ -87,6 +89,7 @@ export async function POST(request: NextRequest) {
   const violations = await checkLedgerIntegrity(db, {
     dailyCapMicros: settings.dailyCapMicros,
     overdraftMicros: settings.overdraftMicros,
+    sharedKeyDailyCapMicros: settings.sharedKeyDailyCapMicros,
   });
   for (const violation of violations) {
     // One report per violation, not one for the batch: each is its own
@@ -114,6 +117,8 @@ export async function POST(request: NextRequest) {
     meteringMode: settings.meteringMode,
     netRevenueMicros: summary.netRevenueMicros.toString(),
     revenueMicros: summary.revenueMicros.toString(),
+    subscriptionsAccrued: subscriptionCycle.accrued,
+    subscriptionsAccruedMicros: subscriptionCycle.accruedMicros.toString(),
     subscriptionsCharged: subscriptionCycle.charged,
     subscriptionsFailed: subscriptionCycle.failures.length,
     subscriptionsOpened: subscriptionCycle.opened,
@@ -141,6 +146,8 @@ export async function POST(request: NextRequest) {
       until: until.toISOString(),
     },
     subscriptions: {
+      accrued: subscriptionCycle.accrued,
+      accrued_micros: subscriptionCycle.accruedMicros.toString(),
       charged: subscriptionCycle.charged,
       failed: subscriptionCycle.failures.length,
       opened: subscriptionCycle.opened,

--- a/cloud/apps/auth-web/app/api/ai/chat/route.ts
+++ b/cloud/apps/auth-web/app/api/ai/chat/route.ts
@@ -506,7 +506,9 @@ export async function POST(request: NextRequest) {
                   });
                   turn.controller.abort(
                     new Error(
-                      "This account reached its daily AI limit during this reply. Today's limit resets at midnight UTC.",
+                      budget.allowance === "shared"
+                        ? "This reply used up today's free AI allowance on the shared key. Nothing is billed for it; it resets at midnight UTC."
+                        : "This account reached its daily AI limit during this reply. Today's limit resets at midnight UTC.",
                     ),
                   );
                 }

--- a/cloud/apps/auth-web/scripts/ai-metering-compare.mjs
+++ b/cloud/apps/auth-web/scripts/ai-metering-compare.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+/* global console, fetch, URL */
+// The Phase 2 gate (cloud/docs/accounting-todo.md §7 Phase 2, §9.3): does
+// the meter agree with the two other parties that counted the same tokens?
+//
+//   1. `ai_usage_records` — what we metered (and will bill on).
+//   2. PostHog `$ai_generation` — the same rounds, captured independently
+//      by the telemetry path. One event per model ROUND; a usage record is
+//      one TURN with `rounds` on it, so the counts compare rounds to rounds.
+//   3. OpenAI's own usage API — what the provider will invoice. This is the
+//      comparison that settles §8.2 (do reasoning tokens bill as output?)
+//      and the one that matters: if it disagrees, the bill is wrong.
+//
+// Written as a script rather than run once by hand so it can be re-run on
+// the next model change, and every side is optional: it compares whatever
+// it has credentials for and says plainly which sides it could not see.
+//
+//   DATABASE_URL=postgres://…                      \
+//   POSTHOG_PERSONAL_API_KEY=phx_… POSTHOG_PROJECT_ID=12345 \
+//   OPENAI_ADMIN_KEY=sk-admin-…                    \
+//   node scripts/ai-metering-compare.mjs [--since 2026-08-26] [--until 2026-09-02] [--json]
+//
+// Days are UTC, `--until` exclusive; the default window is the last seven
+// complete days. Token vocabularies differ and are normalised here:
+//   - the meter stores DISJOINT counts (input_tokens = uncached input),
+//     PostHog and OpenAI both report input INCLUDING the cached part, so the
+//     meter's "reported input" is input + cached;
+//   - reasoning tokens are a subset of output everywhere.
+// Exit status 1 when any side present disagrees with the meter by more
+// than --tolerance (default 1%) on any day/model with real volume.
+
+import process from "node:process";
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const index = args.indexOf(`--${name}`);
+  return index >= 0 ? args[index + 1] : fallback;
+};
+const json = args.includes("--json");
+const tolerance = Number(flag("tolerance", "0.01"));
+
+const today = new Date();
+const utcDay = (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+const until = flag("until") ? new Date(`${flag("until")}T00:00:00Z`) : utcDay(today);
+const since = flag("since")
+  ? new Date(`${flag("since")}T00:00:00Z`)
+  : new Date(until.getTime() - 7 * 24 * 3600 * 1000);
+if (Number.isNaN(since.getTime()) || Number.isNaN(until.getTime()) || since >= until) {
+  console.error("Bad --since/--until (YYYY-MM-DD, since < until)");
+  process.exit(2);
+}
+const dayOf = (d) => new Date(d).toISOString().slice(0, 10);
+
+// day → model → {requests, input, cached, output, reasoning, cost_micros}
+const empty = () => ({ cached: 0, cost_micros: 0, input: 0, output: 0, reasoning: 0, requests: 0 });
+const sides = {};
+const missing = [];
+
+// ---- 1. the meter -------------------------------------------------------
+if (process.env.DATABASE_URL) {
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+  try {
+    const rows = await sql`
+      select to_char(occurred_at at time zone 'UTC', 'YYYY-MM-DD') as day,
+             model,
+             surface,
+             count(*)::int as turns,
+             coalesce(sum(rounds), 0)::int as rounds,
+             coalesce(sum(input_tokens + cached_input_tokens), 0)::bigint as input,
+             coalesce(sum(cached_input_tokens), 0)::bigint as cached,
+             coalesce(sum(output_tokens), 0)::bigint as output,
+             coalesce(sum(reasoning_tokens), 0)::bigint as reasoning,
+             coalesce(sum(cost_micros), 0)::bigint as cost_micros,
+             count(*) filter (where credential_source = 'account')::int as own_key_turns
+        from ai_usage_records
+       where occurred_at >= ${since.toISOString()}::timestamptz
+         and occurred_at < ${until.toISOString()}::timestamptz
+       group by 1, 2, 3
+       order by 1, 2, 3`;
+    const meter = {};
+    const bySurface = {};
+    for (const row of rows) {
+      const bucket = ((meter[row.day] ??= {})[row.model] ??= empty());
+      // Rounds are what PostHog counts; a record from before `rounds` was
+      // stored (0) counts as one, which is the floor a turn can have.
+      bucket.requests += row.rounds > 0 ? row.rounds : row.turns;
+      bucket.turns = (bucket.turns ?? 0) + row.turns;
+      bucket.input += Number(row.input);
+      bucket.cached += Number(row.cached);
+      bucket.output += Number(row.output);
+      bucket.reasoning += Number(row.reasoning);
+      bucket.cost_micros += Number(row.cost_micros);
+      const s = (bySurface[row.surface ?? "(none)"] ??= { own_key_turns: 0, turns: 0 });
+      s.turns += row.turns;
+      s.own_key_turns += row.own_key_turns;
+    }
+    sides.meter = meter;
+    sides.meter_surfaces = bySurface;
+  } finally {
+    await sql.end();
+  }
+} else {
+  missing.push("meter (DATABASE_URL)");
+}
+
+// ---- 2. PostHog ---------------------------------------------------------
+if (process.env.POSTHOG_PERSONAL_API_KEY && process.env.POSTHOG_PROJECT_ID) {
+  const host = (process.env.POSTHOG_HOST || "https://eu.posthog.com").replace(/\/+$/, "");
+  const query = `
+    select toString(toDate(timestamp)) as day,
+           toString(properties.$ai_model) as model,
+           count() as requests,
+           sum(toIntOrZero(toString(properties.$ai_input_tokens))) as input,
+           sum(toIntOrZero(toString(properties.$ai_cache_read_input_tokens))) as cached,
+           sum(toIntOrZero(toString(properties.$ai_output_tokens))) as output,
+           sum(toIntOrZero(toString(properties.$ai_reasoning_tokens))) as reasoning,
+           uniq(properties.$ai_trace_id) as turns
+      from events
+     where event = '$ai_generation'
+       and timestamp >= toDateTime('${since.toISOString().replace("T", " ").slice(0, 19)}')
+       and timestamp < toDateTime('${until.toISOString().replace("T", " ").slice(0, 19)}')
+     group by day, model
+     order by day, model`;
+  const response = await fetch(`${host}/api/projects/${process.env.POSTHOG_PROJECT_ID}/query/`, {
+    body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+    headers: {
+      authorization: `Bearer ${process.env.POSTHOG_PERSONAL_API_KEY}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  if (!response.ok) {
+    console.error(`PostHog query failed: HTTP ${response.status} ${await response.text()}`);
+    process.exit(2);
+  }
+  const payload = await response.json();
+  const posthog = {};
+  for (const [day, model, requests, input, cached, output, reasoning, turns] of payload.results ?? []) {
+    const bucket = ((posthog[day] ??= {})[model] ??= empty());
+    bucket.requests += Number(requests);
+    bucket.turns = (bucket.turns ?? 0) + Number(turns);
+    bucket.input += Number(input);
+    bucket.cached += Number(cached);
+    bucket.output += Number(output);
+    bucket.reasoning += Number(reasoning);
+  }
+  sides.posthog = posthog;
+} else {
+  missing.push("posthog (POSTHOG_PERSONAL_API_KEY + POSTHOG_PROJECT_ID)");
+}
+
+// ---- 3. OpenAI ----------------------------------------------------------
+if (process.env.OPENAI_ADMIN_KEY) {
+  const headers = { authorization: `Bearer ${process.env.OPENAI_ADMIN_KEY}` };
+  const start = Math.floor(since.getTime() / 1000);
+  const end = Math.floor(until.getTime() / 1000);
+  const openai = {};
+  let page;
+  do {
+    const url = new URL("https://api.openai.com/v1/organization/usage/completions");
+    url.searchParams.set("start_time", String(start));
+    url.searchParams.set("end_time", String(end));
+    url.searchParams.set("bucket_width", "1d");
+    url.searchParams.append("group_by", "model");
+    url.searchParams.set("limit", "31");
+    if (page) url.searchParams.set("page", page);
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      console.error(`OpenAI usage query failed: HTTP ${response.status} ${await response.text()}`);
+      process.exit(2);
+    }
+    const payload = await response.json();
+    for (const bucket of payload.data ?? []) {
+      const day = dayOf(bucket.start_time * 1000);
+      for (const result of bucket.results ?? []) {
+        const b = ((openai[day] ??= {})[result.model ?? "(unknown)"] ??= empty());
+        b.requests += result.num_model_requests ?? 0;
+        b.input += result.input_tokens ?? 0;
+        b.cached += result.input_cached_tokens ?? 0;
+        b.output += result.output_tokens ?? 0;
+      }
+    }
+    page = payload.has_more ? payload.next_page : undefined;
+  } while (page);
+  // Dollars, from the costs endpoint: the number on the invoice.
+  const costs = new URL("https://api.openai.com/v1/organization/costs");
+  costs.searchParams.set("start_time", String(start));
+  costs.searchParams.set("end_time", String(end));
+  costs.searchParams.set("bucket_width", "1d");
+  costs.searchParams.set("limit", "31");
+  const costResponse = await fetch(costs, { headers });
+  if (costResponse.ok) {
+    const payload = await costResponse.json();
+    for (const bucket of payload.data ?? []) {
+      const day = dayOf(bucket.start_time * 1000);
+      const micros = (bucket.results ?? []).reduce(
+        (sum, r) => sum + Math.round((r.amount?.value ?? 0) * 1_000_000),
+        0,
+      );
+      ((openai[day] ??= {})["(all models)"] ??= empty()).cost_micros += micros;
+    }
+  }
+  sides.openai = openai;
+} else {
+  missing.push("openai (OPENAI_ADMIN_KEY — an org admin key, not the API key)");
+}
+
+// ---- compare ------------------------------------------------------------
+const metrics = ["turns", "requests", "input", "cached", "output", "reasoning"];
+const days = new Set();
+const models = new Set();
+for (const side of ["meter", "posthog", "openai"]) {
+  for (const [day, byModel] of Object.entries(sides[side] ?? {})) {
+    days.add(day);
+    for (const model of Object.keys(byModel)) models.add(model);
+  }
+}
+const report = [];
+let disagreements = 0;
+for (const day of [...days].sort()) {
+  for (const model of [...models].sort()) {
+    const meter = sides.meter?.[day]?.[model];
+    const posthog = sides.posthog?.[day]?.[model];
+    const openai = sides.openai?.[day]?.[model];
+    if (!meter && !posthog && !openai) continue;
+    const row = { day, model, meter, openai, posthog, deltas: {} };
+    for (const other of ["posthog", "openai"]) {
+      const theirs = row[other];
+      if (!meter || !theirs) continue;
+      for (const metric of metrics) {
+        if (other === "openai" && (metric === "reasoning" || metric === "turns")) continue;
+        const ours = meter[metric] ?? 0;
+        if (theirs[metric] === undefined) continue;
+        const delta = theirs[metric] - ours;
+        const relative = ours === 0 ? (theirs[metric] === 0 ? 0 : 1) : Math.abs(delta) / ours;
+        row.deltas[`${other}.${metric}`] = { delta, relative };
+        if (relative > tolerance && Math.max(ours, theirs[metric]) >= 1000) disagreements += 1;
+      }
+    }
+    report.push(row);
+  }
+}
+const costDays = Object.entries(sides.openai ?? {})
+  .map(([day, byModel]) => ({
+    day,
+    meter_cost_micros: Object.values(sides.meter?.[day] ?? {}).reduce((s, b) => s + b.cost_micros, 0),
+    openai_cost_micros: byModel["(all models)"]?.cost_micros ?? 0,
+  }))
+  .filter((row) => row.openai_cost_micros > 0 || row.meter_cost_micros > 0);
+
+if (json) {
+  console.log(JSON.stringify({ costDays, disagreements, missing, report, since, until, surfaces: sides.meter_surfaces }, null, 2));
+} else {
+  console.log(`AI metering comparison, ${dayOf(since)} → ${dayOf(until)} (UTC, exclusive)`);
+  if (missing.length) console.log(`Sides not available: ${missing.join("; ")}`);
+  const fmt = (n) => (n === undefined ? "—" : String(n).padStart(9));
+  for (const row of report) {
+    console.log(`\n${row.day}  ${row.model}`);
+    console.log(`  ${"".padEnd(10)}${metrics.map((m) => m.padStart(10)).join("")}`);
+    for (const side of ["meter", "posthog", "openai"]) {
+      const b = row[side];
+      if (!b) continue;
+      console.log(`  ${side.padEnd(10)}${metrics.map((m) => fmt(b[m]).padStart(10)).join("")}`);
+    }
+    const bad = Object.entries(row.deltas).filter(([, d]) => d.relative > tolerance);
+    if (bad.length) console.log(`  disagrees: ${bad.map(([k, d]) => `${k} ${d.delta > 0 ? "+" : ""}${d.delta}`).join(", ")}`);
+  }
+  if (sides.meter_surfaces) {
+    console.log("\nMeter turns by surface (own-key turns in brackets — PostHog does not see whose key):");
+    for (const [surface, s] of Object.entries(sides.meter_surfaces)) {
+      console.log(`  ${surface.padEnd(20)} ${String(s.turns).padStart(6)} (${s.own_key_turns})`);
+    }
+  }
+  if (costDays.length) {
+    console.log("\nProvider invoice vs metered cost (micro-USD):");
+    for (const row of costDays) {
+      console.log(`  ${row.day}  openai ${String(row.openai_cost_micros).padStart(12)}  meter ${String(row.meter_cost_micros).padStart(12)}`);
+    }
+  }
+  console.log(`\n${disagreements} disagreement(s) above ${tolerance * 100}% on day/model buckets with volume.`);
+}
+process.exit(disagreements > 0 ? 1 : 0);

--- a/cloud/apps/auth-web/src/components/BillingSettingsForm.tsx
+++ b/cloud/apps/auth-web/src/components/BillingSettingsForm.tsx
@@ -8,6 +8,7 @@ export type BillingSettingsValues = {
   dailyCapMicros: string;
   meteringMode: "live" | "shadow";
   overdraftMicros: string;
+  sharedKeyDailyCapMicros: string;
 };
 
 // The three knobs, and the one warning worth putting in front of a human:
@@ -24,6 +25,7 @@ export function BillingSettingsForm({
   const [margin, setMargin] = useState(values.aiMarginPercent);
   const [overdraft, setOverdraft] = useState(values.overdraftMicros);
   const [dailyCap, setDailyCap] = useState(values.dailyCapMicros);
+  const [sharedCap, setSharedCap] = useState(values.sharedKeyDailyCapMicros);
   const [mode, setMode] = useState<"live" | "shadow">(values.meteringMode);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
@@ -48,6 +50,7 @@ export function BillingSettingsForm({
           ai_metering_mode: mode,
           payg_daily_cap_micros: dailyCap,
           payg_overdraft_micros: overdraft,
+          shared_key_daily_cap_micros: sharedCap,
         },
       }),
       headers: { "content-type": "application/json" },
@@ -96,6 +99,24 @@ export function BillingSettingsForm({
           Postpay&apos;s credit limit: a turn is refused once an account&apos;s
           chargeable AI usage for the UTC day reaches this. 10,000,000 is ten
           dollars; 0 switches the cap off.
+        </p>
+      </div>
+
+      <div className="field">
+        <label htmlFor="billing-shared-cap">Daily allowance on the shared key (micro-dollars)</label>
+        <input
+          className="input"
+          id="billing-shared-cap"
+          inputMode="numeric"
+          onChange={(event) => setSharedCap(event.target.value)}
+          value={sharedCap}
+        />
+        <p className="copy">
+          The cap for accounts running on the deployment&apos;s shared OpenAI
+          key — the free tier. That usage is our money, not theirs, so it
+          gets its own, usually smaller, number; the refusal tells them it is
+          the operator&apos;s allowance rather than their limit. Falls back
+          to the daily cap above until it is set.
         </p>
       </div>
 

--- a/cloud/apps/auth-web/src/components/CustomerBillingControls.tsx
+++ b/cloud/apps/auth-web/src/components/CustomerBillingControls.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+// The operator's two hands on a customer's account, from the statement page
+// (cloud/docs/accounting-todo.md §5.1 "Superadmin side", §9.3): the AI
+// switch and the plan. Both want a reason, both are audited, and both are
+// the same mechanisms the account drives for itself — the difference is
+// only who is holding them and that the answer to "why" gets written down.
+
+export type PlanOption = {
+  code: string;
+  name: string;
+  priceMicros: string;
+  public: boolean;
+};
+
+export function CustomerAiSwitch({
+  accountId,
+  disabledAt,
+}: {
+  accountId: string;
+  disabledAt: string | null;
+}) {
+  const router = useRouter();
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const enabled = disabledAt === null;
+
+  async function flip() {
+    if (
+      enabled &&
+      !window.confirm(
+        "Switch AI off for this account? Scene chat and the app-code assistant stop working for them immediately, and nothing they do can accrue AI cost until it is switched back on.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setMessage(null);
+    const response = await fetch(`/api/admin/billing/customers/${accountId}/ai`, {
+      body: JSON.stringify({ enabled: !enabled, reason }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+    const payload = await response.json().catch(() => ({}));
+    setBusy(false);
+    if (response.ok) {
+      setReason("");
+      router.refresh();
+    } else {
+      setMessage(payload.detail ?? `Failed: ${payload.error ?? response.status}`);
+    }
+  }
+
+  return (
+    <div className="grid">
+      <p className="copy">
+        {enabled
+          ? "AI is on for this account."
+          : `AI is off for this account since ${new Date(disabledAt).toLocaleString()}. Nothing they do can accrue AI cost.`}
+      </p>
+      <div className="inline-actions">
+        <input
+          aria-label="Reason"
+          className="input"
+          onChange={(event) => setReason(event.target.value)}
+          placeholder="Reason (goes in the audit trail)"
+          value={reason}
+        />
+        <button
+          className="button"
+          disabled={busy || reason.trim() === ""}
+          onClick={() => void flip()}
+          type="button"
+        >
+          {enabled ? "Switch AI off" : "Switch AI back on"}
+        </button>
+      </div>
+      {message ? <p className="copy error">{message}</p> : null}
+    </div>
+  );
+}
+
+export function CustomerPlanForm({
+  accountId,
+  currentCode,
+  plans,
+  subscribed,
+}: {
+  accountId: string;
+  currentCode: string;
+  plans: PlanOption[];
+  subscribed: boolean;
+}) {
+  const router = useRouter();
+  const [code, setCode] = useState(currentCode);
+  const [reason, setReason] = useState("");
+  const [immediately, setImmediately] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const target = plans.find((plan) => plan.code === code);
+  const toFree = target ? BigInt(target.priceMicros) === 0n : false;
+
+  async function apply() {
+    if (!toFree && code !== currentCode) {
+      const ok = window.confirm(
+        `Put this account on ${target?.name ?? code}? The first period is charged to their balance now — a receivable Phase 3b has no way to collect yet.`,
+      );
+      if (!ok) {
+        return;
+      }
+    }
+    setBusy(true);
+    setMessage(null);
+    const response = await fetch(`/api/admin/billing/customers/${accountId}/plan`, {
+      body: JSON.stringify({ immediately: toFree && immediately, plan: code, reason }),
+      headers: { "content-type": "application/json" },
+      method: "PUT",
+    });
+    const payload = await response.json().catch(() => ({}));
+    setBusy(false);
+    if (response.ok) {
+      setReason("");
+      router.refresh();
+    } else {
+      setMessage(payload.detail ?? `Failed: ${payload.error ?? response.status}`);
+    }
+  }
+
+  return (
+    <div className="grid">
+      <div className="inline-actions">
+        <select
+          aria-label="Plan"
+          className="input"
+          onChange={(event) => setCode(event.target.value)}
+          value={code}
+        >
+          {plans.map((plan) => (
+            <option key={plan.code} value={plan.code}>
+              {plan.name} ({plan.code}
+              {plan.public ? "" : ", not public"})
+            </option>
+          ))}
+        </select>
+        <input
+          aria-label="Reason"
+          className="input"
+          onChange={(event) => setReason(event.target.value)}
+          placeholder="Reason (goes in the audit trail)"
+          value={reason}
+        />
+        <button
+          className="button"
+          disabled={busy || reason.trim() === "" || (code === currentCode && !(toFree && subscribed))}
+          onClick={() => void apply()}
+          type="button"
+        >
+          Apply
+        </button>
+      </div>
+      {toFree && subscribed ? (
+        <label className="copy">
+          <input
+            checked={immediately}
+            onChange={(event) => setImmediately(event.target.checked)}
+            type="checkbox"
+          />{" "}
+          End it now rather than at the end of the period already charged for
+          (nothing is refunded either way — that is a separate entry on the
+          Journal page).
+        </label>
+      ) : null}
+      <p className="copy">
+        A dearer plan starts now, prorated; a cheaper one takes over at the
+        rollover. Plans not shown on the public ladder are listed here too —
+        that is what they are for.
+      </p>
+      {message ? <p className="copy error">{message}</p> : null}
+    </div>
+  );
+}

--- a/cloud/apps/auth-web/src/components/SceneAiPanel.tsx
+++ b/cloud/apps/auth-web/src/components/SceneAiPanel.tsx
@@ -101,8 +101,10 @@ type FatalState =
   | { kind: "missing_api_key" }
   // The account switched AI off (403): nothing is broken, they asked.
   | { kind: "ai_disabled" }
-  // Today's spend is at the cap (402): back tomorrow on its own.
-  | { kind: "daily_cap_reached"; resetAt: string | null }
+  // Today's spend is at the cap (402): back tomorrow on its own. `shared`
+  // when the cap was the operator's free allowance, which is not money the
+  // account owes and must not be described as their limit.
+  | { kind: "daily_cap_reached"; resetAt: string | null; shared: boolean }
   | { kind: "rate_limited" }
   | { kind: "error"; message: string };
 
@@ -670,7 +672,11 @@ export function SceneAiPanel({
           } else if (error.code === "ai_disabled") {
             setFatal({ kind: "ai_disabled" });
           } else if (error.code === "daily_cap_reached") {
-            setFatal({ kind: "daily_cap_reached", resetAt: error.resetAt ?? null });
+            setFatal({
+              kind: "daily_cap_reached",
+              resetAt: error.resetAt ?? null,
+              shared: error.allowance === "shared",
+            });
           } else if (error.code === "rate_limited" || error.status === 429) {
             setFatal({ kind: "rate_limited" });
           } else {
@@ -1016,12 +1022,20 @@ export function SceneAiPanel({
         ) : null}
         {fatal?.kind === "daily_cap_reached" ? (
           <div className="notice ai-panel__notice" role="alert">
-            <strong className="ai-panel__notice-title">Today&rsquo;s AI limit is used up.</strong>
+            <strong className="ai-panel__notice-title">
+              {fatal.shared
+                ? "Today\u2019s free AI allowance is used up."
+                : "Today\u2019s AI limit is used up."}
+            </strong>
             <p className="copy">
-              The daily limit keeps a runaway loop from costing more than a
-              bounded amount. It resets
+              {fatal.shared
+                ? "This account runs on the operator\u2019s shared key, so nothing is billed for it \u2014 and the allowance is the operator\u2019s daily budget, not yours. It resets"
+                : "The daily limit keeps a runaway loop from costing more than a bounded amount. It resets"}
               {fatal.resetAt ? ` at ${new Date(fatal.resetAt).toLocaleString()}` : " at midnight UTC"}
               ; the reply so far is kept.
+              {fatal.shared
+                ? " Add your own OpenAI key under Settings to keep going without it."
+                : ""}
             </p>
           </div>
         ) : null}

--- a/cloud/apps/auth-web/src/lib/ai-chat-client.ts
+++ b/cloud/apps/auth-web/src/lib/ai-chat-client.ts
@@ -70,15 +70,19 @@ export type AiChatRequest = {
 export class AiChatRequestError extends Error {
   readonly code: string;
   readonly status: number;
-  // When the daily cap refused the turn: the moment today's number resets.
+  // When the daily cap refused the turn: the moment today's number resets,
+  // and whether the cap was the account's own limit or the operator's free
+  // allowance on the shared key ("shared").
   readonly resetAt: string | undefined;
+  readonly allowance: string | undefined;
 
-  constructor(code: string, status: number, detail?: string, resetAt?: string) {
+  constructor(code: string, status: number, detail?: string, resetAt?: string, allowance?: string) {
     super(detail || code);
     this.name = "AiChatRequestError";
     this.code = code;
     this.status = status;
     this.resetAt = resetAt;
+    this.allowance = allowance;
   }
 }
 
@@ -238,6 +242,7 @@ export async function streamAiChat(
   });
   if (!response.ok || !response.body) {
     const payload = (await response.json().catch(() => ({}))) as {
+      allowance?: unknown;
       error?: unknown;
       detail?: unknown;
       reset_at?: unknown;
@@ -253,6 +258,7 @@ export async function streamAiChat(
       response.status,
       typeof payload.detail === "string" ? payload.detail : undefined,
       typeof payload.reset_at === "string" ? payload.reset_at : undefined,
+      typeof payload.allowance === "string" ? payload.allowance : undefined,
     );
   }
 

--- a/cloud/apps/auth-web/src/lib/ai/access.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/access.test.ts
@@ -23,6 +23,7 @@ describe("AI refusal responses", () => {
   // body carries everything a panel needs to say when it comes back.
   it("reports the daily cap with the numbers behind it", async () => {
     const refusal: AiRefusal = {
+      allowance: "shared",
       capMicros: "10000000",
       detail: "This account has reached its daily AI limit.",
       reason: "daily_cap_reached",
@@ -32,6 +33,9 @@ describe("AI refusal responses", () => {
     const response = aiRefusalResponse(refusal);
     expect(response.status).toBe(402);
     expect(await body(response)).toMatchObject({
+      // Whose money the cap guarded: the panel words a shared-key
+      // allowance differently from the account's own limit.
+      allowance: "shared",
       cap_micros: "10000000",
       error: "daily_cap_reached",
       reset_at: "2026-09-02T00:00:00.000Z",

--- a/cloud/apps/auth-web/src/lib/ai/access.ts
+++ b/cloud/apps/auth-web/src/lib/ai/access.ts
@@ -16,6 +16,9 @@ export function aiRefusalResponse(refusal: AiRefusal) {
   }
   if (refusal.reason === "daily_cap_reached") {
     return jsonError("daily_cap_reached", 402, {
+      // "shared" when the cap was the operator's free allowance rather than
+      // the account's own credit limit: the SPA words it differently.
+      allowance: refusal.allowance,
       cap_micros: refusal.capMicros,
       detail: refusal.detail,
       reset_at: refusal.resetAt,

--- a/cloud/apps/auth-web/src/lib/ai/api-key.ts
+++ b/cloud/apps/auth-web/src/lib/ai/api-key.ts
@@ -32,8 +32,19 @@ export type AiCredentials = {
 export type AiRefusal =
   // The account turned AI off. Nothing is wrong; they asked for this.
   | { detail: string; reason: "ai_disabled" }
-  // Today's spend is at the cap. Comes back tomorrow on its own.
-  | { detail: string; reason: "daily_cap_reached"; resetAt: string; capMicros: string; spentMicros: string }
+  // Today's spend is at the cap. Comes back tomorrow on its own. `allowance`
+  // says whose money the cap was guarding: "billable" is the account's own
+  // credit limit, "shared" is the operator's free allowance on the shared
+  // key — a limit on money the account does not owe, and the copy must not
+  // pretend otherwise (§9.3).
+  | {
+      allowance: "billable" | "shared";
+      capMicros: string;
+      detail: string;
+      reason: "daily_cap_reached";
+      resetAt: string;
+      spentMicros: string;
+    }
   // No key available to this account at all — the original meaning of null.
   | { detail: string; reason: "missing_api_key" };
 
@@ -41,6 +52,7 @@ export type AiRefusal =
 // to keep checking against while the turn runs. Absent when no cap applies
 // (their own key, an absorbed surface, a deployment with no cap).
 export type AiSpendBudget = {
+  allowance: "billable" | "shared";
   capMicros: bigint;
   overdraftMicros: bigint;
   spentMicros: bigint;
@@ -82,6 +94,10 @@ export function sharedKeyAllowedFor(
  * its spend queried, let alone be told about a cap), then the key, then the
  * cap — which only binds when the key is OURS, because a turn on the
  * customer's own key costs us nothing and capping it would be gratuitous.
+ *
+ * Two caps, one query: the shared key (the operator's free tier) has its own
+ * `shared_key_daily_cap_micros`, because that usage is our money and not a
+ * bill the account will ever see. It falls back to the main cap when unset.
  */
 export async function resolveAiAccess(
   db: ReturnType<typeof createDb>,
@@ -126,7 +142,10 @@ export async function resolveAiAccess(
   }
 
   const settings = await readBillingSettings(db, env);
-  if (settings.dailyCapMicros > 0n) {
+  const allowance = credentials.source === "shared" ? "shared" : "billable";
+  const capMicros =
+    allowance === "shared" ? settings.sharedKeyDailyCapMicros : settings.dailyCapMicros;
+  if (capMicros > 0n) {
     const window = utcDayWindow();
     const spent = await accountAiSpendMicros(db, accountId, window);
     // Refused AT the cap. A turn's cost is unknown until it ends, so a turn
@@ -135,13 +154,13 @@ export async function resolveAiAccess(
     // mid-flight, and the tolerance the nightly check allows. The gate used
     // to refuse at cap + overdraft, which made the real cap $11 and every
     // honest overshoot a nightly alert (§9.2 item 3).
-    if (spent >= settings.dailyCapMicros) {
+    if (spent >= capMicros) {
       return {
         ok: false,
         refusal: {
-          capMicros: settings.dailyCapMicros.toString(),
-          detail:
-            "This account has reached its daily AI limit. It resets at midnight UTC.",
+          allowance,
+          capMicros: capMicros.toString(),
+          detail: dailyCapDetail(allowance),
           reason: "daily_cap_reached",
           resetAt: window.until.toISOString(),
           spentMicros: spent.toString(),
@@ -150,7 +169,8 @@ export async function resolveAiAccess(
     }
     return {
       budget: {
-        capMicros: settings.dailyCapMicros,
+        allowance,
+        capMicros,
         overdraftMicros: settings.overdraftMicros,
         spentMicros: spent,
       },
@@ -159,6 +179,16 @@ export async function resolveAiAccess(
     };
   }
   return { credentials, ok: true };
+}
+
+// The sentence a refused turn carries. A shared-key user is not "over
+// budget" on anything they owe: the allowance is ours, and the message says
+// whose it is rather than showing them a dollar limit on a bill that does
+// not exist.
+export function dailyCapDetail(allowance: "billable" | "shared"): string {
+  return allowance === "shared"
+    ? "This account has used up today's free AI allowance on the shared key. Nothing is billed for it; it resets at midnight UTC."
+    : "This account has reached its daily AI limit. It resets at midnight UTC.";
 }
 
 export async function resolveAiCredentials(

--- a/cloud/apps/auth-web/src/test/integration/account-usage.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/account-usage.integration.test.ts
@@ -26,7 +26,12 @@ import { storeFrameLogs } from "../../lib/frames";
 import { resetRateLimitForTests } from "../../lib/rate-limit";
 import { hashSecret } from "../../lib/secrets";
 import { createSession, sessionCookieName } from "../../lib/session";
-import { recordAiUsage } from "@frameos-cloud/ledger";
+import {
+  billingSettingKeys,
+  checkDailyCapRespected,
+  recordAiUsage,
+  writeBillingSetting,
+} from "@frameos-cloud/ledger";
 import { resolveAiAccess } from "../../lib/ai/api-key";
 import {
   accountUsage,
@@ -239,6 +244,51 @@ describe("the daily AI cap", () => {
     // An absorbed surface is never refused by the cap.
     const absorbed = await resolveAiAccess(db, accountId, { env, surface: "scene_convert" });
     expect(absorbed.ok).toBe(true);
+  });
+
+  // §9.3: the shared key is the operator's free tier, and its usage is our
+  // money. It gets its own cap, and the refusal says whose allowance ran
+  // out rather than showing a dollar limit on a bill the account does not
+  // owe.
+  it("caps the shared key on its own allowance, and says so", async () => {
+    const accountId = await signIn();
+    for (let n = 1; n <= 3; n += 1) {
+      await turn(accountId, n); // 1,725,360 in all
+    }
+    // Under the $10 default the shared cap falls back to: through, on the
+    // shared allowance.
+    const under = await resolveAiAccess(db, accountId, { env, surface: "scene_chat" });
+    expect(under.ok).toBe(true);
+    if (under.ok) {
+      expect(under.budget).toMatchObject({ allowance: "shared", capMicros: 10_000_000n });
+    }
+
+    // A $1.50 shared allowance: the same three turns are over it, while
+    // the $10 billable cap is untouched.
+    await writeBillingSetting(db, billingSettingKeys.sharedKeyDailyCapMicros, "1500000");
+    const over = await resolveAiAccess(db, accountId, { env, surface: "scene_chat" });
+    expect(over.ok).toBe(false);
+    if (!over.ok) {
+      expect(over.refusal).toMatchObject({
+        allowance: "shared",
+        capMicros: "1500000",
+        reason: "daily_cap_reached",
+        spentMicros: "1725360",
+      });
+      expect(over.refusal.detail).toContain("free AI allowance");
+      expect(over.refusal.detail).not.toContain("daily AI limit");
+    }
+    // The nightly check judges a shared-key day against the shared ceiling.
+    const violations = await checkDailyCapRespected(db, {
+      dailyCapMicros: 10_000_000n,
+      overdraftMicros: 0n,
+      sharedKeyDailyCapMicros: 1_500_000n,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.detail).toContain("past the 1500000 ceiling");
+    expect(
+      await checkDailyCapRespected(db, { dailyCapMicros: 10_000_000n, overdraftMicros: 0n }),
+    ).toEqual([]);
   });
 });
 

--- a/cloud/apps/auth-web/src/test/integration/admin-billing.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/admin-billing.integration.test.ts
@@ -8,6 +8,7 @@ import {
   accounts,
   auditEvents,
   createDb,
+  subscriptions,
   upsertAccountFromIdentity,
 } from "@frameos-cloud/db";
 import {
@@ -24,6 +25,8 @@ import {
   writeBillingSetting,
 } from "@frameos-cloud/ledger";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PUT as putCustomerAi } from "../../../app/api/admin/billing/customers/[accountId]/ai/route";
+import { PUT as putCustomerPlan } from "../../../app/api/admin/billing/customers/[accountId]/plan/route";
 import { POST as postGroups } from "../../../app/api/admin/billing/groups/route";
 import { POST as postJournal } from "../../../app/api/admin/billing/journal/route";
 import { POST as postNightly } from "../../../app/api/admin/billing/nightly/route";
@@ -113,6 +116,16 @@ function postJson(path: string, body: Record<string, unknown>) {
     method: "POST",
   });
 }
+
+function putJson(path: string, body: Record<string, unknown>) {
+  return new NextRequest(new URL(path, baseUrl), {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json", origin: baseUrl },
+    method: "PUT",
+  });
+}
+
+const params = (accountId: string) => ({ params: Promise.resolve({ accountId }) });
 
 async function signIn({ superadmin = false } = {}) {
   userCounter += 1;
@@ -479,5 +492,136 @@ describe("admin billing routes", () => {
     expect(
       await accountBalanceMicros(db, customerReceivableCode(customer)),
     ).toBe(575_120n);
+  });
+
+  // §9.3's operator surfaces: the AI switch (§5.1's "superadmin side") and
+  // putting an account on a plan by hand. Both want a reason and both leave
+  // an audit row, because "why is AI off for me" and "why am I on Studio"
+  // are support questions with a findable answer.
+  it("lets an operator throw a customer's AI switch, with a reason on record", async () => {
+    const customer = await signIn();
+    const admin = await signIn({ superadmin: true });
+
+    const unreasoned = await putCustomerAi(
+      putJson(`/api/admin/billing/customers/${customer}/ai`, { enabled: false }),
+      params(customer),
+    );
+    expect(unreasoned.status).toBe(400);
+    expect((await unreasoned.json()).error).toBe("reason_required");
+
+    const off = await putCustomerAi(
+      putJson(`/api/admin/billing/customers/${customer}/ai`, {
+        enabled: false,
+        reason: "Invoice 30 days overdue",
+      }),
+      params(customer),
+    );
+    expect(off.status).toBe(200);
+    const [row] = await db
+      .select({ aiDisabledAt: accounts.aiDisabledAt })
+      .from(accounts)
+      .where(eq(accounts.id, customer));
+    expect(row?.aiDisabledAt).not.toBeNull();
+
+    const on = await putCustomerAi(
+      putJson(`/api/admin/billing/customers/${customer}/ai`, { enabled: true, reason: "Paid" }),
+      params(customer),
+    );
+    expect(on.status).toBe(200);
+    const [back] = await db
+      .select({ aiDisabledAt: accounts.aiDisabledAt })
+      .from(accounts)
+      .where(eq(accounts.id, customer));
+    expect(back?.aiDisabledAt).toBeNull();
+
+    const audit = await db
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.accountId, customer))
+      .orderBy(auditEvents.createdAt);
+    expect(audit.map((event) => event.eventType)).toEqual([
+      "admin.ai_disabled",
+      "admin.ai_enabled",
+    ]);
+    expect(audit[0]?.metadata).toMatchObject({ reason: "Invoice 30 days overdue" });
+    expect(audit[0]?.actor).toMatchObject({ accountId: admin, kind: "superadmin" });
+
+    const missing = await putCustomerAi(
+      putJson(`/api/admin/billing/customers/00000000-0000-4000-8000-000000000000/ai`, {
+        enabled: false,
+        reason: "x",
+      }),
+      params("00000000-0000-4000-8000-000000000000"),
+    );
+    expect(missing.status).toBe(404);
+  });
+
+  it("lets an operator move a customer between plans, self-serve gate or not", async () => {
+    const customer = await signIn();
+    await signIn({ superadmin: true });
+    await db.execute(sql`
+      INSERT INTO billing_plans ("code", "name", "price_micros", "margin_basis_points", "sort_order", "public") VALUES
+        ('payg', 'Pay as you go', 0, 10000, 0, true),
+        ('maker', 'Maker', 1990000, 5000, 10, true),
+        ('partner', 'Partner', 990000, 2000, 20, false)
+      ON CONFLICT ("code") DO NOTHING
+    `);
+
+    const unknown = await putCustomerPlan(
+      putJson(`/api/admin/billing/customers/${customer}/plan`, { plan: "gold", reason: "x" }),
+      params(customer),
+    );
+    expect(unknown.status).toBe(404);
+
+    // A non-public plan is exactly what this route is for.
+    const partner = await putCustomerPlan(
+      putJson(`/api/admin/billing/customers/${customer}/plan`, {
+        plan: "partner",
+        reason: "Negotiated: hardware partner",
+      }),
+      params(customer),
+    );
+    expect(partner.status).toBe(200);
+    expect(await partner.json()).toMatchObject({ plan: { code: "partner" }, subscribed: true });
+    // The first period is charged the moment the plan is set.
+    expect(await accountBalanceMicros(db, customerReceivableCode(customer))).toBe(990_000n);
+
+    // Back to free: runs to the end of the period charged for by default.
+    const free = await putCustomerPlan(
+      putJson(`/api/admin/billing/customers/${customer}/plan`, { plan: "payg", reason: "Left" }),
+      params(customer),
+    );
+    expect(free.status).toBe(200);
+    const [row] = await db
+      .select({ status: subscriptions.status })
+      .from(subscriptions)
+      .where(eq(subscriptions.accountId, customer));
+    expect(row?.status).toBe("canceling");
+
+    const audit = await db
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.accountId, customer))
+      .orderBy(auditEvents.createdAt);
+    expect(audit.map((event) => event.eventType)).toEqual([
+      "admin.plan_changed",
+      "admin.plan_canceled",
+    ]);
+    expect(audit[0]?.metadata).toMatchObject({ from: null, plan: "partner", reason: "Negotiated: hardware partner" });
+    expect(audit[1]?.metadata).toMatchObject({ from: "partner", immediately: false, plan: "payg" });
+  });
+
+  it("keeps the operator surfaces superadmin only", async () => {
+    const customer = await signIn();
+    const ai = await putCustomerAi(
+      putJson(`/api/admin/billing/customers/${customer}/ai`, { enabled: false, reason: "x" }),
+      params(customer),
+    );
+    expect(ai.status).toBe(403);
+    const plan = await putCustomerPlan(
+      putJson(`/api/admin/billing/customers/${customer}/plan`, { plan: "maker", reason: "x" }),
+      params(customer),
+    );
+    expect(plan.status).toBe(403);
   });
 });

--- a/cloud/docs/accounting-todo.md
+++ b/cloud/docs/accounting-todo.md
@@ -36,6 +36,14 @@ need were all seeded in Phase 0.
   already rendered, which is the most ordinary transaction there is. It also
   deletes three open decisions outright (credit expiry, the prepaid refund
   path, and what a "credit" is worth).
+  *Precisely:* "already rendered" is true of **metered usage**. A
+  **subscription is billed in advance** — the period is charged the day it
+  starts — which is ordinary SaaS and not stored value (the customer is
+  buying a defined month of service, not a balance to spend later), and the
+  ledger treats it as such: deferred on the day it is charged, recognised as
+  it is served (§3.6). The invoice copy has to say both things: the plan fee
+  for the coming period, the AI usage for the past month. `/account/ai` says
+  so already.
 - **Subscriptions after postpay, not instead of it.** Not in the first
   shippable thing — metering, a cap, a visible number and an invoice have to
   work before a plan can promise anything — but they are the destination,
@@ -688,13 +696,27 @@ Entry 'subscription_charge'        (occurred_at: period start)
   Cr liability:deferred:subscriptions        1.990000
 ```
 
-Recognition over the period (daily, or one entry at period end):
+Recognition over the period — **daily, from the nightly job** (built
+2026-09-02, §9.3; it used to be one entry at period end, which made a
+calendar-month P&L lag by up to a month). Each night earns
+`(price − refunded) × whole days served ÷ period length` less what was
+already recognised, with `subscription_periods.recognized_micros` as the
+cursor that makes it idempotent; the close-out at period end earns whatever
+is left and stamps `recognized_at`. Whole days, so a job that runs twice in
+a night posts nothing the second time. A month of Maker therefore reads as
+~31 entries of $0.064:
 
 ```
-Entry 'subscription_recognition'
-  Dr liability:deferred:subscriptions        1.990000
-  Cr revenue:subscriptions                   1.990000
+Entry 'subscription_recognition'        (one per day served)
+  Dr liability:deferred:subscriptions        0.064194
+  Cr revenue:subscriptions                   0.064194
 ```
+
+Refunds and accruals bound each other: a refund may return only what is
+still deferred (`price − refunded − recognized`), and an accrual never
+earns past it, so the deferred account cannot go negative whichever order
+the two land in. Revenue already recognised is not handed back from the
+deferral — that is a reversal, a separate act.
 
 and the same month-end invoice (§3.2) collects the subscription and the
 metered AI together, because both are already sitting on the same
@@ -935,10 +957,17 @@ Shape:
   is actually standing when the thought occurs to them. Turning it off states
   plainly what stops working; turning it back on is one click and audited
   (`recordAuditEvent`) in both directions.
-- **Superadmin side** (*not built as of 2026-09-01 — §9.3*): the same flag
-  readable on `/admin/billing`, and settable by an operator as the terminal
-  step of dunning (§3.2) — an account that has not paid stops accruing
-  before it stops being a customer.
+- **Superadmin side** (built 2026-09-02, §9.3): the same flag, read and
+  thrown from the customer statement page (`/admin/billing/customers`) via
+  `PUT /api/admin/billing/customers/<id>/ai` — reason required, audited as
+  `admin.ai_disabled` / `admin.ai_enabled` with the reason in the metadata.
+  The terminal step of dunning (§3.2): an account that has not paid stops
+  accruing before it stops being a customer. The same page moves an
+  account between plans (`…/plan`, `admin.plan_changed` /
+  `admin.plan_canceled`), non-public plans included and regardless of the
+  self-serve gate — that gate exists because a *customer* subscribing runs
+  up a receivable 3b cannot settle; an operator doing it with a reason on
+  record is the exception it was written around.
 
 ### 5.2 "AI usage": a row in the header, a page behind it
 
@@ -1018,6 +1047,20 @@ $10/day per account (§0), as `billing_settings.payg_daily_cap_micros` so it
 is a superadmin edit rather than a deploy (the field is on the form since
 2026-09-02), with a per-account override column for the accounts that
 eventually need one (*not built*).
+
+**Two caps, since 2026-09-02 (§9.3).** The cap counts every turn on one
+of *our* keys, which for an account on the operator's shared key
+(`FRAMEOS_AI_SHARED_KEY_ACCESS`, the free tier) meant being "limited" at
+$10 on money it does not owe, and seeing a dollar figure with "nothing is
+billed" under it. The shared key now has its own
+`billing_settings.shared_key_daily_cap_micros` — our money, our (usually
+smaller) number; it falls back to the main cap until set — and the
+refusal says whose allowance ran out: the 402 body carries
+`allowance: "shared" | "billable"`, the panel's copy and `/account/ai`'s
+wording differ accordingly, and the nightly check judges a shared-key
+account-day against the shared ceiling. `resolveAiAccess` picks the cap
+from the credential source it already resolved, so it is one query either
+way.
 
 - **Measured** as `SUM(price_micros)` over the account's `ai_usage_records`
   for the current UTC day. Not the ledger: the cap must hold for shadow-mode
@@ -1161,6 +1204,12 @@ Still open, and the gate on Phase 3:
 - [ ] Run a week in production and compare `ai_usage_records` totals against
       PostHog `$ai_generation` sums **and against the provider's own
       invoice** — the second comparison is the one that settles §8.2.
+      **Scripted 2026-09-02** as
+      `apps/auth-web/scripts/ai-metering-compare.mjs` (three optional
+      sides — `DATABASE_URL`, PostHog personal key + project, OpenAI *admin*
+      key — compared per UTC day and model, token vocabularies normalised,
+      exit 1 above 1% disagreement) so it re-runs on the next model change.
+      First run: see §9.6 — there was no week to compare yet.
 
 ### Phase 3 — postpay billing (first revenue)
 
@@ -1216,8 +1265,8 @@ not a one-off hosted checkout (§3.2).
 - [ ] Choose the provider; SDK + env plumbing; webhook endpoint
       `app/api/webhooks/<provider>/route.ts` (signature check, provider
       event id as idempotency key, raw-body handling).
-- [ ] Migration `0047` (0045 went to plans, 0046 to the §9 fixes):
-      `invoices` (period bounds,
+- [ ] Migration `0048` (0045 went to plans, 0046 to the §9 fixes, 0047 to
+      §9.3's daily recognition): `invoices` (period bounds,
       sequential number, status, provider payment ref) and the
       stored-payment-method reference. The
       invoice holds no amount the ledger does not — §3.2 says why.
@@ -1244,10 +1293,11 @@ not a one-off hosted checkout (§3.2).
       satisfied, not before.
 - [ ] Golden-file test: turns → cap refusal → month close → invoice →
       payment → fee → an unpaid month → write-off.
-- [ ] Legal/pricing page copy: that AI is billed monthly in arrears, what
-      the margin is, what the cap is, and how to turn it off. Plus §8.8's
+- [ ] Legal/pricing page copy: that AI is billed monthly in arrears, that
+      a plan is billed in advance for the coming period (§0), what the
+      margin is, what the cap is, and how to turn it off. Plus §8.8's
       billing-records retention line, which must land before the first
-      invoice, not after.
+      invoice, not after — and §8.15's answer (which entity invoices).
 
 ### Phase 4 — books you can actually read + ops — shipped 2026-08-31
 
@@ -1531,6 +1581,35 @@ question that will be asked again.
     product shows is what it costs. Tied to §8.3's allowance question — a
     free monthly allowance makes opt-in-by-default unremarkable, and no
     allowance makes it a decision worth being deliberate about.
+15. **Which legal entity invoices, and from where** (raised by §9.3,
+    2026-09-02; *a decision only the owner can take*, and it comes before
+    §8.7's provider choice, not after). Nothing in this document or the
+    code names the party on the invoice. What has to be settled, in order:
+    - **The entity.** The name, address and registration that go on
+      `invoices` — presumably the operating company, but "presumably" is
+      not a line on an invoice.
+    - **Its VAT position.** Registered or not; if registered, the number
+      goes on every invoice and §8.6's `liability:vat_payable` leg becomes
+      real for domestic B2C sales the day the first invoice is cut.
+    - **Gapless numbering.** Many EU jurisdictions require invoice numbers
+      to be sequential without gaps, per entity (sometimes per series).
+      `invoices.number` was designed for that and nothing assigns it; the
+      assignment must be a database sequence taken inside the same
+      transaction that creates the invoice, never a counter in the app,
+      and a voided invoice keeps its number. If the entity's jurisdiction
+      does not require it, do it anyway — it is cheaper than the argument.
+    - **OSS / cross-border B2C.** Selling to consumers in other EU member
+      states above the €10k union-wide threshold means charging the
+      *customer's* country's VAT and remitting through the One-Stop-Shop
+      — or letting a merchant-of-record do it (§8.7 again). Below the
+      threshold, home-country VAT. Either way the invoice needs the
+      customer's country, which `accounts` does not hold today.
+    - **B2B reverse charge.** A customer with a valid VAT number in
+      another member state is invoiced net with the reverse-charge
+      wording; needs a VAT-number field and a VIES check.
+    Until these are answered 3b's invoice has no header, and the recipes
+    in §3.2 have no tax leg. Decide, then write the answers into this
+    item.
 
 ---
 
@@ -1778,48 +1857,52 @@ right moment to fix it.
 
 - [x] Fix §9.2 items 1–4 and 7–9 first; they are bugs with tests missing,
       not decisions. Items 5 and 6 are decisions and small code; 11 is
-      the biggest piece of new work and gates the first invoice. — All 18
-      done 2026-09-02, migration 0046 (§9.5).
-- [ ] **Run the Phase 2 gate.** It has been open since 2026-08-31 and is
+      the biggest piece of new work and gates the first invoice. *Done in
+      PR #432 (§9.5).* The rest of this list: 2026-09-02, §9.6.
+- [x] **Run the Phase 2 gate.** (Scripted and run 2026-09-02, §9.6 — the
+      meter agrees with PostHog on everything there was to compare, and
+      there was one day of it; the provider side needs an admin key nobody
+      has put in an env yet.) It has been open since 2026-08-31 and is
       the only thing that would tell us the meter is right: a week of
       `ai_usage_records` against PostHog `$ai_generation` sums (turn count
       and token totals) *and* against OpenAI's usage export (§8.2 settles
       there). It is one query on each side and it has not been run. Write
       it as a script so it can be re-run on the next model change.
-- [ ] **Which legal entity invoices, and from where.** Not in this
+- [ ] **Which legal entity invoices, and from where.** *Written up as
+      §8.15 with the questions in order — the answer is the owner's.* Not in this
       document anywhere, and prior to the provider choice: the entity on
       the invoice, its VAT registration, whether it must number invoices
       sequentially by law (many EU jurisdictions require gapless
       sequences — `invoices.number` is designed for that but nothing
       assigns it), and whether B2C sales to other EU countries trigger
       OSS. §8.6/§8.7 assume this is answered.
-- [ ] **Subscriptions are billed in advance**, which is normal SaaS and
+- [x] **Subscriptions are billed in advance**, which is normal SaaS and
       not stored value, but §0's "we invoice for a service already
       rendered" is only true of metered usage. Say so in §0 and in the
       invoice copy; the ledger already treats it correctly (deferred
       until recognised).
-- [ ] **Subscription revenue is recognised only at period end**, so a
+- [x] **Subscription revenue is recognised only at period end**, so a
       calendar-month P&L lags by up to a month. Fine at this size; either
       say so in §3.6 or recognise daily from the nightly job (one more
       idempotent step per period, `recognized_micros` on the row).
-- [ ] **The cap counts shared-key usage** at the customer's margin. That
+- [x] **The cap counts shared-key usage** at the customer's margin. That
       bounds our exposure, which is its job, but a free-tier user is then
       "limited" on money they do not owe and the page shows them a dollar
       figure with "nothing is billed" under it. Either the message for
       shared-key refusals says "the operator's daily allowance", or the
       shared key gets its own smaller cap — it is our money either way.
-- [ ] **Operator surfaces are missing.** §5.1's superadmin view of the AI
+- [x] **Operator surfaces are missing.** §5.1's superadmin view of the AI
       switch, and any way to put an account on a plan other than psql
       ("an operator moves accounts by hand" has no route). Both are small
       admin routes plus audit events; both are needed before 3b's dunning
       step, which ends by throwing the switch.
-- [ ] **The nightly job runs as one person's API token.** If that
+- [x] **The nightly job runs as one person's API token.** If that
       superadmin revokes the token or is removed, the job dies; the
       healthchecks ping is optional in the env example. Make the ping
       mandatory on the production box (verify it is set), and consider a
       dedicated service account for the token.
-- [x] Phase 3b's `invoices` migration is **0047**: Phase 5 took 0045 and
-      the §9 fixes took 0046 (§7 corrected 2026-09-02).
+- [x] Phase 3b's `invoices` migration is **0048**, not 0045 — Phase 5 took
+      that number, the §9 fixes 0046, daily recognition 0047.
 
 ### 9.4 Where this document said something the code did not do
 
@@ -1913,5 +1996,64 @@ Every §9.2 item, with the decision where one had to be made:
 
 Not done here, still §9.3: the Phase 2 comparison against PostHog and the
 provider invoice, the legal-entity/VAT question, the operator surfaces for
-the switch and for plans, and the service account for the nightly token.
-(`docs/todo.md`'s two stale lines were updated the same day.)
+the switch and for plans, the service account for the nightly token, and
+`docs/todo.md`'s two stale lines.
+
+### 9.6 What the pre-3b pass did — 2026-09-02, migration 0047
+
+Every §9.3 item, with the decision where one had to be made:
+
+1. **The Phase 2 gate, run.** `apps/auth-web/scripts/ai-metering-compare.mjs`
+   compares `ai_usage_records` with PostHog `$ai_generation` (and
+   `scene_convert`) and with OpenAI's usage/costs API, per UTC day and
+   model. What production had to compare on 2026-09-02: metering went
+   live at 22:27 UTC on 2026-08-31, so there was **one full day**, not a
+   week. On it the meter and PostHog agree **exactly** — 2026-09-01,
+   gpt-5.6-terra: 7 turns / 18 rounds, 302,723 input (218,110 cached),
+   11,488 output, 986 reasoning on both sides — and the five metered scene
+   conversions match PostHog token-for-token by request id. What is still
+   unproven is the provider's invoice: the script's OpenAI side needs an
+   *organisation admin* key (`OPENAI_ADMIN_KEY`) that nobody has put in an
+   env yet, and §8.2 (reasoning billed as output) is settled only there.
+   **Re-run the script over a real week before flipping metering to live**;
+   the meter-vs-PostHog half is not in doubt any more, the meter-vs-invoice
+   half has not been looked at.
+2. **Invoicing entity** — written up as §8.15 in decision order (entity,
+   VAT position, gapless numbering, OSS, reverse charge). Not decided; it
+   cannot be from here.
+3. **Subscriptions billed in advance** — §0 says so now, `/account/ai` says
+   so on the plan line, and 3b's copy item carries it.
+4. **Daily recognition** — built, not merely documented (§3.6):
+   `subscription_periods.recognized_micros` (0047) is the cursor, the
+   nightly cycle gained an accrual step between charging and close-out,
+   `earnedToDateMicros` is whole-days pro rata of `price − refunded`, and
+   a refund is bounded by what is still deferred after accruals. The
+   deferred-revenue invariant subtracts `recognized_micros`. Tests: the
+   day-by-day walk (10 days → 641,935 of a Maker month; nothing twice for
+   the same day; the close-out books the remainder on the period's last
+   day, not the night the job ran) and a refund after accruals.
+5. **Shared-key cap** — *decided: both.* Its own
+   `shared_key_daily_cap_micros` (falls back to the main cap until set,
+   so nothing changes on its own) AND the refusal names whose allowance
+   it was: `allowance: "shared" | "billable"` on the 402, the panel and
+   `/account/ai` word it as the operator's allowance, and the nightly
+   check judges shared-only account-days against the shared ceiling.
+6. **Operator surfaces** — `PUT /api/admin/billing/customers/<id>/ai` and
+   `…/plan`, both reason-required and audited (`admin.ai_disabled`,
+   `admin.ai_enabled`, `admin.plan_changed`, `admin.plan_canceled`), on the
+   customer statement page, which also now leads with the receivable and
+   hides the prepaid shelf statements unless something posted to them.
+7. **Nightly job identity** — `scripts/accounting-service-account.sh`
+   mints the token on a dedicated superadmin account with no login
+   identity (psql only, so it runs on the box; hash and hint match
+   `api-tokens.ts`); the healthchecks ping is **required** (`none` opts
+   out on purpose) and `install.sh` refuses to arm the timer on
+   placeholders. Found while verifying: **the job had never been
+   installed on production** — no env file, no timer. Installed the same
+   day: token minted on the box for `accounting-job@frameos.net`, a
+   healthchecks check, timer at 04:20 UTC; the first run passed with no
+   violations.
+8. **Numbers** — 3b's `invoices` migration is 0048.
+
+Also in this round: `docs/todo.md`'s two stale lines now point here.
+

--- a/cloud/docs/operational-runbooks.md
+++ b/cloud/docs/operational-runbooks.md
@@ -211,16 +211,32 @@ appear.
 
 `ops/accounting/frameos-cloud-accounting.timer` runs
 `scripts/accounting-nightly.sh` at 04:20, which curls
-`POST /api/admin/billing/nightly`. Two things happen: AI usage records whose
-ledger entries never landed are re-posted (idempotent by turn id, so a night
-that already posted is a no-op), and every ledger invariant runs — each
-violation is `reportError`ed and the run exits non-zero.
+`POST /api/admin/billing/nightly`. Three things happen: AI usage records
+whose ledger entries never landed are re-posted (idempotent by turn id, so a
+night that already posted is a no-op), the subscription cycle runs (open,
+charge, earn the day's share of every running period, close out the ended
+ones), and every ledger invariant runs — each violation is `reportError`ed
+and the run exits non-zero.
 
-Install with `cloud/ops/accounting/install.sh`. The one manual step is the
-token: create a personal API token as a superadmin at `/account/api-tokens`
-and put it in `/etc/frameos-cloud/accounting.env` as
-`ACCOUNTING_API_TOKEN`. Optionally set `ACCOUNTING_HEALTHCHECKS_URL` for the
-same dead-man pattern the backup and uptime jobs use.
+Install with `cloud/ops/accounting/install.sh`. Two manual values in
+`/etc/frameos-cloud/accounting.env`, and the installer refuses to enable the
+timer until both are real:
+
+- `ACCOUNTING_API_TOKEN`: mint it on a **dedicated service account** with
+  `cloud/scripts/accounting-service-account.sh` (run from a machine with
+  `DATABASE_URL` for production — the prod box itself, or an SSH tunnel).
+  The account is a superadmin with no login identity, so nobody can sign in
+  as it, and the token is its only door. Not a person's token: that is
+  revoked on their way out and the job dies with it, silently. Rotate by
+  running the script again (`--rotate`) and replacing the value.
+- `ACCOUNTING_HEALTHCHECKS_URL`: a healthchecks.io ping, the same dead-man
+  pattern the backup and uptime jobs use. **Required**, because the failure
+  that matters is a night that never ran, and only something expecting a
+  ping can notice. `none` opts out deliberately.
+
+**As of 2026-09-02 the job had never been installed on production** — no
+env file, no timer — which is how the doc's "optional" ping stayed
+theoretical. Installing it is the next operator step after this lands.
 
 **A violation is an alert, not something to fix by hand from the psql
 prompt.** The ledger is append-only in the database — `UPDATE` and `DELETE`

--- a/cloud/ops/accounting/accounting.env.example
+++ b/cloud/ops/accounting/accounting.env.example
@@ -1,14 +1,18 @@
 # /etc/frameos-cloud/accounting.env — read by frameos-cloud-accounting.service.
 #
-# A personal API token belonging to a superadmin, created at
-# /account/api-tokens. The nightly job needs no new secret type: it
-# authenticates the way any script against this API does.
+# An API token on a DEDICATED superadmin service account, minted with
+#   cloud/scripts/accounting-service-account.sh
+# Not a person's token: a personal token is revoked on their way out and the
+# job dies with it, silently. The service account has no login identity, so
+# nobody can sign in as it; the token is its only door.
 ACCOUNTING_API_TOKEN=fc_api_replace_me
 
 # The endpoint. Public URL rather than loopback: the app runs on whichever of
 # the blue/green ports is live, and nginx is what knows which.
 ACCOUNTING_URL=https://cloud.frameos.net/api/admin/billing/nightly
 
-# Optional healthchecks.io check, same dead-man pattern as the backup and
-# uptime jobs: a silent night is itself the alert.
-# ACCOUNTING_HEALTHCHECKS_URL=https://hc-ping.com/replace-me
+# REQUIRED: a healthchecks.io check, same dead-man pattern as the backup and
+# uptime jobs. A silent night is itself the alert, and only something that
+# expects a ping can raise it. The script refuses to run without this; set
+# it to "none" to opt out deliberately on a deployment with nowhere to ping.
+ACCOUNTING_HEALTHCHECKS_URL=https://hc-ping.com/replace-me

--- a/cloud/ops/accounting/install.sh
+++ b/cloud/ops/accounting/install.sh
@@ -8,10 +8,14 @@ cd "$(dirname "$0")"
 # an accounting.env seeded from the example if none exists yet. Idempotent —
 # re-run after editing scripts/accounting-nightly.sh to ship the new version.
 #
-# The one manual step is the token: create a personal API token as a
-# superadmin at /account/api-tokens and put it in
-# /etc/frameos-cloud/accounting.env. See cloud/docs/accounting-todo.md §7
-# Phase 4 and cloud/docs/operational-runbooks.md.
+# Two manual steps, both in /etc/frameos-cloud/accounting.env: the token
+# (mint one on a dedicated service account with
+# scripts/accounting-service-account.sh — not a person's) and the
+# healthchecks.io ping URL, which is required. This script checks both are
+# set and refuses to enable the timer otherwise: a timer running a job that
+# exits early on a missing variable every night is a job nobody notices is
+# broken. See cloud/docs/accounting-todo.md §7 Phase 4 and
+# cloud/docs/operational-runbooks.md.
 
 deploy_host="${FRAMEOS_CLOUD_DEPLOY_HOST:-root@167.233.35.240}"
 ssh_key="${FRAMEOS_CLOUD_DEPLOY_SSH_KEY:-$HOME/.ssh/hetzner}"
@@ -31,9 +35,26 @@ if ! run "test -f /etc/frameos-cloud/accounting.env"; then
   echo "Seeding /etc/frameos-cloud/accounting.env from example"
   scp -i "$ssh_key" accounting.env.example "$deploy_host:/etc/frameos-cloud/accounting.env"
   run chmod 600 /etc/frameos-cloud/accounting.env
-  echo "Set ACCOUNTING_API_TOKEN in /etc/frameos-cloud/accounting.env before the first run."
+  echo "Set ACCOUNTING_API_TOKEN and ACCOUNTING_HEALTHCHECKS_URL in /etc/frameos-cloud/accounting.env before the first run."
 fi
 
+# Refuse to arm the timer on placeholders. Both values are the difference
+# between a job that runs and one that fails quietly at 04:20 every night.
+env_ok=true
+if ! run "grep -Eq '^ACCOUNTING_API_TOKEN=fc_api_[A-Za-z0-9_-]{20,}\$' /etc/frameos-cloud/accounting.env" \
+   || run "grep -q '^ACCOUNTING_API_TOKEN=fc_api_replace_me' /etc/frameos-cloud/accounting.env"; then
+  echo "ACCOUNTING_API_TOKEN is not set in /etc/frameos-cloud/accounting.env (mint one with scripts/accounting-service-account.sh)" >&2
+  env_ok=false
+fi
+if ! run "grep -Eq '^ACCOUNTING_HEALTHCHECKS_URL=(https://[^ ]+|none)\$' /etc/frameos-cloud/accounting.env" \
+   || run "grep -q 'replace-me' /etc/frameos-cloud/accounting.env"; then
+  echo "ACCOUNTING_HEALTHCHECKS_URL is not set in /etc/frameos-cloud/accounting.env (a healthchecks.io ping URL, or \"none\" to opt out on purpose)" >&2
+  env_ok=false
+fi
 run systemctl daemon-reload
+if [ "$env_ok" != true ]; then
+  echo "Units installed; the timer is NOT enabled until both values are set. Re-run this script afterwards." >&2
+  exit 1
+fi
 run systemctl enable --now frameos-cloud-accounting.timer
 run systemctl list-timers --no-pager frameos-cloud-accounting.timer

--- a/cloud/packages/db/drizzle/0047_subscription_daily_recognition.sql
+++ b/cloud/packages/db/drizzle/0047_subscription_daily_recognition.sql
@@ -1,0 +1,19 @@
+-- Pre-Phase-3b design changes (cloud/docs/accounting-todo.md §9.3, 2026-09-02).
+--
+-- 1. `subscription_periods.recognized_micros`: how much of the period's
+--    price has been recognised as revenue SO FAR. Recognition used to be one
+--    entry at period end, which made a calendar-month P&L lag by up to a
+--    month (a Maker month taken on the 20th showed no revenue until the
+--    20th of the next month). The nightly job now recognises each period
+--    daily, pro rata by whole days served, and this column is the cursor
+--    that makes that step idempotent: tonight's entry is `earned so far −
+--    recognized_micros`, and a night that runs twice finds nothing left.
+--    Every period that exists today was recognised whole at its end or is
+--    still deferred whole, so 0 is the honest backfill for all of them.
+--
+-- 2. `billing_settings.shared_key_daily_cap_micros` needs no seed row: when
+--    absent it falls back to `payg_daily_cap_micros`, so nothing changes
+--    until an operator sets it (settings.ts).
+
+ALTER TABLE "subscription_periods"
+  ADD COLUMN "recognized_micros" bigint NOT NULL DEFAULT 0 CHECK ("recognized_micros" >= 0);

--- a/cloud/packages/db/src/schema.ts
+++ b/cloud/packages/db/src/schema.ts
@@ -1562,6 +1562,13 @@ export const subscriptionPeriods = pgTable(
     refundedMicros: bigint("refunded_micros", { mode: "bigint" })
       .default(0n)
       .notNull(),
+    // Recognised as revenue so far (migration 0047). The nightly job earns
+    // each period daily, pro rata by whole days served; this is the cursor
+    // that keeps that step idempotent, and at `recognized_at` it equals
+    // price − refunded.
+    recognizedMicros: bigint("recognized_micros", { mode: "bigint" })
+      .default(0n)
+      .notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/cloud/packages/ledger/src/index.ts
+++ b/cloud/packages/ledger/src/index.ts
@@ -31,10 +31,13 @@ export {
   type PlanEntitlements,
 } from "./plans";
 export {
+  accruePeriod,
   addMonth,
   cancelAccountPlan,
   chargePeriod,
   closeOutSubscriptionForDeletedAccount,
+  deferredMicros,
+  earnedToDateMicros,
   recognizePeriod,
   refundUnearnedPeriod,
   runSubscriptionCycle,

--- a/cloud/packages/ledger/src/integrity.ts
+++ b/cloud/packages/ledger/src/integrity.ts
@@ -26,6 +26,10 @@ export interface LedgerIntegrityOptions {
   // How far a customer's credit balance may go below zero before it counts
   // as a violation. Mirrors the payg_overdraft_micros setting.
   overdraftMicros?: bigint | undefined;
+  // The ceiling for account-days that ran entirely on the operator's shared
+  // key (shared_key_daily_cap_micros). Omitted means the same ceiling as
+  // everybody else's, which is also what the setting falls back to.
+  sharedKeyDailyCapMicros?: bigint | undefined;
   // How long an event may sit unposted before it is a problem rather than a
   // sweep still in flight.
   pendingEventGraceMs?: number | undefined;
@@ -255,7 +259,13 @@ export async function checkDailyCapRespected(
   if (cap === undefined || cap <= 0n) {
     return [];
   }
-  const ceiling = cap + (options.overdraftMicros ?? 0n);
+  const overdraft = options.overdraftMicros ?? 0n;
+  const ceiling = cap + overdraft;
+  // An account-day served entirely by the operator's shared key is judged
+  // against the shared key's own cap — the one the gate applied to it. A
+  // day with any billable turn in it is judged against the main cap, which
+  // is the larger of the two whenever the shared one is set at all.
+  const sharedCeiling = (options.sharedKeyDailyCapMicros ?? cap) + overdraft;
   const now = options.now ?? new Date();
   const windowDays = Math.max(1, options.capWindowDays ?? 7);
   const since = new Date(
@@ -263,22 +273,29 @@ export async function checkDailyCapRespected(
   );
   const rows = await db.execute<{
     account_id: string;
+    ceiling: string;
     day: string;
     spent: string;
   }>(sql`
     select account_id::text as account_id,
            to_char(date_trunc('day', occurred_at at time zone 'UTC'), 'YYYY-MM-DD') as day,
-           sum(${chargeableExpression})::text as spent
+           sum(${chargeableExpression})::text as spent,
+           (case when bool_and(credential_source = 'shared')
+                 then ${sharedCeiling.toString()}::numeric
+                 else ${ceiling.toString()}::numeric end)::text as ceiling
       from ai_usage_records
      where account_id is not null
        and occurred_at >= ${since.toISOString()}::timestamptz
        and ${notAbsorbedSurfaceCondition}
      group by 1, 2
-    having sum(${chargeableExpression}) > ${ceiling.toString()}::numeric
+    having sum(${chargeableExpression}) >
+           case when bool_and(credential_source = 'shared')
+                then ${sharedCeiling.toString()}::numeric
+                else ${ceiling.toString()}::numeric end
   `);
   return rows.map((row) => ({
     check: "daily_cap_respected",
-    detail: `Account ${row.account_id} metered ${row.spent} micros on ${row.day}, past the ${ceiling.toString()} ceiling`,
+    detail: `Account ${row.account_id} metered ${row.spent} micros on ${row.day}, past the ${row.ceiling} ceiling`,
   }));
 }
 
@@ -351,7 +368,7 @@ export async function checkDeferredSubscriptions(
          from ledger_postings p
          join ledger_accounts a on a.id = p.ledger_account_id
         where a.code = 'liability:deferred:subscriptions') as deferred,
-      (select coalesce(sum(price_micros - refunded_micros), 0)
+      (select coalesce(sum(price_micros - refunded_micros - recognized_micros), 0)
          from subscription_periods
         where charged_at is not null and recognized_at is null) as booked
   `);

--- a/cloud/packages/ledger/src/settings.ts
+++ b/cloud/packages/ledger/src/settings.ts
@@ -3,8 +3,9 @@ import { billingSettings } from "@frameos-cloud/db";
 import { LedgerError, type LedgerExecutor } from "./types";
 
 // The knobs that change what metering does: the margin over provider cost,
-// how far a customer may overdraw, and whether metering posts to the ledger
-// at all. Rows in `billing_settings`, editable by a superadmin at
+// the daily caps (one for billable usage, one for the operator's shared
+// key), how far a turn may overrun them, and whether metering posts to the
+// ledger at all. Rows in `billing_settings`, editable by a superadmin at
 // /admin/billing, with a code-level default for every key so a database that
 // has never been seeded still boots with sane numbers.
 //
@@ -18,6 +19,7 @@ export const billingSettingKeys = {
   aiMeteringMode: "ai_metering_mode",
   paygDailyCapMicros: "payg_daily_cap_micros",
   paygOverdraftMicros: "payg_overdraft_micros",
+  sharedKeyDailyCapMicros: "shared_key_daily_cap_micros",
 } as const;
 
 export type BillingSettingKey =
@@ -35,6 +37,13 @@ export interface BillingSettings {
   marginBasisPoints: number;
   meteringMode: MeteringMode;
   overdraftMicros: bigint;
+  // The ceiling for an account running on the operator's SHARED key
+  // (§5.3, §9.3). That usage is our money, not theirs — a free-tier user
+  // hitting `dailyCapMicros` was being "limited" on a bill they do not owe,
+  // and shown a dollar figure with "nothing is billed" under it. Its own,
+  // typically smaller, number; falls back to the daily cap when unset so a
+  // deployment that never touches it behaves exactly as before.
+  sharedKeyDailyCapMicros: bigint;
 }
 
 export const defaultBillingSettings: BillingSettings = {
@@ -42,6 +51,7 @@ export const defaultBillingSettings: BillingSettings = {
   marginBasisPoints: 3_000,
   meteringMode: "shadow",
   overdraftMicros: 1_000_000n,
+  sharedKeyDailyCapMicros: 10_000_000n,
 };
 
 export async function readBillingSettings(
@@ -54,11 +64,12 @@ export async function readBillingSettings(
     .where(inArray(billingSettings.key, Object.values(billingSettingKeys)));
   const values = new Map(rows.map((row) => [row.key, row.value]));
 
+  const dailyCapMicros =
+    microsFrom(values.get(billingSettingKeys.paygDailyCapMicros)) ??
+    microsFrom(env.FRAMEOS_CLOUD_AI_DAILY_CAP_MICROS) ??
+    defaultBillingSettings.dailyCapMicros;
   return {
-    dailyCapMicros:
-      microsFrom(values.get(billingSettingKeys.paygDailyCapMicros)) ??
-      microsFrom(env.FRAMEOS_CLOUD_AI_DAILY_CAP_MICROS) ??
-      defaultBillingSettings.dailyCapMicros,
+    dailyCapMicros,
     marginBasisPoints:
       marginBasisPointsFrom(values.get(billingSettingKeys.aiMarginPercent)) ??
       // Bootstrap for a deployment whose settings row has not been written
@@ -72,6 +83,10 @@ export async function readBillingSettings(
     overdraftMicros:
       microsFrom(values.get(billingSettingKeys.paygOverdraftMicros)) ??
       defaultBillingSettings.overdraftMicros,
+    sharedKeyDailyCapMicros:
+      microsFrom(values.get(billingSettingKeys.sharedKeyDailyCapMicros)) ??
+      microsFrom(env.FRAMEOS_CLOUD_AI_SHARED_KEY_DAILY_CAP_MICROS) ??
+      dailyCapMicros,
   };
 }
 
@@ -135,6 +150,14 @@ function validateSetting(key: BillingSettingKey, value: unknown): void {
         throw new LedgerError(
           "invalid_amount",
           "payg_overdraft_micros must be a non-negative whole number of micro-dollars",
+        );
+      }
+      return;
+    case billingSettingKeys.sharedKeyDailyCapMicros:
+      if (microsFrom(value) === undefined) {
+        throw new LedgerError(
+          "invalid_amount",
+          "shared_key_daily_cap_micros must be a non-negative whole number of micro-dollars",
         );
       }
       return;

--- a/cloud/packages/ledger/src/subscriptions.ts
+++ b/cloud/packages/ledger/src/subscriptions.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNull, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
 import { subscriptionPeriods, subscriptions } from "@frameos-cloud/db";
 import { postEvent, type PostEventOptions } from "./kernel";
 import { readPlan, type BillingPlan } from "./plans";
@@ -39,6 +39,15 @@ import { LedgerError, type LedgerExecutor } from "./types";
 //    now, open one at the new price); a downgrade waits for the rollover
 //    (`next_plan_code`). Recognition earns `price − refunded`, never the full
 //    price over a refund (item 6, and the deferred-revenue invariant).
+//
+// And one the pre-3b pass (§9.3) added: revenue is recognised DAILY, not
+// only at period end. Each night earns `(price − refunded) × whole days
+// served / period length` less what was already recognised, so a
+// calendar-month P&L no longer lags by up to a month. `recognized_micros`
+// on the period row is the cursor; the final step at period end earns
+// whatever is left and stamps `recognized_at`. Whole days on purpose: a job
+// that runs at 04:20 and again at 04:25 must not post a second entry for
+// five minutes of subscription.
 
 /** One calendar month on from `at`, clamped for short months — a
  *  subscription started on the 31st renews on the 30th, the 28th, and so on,
@@ -278,15 +287,20 @@ export async function closeOutSubscriptionForDeletedAccount(
 }
 
 export interface SubscriptionCycleResult {
+  // Daily recognition entries posted tonight, and the revenue they earned.
+  accrued: number;
+  accruedMicros: bigint;
   charged: number;
   failures: { error: unknown; periodId: string }[];
   opened: number;
+  // Periods closed out: earned to the end and stamped `recognized_at`.
   recognized: number;
 }
 
 /**
  * The nightly cycle: open the periods that are due, charge the ones that have
- * started, recognize the ones that have ended. Safe to run repeatedly.
+ * started, earn what the running ones have served so far, and close out the
+ * ones that have ended. Safe to run repeatedly.
  */
 export async function runSubscriptionCycle(
   db: LedgerExecutor,
@@ -294,6 +308,8 @@ export async function runSubscriptionCycle(
 ): Promise<SubscriptionCycleResult> {
   const now = options.now ?? new Date();
   const result: SubscriptionCycleResult = {
+    accrued: 0,
+    accruedMicros: 0n,
     charged: 0,
     failures: [],
     opened: 0,
@@ -324,6 +340,32 @@ export async function runSubscriptionCycle(
       result.charged += 1;
     } catch (error) {
       // One bad period must not stop the rest of the night's work.
+      result.failures.push({ error, periodId: period.id });
+    }
+  }
+
+  // Earn what every running period has served so far. Read after the charge
+  // loop so a period charged tonight accrues tonight too — and only charged
+  // ones, for the same reason the close-out below skips the rest.
+  const running = await db
+    .select()
+    .from(subscriptionPeriods)
+    .where(
+      and(
+        isNotNull(subscriptionPeriods.chargedAt),
+        isNull(subscriptionPeriods.recognizedAt),
+        lte(subscriptionPeriods.periodStart, now),
+      ),
+    )
+    .orderBy(asc(subscriptionPeriods.periodStart));
+  for (const period of running) {
+    try {
+      const earned = await accruePeriod(db, period, now, options);
+      if (earned > 0n) {
+        result.accrued += 1;
+        result.accruedMicros += earned;
+      }
+    } catch (error) {
       result.failures.push({ error, periodId: period.id });
     }
   }
@@ -479,8 +521,21 @@ async function currentPeriod(
   return row;
 }
 
+// What is still sitting in liability:deferred:subscriptions for this period:
+// the price, less what was returned to the customer, less what has already
+// been recognised as revenue. Both a refund and tonight's recognition are
+// bounded by it, which is what keeps the deferred account from going
+// negative whichever order the two happen in.
+export function deferredMicros(period: PeriodRow): bigint {
+  const left = period.priceMicros - period.refundedMicros - period.recognizedMicros;
+  return left > 0n ? left : 0n;
+}
+
+const dayMs = 24 * 60 * 60 * 1000;
+
 // The part of a period's price that has not been earned yet at `at`,
-// pro rata by time, less anything already refunded. Rounded half up once.
+// pro rata by time, less anything already refunded or recognised. Rounded
+// half up once.
 export function unearnedMicros(period: PeriodRow, at: Date): bigint {
   const total = BigInt(period.periodEnd.getTime() - period.periodStart.getTime());
   const remaining = BigInt(
@@ -490,12 +545,41 @@ export function unearnedMicros(period: PeriodRow, at: Date): bigint {
     return 0n;
   }
   const unearned = divideRoundHalfUp(period.priceMicros * (total - remaining), total);
-  const left = period.priceMicros - period.refundedMicros;
+  const left = deferredMicros(period);
   return unearned > left ? left : unearned;
 }
 
-// Ends a period now. What recognition then earns is price − refunded, which
-// after a prorated refund is exactly the part that was served.
+/**
+ * How much of a period has been EARNED by `at`: the earnable amount
+ * (price − refunded) pro rata by whole days served. Whole days, so that the
+ * nightly job posts one entry per day however many times it runs; and the
+ * earnable amount rather than the price, so that a period an upgrade closed
+ * early — whose price − refunded is exactly the served part — is earned over
+ * its shortened length rather than over-recognised on its first night. At
+ * or past the period end it is everything earnable, whatever the rounding
+ * said the night before.
+ */
+export function earnedToDateMicros(period: PeriodRow, at: Date): bigint {
+  const totalMs = period.periodEnd.getTime() - period.periodStart.getTime();
+  const earnable = period.priceMicros - period.refundedMicros;
+  if (totalMs <= 0 || earnable <= 0n) {
+    return earnable > 0n ? earnable : 0n;
+  }
+  const elapsedMs = at.getTime() - period.periodStart.getTime();
+  if (elapsedMs >= totalMs) {
+    return earnable;
+  }
+  if (elapsedMs <= 0) {
+    return 0n;
+  }
+  const servedMs = Math.floor(elapsedMs / dayMs) * dayMs;
+  const earned = divideRoundHalfUp(earnable * BigInt(servedMs), BigInt(totalMs));
+  return earned > earnable ? earnable : earned;
+}
+
+// Ends a period now. What recognition then earns is price − refunded −
+// already recognised, which after a prorated refund is exactly the part
+// that was served and not yet earned.
 async function closePeriodAt(db: LedgerExecutor, period: PeriodRow, at: Date): Promise<void> {
   const end = at.getTime() > period.periodStart.getTime() ? at : new Date(period.periodStart.getTime() + 1);
   await db
@@ -583,7 +667,10 @@ export async function recognizePeriod(
     .where(eq(subscriptionPeriods.id, period.id))
     .limit(1);
   const current = fresh ?? period;
-  const earned = current.priceMicros - current.refundedMicros;
+  // What the daily accruals have not earned yet. With the nightly job
+  // running that is the last day or so; with it broken for a month it is
+  // the whole period, and either way the period ends fully recognised.
+  const earned = deferredMicros(current);
   if (earned > 0n) {
     await postEvent(
       db,
@@ -597,6 +684,7 @@ export async function recognizePeriod(
         payload: {
           ...periodPayload(current, await planNameFor(db, current.planCode)),
           priceMicros: earned.toString(),
+          recognizedMicros: current.recognizedMicros.toString(),
           refundedMicros: current.refundedMicros.toString(),
         },
         source: "subscriptions",
@@ -608,8 +696,84 @@ export async function recognizePeriod(
   // A fully refunded period has nothing to recognize; it is still done.
   await db
     .update(subscriptionPeriods)
-    .set({ recognizedAt: new Date() })
+    .set({
+      recognizedAt: new Date(),
+      recognizedMicros: current.recognizedMicros + earned,
+    })
     .where(eq(subscriptionPeriods.id, period.id));
+}
+
+/**
+ * The daily step: earn what this period has served up to `now` that has not
+ * been recognised yet, and move the cursor. Returns what it earned tonight.
+ * Idempotent on `recognized_micros`: a second run the same night computes
+ * the same "earned so far", finds the cursor already there, and posts
+ * nothing; a crash between the post and the cursor update replays the same
+ * idempotency key next time and then moves the cursor.
+ */
+export async function accruePeriod(
+  db: LedgerExecutor,
+  period: PeriodRow,
+  now: Date,
+  options: PostEventOptions = {},
+): Promise<bigint> {
+  const subscription = await subscriptionFor(db, period);
+  if (!subscription) {
+    throw new LedgerError("invalid_draft", "Period has no subscription");
+  }
+  if (!period.chargedAt || period.recognizedAt) {
+    return 0n;
+  }
+  // Re-read: a refund since the caller loaded the row changes what is
+  // earnable, and the cursor must be the one the last accrual left.
+  const [fresh] = await db
+    .select()
+    .from(subscriptionPeriods)
+    .where(eq(subscriptionPeriods.id, period.id))
+    .limit(1);
+  const current = fresh ?? period;
+  const earned = earnedToDateMicros(current, now);
+  const delta = earned - current.recognizedMicros;
+  if (delta <= 0n) {
+    return 0n;
+  }
+  // Never past what is still deferred: a refund that landed after an
+  // accrual can leave earned-so-far above the remainder, and the deferred
+  // account must not go negative for it (the close-out invariant, §6 check 9).
+  const left = deferredMicros(current);
+  const amount = delta > left ? left : delta;
+  if (amount <= 0n) {
+    return 0n;
+  }
+  const at = now.getTime() < current.periodEnd.getTime() ? now : current.periodEnd;
+  await postEvent(
+    db,
+    {
+      accountId: subscription.accountId,
+      eventType: subscriptionRecognitionEventType,
+      // One key per cursor position, like refunds: the second accrual is a
+      // second fact, not a replay of the first.
+      idempotencyKey: `subscription_recognition:${period.id}:${current.recognizedMicros.toString()}`,
+      // Tonight, not the period end: this is the entry that puts the revenue
+      // in the month it was served. Capped at the period end so a late job
+      // cannot push a finished period's revenue past it.
+      occurredAt: at,
+      payload: {
+        ...periodPayload(current, await planNameFor(db, current.planCode)),
+        priceMicros: amount.toString(),
+        recognizedMicros: current.recognizedMicros.toString(),
+        refundedMicros: current.refundedMicros.toString(),
+      },
+      source: "subscriptions",
+      sourceRef: period.id,
+    },
+    options,
+  );
+  await db
+    .update(subscriptionPeriods)
+    .set({ recognizedMicros: current.recognizedMicros + amount })
+    .where(eq(subscriptionPeriods.id, period.id));
+  return amount;
 }
 
 /**
@@ -638,7 +802,10 @@ export async function refundUnearnedPeriod(
       "This period has already been recognized; refund it with a reversal, not a deferral",
     );
   }
-  const left = period.priceMicros - period.refundedMicros;
+  // What is still deferred, after refunds AND after the daily accruals:
+  // revenue already recognised cannot be handed back from the deferral, it
+  // needs a reversal (a different, deliberate act).
+  const left = deferredMicros(period);
   if (amountMicros <= 0n || amountMicros > left) {
     throw new LedgerError(
       "invalid_amount",

--- a/cloud/packages/ledger/src/test/integration/subscriptions.integration.test.ts
+++ b/cloud/packages/ledger/src/test/integration/subscriptions.integration.test.ts
@@ -151,23 +151,85 @@ describe("a subscriber's life through the books", () => {
     expect(await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 })).toEqual([]);
   });
 
-  it("recognizes the period once it has actually been served", async () => {
+  // §9.3: revenue is recognised daily, pro rata by whole days served, so a
+  // calendar-month P&L does not lag a month behind the periods. Jan 10 → Feb
+  // 10 is 31 days; the second period, Feb 10 → Mar 10, is 28.
+  it("earns the period day by day, never twice for the same day, and closes it out at the end", async () => {
     const accountId = await createAccount();
-    await setAccountPlan(db, accountId, "maker");
+    await setAccountPlan(db, accountId, "maker", { now: t0 });
+    const revenue = () =>
+      accountBalanceMicros(db, systemAccountCodes.revenueSubscriptions);
 
-    // Nothing is earned until the period ends, however many nights run.
-    await runSubscriptionCycle(db);
+    // The night it was taken: nothing served yet, nothing earned.
+    expect(await runSubscriptionCycle(db, { now: t0 })).toMatchObject({ accrued: 0, recognized: 0 });
+    expect(await revenue()).toBe(0n);
+
+    // Ten days in: 1,990,000 × 10/31 = 641,935.48 → 641,935, and the rest
+    // stays deferred.
+    const tenDays = new Date(t0.getTime() + 10 * day);
+    expect(await runSubscriptionCycle(db, { now: tenDays })).toMatchObject({
+      accrued: 1,
+      accruedMicros: 641_935n,
+      recognized: 0,
+    });
+    expect(await revenue()).toBe(641_935n);
+    expect(await deferred()).toBe(1_990_000n - 641_935n);
+
+    // The same night again, and five hours later: no new whole day, no
+    // new entry. This is what lets the job run twice without double-earning.
+    expect(await runSubscriptionCycle(db, { now: tenDays })).toMatchObject({ accrued: 0 });
     expect(
-      await accountBalanceMicros(db, systemAccountCodes.revenueSubscriptions),
-    ).toBe(0n);
+      await runSubscriptionCycle(db, { now: new Date(tenDays.getTime() + 5 * 3600 * 1000) }),
+    ).toMatchObject({ accrued: 0 });
+    expect(await revenue()).toBe(641_935n);
 
-    // Forty days on, the first period is over and a second has opened.
-    const later = new Date(Date.now() + 40 * day);
+    // Forty days on: the first period is over (its remainder earned and the
+    // row closed out) and the second, charged tonight, has served nine of
+    // its 28 days: 1,990,000 × 9/28 = 639,642.86 → 639,643.
+    const later = new Date(t0.getTime() + 40 * day);
     const result = await runSubscriptionCycle(db, { now: later });
     expect(result).toMatchObject({ charged: 1, opened: 1, recognized: 1 });
+    expect(result.accruedMicros).toBe(1_990_000n - 641_935n + 639_643n);
+    expect(await revenue()).toBe(1_990_000n + 639_643n);
+    expect(await deferred()).toBe(1_990_000n - 639_643n);
+    const [first, second] = await periodsFor(accountId);
+    expect(first).toMatchObject({ recognizedMicros: 1_990_000n });
+    expect(first?.recognizedAt).not.toBeNull();
+    expect(second).toMatchObject({ recognizedMicros: 639_643n, recognizedAt: null });
+    // The remainder of the first period was booked on its last day, not on
+    // the night the job happened to run.
+    const closing = (await listJournalEntries(db, { limit: 100 })).filter(
+      (entry) =>
+        entry.entryType === "subscription_recognition" &&
+        entry.postings[0]?.amountMicros === 1_990_000n - 641_935n,
+    );
+    expect(closing).toHaveLength(1);
+    expect(closing[0]?.occurredAt).toEqual(first?.periodEnd);
+    expect(await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 })).toEqual([]);
+  });
+
+  it("refunds only what the daily accruals have not already earned", async () => {
+    const accountId = await createAccount();
+    await setAccountPlan(db, accountId, "studio", { now: t0 });
+    // Ten days earned: 6,990,000 × 10/31 = 2,254,838.7 → 2,254,839.
+    await runSubscriptionCycle(db, { now: new Date(t0.getTime() + 10 * day) });
+    const [period] = await periodsFor(accountId);
+    expect(period?.recognizedMicros).toBe(2_254_839n);
+
+    // The whole price is no longer refundable from the deferral: part of it
+    // is revenue now, and that needs a reversal, not a refund.
+    await expect(refundUnearnedPeriod(db, period!, 6_990_000n)).rejects.toThrow(/no larger than/);
+    const left = 6_990_000n - 2_254_839n;
+    await refundUnearnedPeriod(db, period!, left);
+    expect(await deferred()).toBe(0n);
+
+    // Nothing more to earn, tonight or at the end.
+    const [refunded] = await periodsFor(accountId);
+    expect(await runSubscriptionCycle(db, { now: new Date(t0.getTime() + 20 * day) })).toMatchObject({ accrued: 0 });
+    await recognizePeriod(db, refunded!);
     expect(
       await accountBalanceMicros(db, systemAccountCodes.revenueSubscriptions),
-    ).toBe(1_990_000n);
+    ).toBe(2_254_839n);
     expect(await checkLedgerIntegrity(db, { pendingEventGraceMs: 0 })).toEqual([]);
   });
 
@@ -267,7 +329,9 @@ describe("a subscriber's life through the books", () => {
     expect(await accountBalanceMicros(db, receivable)).toBe(995_000n + 6_990_000n);
     expect(await deferred()).toBe(995_000n + 6_990_000n);
 
-    // The next cycle recognizes the Maker half that was served, no more.
+    // The next cycle recognizes the Maker half that was served, no more —
+    // and a minute into the Studio period is not a whole day, so nothing of
+    // it is earned yet.
     const cycle = await runSubscriptionCycle(db, { now: new Date(halfway.getTime() + 60_000) });
     expect(cycle).toMatchObject({ charged: 0, opened: 0, recognized: 1 });
     expect(

--- a/cloud/scripts/accounting-nightly.sh
+++ b/cloud/scripts/accounting-nightly.sh
@@ -14,17 +14,26 @@ set -euo pipefail
 # tsx, which is why this cannot simply be a Node script either — the same
 # reason object-store-sweep.sh is bash.)
 #
-# Authentication is a personal API token belonging to a superadmin, which is
-# an auth mechanism that already exists rather than a new shared secret:
+# Authentication is an API token on a superadmin account, which is an auth
+# mechanism that already exists rather than a new shared secret:
 #
 #   /etc/frameos-cloud/accounting.env
 #     ACCOUNTING_API_TOKEN=fc_api_...
 #     ACCOUNTING_URL=https://cloud.frameos.net/api/admin/billing/nightly
-#     ACCOUNTING_HEALTHCHECKS_URL=https://hc-ping.com/...   # optional
+#     ACCOUNTING_HEALTHCHECKS_URL=https://hc-ping.com/...   # or "none"
 #
-# Create the token at /account/api-tokens as a superadmin. Run nightly via
+# Whose token: a dedicated service account, minted by
+# scripts/accounting-service-account.sh, NOT a person's. A personal token
+# dies with the person — revoked on their way out, or expired with their
+# account — and the job with it, silently (§9.3). Run nightly via
 # ops/accounting/frameos-cloud-accounting.timer; see
 # cloud/docs/operational-runbooks.md.
+#
+# The healthchecks ping is REQUIRED. This is a dead-man job: the failure
+# mode that matters is not a loud error but a night that never ran, and
+# only an external check that expects a ping can notice that. A deployment
+# that genuinely has nowhere to ping says so with ACCOUNTING_HEALTHCHECKS_URL=none
+# rather than by leaving it unset.
 #
 # Exit status is the alert: 0 when the sweep worked and every invariant
 # holds, 1 when anything needs a human. Violations are NOT fixed
@@ -33,7 +42,10 @@ set -euo pipefail
 
 url="${ACCOUNTING_URL:-http://127.0.0.1:3000/api/admin/billing/nightly}"
 token="${ACCOUNTING_API_TOKEN:?set ACCOUNTING_API_TOKEN in /etc/frameos-cloud/accounting.env}"
-ping_url="${ACCOUNTING_HEALTHCHECKS_URL:-}"
+ping_url="${ACCOUNTING_HEALTHCHECKS_URL:?set ACCOUNTING_HEALTHCHECKS_URL in /etc/frameos-cloud/accounting.env (a healthchecks.io ping URL, or "none" to opt out of the dead-man check on purpose)}"
+if [ "$ping_url" = "none" ]; then
+  ping_url=""
+fi
 
 response="$(mktemp)"
 trap 'rm -f "$response"' EXIT

--- a/cloud/scripts/accounting-service-account.sh
+++ b/cloud/scripts/accounting-service-account.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Mint (or rotate) the API token the nightly accounting job runs as, on a
+# dedicated superadmin service account rather than a person's.
+#
+# Usage:
+#   scripts/accounting-service-account.sh            # create account if absent, mint a token
+#   scripts/accounting-service-account.sh --rotate   # revoke the job's live tokens, mint a new one
+#
+# Why a service account (cloud/docs/accounting-todo.md §9.3): a personal
+# token is revoked on its owner's way out, or expires with their account,
+# and the job dies with it — silently, at 04:20, with nothing but a missing
+# healthchecks ping to say so. The account made here has no login identity
+# (no account_identities row), so nobody can sign in as it; the token is
+# its only door, and this script is the only thing that mints one.
+#
+# Prints the token ONCE. Put it in /etc/frameos-cloud/accounting.env as
+# ACCOUNTING_API_TOKEN. Uses DATABASE_URL from the environment or .env.local,
+# like grant-superadmin.sh — run it on the production box or over a tunnel.
+#
+# The token format and hash match src/lib/api-tokens.ts + secrets.ts:
+# `fc_api_` + base64url(32 random bytes), stored as base64url(sha256(token)).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+rotate=false
+if [ "${1:-}" = "--rotate" ]; then
+  rotate=true
+  shift
+fi
+
+email="${ACCOUNTING_SERVICE_EMAIL:-accounting-job@frameos.net}"
+name="${ACCOUNTING_SERVICE_NAME:-Accounting nightly job}"
+token_name="${ACCOUNTING_TOKEN_NAME:-nightly accounting job}"
+
+if [ -z "${DATABASE_URL:-}" ] && [ -f .env.local ]; then
+  DATABASE_URL="$(sed -n 's/^DATABASE_URL=//p' .env.local | head -n 1)"
+fi
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is not set and .env.local does not provide it" >&2
+  exit 1
+fi
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+token="fc_api_$(openssl rand 32 | b64url)"
+token_hash="$(printf '%s' "$token" | openssl dgst -sha256 -binary | b64url)"
+token_hint="${token:0:11}"
+
+account_id="$(psql "$DATABASE_URL" --tuples-only --no-align -v ON_ERROR_STOP=1 \
+  --set=email="$email" --set=name="$name" <<'SQL'
+INSERT INTO accounts (display_name, primary_email, is_superadmin)
+SELECT :'name', :'email', true
+WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE primary_email = :'email');
+UPDATE accounts SET is_superadmin = true, updated_at = now()
+ WHERE primary_email = :'email' AND NOT is_superadmin;
+SELECT id FROM accounts WHERE primary_email = :'email';
+SQL
+)"
+account_id="$(printf '%s' "$account_id" | tail -n 1)"
+if [ -z "$account_id" ]; then
+  echo "Could not create or find the service account $email" >&2
+  exit 1
+fi
+
+# A service account must never be able to log in: refuse if somebody has
+# attached an identity to it since.
+# (Heredoc, not -c: psql only interpolates :'var' in SQL read from stdin.)
+identities="$(psql "$DATABASE_URL" --tuples-only --no-align -v ON_ERROR_STOP=1 \
+  --set=id="$account_id" <<'SQL'
+SELECT count(*) FROM account_identities WHERE account_id = :'id';
+SQL
+)"
+if [ "$identities" != "0" ]; then
+  echo "Refusing: $email has $identities login identity(ies) — a service account must have none" >&2
+  exit 1
+fi
+
+if [ "$rotate" = true ]; then
+  revoked="$(psql "$DATABASE_URL" --tuples-only --no-align -v ON_ERROR_STOP=1 \
+    --set=id="$account_id" --set=token_name="$token_name" <<'SQL'
+UPDATE account_api_tokens SET revoked_at = now(), updated_at = now()
+ WHERE account_id = :'id' AND name = :'token_name' AND revoked_at IS NULL
+RETURNING token_hint;
+SQL
+)"
+  echo "Revoked: ${revoked:-nothing was live}"
+fi
+
+psql "$DATABASE_URL" --tuples-only --no-align -v ON_ERROR_STOP=1 \
+  --set=id="$account_id" --set=token_name="$token_name" \
+  --set=token_hash="$token_hash" --set=token_hint="$token_hint" >/dev/null <<'SQL'
+INSERT INTO account_api_tokens (account_id, name, access, token_hash, token_hint)
+VALUES (:'id', :'token_name', 'full', :'token_hash', :'token_hint');
+INSERT INTO audit_events (account_id, actor, event_type, target, metadata)
+VALUES (:'id', '{"kind":"script","script":"accounting-service-account.sh"}'::jsonb,
+        'api_token.created', json_build_object('accountId', :'id', 'kind', 'account')::jsonb,
+        json_build_object('name', :'token_name', 'tokenHint', :'token_hint')::jsonb);
+SQL
+
+cat <<MSG
+Service account: $email ($account_id)
+Token (shown once — put it in /etc/frameos-cloud/accounting.env as ACCOUNTING_API_TOKEN):
+
+  $token
+
+MSG

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -129,7 +129,7 @@ file's "Current gaps".
   ladder, double-entry ledger, one invoice a month
   (`cloud/docs/accounting-todo.md` §0). Still open there, and blocking the
   first invoice: the payment provider (merchant-of-record vs direct PSP,
-  §8.7), which legal entity invoices and from where (§9.3), and the plan
+  §8.7), which legal entity invoices and from where (§8.15), and the plan
   numbers (§8.13).
 - `store:publish` human review: always, only for the public store, or
   pre-review for risky (shell-app) scenes? Today it is automated moderation +


### PR DESCRIPTION
Does every item on `cloud/docs/accounting-todo.md` §9.3 (the list left after #432), written up in the doc as **§9.6**.

## What changed

- **Daily revenue recognition** (migration `0047`): `subscription_periods.recognized_micros` is the cursor; the nightly cycle gained an accrual step that earns `(price − refunded) × whole days served ÷ period length` minus what was already recognised, and the close-out at period end earns the rest. Whole days, so a job that runs twice in a night posts nothing the second time. Refunds are bounded by what is still deferred after accruals; the deferred-revenue invariant subtracts the cursor. A Maker month now shows up as ~31 entries instead of one a month late.
- **Shared-key daily cap**: `billing_settings.shared_key_daily_cap_micros` (falls back to the main cap until set, so nothing changes on its own). `resolveAiAccess` picks it by credential source; the 402 body carries `allowance: "shared" | "billable"`; the scene AI panel, the app-chat abort message and `/account/ai` say it is the operator's allowance, not the account's limit; the nightly cap check judges shared-only account-days against the shared ceiling. New field on the admin settings form.
- **Operator surfaces**: `PUT /api/admin/billing/customers/[id]/ai` and `…/plan`, both reason-required and audited (`admin.ai_disabled/enabled`, `admin.plan_changed/canceled`). Non-public plans allowed, self-serve gate not applied (that gate exists for customers). Controls live on the customer statement page, which now leads with the receivable and hides the prepaid shelf statements unless something posted to them.
- **Nightly job identity**: `cloud/scripts/accounting-service-account.sh` mints the token on a dedicated superadmin account with no login identity (psql only, so it runs on the box). `ACCOUNTING_HEALTHCHECKS_URL` is now required (`none` opts out on purpose) and `install.sh` refuses to arm the timer on placeholders.
- **Phase 2 gate**: `apps/auth-web/scripts/ai-metering-compare.mjs` compares `ai_usage_records` with PostHog `$ai_generation`/`scene_convert` and with OpenAI's usage + costs API, per UTC day and model, exit 1 above 1% disagreement.
- Docs: §0 says plans bill in advance (and `/account/ai` says so on the plan line); §3.6 describes daily recognition; §5.1/§5.3 updated; **§8.15** lists the invoicing-entity questions (entity, VAT position, gapless numbering, OSS, reverse charge) in decision order; 3b's `invoices` migration is `0048`; `docs/todo.md`'s two stale lines point at the decisions.

## Two findings

1. **The nightly accounting job has never been installed on production** — no `/etc/frameos-cloud/accounting.env`, no timer. Next operator step: run the service-account script on the box, put the token and a healthchecks URL in the env, run `ops/accounting/install.sh`.
2. **Gate result**: metering went live on prod at 22:27 UTC on 2026-08-31, so there was one full day to compare, not a week. On it the meter and PostHog agree **exactly** (2026-09-01, gpt-5.6-terra: 7 turns / 18 rounds, 302,723 input incl. 218,110 cached, 11,488 output, 986 reasoning), and the five metered scene conversions match PostHog token-for-token by request id. The provider-invoice side needs an OpenAI **org admin** key that no env has; §8.2 is still settled only there. Re-run over a real week before flipping metering to live.

## Not done (needs the owner)

§8.15 — which legal entity invoices — is a decision, not code.

## Tests

- ledger integration: 51 pass (new: day-by-day recognition walk, refund after accruals; shared-cap invariant)
- auth-web integration (admin-billing, account-usage): 20 pass (new: operator routes incl. 403/404/reason-required and audit rows; shared-key cap refusal wording)
- eslint clean on touched files; service-account script exercised against the local test DB (hash/hint match `api-tokens.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTK7dyDo8WLpU25yJPGWAQ
