### PR TITLE
Device secrets: write-only fields on the ESP32 frame JSON; WPA2 provisioning AP with a per-device passphrase

### DIFF
--- a/backend/app/api/frame_sync.py
+++ b/backend/app/api/frame_sync.py
@@ -173,6 +173,7 @@ FRAME_SYNC_SECRET_PATH_PARTS = {
     "server_key",
     "serverKey",
     "client_ca",
+    "wifiPassword",
     "clientCa",
     "private_key",
     "privateKey",
@@ -759,6 +760,45 @@ def _extract_remote_frame_payload(payload: Any) -> dict[str, Any]:
     raise HTTPException(status_code=HTTPStatus.BAD_GATEWAY, detail="Frame returned an invalid sync payload")
 
 
+def _restore_write_only_secrets(remote_frame: dict[str, Any], backend_frame: Frame | dict[str, Any]) -> dict[str, Any]:
+    """Fill secrets the device blanked with the backend's own copy.
+
+    The ESP32 serves "" for its admin password, TLS private key, backend API
+    key and Wi-Fi passphrase (embedded/esp32/main/fos_http.c: write-only, the
+    backend↔frame hop is plain HTTP by default). Read literally, every sync
+    would show those as "changed on the frame" and a "take the frame's
+    value" choice would blank the row, which the next deploy pushes back to
+    the device. So a blank secret leaf means "unchanged": it takes the value
+    the backend already holds, and only a secret the device does report
+    replaces it. Non-secret leaves are untouched; shapes that do not match
+    (a section missing on either side, a non-dict where a dict is expected)
+    are left as the device sent them.
+    """
+    if not isinstance(remote_frame, dict):
+        return remote_frame
+
+    def backend_value(key: str) -> Any:
+        if isinstance(backend_frame, dict):
+            return backend_frame.get(key)
+        return getattr(backend_frame, key, None)
+
+    def restore(remote: dict[str, Any], backend: dict[str, Any], *, top: bool) -> dict[str, Any]:
+        restored: dict[str, Any] = {}
+        for key, value in remote.items():
+            other = backend.get(key)
+            is_secret = key in FRAME_SYNC_SECRET_PATH_PARTS or (top and key in FRAME_SYNC_SECRET_KEYS)
+            if is_secret and value in (None, "") and isinstance(other, str) and other:
+                restored[key] = other
+            elif isinstance(value, dict) and isinstance(other, dict):
+                restored[key] = restore(value, other, top=False)
+            else:
+                restored[key] = value
+        return restored
+
+    backend_view = {key: backend_value(key) for key in remote_frame.keys()}
+    return restore(remote_frame, backend_view, top=True)
+
+
 async def _load_live_frame_api_payload(
     frame: Frame, redis: Redis, fetch_frame_http_bytes: FrameFetch
 ) -> dict[str, Any]:
@@ -772,9 +812,10 @@ async def _load_live_frame_api_payload(
         if status != 200:
             continue
         try:
-            return _extract_remote_frame_payload(json.loads(body.decode("utf-8")))
+            remote_frame = _extract_remote_frame_payload(json.loads(body.decode("utf-8")))
         except json.JSONDecodeError as exc:
             raise HTTPException(status_code=HTTPStatus.BAD_GATEWAY, detail=f"Frame returned invalid JSON: {exc}")
+        return _restore_write_only_secrets(remote_frame, frame)
     # Whatever answered on that address does not get its body relayed to the
     # browser; a structured `detail`/`error` from a FrameOS runtime does.
     raise HTTPException(

--- a/backend/app/api/tests/test_frame_sync_secrets.py
+++ b/backend/app/api/tests/test_frame_sync_secrets.py
@@ -1,0 +1,126 @@
+"""Write-only secrets on the device side of frame sync.
+
+The ESP32 serves "" for its admin password, TLS private key, backend API key
+and Wi-Fi passphrase (embedded/esp32/main/fos_http.c): they are accepted on
+POST and never read back. The backend must read that "" as "unchanged" —
+neither a diff to show nor a value to import — or a routine sync would blank
+the backend's copy and the next deploy would push the blank to the device.
+"""
+
+from app.api.frame_sync import (
+    _build_frame_sync_section,
+    _restore_write_only_secrets,
+    _sync_frame_value,
+)
+from app.models.frame import Frame
+
+
+def _backend_frame() -> dict:
+    return {
+        "server_api_key": "backend-api-key",
+        "frame_access_key": "access-key",
+        "ssh_pass": "ssh-secret",
+        "frame_admin_auth": {"enabled": True, "user": "admin", "pass": "admin-secret"},
+        "https_proxy": {
+            "enable": True,
+            "port": 8443,
+            "expose_only_port": True,
+            "certs": {"server": "CERT", "server_key": "KEY", "client_ca": ""},
+        },
+        "network": {"wifiSSID": "home", "wifiPassword": "wifi-secret", "wifiHotspot": "disabled"},
+        "interval": 300,
+    }
+
+
+def _device_frame() -> dict:
+    # What the ESP32 answers: the same shape with every secret leaf blanked.
+    return {
+        "server_api_key": "",
+        "frame_access_key": "",
+        "ssh_pass": "",
+        "frame_admin_auth": {"enabled": True, "user": "admin", "pass": ""},
+        "https_proxy": {
+            "enable": True,
+            "port": 8443,
+            "expose_only_port": True,
+            "certs": {"server": "CERT", "server_key": "", "client_ca": ""},
+        },
+        "network": {"wifiSSID": "home", "wifiPassword": "", "wifiHotspot": "disabled"},
+        "interval": 300,
+    }
+
+
+def test_blank_device_secrets_are_filled_from_the_backend_copy():
+    restored = _restore_write_only_secrets(_device_frame(), _backend_frame())
+    assert restored["server_api_key"] == "backend-api-key"
+    assert restored["frame_access_key"] == "access-key"
+    assert restored["ssh_pass"] == "ssh-secret"
+    assert restored["frame_admin_auth"]["pass"] == "admin-secret"
+    assert restored["https_proxy"]["certs"]["server_key"] == "KEY"
+    assert restored["network"]["wifiPassword"] == "wifi-secret"
+    # Non-secret leaves are the device's own.
+    assert restored["frame_admin_auth"]["user"] == "admin"
+    assert restored["https_proxy"]["certs"]["server"] == "CERT"
+
+
+def test_a_secret_the_device_does_report_wins_over_the_backend_copy():
+    device = _device_frame()
+    device["frame_admin_auth"]["pass"] = "device-set-secret"
+    restored = _restore_write_only_secrets(device, _backend_frame())
+    assert restored["frame_admin_auth"]["pass"] == "device-set-secret"
+
+
+def test_a_blank_on_both_sides_stays_blank():
+    backend = _backend_frame()
+    backend["https_proxy"]["certs"]["server_key"] = ""
+    restored = _restore_write_only_secrets(_device_frame(), backend)
+    assert restored["https_proxy"]["certs"]["server_key"] == ""
+
+
+def test_restore_copes_with_missing_or_foreign_shapes():
+    # A device without the section, or with a non-dict where a dict is
+    # expected, must not raise and must not invent structure.
+    device = {"frame_admin_auth": "nope", "interval": 10}
+    restored = _restore_write_only_secrets(device, _backend_frame())
+    assert restored["frame_admin_auth"] == "nope"
+    assert "https_proxy" not in restored
+
+
+def test_blanked_secrets_do_not_show_as_changes_once_restored():
+    backend = _backend_frame()
+    device = _restore_write_only_secrets(_device_frame(), backend)
+    section = _build_frame_sync_section(backend, device, backend)
+    assert section["has_changes"] is False
+    assert section["changes"] == []
+
+
+def test_without_restore_the_blanks_would_read_as_changes():
+    # The guard the test above depends on: the raw payload really differs.
+    backend = _backend_frame()
+    section = _build_frame_sync_section(backend, _device_frame(), backend)
+    paths = {change["path"] for change in section["changes"]}
+    assert "frame_admin_auth" in paths
+    assert "https_proxy" in paths
+    assert _sync_frame_value("frame_admin_auth", _device_frame()["frame_admin_auth"]) != _sync_frame_value(
+        "frame_admin_auth", backend["frame_admin_auth"]
+    )
+
+
+def test_restore_reads_the_backend_copy_off_a_frame_row():
+    frame = Frame(
+        name="esp",
+        frame_host="10.0.0.5",
+        frame_port=80,
+        server_host="backend.local",
+        server_port=8989,
+        server_api_key="row-api-key",
+        frame_admin_auth={"enabled": True, "user": "admin", "pass": "row-admin-secret"},
+        https_proxy={"enable": True, "certs": {"server": "CERT", "server_key": "ROW-KEY"}},
+        network={"wifiSSID": "home", "wifiPassword": "row-wifi-secret"},
+        mode="embedded",
+    )
+    restored = _restore_write_only_secrets(_device_frame(), frame)
+    assert restored["server_api_key"] == "row-api-key"
+    assert restored["frame_admin_auth"]["pass"] == "row-admin-secret"
+    assert restored["https_proxy"]["certs"]["server_key"] == "ROW-KEY"
+    assert restored["network"]["wifiPassword"] == "row-wifi-secret"

--- a/docs/api-triality.md
+++ b/docs/api-triality.md
@@ -163,6 +163,15 @@ the runtime types, and its next save would otherwise lose it. Unprivileged
 readers get secrets blanked: access/API keys, TLS material, admin credentials,
 mount passwords, the hotspot password and the agent secret.
 
+On the ESP32 four of those are **write-only for every reader**, admin
+session included: `frame_admin_auth.pass`, `https_proxy.certs.server_key`,
+`server_api_key` and `network.wifiPassword` are accepted on `POST` and come
+back as `""` on `GET` (the backend↔frame hop is plain HTTP by default). The
+device treats `""` on a write as "keep what is stored", and the backend
+fills a blank secret from its own row before comparing or importing
+(`_restore_write_only_secrets` in `frame_sync.py`), so a round-tripped
+payload never clears anything.
+
 `frame.json` itself is parsed straight into the typed config with jsony
 (`frameos/src/frameos/config.nim`): field names are the JSON keys, defaults
 live in `newHook`s, and scalars are read leniently (a quoted number, a

--- a/embedded/esp32/main/fos_config.c
+++ b/embedded/esp32/main/fos_config.c
@@ -127,6 +127,7 @@ esp_err_t fos_config_init(void)
     nvs_get_string(nvs, "assets_path", s_config.assets_path, sizeof(s_config.assets_path));
     nvs_get_string(nvs, "admin_user", s_config.admin_user, sizeof(s_config.admin_user));
     nvs_get_string(nvs, "admin_pass", s_config.admin_pass, sizeof(s_config.admin_pass));
+    nvs_get_string(nvs, "ap_psk", s_config.ap_psk, sizeof(s_config.ap_psk));
     char gpio_buttons[FOS_GPIO_BUTTONS_SPEC_LEN] = "";
     size_t gpio_buttons_len = sizeof(gpio_buttons);
     esp_err_t buttons_err = nvs_get_str(nvs, "gpio_buttons", gpio_buttons, &gpio_buttons_len);
@@ -232,6 +233,7 @@ esp_err_t fos_config_save(void)
     nvs_set_str(nvs, "assets_path", s_config.assets_path);
     nvs_set_str(nvs, "admin_user", s_config.admin_user);
     nvs_set_str(nvs, "admin_pass", s_config.admin_pass);
+    nvs_set_str(nvs, "ap_psk", s_config.ap_psk);
     nvs_set_u32(nvs, "frame_id", s_config.frame_id);
     nvs_set_u32(nvs, "interval", s_config.interval_sec);
     nvs_set_u16(nvs, "rotate", s_config.rotate);

--- a/embedded/esp32/main/fos_config.h
+++ b/embedded/esp32/main/fos_config.h
@@ -14,6 +14,7 @@
 #include "esp_err.h"
 
 #define FOS_STR_LEN 128
+#define FOS_AP_PSK_LEN 64          /* WPA2 passphrases are 8-63 characters */
 #define FOS_URL_LEN 256
 #define FOS_TLS_PEM_LEN 4096
 #define FOS_GPIO_BUTTONS_MAX 8
@@ -109,6 +110,12 @@ typedef struct {
     bool admin_auth_enabled;       /* protect setup/control routes outside hotspot mode */
     char admin_user[FOS_STR_LEN];
     char admin_pass[FOS_STR_LEN];
+    /* WPA2 passphrase of the provisioning AP (FrameOS-XXXX). Minted from
+     * hardware entropy the first time the portal starts and kept in NVS, so
+     * a fresh device is not provisioned by whoever is nearest; shown on the
+     * status screen and over the console (`config`), settable with
+     * `set ap_psk`. */
+    char ap_psk[FOS_AP_PSK_LEN];
     char assets_path[FOS_ASSETS_PATH_LEN]; /* VFS mount point for local assets, default /srv/assets */
     fos_assets_sd_config_t assets_sd;
     bool deep_sleep;               /* deep sleep between refreshes */

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -188,6 +188,10 @@ static int cmd_status(int argc, char **argv)
     printf("admin_auth:  %s user=%s\n",
            (config->admin_auth_enabled && config->admin_user[0] && config->admin_pass[0]) ? "enabled" : "disabled",
            config->admin_user[0] ? config->admin_user : "(unset)");
+    /* The provisioning AP's passphrase: the panel shows it, and this is the
+     * other place to read it from (a headless board, or a panel that cannot
+     * be seen). Minted on first use, so a fresh device says so. */
+    printf("ap_psk:      %s\n", config->ap_psk[0] ? config->ap_psk : "(minted when the setup network first starts)");
     printf("hardware:    %s\n", config->hardware_preset[0] ? config->hardware_preset : "(custom)");
     printf("panel:       %s (%dx%d)\n", config->panel, fos_display_width(), fos_display_height());
     printf("pins:        %s\n", pins);
@@ -423,7 +427,7 @@ static int cmd_set(int argc, char **argv)
                "assets_path|assets_sd|assets_sd_pins|assets_sd_freq|"
                "assets_sd_autoformat|"
                "deep_sleep|deep_sleep_on_battery|wake_check|wake_schedule|"
-               "battery_pin|battery_divider|battery_enable_pin|pins|gpio_buttons> <value...>\n");
+               "battery_pin|battery_divider|battery_enable_pin|pins|gpio_buttons|ap_psk> <value...>\n");
         return 1;
     }
     fos_config_t *config = fos_config();
@@ -439,6 +443,14 @@ static int cmd_set(int argc, char **argv)
     else if (strcmp(key, "wifi_pass") == 0) strlcpy(config->wifi_pass, value, sizeof(config->wifi_pass));
     else if (strcmp(key, "backend") == 0) strlcpy(config->backend_url, value, sizeof(config->backend_url));
     else if (strcmp(key, "api_key") == 0) strlcpy(config->api_key, value, sizeof(config->api_key));
+    else if (strcmp(key, "ap_psk") == 0) {
+        size_t len = strlen(value);
+        if (len != 0 && (len < 8 || len > 63)) {
+            printf("ap_psk must be 8-63 characters (or empty to mint a new one at the next portal start)\n");
+            return 1;
+        }
+        strlcpy(config->ap_psk, value, sizeof(config->ap_psk));
+    }
     /* Cloud-frame provisioning (browser flasher / manual): the enrollment
      * task picks these up once Wi-Fi is connected. The claim token is single
      * use and never echoed back — check `status` for the enrollment state. */

--- a/embedded/esp32/main/fos_http.c
+++ b/embedded/esp32/main/fos_http.c
@@ -1481,7 +1481,13 @@ static cJSON *frame_api_frame_json(void)
     cJSON *admin = cJSON_CreateObject();
     cJSON_AddBoolToObject(admin, "enabled", config->admin_auth_enabled);
     cJSON_AddStringToObject(admin, "user", config->admin_user);
-    cJSON_AddStringToObject(admin, "pass", config->admin_pass);
+    /* Write-only fields (docs/api-triality.md): the admin password, the TLS
+     * private key, the backend API key and the Wi-Fi passphrase are accepted
+     * on POST and never read back. The backend↔frame hop is plain HTTP by
+     * default, so anyone on the WPA2 network could otherwise read them from
+     * a captured request; the backend keeps its own copy and treats "" from
+     * the device as "unchanged" (frame_sync.py). */
+    cJSON_AddStringToObject(admin, "pass", "");
     cJSON_AddItemToObject(frame, "frame_admin_auth", admin);
 
     cJSON *https = cJSON_CreateObject();
@@ -1490,7 +1496,7 @@ static cJSON *frame_api_frame_json(void)
     cJSON_AddBoolToObject(https, "expose_only_port", true);
     cJSON *certs = cJSON_CreateObject();
     cJSON_AddStringToObject(certs, "server", config->tls_server_cert);
-    cJSON_AddStringToObject(certs, "server_key", config->tls_server_key);
+    cJSON_AddStringToObject(certs, "server_key", "");
     cJSON_AddStringToObject(certs, "client_ca", "");
     cJSON_AddItemToObject(https, "certs", certs);
     cJSON_AddNullToObject(https, "server_cert_not_valid_after");
@@ -1503,7 +1509,7 @@ static cJSON *frame_api_frame_json(void)
     cJSON_AddItemToObject(frame, "ssh_keys", cJSON_CreateArray());
     cJSON_AddStringToObject(frame, "server_host", config->backend_url);
     cJSON_AddNumberToObject(frame, "server_port", 0);
-    cJSON_AddStringToObject(frame, "server_api_key", config->api_key);
+    cJSON_AddStringToObject(frame, "server_api_key", "");
     cJSON_AddBoolToObject(frame, "server_send_logs", config->server_send_logs);
     cJSON_AddStringToObject(frame, "status", "online");
     cJSON_AddBoolToObject(frame, "archived", false);
@@ -1551,7 +1557,7 @@ static cJSON *frame_api_frame_json(void)
 
     cJSON *network = cJSON_CreateObject();
     cJSON_AddStringToObject(network, "wifiSSID", config->wifi_ssid);
-    cJSON_AddStringToObject(network, "wifiPassword", config->wifi_pass);
+    cJSON_AddStringToObject(network, "wifiPassword", "");
     cJSON_AddItemToObject(frame, "network", network);
 
     cJSON_AddItemToObject(frame, "agent", cJSON_CreateObject());
@@ -1617,6 +1623,19 @@ static bool json_copy_string_item(const cJSON *object, const char *key, char *ou
     return true;
 }
 
+/* A write-only secret: the GET side serves "" for it, so an editor that
+ * round-trips the payload sends "" back, and that must mean "keep what is
+ * stored" rather than "clear it". Clearing goes through the specific route
+ * (admin auth is disabled with `enabled: false`; Wi-Fi is re-set from the
+ * console / portal with `set wifi`). */
+static bool json_copy_secret_item(const cJSON *object, const char *key, char *out, size_t out_len)
+{
+    const cJSON *item = cJSON_GetObjectItem(object, key);
+    if (!cJSON_IsString(item) || !item->valuestring || !item->valuestring[0]) return false;
+    strlcpy(out, item->valuestring, out_len);
+    return true;
+}
+
 static bool json_u32_item(const cJSON *object, const char *key, uint32_t *out)
 {
     const cJSON *item = cJSON_GetObjectItem(object, key);
@@ -1665,7 +1684,7 @@ static esp_err_t frame_update_post_handler(httpd_req_t *req)
     if (json_u32_item(root, "max_http_response_bytes", &value) && value >= 1024) {
         config->max_http_response_bytes = value;
     }
-    json_copy_string_item(root, "server_api_key", config->api_key, sizeof(config->api_key));
+    json_copy_secret_item(root, "server_api_key", config->api_key, sizeof(config->api_key));
     update_backend_url_from_frame_payload(config, root);
 
     const cJSON *send_logs = cJSON_GetObjectItem(root, "server_send_logs");
@@ -1674,7 +1693,7 @@ static esp_err_t frame_update_post_handler(httpd_req_t *req)
     const cJSON *network = cJSON_GetObjectItem(root, "network");
     if (cJSON_IsObject(network)) {
         json_copy_string_item(network, "wifiSSID", config->wifi_ssid, sizeof(config->wifi_ssid));
-        json_copy_string_item(network, "wifiPassword", config->wifi_pass, sizeof(config->wifi_pass));
+        json_copy_secret_item(network, "wifiPassword", config->wifi_pass, sizeof(config->wifi_pass));
     }
 
     const cJSON *device_config = cJSON_GetObjectItem(root, "device_config");
@@ -1695,7 +1714,7 @@ static esp_err_t frame_update_post_handler(httpd_req_t *req)
         strlcpy(next_user, config->admin_user, sizeof(next_user));
         strlcpy(next_pass, config->admin_pass, sizeof(next_pass));
         json_copy_string_item(admin, "user", next_user, sizeof(next_user));
-        json_copy_string_item(admin, "pass", next_pass, sizeof(next_pass));
+        json_copy_secret_item(admin, "pass", next_pass, sizeof(next_pass));
         if (next_enabled && (!next_user[0] || !next_pass[0])) {
             cJSON_Delete(root);
             free(body);
@@ -1716,7 +1735,7 @@ static esp_err_t frame_update_post_handler(httpd_req_t *req)
         const cJSON *certs = cJSON_GetObjectItem(https, "certs");
         if (cJSON_IsObject(certs)) {
             json_copy_string_item(certs, "server", config->tls_server_cert, sizeof(config->tls_server_cert));
-            json_copy_string_item(certs, "server_key", config->tls_server_key, sizeof(config->tls_server_key));
+            json_copy_secret_item(certs, "server_key", config->tls_server_key, sizeof(config->tls_server_key));
         }
     }
 

--- a/embedded/esp32/main/fos_status_screen.c
+++ b/embedded/esp32/main/fos_status_screen.c
@@ -248,7 +248,7 @@ static int draw_header(uint8_t *buf, int width, int height, fos_pixel_format_t f
     return y + header_h;
 }
 
-esp_err_t fos_status_screen_show_portal(const char *ssid, const char *ip)
+esp_err_t fos_status_screen_show_portal(const char *ssid, const char *psk, const char *ip)
 {
     if (!fos_display_present()) return ESP_ERR_INVALID_STATE;
 
@@ -268,8 +268,10 @@ esp_err_t fos_status_screen_show_portal(const char *ssid, const char *ip)
     int gap = scale * 4;
 
     char ssid_line[48];
+    char psk_line[80];
     char ip_line[64];
     snprintf(ssid_line, sizeof(ssid_line), "Wi-Fi: %s", ssid && ssid[0] ? ssid : "FrameOS");
+    snprintf(psk_line, sizeof(psk_line), "Password: %s", psk && psk[0] ? psk : "(none)");
     snprintf(ip_line, sizeof(ip_line), "then open http://%s/", ip && ip[0] ? ip : "192.168.4.1");
 
     int avail = width - 2 * margin;
@@ -282,6 +284,9 @@ esp_err_t fos_status_screen_show_portal(const char *ssid, const char *ip)
     int ssid_scale = fit_scale(ssid_line, scale + 1, avail);
     draw_text(buf, width, height, format, ssid_line, margin, y, ssid_scale);
     y += 7 * ssid_scale + gap;
+    int psk_scale = fit_scale(psk_line, scale + 1, avail);
+    draw_text(buf, width, height, format, psk_line, margin, y, psk_scale);
+    y += 7 * psk_scale + gap;
     draw_text(buf, width, height, format, ip_line, margin, y, fit_scale(ip_line, scale, avail));
 
     esp_err_t err = fos_display_blit(buf, len);

--- a/embedded/esp32/main/fos_status_screen.h
+++ b/embedded/esp32/main/fos_status_screen.h
@@ -3,4 +3,4 @@
 #include "esp_err.h"
 
 /* Render a minimal on-device status screen without using Nim/pixie. */
-esp_err_t fos_status_screen_show_portal(const char *ssid, const char *ip);
+esp_err_t fos_status_screen_show_portal(const char *ssid, const char *psk, const char *ip);

--- a/embedded/esp32/main/fos_wifi.c
+++ b/embedded/esp32/main/fos_wifi.c
@@ -12,6 +12,7 @@
 #include "esp_mac.h"
 #include "esp_netif.h"
 #include "esp_netif_sntp.h"
+#include "esp_random.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "lwip/sockets.h"
@@ -344,6 +345,34 @@ void fos_wifi_set_portal_exit_cb(fos_wifi_portal_exit_cb cb)
     if (run_now) cb();
 }
 
+/* Readable and unambiguous on a small e-paper panel: no 0/O, 1/l/I. 31
+ * symbols, so bytes >= 248 (= 8 * 31) are rejected rather than folded, which
+ * would make the first few symbols likelier — this is a WPA2 passphrase. */
+static const char AP_PSK_ALPHABET[] = "abcdefghjkmnpqrstuvwxyz23456789";
+#define AP_PSK_LENGTH 10
+
+const char *fos_wifi_ap_psk(void)
+{
+    fos_config_t *config = fos_config();
+    if (config->ap_psk[0]) return config->ap_psk;
+    size_t n = 0;
+    while (n < AP_PSK_LENGTH) {
+        uint32_t word = esp_random();
+        for (int i = 0; i < 4 && n < AP_PSK_LENGTH; i++) {
+            uint8_t byte = (uint8_t)(word >> (8 * i));
+            if (byte >= 248) continue;
+            config->ap_psk[n++] = AP_PSK_ALPHABET[byte % (sizeof(AP_PSK_ALPHABET) - 1)];
+        }
+    }
+    config->ap_psk[n] = '\0';
+    esp_err_t err = fos_config_save();
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "portal passphrase minted but not saved: %s (it changes on the next boot)",
+                 esp_err_to_name(err));
+    }
+    return config->ap_psk;
+}
+
 esp_err_t fos_wifi_start_portal(void)
 {
     if (!s_ap_netif) {
@@ -352,16 +381,19 @@ esp_err_t fos_wifi_start_portal(void)
     uint8_t mac[6];
     esp_read_mac(mac, ESP_MAC_WIFI_SOFTAP);
     snprintf(s_ap_ssid, sizeof(s_ap_ssid), "FrameOS-%02X%02X", mac[4], mac[5]);
+    const char *psk = fos_wifi_ap_psk();
 
     wifi_config_t ap_config = {
         .ap = {
             .channel = 1,
             .max_connection = 4,
-            .authmode = WIFI_AUTH_OPEN,
+            .authmode = WIFI_AUTH_WPA2_PSK,
+            .pmf_cfg = { .required = false },
         },
     };
     strlcpy((char *)ap_config.ap.ssid, s_ap_ssid, sizeof(ap_config.ap.ssid));
     ap_config.ap.ssid_len = strlen(s_ap_ssid);
+    strlcpy((char *)ap_config.ap.password, psk, sizeof(ap_config.ap.password));
 
     bool keep_sta_retrying = fos_config_wifi_ready();
     ESP_ERROR_CHECK(esp_wifi_set_mode(keep_sta_retrying ? WIFI_MODE_APSTA : WIFI_MODE_AP));

--- a/embedded/esp32/main/fos_wifi.h
+++ b/embedded/esp32/main/fos_wifi.h
@@ -17,7 +17,8 @@ typedef enum {
 esp_err_t fos_wifi_init(void);
 /* Connect with stored credentials; blocks up to timeout_ms. */
 esp_err_t fos_wifi_connect(uint32_t timeout_ms);
-/* SoftAP "FrameOS-XXXX" + DNS hijack; portal pages come from fos_http. */
+/* SoftAP "FrameOS-XXXX" (WPA2, per-device passphrase — see fos_wifi_ap_psk)
+ * + DNS hijack; portal pages come from fos_http. */
 esp_err_t fos_wifi_start_portal(void);
 /* The provisioning portal keeps retrying the stored network in APSTA mode.
  * Once the station gets an address the open AP is stopped and this callback
@@ -30,6 +31,10 @@ fos_wifi_state_t fos_wifi_state(void);
 /* IP as string when connected, AP IP in portal mode, else "". */
 const char *fos_wifi_ip(void);
 const char *fos_wifi_ap_ssid(void);
+/* The portal AP passphrase. Minted from hardware entropy and stored in NVS
+ * the first time it is needed (this call or the portal start), so it is the
+ * same every boot and can be read off the status screen or the console. */
+const char *fos_wifi_ap_psk(void);
 int fos_wifi_rssi(void);
 /* Wait up to timeout for SNTP time sync after connecting. */
 esp_err_t fos_wifi_sync_time(uint32_t timeout_ms);

--- a/embedded/esp32/main/main.c
+++ b/embedded/esp32/main/main.c
@@ -405,7 +405,7 @@ void app_main(void)
         s_blink_period_ms = 400;
         fos_wifi_start_portal();
         fos_http_start(true);
-        fos_status_screen_show_portal(fos_wifi_ap_ssid(), fos_wifi_ip());
+        fos_status_screen_show_portal(fos_wifi_ap_ssid(), fos_wifi_ap_psk(), fos_wifi_ip());
         /* Registered after the portal httpd is up, so a station that comes
          * back right away still ends with httpd in status mode (a recovery
          * before this line is replayed by the call). */


### PR DESCRIPTION
Two items from `docs/security-todo.md`, ESP32 only. The Pi setup hotspot keeps its well-known default password by decision (2026-09-03): security is layered, the default still deters some, and a headless or display-less Pi would have no way to read a minted one.

## ESP32 frame JSON
`GET /api/frames` returned `network.wifiPassword`, `admin.pass`, `server_api_key`, `certs.server_key` over a plain-HTTP hop. They now read back as `""`; on POST an empty value means "keep what is stored" (`json_copy_secret_item`), so round-tripped payloads never clear a secret. Backend: `_restore_write_only_secrets()` in `frame_sync.py` fills blank secret leaves from the frame row inside `_load_live_frame_api_payload`, so sync shows no phantom diff and "take the frame's value" cannot blank the row. `wifiPassword` joins `FRAME_SYNC_SECRET_PATH_PARTS`. Documented in `docs/api-triality.md`. Clearing a write-only field via JSON is impossible by design (admin auth: `enabled:false`; Wi-Fi: console/portal).

## ESP32 provisioning AP
The portal AP was open. It is now WPA2-PSK: `ap_psk` minted from `esp_random()` (10 chars, unambiguous alphabet, rejection-sampled) the first time the portal starts, kept in NVS, shown on the portal status screen, printed by `config` over USB (so a board without a panel can always be read), `set ap_psk` overrides (8–63) or re-mints (empty).

## Not done / unverified
- `tls_enable` auto-on when TLS material exists — a deploy-path policy change, left out.
- No hardware: WPA2 join + panel render on a board. ESP-IDF build passes; firmware size is measured by CI.

## Tests
Backend: new `test_frame_sync_secrets.py` (7) + frames/embedded suites pass. ESP32 `idf.py build` (esp32s3) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKnsuRU12dtVXgsHYYcLdi