### PR TITLE
Release: one signed ESP32 image per flash layout; the backend flashes the matching one

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -523,6 +523,133 @@ jobs:
             release-assets/*-esp32-c3-generic-size.json
           if-no-files-found: error
 
+  # The same firmware on every other flash layout a board can have: one signed
+  # image per chip × {4mb,8mb,16mb,32mb}, minus the two the generic pair
+  # already IS (esp32-s3 = 8MB, esp32-c3 = 4MB). A backend then flashes a
+  # 16MB XTEINK X4 or a 32MB 13.3E6 board with the partition table it actually
+  # has instead of the generic image's, which is step 1 of docs/todo.md "the
+  # self-hosted backend flashes what the cloud flashes". One job per chip on
+  # GitHub-hosted runners (the three layouts share one build tree and, on the
+  # S3, one Nim compile) so nothing here queues behind the epyc pool; the
+  # generic job above stays exactly as it was — the cloud flasher depends on
+  # its assets and its Depot layer cache.
+  build-esp32-layout-firmware:
+    name: Build ESP32 firmware per flash layout
+    needs: [update-versions]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - chip: esp32-s3
+            layouts: "4mb 16mb 32mb"
+          - chip: esp32-c3
+            layouts: "8mb 16mb 32mb"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.update-versions.outputs.release_sha }}
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      # Byte-identical in its cache-relevant inputs to the esp32-ci builds in
+      # this workflow's generic job and in e2e-docker.yml, so it only ever
+      # pulls the warm image (see the generic job's comment).
+      - name: Build ESP32 CI Docker image
+        uses: depot/build-push-action@v1
+        with:
+          project: rsbh2wrlkj
+          token: ${{ secrets.DEPOT_TOKEN }}
+          context: .
+          target: esp32-ci
+          tags: frameos-esp32-ci
+          load: true
+          push: false
+
+      - name: Build firmware
+        timeout-minutes: 60
+        env:
+          DOCKER_VERSION: ${{ needs.update-versions.outputs.docker_version }}
+          CHIP: ${{ matrix.chip }}
+          LAYOUTS: ${{ matrix.layouts }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          # Values reach the container through the environment, never spliced
+          # into the inner script (same reason as the generic job).
+          docker run --rm \
+            -e FRAMEOS_SELECTED_PANEL=EPD_7in5_V2 \
+            -e DOCKER_VERSION \
+            -e CHIP \
+            -e LAYOUTS \
+            -e FRAMEOS_VERSION="$DOCKER_VERSION" \
+            -v "$PWD/release-assets:/release-assets" \
+            frameos-esp32-ci \
+            bash -lc '
+              set -euo pipefail
+              for layout in $LAYOUTS; do
+                platform="$CHIP-$layout"
+                # Fresh build dir per layout (the script refuses to reuse one);
+                # the Nim side is shared through nimcache.
+                FRAMEOS_ESP32_PLATFORM="$platform" \
+                  FRAMEOS_ESP32_BUILD_DIR="build-ci-$layout" \
+                  bash embedded/esp32/ci_build_image.sh
+                # Same trio as the generic assets, same meaning: the merged
+                # image is what a USB flasher writes from 0x0, -app.bin is the
+                # bare app image an OTA slot accepts, -size.json is the
+                # size-report baseline for this layout.
+                cp "embedded/esp32/build-ci-$layout/merged-binary.bin" \
+                  "/release-assets/frameos-$DOCKER_VERSION-$platform.bin"
+                cp "embedded/esp32/build-ci-$layout/frameos_esp32.bin" \
+                  "/release-assets/frameos-$DOCKER_VERSION-$platform-app.bin"
+                cp "embedded/esp32/build-ci-$layout/firmware-size.json" \
+                  "/release-assets/frameos-$DOCKER_VERSION-$platform-size.json"
+              done
+            '
+          ls -lh release-assets/
+
+      # Same signing step as the generic job: every image gets its .minisig,
+      # a missing secret fails the release.
+      - name: Sign ESP32 firmware
+        env:
+          FRAMEOS_FIRMWARE_SIGNING_KEY: ${{ secrets.FRAMEOS_FIRMWARE_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FRAMEOS_FIRMWARE_SIGNING_KEY:-}" ]; then
+            echo "::error::FRAMEOS_FIRMWARE_SIGNING_KEY secret is not set — refusing to publish unsigned firmware"
+            exit 1
+          fi
+          python3 -m pip install --quiet --break-system-packages cryptography==50.0.0 \
+            || python3 -m pip install --quiet cryptography==50.0.0
+          keyfile=$(mktemp)
+          printf '%s\n' "$FRAMEOS_FIRMWARE_SIGNING_KEY" > "$keyfile"
+          status=0
+          python3 tools/sign_firmware.py sign --secret "$keyfile" \
+            release-assets/frameos-*.bin || status=$?
+          shred -u "$keyfile"
+          [ "$status" -eq 0 ] || exit "$status"
+          for bin in release-assets/frameos-*.bin; do
+            python3 tools/sign_firmware.py verify \
+              --public release-assets/firmware-signing.pub "$bin"
+          done
+          ls -lh release-assets/
+
+      - name: Upload ESP32 firmware
+        uses: actions/upload-artifact@v4
+        with:
+          # Downloaded by the github-release job by the frameos-<version>-*
+          # name pattern.
+          name: frameos-${{ needs.update-versions.outputs.docker_version }}-${{ matrix.chip }}-layouts
+          path: |
+            release-assets/*-${{ matrix.chip }}-*mb.bin
+            release-assets/*-${{ matrix.chip }}-*mb.bin.minisig
+            release-assets/*-${{ matrix.chip }}-*mb-app.bin
+            release-assets/*-${{ matrix.chip }}-*mb-app.bin.minisig
+            release-assets/*-${{ matrix.chip }}-*mb-size.json
+          if-no-files-found: error
+
   # Prebuilt thin-client firmware for Raspberry Pi Pico W / Pico 2 W (the
   # Pimoroni Inky Frame family). Generic on purpose: UF2s flash over BOOTSEL
   # drag-drop and provision over the USB serial console, the backend never
@@ -727,7 +854,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [update-versions, push-multiarch, build-prebuilt-cross, build-buildroot-release-image, build-esp32-generic-firmware, build-pico-firmware, update-addon-repo, release-notes]
+    needs: [update-versions, push-multiarch, build-prebuilt-cross, build-buildroot-release-image, build-esp32-generic-firmware, build-esp32-layout-firmware, build-pico-firmware, update-addon-repo, release-notes]
     runs-on: ubuntu-latest
     steps:
       # Shallow: this job only needs a working directory for `gh` and the

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -214,9 +214,11 @@ jobs:
           gh release view --repo "$GITHUB_REPOSITORY" --json tagName,assets > .firmware-size/release.json
           tag="$(jq -r .tagName .firmware-size/release.json)"
           echo "BASELINE_TAG=$tag" >> "$GITHUB_ENV"
-          # Size documents published by the release workflow, when present.
+          # Size documents published by the release workflow, when present —
+          # the generic pair plus one per flash layout, so the 32MB build
+          # above diffs against its own baseline rather than none.
           gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-            --pattern '*-esp32-*-generic-size.json' --dir .firmware-size/baseline || true
+            --pattern '*-esp32-*-size.json' --dir .firmware-size/baseline || true
           for f in .firmware-size/baseline/*-size.json; do
             [ -f "$f" ] || continue
             platform="$(jq -r .platform "$f")"

--- a/backend/app/api/firmware_release.py
+++ b/backend/app/api/firmware_release.py
@@ -42,19 +42,24 @@ import httpx
 from fastapi import HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
+from app.tasks.embedded_firmware import embedded_release_asset_names
+
 from . import api_project
 
 RELEASE_API_URL = "https://api.github.com/repos/FrameOS/frameos/releases/latest"
 
-# Explicit allow-list of platform -> exact asset suffix, kept in sync with
-# firmware-release.ts provisioningAssets (which is kept in sync with the esp32
-# job in .github/workflows/docker-publish-multi.yml). These are the MERGED
-# provisioning images (bootloader at 0x0, partition table, blank otadata, app)
-# — what a flasher writes to a board, not the bare OTA app image.
+# Explicit allow-list of platform -> exact asset suffix. The ESP32 entries
+# come from the flash profiles (EMBEDDED_FLASH_PROFILES.releaseAssets, one
+# image per chip and flash layout, generic first) — the same table the
+# provisioning plan picks from, so the listing and the plan cannot disagree
+# about what exists. The cloud's firmware-release.ts provisioningAssets lists
+# only the generic pair; the esp32 jobs in
+# .github/workflows/docker-publish-multi.yml publish all of them. These are
+# the MERGED provisioning images (bootloader at 0x0, partition table, blank
+# otadata, app) — what a flasher writes to a board, not the bare OTA app image.
 PROVISIONING_ASSETS: list[dict[str, str]] = [
-    {"platform": "esp32-s3-generic", "suffix": "-esp32-s3-generic.bin"},
+    *({"platform": asset, "suffix": f"-{asset}.bin"} for asset in embedded_release_asset_names()),
     {"platform": "esp32-s3-epd7in5v2", "suffix": "-esp32-s3-epd7in5v2.bin"},
-    {"platform": "esp32-c3-generic", "suffix": "-esp32-c3-generic.bin"},
     {"platform": "raspberry-pi-32", "suffix": "-raspberry-pi-32-buildroot.img.gz"},
     {"platform": "raspberry-pi-64", "suffix": "-raspberry-pi-64-buildroot.img.gz"},
     {"platform": "raspberry-pi-5", "suffix": "-raspberry-pi-5-buildroot.img.gz"},
@@ -64,9 +69,7 @@ PROVISIONING_ASSETS: list[dict[str, str]] = [
 # gigabyte-sized buildroot SD images appear in the listing but are not
 # streamable through this route.
 STREAMABLE_PLATFORMS = {
-    "esp32-s3-generic",
-    "esp32-s3-epd7in5v2",
-    "esp32-c3-generic",
+    entry["platform"] for entry in PROVISIONING_ASSETS if entry["platform"].startswith("esp32-")
 }
 
 # Development / self-hosted escape hatch: point this at a locally built merged
@@ -128,6 +131,20 @@ async def _latest_release_cached() -> Optional[dict[str, Any]]:
     _release_cache["at"] = now
     _release_cache["release"] = release
     return release
+
+
+def published_provisioning_assets(release: Optional[dict[str, Any]]) -> Optional[set[str]]:
+    """The provisioning platforms a release listing actually carries, or None
+    when there is no listing to read (the provisioning plan then falls back
+    to the generic image rather than guessing)."""
+    if release is None:
+        return None
+    return {entry["platform"] for entry in PROVISIONING_ASSETS if _find_asset(release, entry["suffix"])}
+
+
+async def latest_published_provisioning_assets() -> Optional[set[str]]:
+    """Same, for the cached latest release — what the provisioning route asks."""
+    return published_provisioning_assets(await _latest_release_cached())
 
 
 def _find_asset(release: dict[str, Any], suffix: str) -> Optional[dict[str, Any]]:

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -177,6 +177,7 @@ from app.tasks.buildroot_image import (
 from app.codegen.drivers_nim import frame_compilation_mode
 from app.drivers.devices import apply_device_config_defaults, apply_device_gpio_button_defaults
 from app.api.project_scope import project_get_or_404
+from app.api.firmware_release import latest_published_provisioning_assets
 from app.utils.local_exec import exec_local_command
 from app.utils.jwt_tokens import validate_scoped_token
 from app.tenancy import current_project_id, get_user_project
@@ -3408,8 +3409,12 @@ async def api_frame_embedded_provisioning(
         _not_found()
     if (frame.mode or "rpios") != "embedded":
         _bad_request("Firmware provisioning is only available for embedded frames")
+    # Which images the release carries decides between the layout-matched
+    # asset and the generic one; the listing is the same cached lookup the
+    # flasher's download goes through, so this costs no GitHub request.
+    published_assets = await latest_published_provisioning_assets()
     try:
-        return {"provisioning": embedded_provisioning_plan(frame)}
+        return {"provisioning": embedded_provisioning_plan(frame, published_assets)}
     except ValueError as exc:
         _bad_request(str(exc))
 

--- a/backend/app/api/tests/test_embedded_firmware.py
+++ b/backend/app/api/tests/test_embedded_firmware.py
@@ -39,6 +39,7 @@ from app.tasks.embedded_firmware import (
     embedded_pixel_format_for_panel,
     embedded_pixie_path,
     embedded_provisioning_plan,
+    embedded_release_asset_names,
     embedded_required_sdkconfig_for_frame,
     embedded_render_psram_bytes,
     embedded_render_canvas_bytes_per_pixel,
@@ -1407,6 +1408,66 @@ def test_provisioning_plan_warns_about_the_published_images_flash_layout():
     assert any("no OTA slot" in warning for warning in plan["warnings"])
 
 
+def test_provisioning_plan_prefers_the_image_built_for_the_frames_flash_layout():
+    """Once the release publishes per-layout images, a 16MB XTEINK X4 is
+    flashed with the 16MB OTA layout — the whole chip, and OTA — not the
+    generic 4MB image, and neither layout warning applies."""
+    frame = Frame(id=9, embedded={"hardwarePreset": "xteink_x4"}, server_host="host",
+                  server_api_key="key", network={"wifiSSID": "net"})
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame, published_assets={"esp32-c3-generic", "esp32-c3-16mb"})
+
+    assert plan["releasePlatform"] == "esp32-c3-16mb"
+    assert plan["releaseFlashSize"] == "16MB"
+    assert not any("partition layout" in warning for warning in plan["warnings"])
+    assert not any("no OTA slot" in warning for warning in plan["warnings"])
+
+
+def test_provisioning_plan_falls_back_to_the_generic_image_without_a_layout_match():
+    """An older release (no per-layout images), or no listing at all, keeps
+    flashing the generic image with the same warnings as before."""
+    frame = Frame(id=9, embedded={"hardwarePreset": "xteink_x4"}, server_host="host",
+                  server_api_key="key", network={"wifiSSID": "net"})
+    ensure_embedded_frame_defaults(frame)
+
+    for published in ({"esp32-c3-generic", "esp32-s3-generic"}, None):
+        plan = embedded_provisioning_plan(frame, published_assets=published)
+        assert plan["releasePlatform"] == "esp32-c3-generic"
+        assert plan["releaseFlashSize"] == "4MB"
+        assert any("4MB partition layout" in warning for warning in plan["warnings"])
+
+
+def test_provisioning_plan_never_needs_a_listing_for_the_generic_layouts():
+    """The generic images ARE the 8MB S3 and 4MB C3 layouts, so a frame on one
+    of those resolves to them whatever the release lists."""
+    frame = Frame(id=9, device="waveshare.EPD_7in5_V2", server_host="host",
+                  server_api_key="key", network={"wifiSSID": "net"})
+    ensure_embedded_frame_defaults(frame)
+
+    plan = embedded_provisioning_plan(frame, published_assets=set())
+
+    assert plan["releasePlatform"] == "esp32-s3-generic"
+    assert plan["releaseFlashSize"] == "8MB"
+
+
+def test_release_asset_names_cover_every_flash_layout_once():
+    names = embedded_release_asset_names()
+    # Generic first: they are the fallback and what the cloud flasher ships.
+    assert names[:2] == ["esp32-s3-generic", "esp32-c3-generic"]
+    assert len(names) == len(set(names))
+    assert set(names) == {
+        "esp32-s3-generic",
+        "esp32-c3-generic",
+        "esp32-s3-4mb",
+        "esp32-s3-16mb",
+        "esp32-s3-32mb",
+        "esp32-c3-8mb",
+        "esp32-c3-16mb",
+        "esp32-c3-32mb",
+    }
+
+
 def test_provisioning_plan_sends_sd_card_pins_before_enabling_the_socket():
     frame = Frame(
         id=9,
@@ -1492,7 +1553,16 @@ def test_provisioning_plan_warns_when_the_hostname_cannot_be_provisioned():
 async def test_provisioning_endpoint_returns_the_plan(async_client):
     frame = await create_embedded_frame(async_client)
 
-    response = await async_client.get(f"/api/frames/{frame['id']}/embedded/provisioning")
+    # The route consults the cached release listing to pick a layout-matched
+    # image; GitHub is not on the test's network.
+    from unittest.mock import AsyncMock, patch
+
+    from app.api import firmware_release
+
+    firmware_release.clear_release_cache()
+    with patch("app.api.firmware_release._fetch_latest_release", new_callable=AsyncMock, return_value=None):
+        response = await async_client.get(f"/api/frames/{frame['id']}/embedded/provisioning")
+    firmware_release.clear_release_cache()
 
     assert response.status_code == 200, response.text
     plan = response.json()["provisioning"]

--- a/backend/app/api/tests/test_firmware_release.py
+++ b/backend/app/api/tests/test_firmware_release.py
@@ -82,6 +82,54 @@ async def test_firmware_listing(async_client):
     second_fetch.assert_not_awaited()
 
 
+def _asset(name: str, size: int) -> dict:
+    return {
+        "name": name,
+        "size": size,
+        "browser_download_url": f"https://github.com/FrameOS/frameos/releases/download/v1.3.0/{name}",
+    }
+
+
+@pytest.mark.asyncio
+async def test_firmware_listing_includes_the_per_layout_images(async_client):
+    # A release since docs/todo.md step 1 carries one image per chip and flash
+    # layout next to the generic pair; the listing names each by its platform
+    # and still never lists a bare -app.bin.
+    release = {
+        "tag_name": "v1.3.0",
+        "assets": [
+            *RELEASE["assets"],
+            _asset("frameos-1.3.0-esp32-s3-32mb.bin", 70),
+            _asset("frameos-1.3.0-esp32-s3-32mb-app.bin", 50),
+            _asset("frameos-1.3.0-esp32-c3-16mb.bin", 40),
+        ],
+    }
+    with patch_release(release=release):
+        response = await async_client.get("/api/frames/firmware")
+
+    assert response.status_code == 200, response.text
+    assert [asset["platform"] for asset in response.json()["assets"]] == [
+        "esp32-s3-generic",
+        "esp32-c3-generic",
+        "esp32-c3-16mb",
+        "esp32-s3-32mb",
+        "raspberry-pi-64",
+    ]
+    assert firmware_release_module.published_provisioning_assets(release) == {
+        "esp32-s3-generic",
+        "esp32-c3-generic",
+        "esp32-c3-16mb",
+        "esp32-s3-32mb",
+        "raspberry-pi-64",
+    }
+    # No listing at all is "unknown", not "nothing published".
+    assert firmware_release_module.published_provisioning_assets(None) is None
+    # Every per-layout image is streamable like the generic ones.
+    assert "esp32-c3-16mb" in firmware_release_module.STREAMABLE_PLATFORMS
+    assert "esp32-s3-32mb" in firmware_release_module.STREAMABLE_PLATFORMS
+    assert "raspberry-pi-64" not in firmware_release_module.STREAMABLE_PLATFORMS
+
+
 @pytest.mark.asyncio
 async def test_firmware_listing_502_when_github_unreachable(async_client):
     with patch_release(release=None):

--- a/backend/app/tasks/embedded_firmware.py
+++ b/backend/app/tasks/embedded_firmware.py
@@ -569,6 +569,15 @@ EMBEDDED_PANEL_FORMATS = {
 EMBEDDED_SUPPORTED_PANELS = {"none", *EMBEDDED_PANEL_FORMATS.keys()}
 EMBEDDED_FLASH_OFFSET = "0x0"
 EMBEDDED_DEFAULT_FLASH_SIZE = "8MB"
+# One entry per flash layout. Two things live here, on their way to being
+# one: the partition table + sdkconfig overlay the per-frame builds still
+# compile with, and ``releaseAssets`` — the published release image (per
+# chip) built with exactly that layout, which is what a board is flashed
+# with instead of a build (docs/todo.md, "the self-hosted backend flashes
+# what the cloud flashes"; the builds go in its step 4, the assets stay).
+# The asset names are the esp32 jobs' in .github/workflows/docker-publish-
+# multi.yml via embedded/esp32/ci_build_image.sh; the generic images ARE
+# the 8MB (S3) and 4MB (C3) layouts, so those entries name them.
 EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
     # Pico W (RP2040). Informational only: pico-family firmware is a generic
     # UF2 flashed over BOOTSEL, the backend never builds or partitions it.
@@ -578,6 +587,7 @@ EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
         "sdkconfigDefaults": (),
         "partitionTable": None,
         "otaSupported": False,
+        "releaseAssets": {},
     },
     "4MB": {
         "flashSize": "4MB",
@@ -585,6 +595,7 @@ EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
         "sdkconfigDefaults": ("sdkconfig.defaults", "sdkconfig.defaults.4mb-no-ota"),
         "partitionTable": "partitions_4mb.csv",
         "otaSupported": False,
+        "releaseAssets": {"esp32-s3": "esp32-s3-4mb", "esp32-c3": "esp32-c3-generic"},
     },
     "8MB": {
         "flashSize": "8MB",
@@ -592,6 +603,7 @@ EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
         "sdkconfigDefaults": ("sdkconfig.defaults",),
         "partitionTable": "partitions.csv",
         "otaSupported": True,
+        "releaseAssets": {"esp32-s3": "esp32-s3-generic", "esp32-c3": "esp32-c3-8mb"},
     },
     "16MB": {
         "flashSize": "16MB",
@@ -599,6 +611,7 @@ EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
         "sdkconfigDefaults": ("sdkconfig.defaults", "sdkconfig.defaults.16mb-ota"),
         "partitionTable": "partitions_ota_16mb.csv",
         "otaSupported": True,
+        "releaseAssets": {"esp32-s3": "esp32-s3-16mb", "esp32-c3": "esp32-c3-16mb"},
     },
     "32MB": {
         "flashSize": "32MB",
@@ -606,18 +619,55 @@ EMBEDDED_FLASH_PROFILES: dict[str, dict[str, Any]] = {
         "sdkconfigDefaults": ("sdkconfig.defaults", "sdkconfig.defaults.32mb-ota"),
         "partitionTable": "partitions_ota_32mb.csv",
         "otaSupported": True,
+        "releaseAssets": {"esp32-s3": "esp32-s3-32mb", "esp32-c3": "esp32-c3-32mb"},
     },
 }
 # The published GENERIC images (release assets), and the layout each is built
-# with — the esp32 job in .github/workflows/docker-publish-multi.yml, via
-# embedded/esp32/ci_build_image.sh. They carry no per-frame configuration at
-# all: a board flashed with one is told what it is over the USB console
-# afterwards (embedded_provisioning_plan). Keep in sync with
-# PROVISIONING_ASSETS in app/api/firmware_release.py.
+# with. They carry no per-frame configuration at all: a board flashed with
+# one is told what it is over the USB console afterwards
+# (embedded_provisioning_plan). These are the fallback when a release predates
+# the per-layout assets above, and what the cloud flasher ships. Keep in sync
+# with PROVISIONING_ASSETS in app/api/firmware_release.py.
 EMBEDDED_RELEASE_FIRMWARE: dict[str, dict[str, str]] = {
     "esp32-s3": {"asset": "esp32-s3-generic", "flashSize": "8MB"},
     "esp32-c3": {"asset": "esp32-c3-generic", "flashSize": "4MB"},
 }
+
+
+def embedded_release_asset_names() -> list[str]:
+    """Every release asset the flash profiles name, generic ones first."""
+    names = [release["asset"] for release in EMBEDDED_RELEASE_FIRMWARE.values()]
+    for profile in EMBEDDED_FLASH_PROFILES.values():
+        for asset in profile["releaseAssets"].values():
+            if asset not in names:
+                names.append(asset)
+    return names
+
+
+def embedded_release_firmware_for_frame(
+    frame: Frame, published_assets: Optional[set[str]] = None
+) -> Optional[dict[str, Any]]:
+    """The release image to flash this frame with: the one built for its
+    flash layout when the release publishes it, else the chip's generic image.
+
+    ``published_assets`` is the set of provisioning platforms the current
+    release actually carries (app/api/firmware_release.py). None means
+    "unknown" (GitHub unreachable, or a caller with no listing) and resolves
+    to the generic image, which every release since the flasher exists has
+    shipped — the size-matched assets only started with docs/todo.md step 1,
+    so an older release must keep flashing.
+    """
+    platform = embedded_platform_for_frame(frame)
+    generic = EMBEDDED_RELEASE_FIRMWARE.get(platform)
+    if generic is None:
+        return None
+    flash_size = embedded_flash_size_for_frame(frame)
+    profile = EMBEDDED_FLASH_PROFILES[flash_size]
+    asset = profile["releaseAssets"].get(platform)
+    if asset and (asset == generic["asset"] or (published_assets is not None and asset in published_assets)):
+        return {"asset": asset, "flashSize": flash_size, "otaSupported": bool(profile["otaSupported"])}
+    generic_profile = EMBEDDED_FLASH_PROFILES[generic["flashSize"]]
+    return {**generic, "otaSupported": bool(generic_profile["otaSupported"])}
 # Memory guardrail (M4): the on-device renderer composites into a pixie canvas
 # (frameos/src/embedded/embedded_runtime.nim `renderCanvas`), packs it to the
 # selected panel format, and needs headroom for the Nim heap + QuickJS. The
@@ -1686,8 +1736,8 @@ def _provisioning_setting(key: str, value: object, secret: bool = False) -> dict
     return {"key": key, "value": str(value), "secret": secret}
 
 
-def embedded_provisioning_plan(frame: Frame) -> dict[str, Any]:
-    """What the published GENERIC firmware has to be told to become this frame.
+def embedded_provisioning_plan(frame: Frame, published_assets: Optional[set[str]] = None) -> dict[str, Any]:
+    """What the published firmware has to be told to become this frame.
 
     The browser flasher's other path builds a per-frame image, which bakes
     every setting below into generated_config.h — a full ESP-IDF compile, tens
@@ -1708,9 +1758,13 @@ def embedded_provisioning_plan(frame: Frame) -> dict[str, Any]:
     frame that needs one cannot be provisioned this way at all and has to build
     an image. ``warnings`` are differences the user should know about but that
     still leave a working frame.
+
+    ``published_assets`` — which provisioning images the current release
+    carries — picks the image built for this frame's flash layout over the
+    generic one (embedded_release_firmware_for_frame).
     """
     platform = embedded_platform_for_frame(frame)
-    release = EMBEDDED_RELEASE_FIRMWARE.get(platform)
+    release = embedded_release_firmware_for_frame(frame, published_assets)
     blockers: list[str] = []
     warnings: list[str] = []
     settings: list[dict[str, Any]] = []
@@ -1833,13 +1887,12 @@ def embedded_provisioning_plan(frame: Frame) -> dict[str, Any]:
 
     if release is not None:
         frame_flash_size = embedded_flash_size_for_frame(frame)
-        release_profile = EMBEDDED_FLASH_PROFILES[release["flashSize"]]
         if frame_flash_size != release["flashSize"]:
             warnings.append(
                 f"The published image uses the {release['flashSize']} partition layout; this frame is configured "
                 f"for {frame_flash_size} flash, so the rest of the chip stays unused."
             )
-        if embedded_ota_supported_for_frame(frame) and not release_profile["otaSupported"]:
+        if embedded_ota_supported_for_frame(frame) and not release["otaSupported"]:
             warnings.append(
                 "The published image has no OTA slot, so future firmware updates need the USB cable again."
             )

--- a/embedded/esp32/ci_build_image.sh
+++ b/embedded/esp32/ci_build_image.sh
@@ -10,9 +10,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Boot-time default panel only: every supported panel driver is compiled into
 # the image and can be selected at runtime (`set panel <key>` / setup portal).
 PANEL="${FRAMEOS_SELECTED_PANEL:-EPD_7in5_V2}"
-# esp32-s3 (default): full firmware with the on-device Nim renderer.
-# esp32-c3: thin-client firmware (no PSRAM on supported C3 boards → no local
-# rendering), built for the 4MB no-OTA layout that fits every C3 target.
+# FRAMEOS_ESP32_PLATFORM names a chip and a flash layout:
+#   esp32-s3            full firmware with the on-device Nim renderer, 8MB
+#                       OTA A/B layout (the generic release image)
+#   esp32-c3            thin-client firmware (no PSRAM on any supported C3
+#                       board → no local rendering), 4MB no-OTA layout (the
+#                       generic release image)
+#   esp32-{s3,c3}-{4mb,8mb,16mb,32mb}
+#                       the same firmware on an explicit layout — one release
+#                       asset per layout, so a board is flashed with the
+#                       partition table its chip actually has instead of the
+#                       generic image's (docs/todo.md, "the self-hosted backend
+#                       flashes what the cloud flashes")
+# The layouts mirror EMBEDDED_FLASH_PROFILES in
+# backend/app/tasks/embedded_firmware.py and the partitions*.csv +
+# sdkconfig.defaults.* files next to this script.
 PLATFORM="${FRAMEOS_ESP32_PLATFORM:-esp32-s3}"
 BUILD_NAME="${FRAMEOS_ESP32_BUILD_DIR:-build-ci}"
 if [[ "$BUILD_NAME" = /* ]]; then
@@ -25,34 +37,76 @@ SDKCONFIG_PATH="${FRAMEOS_ESP32_SDKCONFIG:-$BUILD_DIR/sdkconfig}"
 QEMU_SMOKE="${FRAMEOS_ESP32_QEMU:-0}"
 QEMU_TIMEOUT_SECONDS="${FRAMEOS_ESP32_QEMU_TIMEOUT_SECONDS:-60}"
 case "$PLATFORM" in
-    esp32-s3)
-        IDF_TARGET_NAME="esp32s3"
-        DEFAULT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults"
-        ;;
-    esp32-s3-32mb)
-        # The 32MB/16MB-PSRAM boards (e.g. ESP32-S3-ePaper-13.3E6): same
-        # firmware as esp32-s3, bigger OTA slots + 24M state partition.
-        # Validated here because nobody else build-tests this layout.
-        IDF_TARGET_NAME="esp32s3"
-        DEFAULT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults;$SCRIPT_DIR/sdkconfig.defaults.32mb-ota"
-        if [[ "$QEMU_SMOKE" == "1" ]]; then
-            echo "QEMU smoke only covers the 8MB esp32-s3 layout" >&2
-            exit 1
-        fi
-        ;;
-    esp32-c3)
-        IDF_TARGET_NAME="esp32c3"
-        DEFAULT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults;$SCRIPT_DIR/sdkconfig.defaults.4mb-no-ota;$SCRIPT_DIR/sdkconfig.defaults.esp32c3"
-        if [[ "$QEMU_SMOKE" == "1" ]]; then
-            echo "QEMU smoke is only wired up for esp32-s3 (qemu-xtensa)" >&2
-            exit 1
-        fi
-        ;;
+    esp32-s3)              CHIP="esp32-s3"; LAYOUT="8mb" ;;
+    esp32-c3)              CHIP="esp32-c3"; LAYOUT="4mb" ;;
+    esp32-s3-4mb|esp32-s3-8mb|esp32-s3-16mb|esp32-s3-32mb)
+                           CHIP="esp32-s3"; LAYOUT="${PLATFORM#esp32-s3-}" ;;
+    esp32-c3-4mb|esp32-c3-8mb|esp32-c3-16mb|esp32-c3-32mb)
+                           CHIP="esp32-c3"; LAYOUT="${PLATFORM#esp32-c3-}" ;;
     *)
-        echo "Unsupported FRAMEOS_ESP32_PLATFORM: $PLATFORM (expected esp32-s3, esp32-s3-32mb or esp32-c3)" >&2
+        echo "Unsupported FRAMEOS_ESP32_PLATFORM: $PLATFORM (expected esp32-s3, esp32-c3, or esp32-{s3,c3}-{4mb,8mb,16mb,32mb})" >&2
         exit 1
         ;;
 esac
+
+# The flash layout: partition table, sdkconfig overlay, and the sizes the
+# checks below hold the build to. APP_SLOT_BYTES is the app partition's size
+# (factory on 4MB, ota_0/ota_1 elsewhere); a firmware that outgrows it does
+# not fit the chip, whatever the merged image says.
+case "$LAYOUT" in
+    4mb)
+        # 4MB modules cannot hold two app slots plus state: one factory app,
+        # no OTA.
+        LAYOUT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults.4mb-no-ota"
+        PARTITION_TABLE="partitions_4mb.csv"
+        FLASH_SIZE="4MB"
+        OTA_SUPPORTED=0
+        APP_SLOT_BYTES=$((3520 * 1024))
+        ;;
+    8mb)
+        LAYOUT_SDKCONFIG_DEFAULTS=""
+        PARTITION_TABLE="partitions.csv"
+        FLASH_SIZE="8MB"
+        OTA_SUPPORTED=1
+        APP_SLOT_BYTES=$((3520 * 1024))
+        ;;
+    16mb)
+        LAYOUT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults.16mb-ota"
+        PARTITION_TABLE="partitions_ota_16mb.csv"
+        FLASH_SIZE="16MB"
+        OTA_SUPPORTED=1
+        APP_SLOT_BYTES=$((4032 * 1024))
+        ;;
+    32mb)
+        # The 32MB/16MB-PSRAM boards (e.g. ESP32-S3-ePaper-13.3E6): bigger
+        # OTA slots + a 24M state partition.
+        LAYOUT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults.32mb-ota"
+        PARTITION_TABLE="partitions_ota_32mb.csv"
+        FLASH_SIZE="32MB"
+        OTA_SUPPORTED=1
+        APP_SLOT_BYTES=$((4032 * 1024))
+        ;;
+esac
+FLASH_BYTES=$(( ${FLASH_SIZE%MB} * 1024 * 1024 ))
+
+DEFAULT_SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults"
+if [[ -n "$LAYOUT_SDKCONFIG_DEFAULTS" ]]; then
+    DEFAULT_SDKCONFIG_DEFAULTS="$DEFAULT_SDKCONFIG_DEFAULTS;$LAYOUT_SDKCONFIG_DEFAULTS"
+fi
+case "$CHIP" in
+    esp32-s3)
+        IDF_TARGET_NAME="esp32s3"
+        ;;
+    esp32-c3)
+        IDF_TARGET_NAME="esp32c3"
+        # The chip overlay applies LAST, after the flash-size profile.
+        DEFAULT_SDKCONFIG_DEFAULTS="$DEFAULT_SDKCONFIG_DEFAULTS;$SCRIPT_DIR/sdkconfig.defaults.esp32c3"
+        ;;
+esac
+if [[ "$QEMU_SMOKE" == "1" && "$PLATFORM" != "esp32-s3" ]]; then
+    echo "QEMU smoke only covers the 8MB esp32-s3 layout (qemu-xtensa)" >&2
+    exit 1
+fi
 SDKCONFIG_DEFAULTS="${FRAMEOS_ESP32_SDKCONFIG_DEFAULTS:-$DEFAULT_SDKCONFIG_DEFAULTS}"
 if [[ "$QEMU_SMOKE" == "1" && -z "${FRAMEOS_ESP32_SDKCONFIG_DEFAULTS:-}" ]]; then
     SDKCONFIG_DEFAULTS="$SCRIPT_DIR/sdkconfig.defaults;$SCRIPT_DIR/sdkconfig.qemu.defaults"
@@ -129,8 +183,8 @@ cd "$SCRIPT_DIR"
 
 export FRAMEOS_SELECTED_PANEL="$PANEL"
 export IDF_TARGET="$IDF_TARGET_NAME"
-echo "Building FrameOS ESP32 firmware for $PLATFORM (all panels compiled in, default panel $FRAMEOS_SELECTED_PANEL)"
-if [[ "$PLATFORM" == "esp32-c3" ]]; then
+echo "Building FrameOS ESP32 firmware for $PLATFORM ($CHIP, $FLASH_SIZE flash, $PARTITION_TABLE; all panels compiled in, default panel $FRAMEOS_SELECTED_PANEL)"
+if [[ "$CHIP" == "esp32-c3" ]]; then
     # Thin client: leave nimcache empty so the stub links in. A stale Xtensa
     # nimcache from an earlier S3 build must not leak into a RISC-V image.
     ./build_nim.sh clean
@@ -168,21 +222,20 @@ require_line '^CONFIG_ESP_CONSOLE_UART_DEFAULT=y$' "$SDKCONFIG_PATH"
 if [[ "$QEMU_SMOKE" != "1" ]]; then
     require_line '^CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y$' "$SDKCONFIG_PATH"
 fi
-if [[ "$PLATFORM" == "esp32-c3" ]]; then
-    require_line '^CONFIG_IDF_TARGET="esp32c3"$' "$SDKCONFIG_PATH"
-    require_line '^CONFIG_ESPTOOLPY_FLASHSIZE="4MB"$' "$SDKCONFIG_PATH"
-    require_line '^CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_4mb.csv"$' "$SDKCONFIG_PATH"
-elif [[ "$PLATFORM" == "esp32-s3-32mb" ]]; then
+require_line "^CONFIG_IDF_TARGET=\"$IDF_TARGET_NAME\"\$" "$SDKCONFIG_PATH"
+require_line "^CONFIG_ESPTOOLPY_FLASHSIZE=\"$FLASH_SIZE\"\$" "$SDKCONFIG_PATH"
+require_line "^CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"$PARTITION_TABLE\"\$" "$SDKCONFIG_PATH"
+if [[ "$OTA_SUPPORTED" == "1" ]]; then
     require_line '^CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y$' "$SDKCONFIG_PATH"
-    require_line '^CONFIG_ESPTOOLPY_FLASHSIZE="32MB"$' "$SDKCONFIG_PATH"
-    require_line '^CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_ota_32mb.csv"$' "$SDKCONFIG_PATH"
+elif grep -Eq '^CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y$' "$SDKCONFIG_PATH"; then
+    # One factory slot: rollback would have nothing to roll back to.
+    echo "Rollback is enabled in $SDKCONFIG_PATH but the $LAYOUT layout has no OTA slot" >&2
+    exit 1
+fi
+if [[ "$LAYOUT" == "32mb" ]]; then
     # 24M SPIFFS needs 512-byte pages; 256-byte pages cap out at 16MB and the
     # mount fails ESP_ERR_INVALID_ARG at runtime (scene upload 500s).
     require_line '^CONFIG_SPIFFS_PAGE_SIZE=512$' "$SDKCONFIG_PATH"
-else
-    require_line '^CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y$' "$SDKCONFIG_PATH"
-    require_line '^CONFIG_ESPTOOLPY_FLASHSIZE="8MB"$' "$SDKCONFIG_PATH"
-    require_line '^CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"$' "$SDKCONFIG_PATH"
 fi
 if [[ "$QEMU_SMOKE" == "1" ]]; then
     require_line '^CONFIG_ESP_CONSOLE_UART_DEFAULT=y$' "$SDKCONFIG_PATH"
@@ -194,35 +247,38 @@ PARTITION_DUMP="$BUILD_DIR/partition-table.generated.csv"
 python3 "$IDF_PATH/components/partition_table/gen_esp32part.py" \
     "$BUILD_DIR/partition_table/partition-table.bin" > "$PARTITION_DUMP"
 
-if [[ "$PLATFORM" == "esp32-c3" ]]; then
-    require_line '^factory,app,factory,0x10000,3520K,' "$PARTITION_DUMP"
-    require_line '^state,data,spiffs,0x380000,512K,' "$PARTITION_DUMP"
-elif [[ "$PLATFORM" == "esp32-s3-32mb" ]]; then
-    require_line '^otadata,data,ota,0xf000,8K,' "$PARTITION_DUMP"
-    require_line '^ota_0,app,ota_0,0x20000,4032K,' "$PARTITION_DUMP"
-    require_line '^ota_1,app,ota_1,0x410000,4032K,' "$PARTITION_DUMP"
-    require_line '^state,data,spiffs,0x800000,24M,' "$PARTITION_DUMP"
-else
-    require_line '^otadata,data,ota,0xd000,8K,' "$PARTITION_DUMP"
-    require_line '^ota_0,app,ota_0,0x10000,3520K,' "$PARTITION_DUMP"
-    require_line '^ota_1,app,ota_1,0x380000,3520K,' "$PARTITION_DUMP"
-    require_line '^state,data,spiffs,0x6f0000,1M,' "$PARTITION_DUMP"
-fi
+# The partition table the image actually carries, per layout. These are what
+# the flasher's write plan (frontend embeddedFlashImage.ts) and the device's
+# OTA code assume; a partitions*.csv edit that moves them must show up here.
+case "$LAYOUT" in
+    4mb)
+        require_line '^factory,app,factory,0x10000,3520K,' "$PARTITION_DUMP"
+        require_line '^state,data,spiffs,0x380000,512K,' "$PARTITION_DUMP"
+        ;;
+    8mb)
+        require_line '^otadata,data,ota,0xd000,8K,' "$PARTITION_DUMP"
+        require_line '^ota_0,app,ota_0,0x10000,3520K,' "$PARTITION_DUMP"
+        require_line '^ota_1,app,ota_1,0x380000,3520K,' "$PARTITION_DUMP"
+        require_line '^state,data,spiffs,0x6f0000,1M,' "$PARTITION_DUMP"
+        ;;
+    16mb)
+        require_line '^otadata,data,ota,0xf000,8K,' "$PARTITION_DUMP"
+        require_line '^ota_0,app,ota_0,0x20000,4032K,' "$PARTITION_DUMP"
+        require_line '^ota_1,app,ota_1,0x410000,4032K,' "$PARTITION_DUMP"
+        require_line '^state,data,spiffs,0x800000,8M,' "$PARTITION_DUMP"
+        ;;
+    32mb)
+        require_line '^otadata,data,ota,0xf000,8K,' "$PARTITION_DUMP"
+        require_line '^ota_0,app,ota_0,0x20000,4032K,' "$PARTITION_DUMP"
+        require_line '^ota_1,app,ota_1,0x410000,4032K,' "$PARTITION_DUMP"
+        require_line '^state,data,spiffs,0x800000,24M,' "$PARTITION_DUMP"
+        ;;
+esac
 
 APP_BIN="$BUILD_DIR/frameos_esp32.bin"
 MERGED_BIN="$BUILD_DIR/merged-binary.bin"
 BOOTLOADER_BIN="$BUILD_DIR/bootloader/bootloader.bin"
 PARTITION_BIN="$BUILD_DIR/partition_table/partition-table.bin"
-
-APP_SLOT_BYTES=$((3520 * 1024))
-if [[ "$PLATFORM" == "esp32-c3" ]]; then
-    FLASH_BYTES=$((4 * 1024 * 1024))
-elif [[ "$PLATFORM" == "esp32-s3-32mb" ]]; then
-    APP_SLOT_BYTES=$((4032 * 1024))
-    FLASH_BYTES=$((32 * 1024 * 1024))
-else
-    FLASH_BYTES=$((8 * 1024 * 1024))
-fi
 
 APP_BYTES="$(file_size "$APP_BIN")"
 MERGED_BYTES="$(file_size "$MERGED_BIN")"

--- a/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
+++ b/frontend/src/scenes/workspace/EmbeddedUsbFirmwareUpdate.tsx
@@ -86,9 +86,31 @@ export interface ReleaseFirmwareListing {
   release?: string
 }
 
-/** Which published asset fits this frame's hardware. */
+/** Which published asset fits this frame's chip: the generic image, the
+ * answer when nothing better is known (see releaseFirmwarePlatformForFrame). */
 export function releaseFirmwarePlatform(frame: FrameType): string {
   return releasePlatformByHardware[frameHardwarePlatform(frame)] ?? 'esp32-s3-generic'
+}
+
+/** The control plane's own answer for this frame — the image built for its
+ * flash layout (esp32-c3-16mb for a 16MB XTEINK X4, esp32-s3-32mb for a 13.3E6
+ * board) when the release publishes one, which is also the only image whose
+ * partition table matches such a board, so the update's layout check passes.
+ * Falls back to the per-chip generic image wherever the provisioning route
+ * does not exist (the cloud) or cannot answer. */
+export async function releaseFirmwarePlatformForFrame(frame: FrameType): Promise<string> {
+  try {
+    const response = await apiFetch(`/api/frames/${frame.id}/embedded/provisioning`)
+    if (response.ok) {
+      const platform = (await response.json())?.provisioning?.releasePlatform
+      if (typeof platform === 'string' && platform) {
+        return platform
+      }
+    }
+  } catch {
+    // The static per-chip answer below is what this flow always used.
+  }
+  return releaseFirmwarePlatform(frame)
 }
 
 /** The published release and its assets — also how the deploy drawer learns
@@ -210,7 +232,7 @@ export function EmbeddedUsbFirmwareUpdate({ frame }: { frame: FrameType }): JSX.
       openFrameToolBehindDrawer(frame.id, 'logs')
 
       setPhase('preparing')
-      const platform = releaseFirmwarePlatform(frame)
+      const platform = await releaseFirmwarePlatformForFrame(frame)
       const firmware = await downloadReleaseFirmware(platform, setFlashMessage)
       // Planned before the board is touched: a plan that cannot spare the NVS
       // must fail while nothing has been written.

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -83,6 +83,7 @@ import {
   fetchReleaseFirmwareListing,
   hasReleaseFirmwarePlatform,
   releaseFirmwarePlatform,
+  releaseFirmwarePlatformForFrame,
 } from './EmbeddedUsbFirmwareUpdate'
 import { registeredFramePanel } from './addFramePanelRegistry'
 import { pushScenesOverUsb, pushedScenesMessage } from './embeddedUsbScenePush'
@@ -2191,12 +2192,11 @@ function useCloudFirmwareRelease(frame: FrameType, enabled: boolean): CloudFirmw
     }
     let cancelled = false
     setInfo({ loading: true, error: null, release: null, assetSize: null })
-    fetchReleaseFirmwareListing()
-      .then((listing) => {
+    Promise.all([fetchReleaseFirmwareListing(), releaseFirmwarePlatformForFrame(frame)])
+      .then(([listing, platform]) => {
         if (cancelled) {
           return
         }
-        const platform = releaseFirmwarePlatform(frame)
         const asset = listing.assets?.find((entry) => entry.platform === platform)
         setInfo({
           loading: false,


### PR DESCRIPTION
Step 1 of "ESP32: the self-hosted backend flashes what the cloud flashes" (`docs/todo.md`).

## Release job
- New `build-esp32-layout-firmware` job (matrix per chip, GitHub-hosted, same Depot image and signing step as the generic job): `esp32-s3-{4mb,16mb,32mb}` and `esp32-c3-{8mb,16mb,32mb}`, each as merged `.bin` + `-app.bin` (both `.minisig`) + `-size.json`. The generic pair is untouched; it already *is* the S3 8MB / C3 4MB layout, so the profile table maps those layouts to it rather than publishing duplicates.
- `ci_build_image.sh` generalised to chip × layout with per-layout sdkconfig and partition-dump assertions; `esp32-s3`, `esp32-c3`, `esp32-s3-32mb` still work (e2e-docker unaffected).
- PR size-report baseline pattern widened to `*-esp32-*-size.json`.

## Backend / frontend
- `EMBEDDED_FLASH_PROFILES[...].releaseAssets`; `embedded_release_firmware_for_frame(frame, published_assets)` picks the layout-matched asset when the cached release listing has it, else the generic (older releases keep flashing). `PROVISIONING_ASSETS` / `STREAMABLE_PLATFORMS` derive from it.
- Provisioning route passes the listing in, so the X4's "4MB layout / no OTA" warnings go away once a release carries `esp32-c3-16mb`.
- "Update over USB" + deploy drawer ask for the matched platform, fall back to generic.

## Verified
`test_firmware_release.py` + `test_embedded_firmware.py`: 101 passed (4 new). Frontend `tsc` clean. Workflows parse. **Not verified:** the ESP-IDF builds themselves — the C3 OTA layouts have never been built; the first release run proves them.

Cloud flasher unchanged on purpose (`firmware-release.ts` still lists the generic pair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKnsuRU12dtVXgsHYYcLdi