### PR TITLE
The wasm runtime is a signed release asset; the cloud installs the pinned one

### DIFF
--- a/.github/workflows/cloud-ci.yml
+++ b/.github/workflows/cloud-ci.yml
@@ -1,9 +1,13 @@
 name: Cloud CI
 
 # The cloud app consumes frameos-wasm, frameos-editor and cloud-frontend as
-# workspace packages, so its build pulls in the frontend build and the wasm
-# runtime (nim + emscripten). Turbo caches every step: warm runs skip whatever
-# didn't change.
+# workspace packages, so its build pulls in the frontend build. The wasm
+# runtime itself is NOT built here: auth-web's prebuild installs the signed
+# frameos-<version>-wasm.tar.gz from the release pinned in versions.json
+# (scripts/lib/wasm-runtime.mjs), so the preview renders with the interpreter
+# frames run — a runtime built from main showed features the last firmware
+# did not have. Turbo caches every step: warm runs skip whatever didn't
+# change.
 #
 # These paths are the inputs of everything `turbo run build
 # --filter=@frameos-cloud/auth-web` builds (see turbo.json). A missing one is
@@ -23,13 +27,11 @@ on:
       - "repo/**"
       - "frameos/wasm/**"
       - "frameos/editor/**"
-      # Inputs of frameos-wasm#build:runtime — the wasm the cloud editor's
-      # live preview runs. If they do not trigger a deploy, the preview
-      # silently drifts from what frames actually render.
-      - "frameos/src/wasm/**"
-      - "frameos/src/frameos/**"
-      - "frameos/frameos.nimble"
-      - "frameos/tools/build_wasm.sh"
+      # The Nim runtime sources are deliberately NOT here: the wasm bundle
+      # comes from the release pinned in versions.json, and a release
+      # reaches production through the workflow_run trigger below.
+      - "versions.json"
+      - "release-assets/firmware-signing.pub"
       - "turbo.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -56,13 +58,8 @@ on:
       - "repo/**"
       - "frameos/wasm/**"
       - "frameos/editor/**"
-      # Inputs of frameos-wasm#build:runtime — the wasm the cloud editor's
-      # live preview runs. If they do not trigger a deploy, the preview
-      # silently drifts from what frames actually render.
-      - "frameos/src/wasm/**"
-      - "frameos/src/frameos/**"
-      - "frameos/frameos.nimble"
-      - "frameos/tools/build_wasm.sh"
+      - "versions.json"
+      - "release-assets/firmware-signing.pub"
       - "turbo.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -77,9 +74,8 @@ concurrency:
 # The token GitHub hands the jobs is read-only. Neither job comments on PRs,
 # writes checks or statuses, or uses OIDC: verify only checks out and builds,
 # and deploy reaches production over an SSH key held in the `production`
-# environment, not through the GitHub API. The only token use is
-# setup-nim-action's `repo-token`, which reads nim-lang releases (an
-# unauthenticated rate-limit dodge; `contents: read` is plenty).
+# environment, not through the GitHub API. The wasm runtime download is a
+# plain unauthenticated GET of a public release asset.
 permissions:
   contents: read
 
@@ -143,43 +139,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      # nim-lang.org drops connections and serves 503s often enough to fail
-      # real runs — one observed window outlasted curl's five retries AND a
-      # spaced second attempt. Cache the installed toolchain: on a hit the
-      # host is never contacted at all; the download (with its one retry
-      # below) only runs when this key has never been populated.
-      - name: Cache Nim toolchain
-        id: cache_nim_toolchain
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.choosenim
-            ~/.nimble/bin
-          key: ${{ runner.os }}-nim-toolchain-2.2.4
-
-      - uses: jiro4989/setup-nim-action@v1
-        if: steps.cache_nim_toolchain.outputs.cache-hit != 'true'
-        id: setup_nim
-        continue-on-error: true
-        with:
-          nim-version: 2.2.4
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Retry Nim setup once
-        if: steps.cache_nim_toolchain.outputs.cache-hit != 'true' && steps.setup_nim.outcome == 'failure'
-        uses: jiro4989/setup-nim-action@v1
-        with:
-          nim-version: 2.2.4
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add cached Nim to PATH
-        if: steps.cache_nim_toolchain.outputs.cache-hit == 'true'
-        run: echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-
-      - uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: 6.0.2
-
       - uses: actions/cache@v4
         with:
           path: .turbo
@@ -188,15 +147,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # The wasm runtime (frameos.js/frameos.wasm) is a build output, not
-      # committed; turbo caches it against the nim sources.
-      - name: Build the wasm runtime
-        run: |
-          (cd frameos && nimble install -d -y)
-          pnpm exec turbo run build:runtime --filter=frameos-wasm
-
       # Lint, typecheck, test, and build the cloud workspace; turbo builds
-      # the frontend, editor, and wasm packages it depends on.
+      # the frontend, editor, and wasm packages it depends on. auth-web's
+      # prebuild downloads and verifies the release's wasm runtime.
       - run: pnpm exec turbo run lint typecheck test build --filter='@frameos-cloud/*'
 
       # Backend-linking flow against the Postgres service container.
@@ -318,35 +271,8 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      # Same cache as verify, for the same reason (nim-lang.org is unreliable).
-      - name: Cache Nim toolchain
-        if: steps.freshness.outputs.proceed == 'true'
-        id: cache_nim_toolchain
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.choosenim
-            ~/.nimble/bin
-          key: ${{ runner.os }}-nim-toolchain-2.2.4
-
-      - uses: jiro4989/setup-nim-action@2af8a1a117733b60524c7c873a4cc91885796cfe # v1.5.2
-        if: steps.freshness.outputs.proceed == 'true' && steps.cache_nim_toolchain.outputs.cache-hit != 'true'
-        with:
-          nim-version: 2.2.4
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add cached Nim to PATH
-        if: steps.freshness.outputs.proceed == 'true' && steps.cache_nim_toolchain.outputs.cache-hit == 'true'
-        run: echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
-
-      - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
-        if: steps.freshness.outputs.proceed == 'true'
-        with:
-          version: 6.0.2
-
       # verify just wrote this exact key, so the build below is mostly cache
-      # replay rather than a second full build of the frontend and the wasm
-      # runtime.
+      # replay rather than a second full build of the frontend.
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: steps.freshness.outputs.proceed == 'true'
         with:
@@ -358,20 +284,11 @@ jobs:
         if: steps.freshness.outputs.proceed == 'true'
         run: pnpm install --frozen-lockfile
 
-      # build:runtime is not part of the `build` task graph, so the deploy has
-      # to ask for it explicitly or the editor would ship whatever wasm
-      # happened to be lying around.
-      - name: Build the wasm runtime
-        if: steps.freshness.outputs.proceed == 'true'
-        run: |
-          (cd frameos && nimble install -d -y)
-          pnpm exec turbo run build:runtime --filter=frameos-wasm
-          # deploy.sh refuses a dirty tree, and "commit or stash" is unhelpful
-          # advice on a runner: say what actually moved.
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::warning::the build left the tree dirty; the deploy will refuse it"
-            git status --porcelain
-          fi
+      # The wasm runtime is not built here: `pnpm deploy:prod` below runs
+      # auth-web's prebuild, which installs the signed bundle of the release
+      # pinned in versions.json (scripts/lib/wasm-runtime.mjs). A deploy
+      # between a release's version bump and its assets landing fails on
+      # that download and is simply re-run.
 
       # Written only now, after every third-party action in this job has
       # run: the key is root on the production box, and nothing that is
@@ -403,7 +320,7 @@ jobs:
       # must not silently take that away while someone is using it. Deploying
       # main by hand when you are done re-arms this.
       # Runs here, after Configure SSH, because it is the first thing that
-      # needs the key; the wasm build above is wasted when it stands down,
+      # needs the key; the install above is wasted when it stands down,
       # which is the cheaper side of "the key is on disk only after every
       # third-party action in the job".
       - name: Stand down if production is running a branch

--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -83,13 +83,16 @@ jobs:
 
   publish-npm:
     name: Publish FrameOS npm packages
-    needs: update-versions
+    needs: [update-versions, build-wasm-runtime]
     runs-on: ubuntu-latest
     steps:
       # npm auth uses trusted publishing (OIDC), which matches on the
       # top-level workflow file — so publishing lives in npm-publish.yml and
       # is dispatched here rather than run inline. That workflow is also
       # manually dispatchable to re-publish without bumping versions.
+      # The run id lets it download the wasm runtime this run already built
+      # (build-wasm-runtime) instead of compiling a second copy: the npm
+      # package then ships byte-for-byte what the release attached.
       - name: Dispatch npm publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
@@ -98,7 +101,8 @@ jobs:
           gh workflow run npm-publish.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
-            -f ref="$RELEASE_SHA"
+            -f ref="$RELEASE_SHA" \
+            -f runtime_run_id="$GITHUB_RUN_ID"
 
   release-notes:
     name: Generate Release Notes
@@ -650,6 +654,88 @@ jobs:
             release-assets/*-${{ matrix.chip }}-*mb-size.json
           if-no-files-found: error
 
+  # The interpreted-scene runtime compiled to WebAssembly: what the cloud's
+  # browser preview and headless renderer run, and what the frameos-wasm npm
+  # package ships. Built once here from the release commit and attached to
+  # the release as frameos-<version>-wasm.tar.gz — signed with the firmware
+  # key in the github-release job like every other .tar.gz — so FrameOS
+  # Cloud installs the runtime frames actually run instead of compiling one
+  # from main (cloud/apps/auth-web/scripts/lib/wasm-runtime.mjs pins the
+  # release version from versions.json and verifies the .minisig). The npm
+  # publish job downloads this artifact rather than building again.
+  build-wasm-runtime:
+    name: Build wasm runtime
+    needs: [update-versions]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.update-versions.outputs.release_sha }}
+
+      # Same Nim toolchain cache as npm-publish.yml, for the same reason
+      # (nim-lang.org drops connections often enough to fail real runs).
+      - name: Cache Nim toolchain
+        id: cache_nim_toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.choosenim
+            ~/.nimble/bin
+          key: ${{ runner.os }}-nim-toolchain-2.2.4
+
+      - uses: jiro4989/setup-nim-action@v1
+        if: steps.cache_nim_toolchain.outputs.cache-hit != 'true'
+        id: setup_nim
+        continue-on-error: true
+        with:
+          nim-version: 2.2.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retry Nim setup once
+        if: steps.cache_nim_toolchain.outputs.cache-hit != 'true' && steps.setup_nim.outcome == 'failure'
+        uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 2.2.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add cached Nim to PATH
+        if: steps.cache_nim_toolchain.outputs.cache-hit == 'true'
+        run: echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 6.0.2
+
+      # build_wasm.sh writes frameos.js, frameos.wasm, preview-worker.js and
+      # a version.json stamp (interpreter version, release, commit) into the
+      # output directory; the tarball holds those four files at its top
+      # level. Named by the release version like the firmware images, so
+      # the cloud can pin it from versions.json's `docker` entry.
+      - name: Build the wasm runtime
+        env:
+          DOCKER_VERSION: ${{ needs.update-versions.outputs.docker_version }}
+          FRAMEOS_WASM_COMMIT: ${{ needs.update-versions.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          out="$PWD/release-assets/frameos-$DOCKER_VERSION-wasm"
+          mkdir -p "$out"
+          (cd frameos && nimble install -d -y && ./tools/build_wasm.sh --out "$out")
+          test -f "$out/version.json"
+          tar -czf "release-assets/frameos-$DOCKER_VERSION-wasm.tar.gz" \
+            -C "$out" frameos.js frameos.wasm preview-worker.js version.json
+          rm -rf "$out"
+          ls -lh release-assets/
+
+      - name: Upload wasm runtime
+        uses: actions/upload-artifact@v4
+        with:
+          # frameos-<version>-* so the github-release job picks it up and
+          # signs it with the other archives.
+          name: frameos-${{ needs.update-versions.outputs.docker_version }}-wasm
+          path: release-assets/*-wasm.tar.gz
+          if-no-files-found: error
+
   # Prebuilt thin-client firmware for Raspberry Pi Pico W / Pico 2 W (the
   # Pimoroni Inky Frame family). Generic on purpose: UF2s flash over BOOTSEL
   # drag-drop and provision over the USB serial console, the backend never
@@ -854,7 +940,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [update-versions, push-multiarch, build-prebuilt-cross, build-buildroot-release-image, build-esp32-generic-firmware, build-esp32-layout-firmware, build-pico-firmware, update-addon-repo, release-notes]
+    needs: [update-versions, push-multiarch, build-prebuilt-cross, build-buildroot-release-image, build-esp32-generic-firmware, build-esp32-layout-firmware, build-wasm-runtime, build-pico-firmware, update-addon-repo, release-notes]
     runs-on: ubuntu-latest
     steps:
       # Shallow: this job only needs a working directory for `gh` and the

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,10 +16,21 @@ on:
         required: false
         type: string
         default: main
+      runtime_run_id:
+        description: >-
+          Run id of a "Release FrameOS" run whose build-wasm-runtime job
+          built the wasm bundle: download that artifact instead of compiling
+          the runtime here (the release job passes its own id). Leave empty to
+          build from source.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
   id-token: write
+  # `gh run download` of the release run's wasm artifact.
+  actions: read
 
 concurrency:
   group: npm-publish
@@ -57,7 +68,10 @@ jobs:
       # spaced second attempt. Cache the installed toolchain: on a hit the
       # host is never contacted at all; the download (with its one retry
       # below) only runs when this key has never been populated.
+      # The toolchain is only needed when this run compiles the runtime
+      # itself (no runtime_run_id): a release hands over the bundle it built.
       - name: Cache Nim toolchain
+        if: inputs.runtime_run_id == ''
         id: cache_nim_toolchain
         uses: actions/cache@v4
         with:
@@ -67,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-nim-toolchain-2.2.4
 
       - uses: jiro4989/setup-nim-action@v1
-        if: steps.cache_nim_toolchain.outputs.cache-hit != 'true'
+        if: inputs.runtime_run_id == '' && steps.cache_nim_toolchain.outputs.cache-hit != 'true'
         id: setup_nim
         continue-on-error: true
         with:
@@ -75,26 +89,47 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retry Nim setup once
-        if: steps.cache_nim_toolchain.outputs.cache-hit != 'true' && steps.setup_nim.outcome == 'failure'
+        if: inputs.runtime_run_id == '' && steps.cache_nim_toolchain.outputs.cache-hit != 'true' && steps.setup_nim.outcome == 'failure'
         uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: 2.2.4
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add cached Nim to PATH
-        if: steps.cache_nim_toolchain.outputs.cache-hit == 'true'
+        if: inputs.runtime_run_id == '' && steps.cache_nim_toolchain.outputs.cache-hit == 'true'
         run: echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
       - uses: mymindstorm/setup-emsdk@v14
+        if: inputs.runtime_run_id == ''
         with:
           version: 6.0.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # A release dispatches this workflow with the run id whose
+      # build-wasm-runtime job built the bundle, so the npm package ships
+      # the exact frameos-<version>-wasm.tar.gz the release attached —
+      # extracted to where build_wasm.sh would have written it, so the
+      # package build below does not know the difference.
+      - name: Download the release's wasm runtime
+        if: inputs.runtime_run_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUNTIME_RUN_ID: ${{ inputs.runtime_run_id }}
+        run: |
+          set -euo pipefail
+          version=$(python3 -c "import json; print(json.load(open('versions.json'))['docker'].split('+', 1)[0])")
+          gh run download "$RUNTIME_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "frameos-${version}-wasm" --dir release-assets
+          mkdir -p frontend/public/frameos-wasm
+          tar -xzf "release-assets/frameos-${version}-wasm.tar.gz" -C frontend/public/frameos-wasm
+          ls -la frontend/public/frameos-wasm
+
       # The runtime assets (frameos.js/frameos.wasm) are build outputs, not
       # committed — compile them like the Dockerfile does.
       - name: Build the wasm runtime
+        if: inputs.runtime_run_id == ''
         run: |
           cd frameos
           nimble install -d -y

--- a/cloud/apps/auth-web/app/api/scenes/render/route.ts
+++ b/cloud/apps/auth-web/app/api/scenes/render/route.ts
@@ -16,6 +16,7 @@ import {
   maxRenderDimension,
   maxRenderPixels,
   minRenderDimension,
+  rendererVersion,
   renderScenes,
   SceneRenderError,
 } from "../../../../src/lib/scene-render";
@@ -137,6 +138,7 @@ export async function POST(request: NextRequest) {
           logs: result.logs,
           png_base64: result.png.toString("base64"),
           render_ms: result.renderMs,
+          runtime_version: rendererVersion(),
           state: result.state,
           ...(sceneVersion ? { version: sceneVersion } : {}),
           width: result.width,
@@ -148,6 +150,7 @@ export async function POST(request: NextRequest) {
       headers: {
         "cache-control": "no-store",
         "content-length": String(result.png.length),
+        ...(rendererVersion() ? { "x-frameos-runtime-version": rendererVersion() as string } : {}),
         "content-type": "image/png",
         "x-render-errors": String(result.errors.length),
         "x-render-ms": String(result.renderMs),

--- a/cloud/apps/auth-web/scripts/copy-editor-assets.mjs
+++ b/cloud/apps/auth-web/scripts/copy-editor-assets.mjs
@@ -12,6 +12,7 @@ import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveRuntimeDir, runtimeFilesIn } from "./lib/wasm-runtime.mjs";
 
 const appDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const require = createRequire(join(appDir, "package.json"));
@@ -43,10 +44,18 @@ cpSync(editorDist, target, { recursive: true });
 // The editor's built-in Preview panel loads the frameos-wasm runtime from
 // ./frameos-wasm/ relative to its own directory (the bundle resolves asset
 // URLs against its ingress path), so the runtime assets must sit next to it.
-const wasmAssetsDir = dirname(require.resolve("frameos-wasm/assets/preview-worker.js"));
+// Same source as copy-wasm-assets.mjs: the release's signed bundle, or the
+// local build with FRAMEOS_WASM_SOURCE=local.
+let wasmAssetsDir;
+try {
+  wasmAssetsDir = await resolveRuntimeDir();
+} catch (error) {
+  console.error(`frameos-wasm runtime: ${error.message}`);
+  process.exit(1);
+}
 const wasmTarget = join(target, "frameos-wasm");
 mkdirSync(wasmTarget, { recursive: true });
-for (const file of ["frameos.js", "frameos.wasm", "preview-worker.js"]) {
+for (const file of runtimeFilesIn(wasmAssetsDir)) {
   cpSync(join(wasmAssetsDir, file), join(wasmTarget, file));
 }
-console.log(`Copied frameos-editor assets (with frameos-wasm runtime) to ${target}`);
+console.log(`Copied frameos-editor assets (with the frameos-wasm runtime) to ${target}`);

--- a/cloud/apps/auth-web/scripts/copy-wasm-assets.mjs
+++ b/cloud/apps/auth-web/scripts/copy-wasm-assets.mjs
@@ -1,19 +1,28 @@
 // The frameos-wasm runtime runs in a Web Worker and must be served
-// same-origin: copy its assets out of node_modules into public/ (gitignored)
-// before dev/build. See src/components/SceneLivePreview.tsx.
-/* global console */
+// same-origin: install it into public/frameos-wasm (gitignored) before
+// dev/build. See src/components/SceneLivePreview.tsx.
+//
+// Where it comes from is lib/wasm-runtime.mjs's business: by default the
+// signed, version-pinned bundle from the FrameOS release (so the preview
+// renders with the interpreter frames actually run), or the workspace
+// package's own build with FRAMEOS_WASM_SOURCE=local.
+/* global console, process */
 import { copyFileSync, mkdirSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveRuntimeDir, runtimeFilesIn } from "./lib/wasm-runtime.mjs";
 
 const appDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const require = createRequire(join(appDir, "package.json"));
-const assetsDir = dirname(require.resolve("frameos-wasm/assets/preview-worker.js"));
 const target = join(appDir, "public", "frameos-wasm");
 
-mkdirSync(target, { recursive: true });
-for (const file of ["frameos.js", "frameos.wasm", "preview-worker.js"]) {
-  copyFileSync(join(assetsDir, file), join(target, file));
+try {
+  const source = await resolveRuntimeDir();
+  mkdirSync(target, { recursive: true });
+  for (const file of runtimeFilesIn(source)) {
+    copyFileSync(join(source, file), join(target, file));
+  }
+  console.log(`Installed the frameos-wasm runtime into ${target}`);
+} catch (error) {
+  console.error(`frameos-wasm runtime: ${error.message}`);
+  process.exit(1);
 }
-console.log(`Copied frameos-wasm assets to ${target}`);

--- a/cloud/apps/auth-web/scripts/lib/wasm-runtime.mjs
+++ b/cloud/apps/auth-web/scripts/lib/wasm-runtime.mjs
@@ -1,0 +1,257 @@
+// Where the wasm runtime the cloud serves comes from.
+//
+// The runtime (frameos.js / frameos.wasm / preview-worker.js) is the
+// interpreter frames run, compiled to WebAssembly. Frames run the last
+// release; a preview that renders with a runtime built from `main` shows
+// features the frame's firmware does not have yet — one skew shipped a scene
+// that previewed fine and painted "No image provided" on the panel. So the
+// cloud does not build the runtime: it installs the one the release job
+// built, signed and attached to the GitHub release (frameos-<v>-wasm.tar.gz
+// + .minisig, signed with the firmware key in release-assets/), pinned by
+// the release version in the repo's versions.json — the one place the
+// release bump already updates. A new interpreter feature reaches the
+// browser preview with the next release, exactly when it reaches frames.
+//
+// FRAMEOS_WASM_SOURCE=local is the development escape hatch: use the
+// workspace package's own build (frameos/wasm/dist/assets, from
+// `turbo run build:runtime --filter=frameos-wasm`) — for working on the
+// Nim runtime itself, or when there is no network.
+/* global Buffer, console, fetch, process */
+import { createHash, createPublicKey, verify as cryptoVerify } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const runtimeFiles = ["frameos.js", "frameos.wasm", "preview-worker.js"];
+// Shipped by build_wasm.sh next to the bundle; older release tarballs may
+// not carry it, so it is optional everywhere it is read.
+export const runtimeStampFile = "version.json";
+
+const appDir = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const repoRoot = dirname(dirname(dirname(appDir)));
+
+export const defaultReleaseRepo = "FrameOS/frameos";
+
+/** The release version the cloud pins its runtime to: the `docker` entry of
+ * the repo's versions.json (the release tag is v<that>), without the hash. */
+export function pinnedReleaseVersion(versionsPath = join(repoRoot, "versions.json")) {
+  const versions = JSON.parse(readFileSync(versionsPath, "utf8"));
+  const version = String(versions.docker ?? "").split("+")[0];
+  if (!/^\d{4}\.\d{1,2}\.\d+$/.test(version)) {
+    throw new Error(`versions.json has no usable release version (docker: ${versions.docker})`);
+  }
+  return version;
+}
+
+export function releaseAssetName(version) {
+  return `frameos-${version}-wasm.tar.gz`;
+}
+
+export function releaseAssetUrl(version, repo = defaultReleaseRepo) {
+  return `https://github.com/${repo}/releases/download/v${version}/${releaseAssetName(version)}`;
+}
+
+// --- minisign (as tools/sign_firmware.py writes it) ------------------------
+//
+// Public key file: "untrusted comment: …" then base64("Ed" + keyId8 + pub32).
+// Signature file: untrusted comment, base64("ED" + keyId8 + sig64), trusted
+// comment, base64(globalSig64). "ED" is minisign's pre-hashed mode: the
+// Ed25519 message is BLAKE2b-512 of the file; the global signature covers
+// sig64 + the trusted comment text.
+
+function decodeKeyLine(text, label) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("untrusted comment:") && !line.startsWith("trusted comment:"));
+  if (lines.length === 0) {
+    throw new Error(`${label}: no key material`);
+  }
+  return lines;
+}
+
+export function parseMinisignPublicKey(text) {
+  const [line] = decodeKeyLine(text, "public key");
+  const blob = Buffer.from(line, "base64");
+  if (blob.length !== 42 || blob.subarray(0, 2).toString("latin1") !== "Ed") {
+    throw new Error("public key blob must be base64(Ed + keyid8 + pubkey32)");
+  }
+  return { keyId: blob.subarray(2, 10), publicKey: blob.subarray(10, 42) };
+}
+
+export function parseMinisignSignature(text) {
+  const lines = decodeKeyLine(text, "signature");
+  const blob = Buffer.from(lines[0], "base64");
+  if (blob.length !== 74 || blob.subarray(0, 2).toString("latin1") !== "ED") {
+    throw new Error("signature blob must be base64(ED + keyid8 + signature64)");
+  }
+  const trusted = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("trusted comment:"));
+  return {
+    keyId: blob.subarray(2, 10),
+    signature: blob.subarray(10, 74),
+    trustedComment: trusted ? trusted.slice("trusted comment:".length).trim() : null,
+    globalSignature: lines[1] ? Buffer.from(lines[1], "base64") : null,
+  };
+}
+
+// Node wants an SPKI key object; this is the DER prefix for a raw Ed25519 key.
+const ed25519SpkiPrefix = Buffer.from("302a300506032b6570032100", "hex");
+
+function ed25519Verify(publicKey, message, signature) {
+  const key = createPublicKey({
+    key: Buffer.concat([ed25519SpkiPrefix, publicKey]),
+    format: "der",
+    type: "spki",
+  });
+  return cryptoVerify(null, message, key, signature);
+}
+
+/** Throws unless `fileBytes` carries a valid minisign signature from the key. */
+export function verifyMinisign({ publicKeyText, signatureText, fileBytes, label = "file" }) {
+  const pub = parseMinisignPublicKey(publicKeyText);
+  const sig = parseMinisignSignature(signatureText);
+  if (!sig.keyId.equals(pub.keyId)) {
+    throw new Error(`${label}: signature key id ${sig.keyId.toString("hex")} does not match the release key ${pub.keyId.toString("hex")}`);
+  }
+  const digest = createHash("blake2b512").update(fileBytes).digest();
+  if (!ed25519Verify(pub.publicKey, digest, sig.signature)) {
+    throw new Error(`${label}: signature does not verify against the release key`);
+  }
+  if (sig.globalSignature && sig.trustedComment !== null) {
+    const message = Buffer.concat([sig.signature, Buffer.from(sig.trustedComment, "utf8")]);
+    if (!ed25519Verify(pub.publicKey, message, sig.globalSignature)) {
+      throw new Error(`${label}: trusted comment does not verify against the release key`);
+    }
+  }
+  return { keyId: pub.keyId.toString("hex"), trustedComment: sig.trustedComment };
+}
+
+// --- fetching + unpacking --------------------------------------------------
+
+async function download(url, { fetchImpl = fetch } = {}) {
+  const response = await fetchImpl(url, { redirect: "follow" });
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> HTTP ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+function extractedRuntimeDir(dir) {
+  // The release tarball holds the files at its top level; tolerate one
+  // wrapping directory so a hand-made tarball works too.
+  if (runtimeFiles.every((file) => existsSync(join(dir, file)))) {
+    return dir;
+  }
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory() && runtimeFiles.every((file) => existsSync(join(dir, entry.name, file)))) {
+      return join(dir, entry.name);
+    }
+  }
+  throw new Error(`the runtime tarball does not contain ${runtimeFiles.join(", ")}`);
+}
+
+/**
+ * Downloads (once) and verifies the release's wasm runtime, unpacks it, and
+ * returns the directory holding frameos.js / frameos.wasm / preview-worker.js
+ * (+ version.json). The signature is re-checked on every call, cached or not:
+ * the cache is a convenience, the key is the trust.
+ */
+export async function installReleaseRuntime({
+  version = pinnedReleaseVersion(),
+  repo = process.env.FRAMEOS_WASM_RELEASE_REPO || defaultReleaseRepo,
+  cacheDir = join(appDir, "node_modules", ".cache", "frameos-wasm"),
+  publicKeyPath = join(repoRoot, "release-assets", "firmware-signing.pub"),
+  fetchImpl = fetch,
+  log = console.log,
+} = {}) {
+  const versionDir = join(cacheDir, version);
+  const tarball = join(versionDir, releaseAssetName(version));
+  const signature = `${tarball}.minisig`;
+  const url = releaseAssetUrl(version, repo);
+  mkdirSync(versionDir, { recursive: true });
+
+  if (!existsSync(tarball) || !existsSync(signature)) {
+    log(`Downloading the FrameOS ${version} wasm runtime from ${url}`);
+    let bytes;
+    let sigBytes;
+    try {
+      bytes = await download(url, { fetchImpl });
+      sigBytes = await download(`${url}.minisig`, { fetchImpl });
+    } catch (error) {
+      throw new Error(
+        `Could not fetch the wasm runtime for release ${version} (${error.message}). ` +
+          `If the release is still being published, retry in a few minutes; ` +
+          `to build the runtime locally instead, set FRAMEOS_WASM_SOURCE=local.`,
+      );
+    }
+    writeFileSync(tarball, bytes);
+    writeFileSync(signature, sigBytes);
+  }
+
+  const publicKeyText = readFileSync(publicKeyPath, "utf8");
+  const verified = verifyMinisign({
+    publicKeyText,
+    signatureText: readFileSync(signature, "utf8"),
+    fileBytes: readFileSync(tarball),
+    label: releaseAssetName(version),
+  });
+
+  const extractDir = join(versionDir, "runtime");
+  rmSync(extractDir, { force: true, recursive: true });
+  mkdirSync(extractDir, { recursive: true });
+  execFileSync("tar", ["-xzf", tarball, "-C", extractDir], { stdio: "inherit" });
+  const dir = extractedRuntimeDir(extractDir);
+  const stamp = readRuntimeStamp(dir);
+  log(
+    `Verified the FrameOS ${version} wasm runtime (key ${verified.keyId}` +
+      (stamp?.version ? `, interpreter ${stamp.version}` : "") +
+      `)`,
+  );
+  return dir;
+}
+
+/** The version.json shipped next to the bundle, or null when absent. */
+export function readRuntimeStamp(dir) {
+  const path = join(dir, runtimeStampFile);
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** The workspace package's own build (FRAMEOS_WASM_SOURCE=local). */
+export function localRuntimeDir() {
+  const require = createRequire(join(appDir, "package.json"));
+  return dirname(require.resolve("frameos-wasm/assets/preview-worker.js"));
+}
+
+/**
+ * The directory the copy scripts install from, per FRAMEOS_WASM_SOURCE:
+ * "release" (default) or "local".
+ */
+export async function resolveRuntimeDir({ env = process.env, log = console.log } = {}) {
+  const source = (env.FRAMEOS_WASM_SOURCE || "release").trim();
+  if (source === "local") {
+    const dir = localRuntimeDir();
+    log(`Using the locally built wasm runtime from ${dir} (FRAMEOS_WASM_SOURCE=local)`);
+    return dir;
+  }
+  if (source !== "release") {
+    throw new Error(`FRAMEOS_WASM_SOURCE must be "release" or "local", not "${source}"`);
+  }
+  return installReleaseRuntime({ log });
+}
+
+/** Files to copy out of a runtime dir: the bundle plus the stamp when present. */
+export function runtimeFilesIn(dir) {
+  return existsSync(join(dir, runtimeStampFile)) ? [...runtimeFiles, runtimeStampFile] : runtimeFiles;
+}

--- a/cloud/apps/auth-web/scripts/lib/wasm-runtime.test.mjs
+++ b/cloud/apps/auth-web/scripts/lib/wasm-runtime.test.mjs
@@ -1,0 +1,198 @@
+// The cloud installs the wasm runtime from a signed release asset; these
+// tests pin the two things that make that safe — the signature check is the
+// same format tools/sign_firmware.py writes, and the installer refuses a
+// tarball the release key did not sign — plus the version pin's source.
+/* global Buffer, URL */
+import { execFileSync } from "node:child_process";
+import { createHash, generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  installReleaseRuntime,
+  parseMinisignPublicKey,
+  pinnedReleaseVersion,
+  readRuntimeStamp,
+  releaseAssetName,
+  releaseAssetUrl,
+  runtimeFiles,
+  verifyMinisign,
+} from "./wasm-runtime.mjs";
+
+// A throwaway Ed25519 key in the layout sign_firmware.py uses: raw 32-byte
+// public key behind "Ed" + an 8-byte key id; signatures "ED" + id + sig64.
+function makeKey() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  const raw = spki.subarray(spki.length - 32);
+  const keyId = Buffer.from("0102030405060708", "hex");
+  const publicKeyText =
+    "untrusted comment: test key\n" + Buffer.concat([Buffer.from("Ed"), keyId, raw]).toString("base64") + "\n";
+  function signFile(bytes, name) {
+    const digest = createHash("blake2b512").update(bytes).digest();
+    const signature = cryptoSign(null, digest, privateKey);
+    const trusted = `frameos ${name}`;
+    const globalSig = cryptoSign(null, Buffer.concat([signature, Buffer.from(trusted)]), privateKey);
+    return (
+      "untrusted comment: signature from FrameOS firmware key\n" +
+      Buffer.concat([Buffer.from("ED"), keyId, signature]).toString("base64") +
+      "\n" +
+      `trusted comment: ${trusted}\n` +
+      globalSig.toString("base64") +
+      "\n"
+    );
+  }
+  return { publicKeyText, signFile, keyId };
+}
+
+describe("minisign verification", () => {
+  it("accepts a signature from the key, over the file's BLAKE2b-512 digest", () => {
+    const key = makeKey();
+    const bytes = Buffer.from("hello runtime");
+    const result = verifyMinisign({
+      publicKeyText: key.publicKeyText,
+      signatureText: key.signFile(bytes, "x.tar.gz"),
+      fileBytes: bytes,
+    });
+    expect(result.keyId).toBe("0102030405060708");
+    expect(result.trustedComment).toBe("frameos x.tar.gz");
+  });
+
+  it("refuses a tampered file, a foreign key and a forged trusted comment", () => {
+    const key = makeKey();
+    const other = makeKey();
+    const bytes = Buffer.from("hello runtime");
+    const signatureText = key.signFile(bytes, "x.tar.gz");
+    expect(() =>
+      verifyMinisign({ publicKeyText: key.publicKeyText, signatureText, fileBytes: Buffer.from("hello runtimf") }),
+    ).toThrow(/does not verify/);
+    expect(() => verifyMinisign({ publicKeyText: other.publicKeyText, signatureText, fileBytes: bytes })).toThrow(
+      /does not verify/,
+    );
+    const forged = signatureText.replace("trusted comment: frameos x.tar.gz", "trusted comment: frameos y.tar.gz");
+    expect(() => verifyMinisign({ publicKeyText: key.publicKeyText, signatureText: forged, fileBytes: bytes })).toThrow(
+      /trusted comment/,
+    );
+  });
+
+  it("reads the committed release key", () => {
+    const text = readFileSync(new URL("../../../../../release-assets/firmware-signing.pub", import.meta.url), "utf8");
+    const parsed = parseMinisignPublicKey(text);
+    expect(parsed.publicKey.length).toBe(32);
+    expect(parsed.keyId.length).toBe(8);
+  });
+});
+
+describe("release pin", () => {
+  it("is the release version in versions.json, without the build hash", () => {
+    const dir = mkdtempSync(join(tmpdir(), "frameos-wasm-pin-"));
+    writeFileSync(join(dir, "versions.json"), JSON.stringify({ docker: "2026.9.1+abcdef", frameos: "2026.9.0+123" }));
+    expect(pinnedReleaseVersion(join(dir, "versions.json"))).toBe("2026.9.1");
+    expect(releaseAssetName("2026.9.1")).toBe("frameos-2026.9.1-wasm.tar.gz");
+    expect(releaseAssetUrl("2026.9.1")).toBe(
+      "https://github.com/FrameOS/frameos/releases/download/v2026.9.1/frameos-2026.9.1-wasm.tar.gz",
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads the repo's own versions.json", () => {
+    expect(pinnedReleaseVersion()).toMatch(/^\d{4}\.\d{1,2}\.\d+$/);
+  });
+});
+
+describe("installReleaseRuntime", () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "frameos-wasm-install-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeTarball(name) {
+    const src = join(dir, "src");
+    mkdirSync(src, { recursive: true });
+    for (const file of runtimeFiles) {
+      writeFileSync(join(src, file), `// ${file}\n`);
+    }
+    writeFileSync(join(src, "version.json"), JSON.stringify({ version: "2026.9.0", release: "2026.9.1" }));
+    const tarball = join(dir, name);
+    execFileSync("tar", ["-czf", tarball, "-C", src, ...runtimeFiles, "version.json"]);
+    return readFileSync(tarball);
+  }
+
+  function fetcher(responses) {
+    const calls = [];
+    const fetchImpl = async (url) => {
+      calls.push(url);
+      const body = responses[url];
+      if (!body) {
+        return { ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) };
+      }
+      return { ok: true, status: 200, arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) };
+    };
+    return { fetchImpl, calls };
+  }
+
+  it("downloads, verifies, unpacks, and reuses the cached download", async () => {
+    const key = makeKey();
+    writeFileSync(join(dir, "key.pub"), key.publicKeyText);
+    const name = releaseAssetName("2026.9.1");
+    const tarball = makeTarball(name);
+    const url = releaseAssetUrl("2026.9.1");
+    const { fetchImpl, calls } = fetcher({
+      [url]: tarball,
+      [`${url}.minisig`]: Buffer.from(key.signFile(tarball, name)),
+    });
+    const options = {
+      version: "2026.9.1",
+      cacheDir: join(dir, "cache"),
+      publicKeyPath: join(dir, "key.pub"),
+      fetchImpl,
+      log: () => {},
+    };
+    const runtimeDir = await installReleaseRuntime(options);
+    for (const file of runtimeFiles) {
+      expect(readFileSync(join(runtimeDir, file), "utf8")).toBe(`// ${file}\n`);
+    }
+    expect(readRuntimeStamp(runtimeDir)).toMatchObject({ version: "2026.9.0", release: "2026.9.1" });
+    expect(calls).toHaveLength(2);
+
+    await installReleaseRuntime(options);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("refuses a tarball the release key did not sign, and a missing asset", async () => {
+    const key = makeKey();
+    const impostor = makeKey();
+    writeFileSync(join(dir, "key.pub"), key.publicKeyText);
+    const name = releaseAssetName("2026.9.1");
+    const tarball = makeTarball(name);
+    const url = releaseAssetUrl("2026.9.1");
+    const signed = fetcher({
+      [url]: tarball,
+      [`${url}.minisig`]: Buffer.from(impostor.signFile(tarball, name)),
+    });
+    await expect(
+      installReleaseRuntime({
+        version: "2026.9.1",
+        cacheDir: join(dir, "cache-a"),
+        publicKeyPath: join(dir, "key.pub"),
+        fetchImpl: signed.fetchImpl,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/does not verify/);
+
+    const missing = fetcher({});
+    await expect(
+      installReleaseRuntime({
+        version: "2026.9.2",
+        cacheDir: join(dir, "cache-b"),
+        publicKeyPath: join(dir, "key.pub"),
+        fetchImpl: missing.fetchImpl,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/Could not fetch the wasm runtime for release 2026.9.2/);
+  });
+});

--- a/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
+++ b/cloud/apps/auth-web/src/components/SceneLivePreview.tsx
@@ -365,6 +365,10 @@ export function SceneLivePreviewPanel({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const previewRef = useRef<FrameOSPreview | null>(null);
   const [sceneInfo, setSceneInfo] = useState<SceneInfo | null>(null);
+  // Which FrameOS version the runtime is. The cloud installs the bundle from
+  // a release, so this is the last release's interpreter — a frame on newer
+  // or older firmware can render a scene differently.
+  const [runtimeVersion, setRuntimeVersion] = useState<string | null>(null);
   const [currentSceneId, setCurrentSceneId] = useState<string | null>(null);
   const [runtimeState, setRuntimeState] = useState<Record<string, unknown>>({});
   // State-field values edited in the form, overriding the runtime's reported
@@ -549,11 +553,12 @@ export function SceneLivePreviewPanel({
             setAssetsVersion((version) => version + 1);
           }
         },
-        onReady: (info) => {
+        onReady: (info, _assets, runtime) => {
           if (cancelled || !preview) {
             return;
           }
           setSceneInfo(info ?? null);
+          setRuntimeVersion(runtime?.version ?? null);
           setStatus("");
           // Show the scene being edited, not the default one, when the
           // editor has several.
@@ -1316,6 +1321,14 @@ export function SceneLivePreviewPanel({
               deviceMemory.limitBytes - (deviceLimits?.previewOverheadBytes ?? 0)
             )}{" "}
             usable
+          </span>
+        ) : null}
+        {runtimeVersion ? (
+          <span
+            className="viewport-controls__hint"
+            title="The FrameOS version this preview renders with. Frames render with their own firmware; a scene can look different on a frame running another version."
+          >
+            runtime {runtimeVersion}
           </span>
         ) : null}
       </div>

--- a/cloud/apps/auth-web/src/lib/scene-render.test.ts
+++ b/cloud/apps/auth-web/src/lib/scene-render.test.ts
@@ -3,6 +3,7 @@ import {
   encodePng,
   isRenderErrorLine,
   rendererAvailable,
+  rendererVersion,
   renderScenes,
 } from "./scene-render";
 
@@ -33,6 +34,18 @@ describe("isRenderErrorLine", () => {
     expect(isRenderErrorLine('{"event":"render:done"}')).toBe(false);
     expect(isRenderErrorLine("http error while fetching")).toBe(true);
     expect(isRenderErrorLine("scene initialized")).toBe(false);
+  });
+});
+
+describe("rendererVersion", () => {
+  // The stamp ships next to the bundle (build_wasm.sh / the release
+  // tarball); without a bundle, or with one from before the stamp, it is
+  // simply unknown rather than an error.
+  it("is the bundle's published FrameOS version, or null", () => {
+    const version = rendererVersion();
+    if (version !== null) {
+      expect(version).toMatch(/^\d{4}\.\d{1,2}\.\d+$/);
+    }
   });
 });
 

--- a/cloud/apps/auth-web/src/lib/scene-render.ts
+++ b/cloud/apps/auth-web/src/lib/scene-render.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { zlibSync } from "fflate";
@@ -72,6 +72,27 @@ export class SceneRenderError extends Error {
 
 export function wasmAssetsDir(): string {
   return path.join(process.cwd(), "public", "frameos-wasm");
+}
+
+// The stamp build_wasm.sh writes next to the bundle and the release tarball
+// carries (scripts/lib/wasm-runtime.mjs installs it with the runtime): which
+// FrameOS version the interpreter is. Frames run their own firmware, so a
+// render's caller can tell whether the two match. Null when the bundle is
+// missing or predates the stamp.
+export function rendererVersion(): string | null {
+  const stampPath = path.join(wasmAssetsDir(), "version.json");
+  if (!existsSync(stampPath)) {
+    return null;
+  }
+  try {
+    const stamp: unknown = JSON.parse(readFileSync(stampPath, "utf8"));
+    if (stamp && typeof stamp === "object" && typeof (stamp as { version?: unknown }).version === "string") {
+      return (stamp as { version: string }).version;
+    }
+  } catch {
+    // unreadable stamp: same answer as no stamp
+  }
+  return null;
 }
 
 export function rendererAvailable(): boolean {

--- a/cloud/docs/deployment.md
+++ b/cloud/docs/deployment.md
@@ -90,7 +90,8 @@ you are done.**
 The deploy builds locally and ships a self-contained bundle:
 
 1. `turbo run build --filter=@frameos-cloud/auth-web` builds the editor and
-   wasm packages as needed and produces `.next/standalone`
+   wasm packages as needed, installs the wasm runtime from the pinned
+   release (below), and produces `.next/standalone`
    (`output: "standalone"` in `next.config.ts`, traced from the monorepo root
    so pnpm workspace dependencies resolve into the bundle).
 2. The script assembles `.next/standalone` + `.next/static` + `public/`
@@ -254,8 +255,10 @@ which never answers `/healthz` is a failed deploy rather than an outage.
 
 Which merges count is the workflow's `paths:` filter, and it mirrors the
 input closure of `turbo run build --filter=@frameos-cloud/auth-web` — the
-shared `frontend/`, the frames SPA in `cloud-frontend/`, `repo/`, and the Nim
-sources the editor's wasm preview is built from, not just `cloud/`. A path
+shared `frontend/`, the frames SPA in `cloud-frontend/`, `repo/`, and
+`versions.json` (the wasm runtime pin, below), not just `cloud/`. The Nim
+runtime sources are deliberately absent: they reach the cloud through a
+release, never through a merge. A path
 missing from that list is not a saved CI run: it is a change that merges,
 looks shipped, and never reaches production. Re-derive the closure with
 `pnpm exec turbo run build --filter=@frameos-cloud/auth-web --dry=json`
@@ -361,6 +364,51 @@ in Actions either way. Production is untouched by a failure before the flip;
 `frameos-cloud-update --status` on the box is the source of truth, and
 `--rollback` is unchanged. Nothing about the automatic path is required — the
 manual one keeps working with the switch off.
+
+## The wasm runtime is a release asset
+
+The interpreter the browser preview, the fleet tiles and the headless
+renderer (`src/lib/scene-render.ts`, `POST /api/scenes/render`, MCP
+`scene_render`) run is the FrameOS runtime compiled to WebAssembly —
+`frameos.js`, `frameos.wasm`, `preview-worker.js`. It used to be compiled
+from whatever `main` the deploy checked out, so the preview rendered with
+features the frames' firmware did not have yet; one skew shipped a scene that
+previewed fine and painted "No image provided" on the panel.
+
+Since 2026-09 the cloud does not build it. Every "Release FrameOS" run
+attaches `frameos-<version>-wasm.tar.gz` (the three files plus a
+`version.json` stamp) and its `.minisig`, signed with the same key as the
+firmware and the Pi release archives. auth-web's prebuild
+(`scripts/copy-wasm-assets.mjs` and `copy-editor-assets.mjs`, through
+`scripts/lib/wasm-runtime.mjs`) reads the release version from the repo's
+`versions.json` (`docker`, the tag's version — the one place the release bump
+already updates), downloads that asset once into `node_modules/.cache/`,
+verifies the signature against the committed
+`release-assets/firmware-signing.pub` on every run, and installs it under
+`public/frameos-wasm/` and `public/frameos-editor/frameos-wasm/`. Nothing on
+the production box changes: the bundle ships inside the deploy archive as
+before.
+
+Consequences worth knowing:
+
+- **A new interpreter feature reaches the preview with the next release**, at
+  the same moment it reaches frames. Merging runtime changes to `main` no
+  longer moves the preview, and no longer triggers a cloud deploy.
+- **Which runtime the preview is** is visible: the bundle answers
+  `frameos_wasm_version()`, the preview panel shows "runtime 2026.9.0" next
+  to the memory picker, `POST /api/scenes/render` returns `runtime_version`
+  in its JSON reply (and an `x-frameos-runtime-version` header on the PNG
+  reply). The `version.json` next to the bundle carries the interpreter
+  version, the release it belongs to and the commit.
+- **Working on the runtime itself**: `FRAMEOS_WASM_SOURCE=local pnpm dev`
+  (or `build`) installs the workspace package's own build instead —
+  `turbo run build:runtime --filter=frameos-wasm` after `nimble install -d`
+  in `frameos/`, needs nim + emscripten. Nothing else changes.
+- **A deploy in the window between a release's `chore: version X` commit and
+  its assets landing** fails on the download with a message saying so; the
+  release's own `workflow_run` deploy follows minutes later, or re-run the
+  job. `FRAMEOS_WASM_RELEASE_REPO` points the download at a fork's releases
+  for testing.
 
 ## Frame hub
 

--- a/cloud/docs/mcp.md
+++ b/cloud/docs/mcp.md
@@ -72,7 +72,9 @@ How it plugs in (`src/lib/api-tokens.ts`):
 ### Server-side rendering
 
 `src/lib/scene-render.ts` runs the same `frameos-wasm` bundle the browser
-live preview uses (`public/frameos-wasm`, built with `node` in its emscripten
+live preview uses (`public/frameos-wasm` — the signed bundle of the release
+pinned in `versions.json`, not a build of `main`; see `deployment.md`, "The
+wasm runtime is a release asset" — built with `node` in its emscripten
 `ENVIRONMENT`) in a `worker_threads` Worker: init → load scenes → render →
 a 1.5 s settle for scenes that ask to re-render → raw RGBA → PNG (fflate).
 No Chromium. Scene apps' HTTP goes through a synchronous XHR shim that runs
@@ -80,7 +82,10 @@ each request in a short-lived child Node with the same SSRF guard as the
 preview proxy (`src/lib/ssrf.ts`), capped at 24 requests and 10 MB per
 render. Two renders run concurrently, eight queue, 30 s timeout, one fresh
 64 MB wasm heap per render — nothing is shared between two accounts' scenes.
-`renderer_unavailable` (501) means the bundle is not on disk.
+`renderer_unavailable` (501) means the bundle is not on disk. The JSON reply
+carries `runtime_version` (the PNG reply an `x-frameos-runtime-version`
+header): the interpreter version the render used, which is the last release's
+and may differ from a frame's firmware.
 
 ## The MCP server
 

--- a/frameos/src/wasm/wasm_main.nim
+++ b/frameos/src/wasm/wasm_main.nim
@@ -20,6 +20,7 @@ import frameos/utils/image as frameos_image
 import frameos/utils/memory
 import frameos/js_runtime/runtime as jsRuntime
 import lib/tz
+import frameos/version
 
 # ------------------------------------------------------------------ JS hooks
 # Implemented in tools/wasm/frameos_library.js and linked by emcc.
@@ -47,6 +48,7 @@ var
   sceneInfoBuffer: string
   sceneStateBuffer: string
   lastErrorBuffer: string
+  versionBuffer: string
   # Backend-persisted scene state, seeded via frameos_wasm_set_scene_state
   # before the scene's first render and merged into scene.state at init.
   pendingSceneStates = initTable[string, JsonNode]()
@@ -463,6 +465,14 @@ proc frameos_wasm_scene_state(): cstring {.exportc, cdecl.} =
 
 proc frameos_wasm_last_error(): cstring {.exportc, cdecl.} =
   lastErrorBuffer.cstring
+
+# The FrameOS version this runtime was built from, in the same published form
+# a frame reports ("2026.9.0", no build hash) — so a preview can say which
+# interpreter it renders with, and whether that is the firmware the frame
+# actually runs. Baked at build time (-d:frameosVersion, from versions.json).
+proc frameos_wasm_version(): cstring {.exportc, cdecl.} =
+  versionBuffer = publishedFrameOSVersion(compiledFrameOSVersion())
+  versionBuffer.cstring
 
 # ---------------------------------------------------------------- keep alive
 # Nim/ARC emits destructor calls for every module-level global at the end of

--- a/frameos/tools/build_wasm.sh
+++ b/frameos/tools/build_wasm.sh
@@ -134,7 +134,7 @@ FRAMEOS_VERSION="$(python3 tools/frameos_version.py ../versions.json)"
 # _main keeps Nim's generated main() alive: emscripten calls it on module
 # startup and that runs NimMain (all Nim module initializers, e.g. the
 # baked-in font asset tables).
-EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error,_frameos_wasm_tz_offset_seconds,_frameos_wasm_set_memory_limit,_frameos_wasm_memory_limit,_frameos_wasm_memory_used,_frameos_wasm_memory_peak,_frameos_wasm_memory_failed,_frameos_wasm_memory_reset_peak,_frameos_wasm_memory_render_headroom
+EXPORTED_FUNCTIONS=_main,_malloc,_free,_frameos_wasm_init,_frameos_wasm_load_scenes,_frameos_wasm_select_scene,_frameos_wasm_set_fusion,_frameos_wasm_set_save_assets,_frameos_wasm_set_scene_state,_frameos_wasm_render,_frameos_wasm_buffer,_frameos_wasm_buffer_len,_frameos_wasm_width,_frameos_wasm_height,_frameos_wasm_event,_frameos_wasm_render_requested,_frameos_wasm_next_sleep,_frameos_wasm_scene_interval,_frameos_wasm_scene_info,_frameos_wasm_scene_state,_frameos_wasm_last_error,_frameos_wasm_version,_frameos_wasm_tz_offset_seconds,_frameos_wasm_set_memory_limit,_frameos_wasm_memory_limit,_frameos_wasm_memory_used,_frameos_wasm_memory_peak,_frameos_wasm_memory_failed,_frameos_wasm_memory_reset_peak,_frameos_wasm_memory_render_headroom
 # FS lets the render harness preload a virtual frame's assets into MEMFS;
 # IDBFS (linked below with -lidbfs.js) backs the browser preview's
 # /srv/assets folder with IndexedDB (see tools/wasm/preview-worker.js).
@@ -192,6 +192,26 @@ nim c \
 
 mkdir -p "$OUT_DIR"
 cp "$BUILD_DIR/frameos.js" "$BUILD_DIR/frameos.wasm" "$OUT_DIR/"
+# The stamp the release ships next to the bundle: which FrameOS version the
+# interpreter is (the published form a frame reports), which release the
+# bundle belongs to, and the commit. The runtime also answers it at run time
+# (frameos_wasm_version); this file is for whoever holds the tarball.
+FRAMEOS_RELEASE="$(python3 tools/frameos_version.py --key=docker ../versions.json)"
+WASM_COMMIT="${FRAMEOS_WASM_COMMIT:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+python3 - "$OUT_DIR/version.json" "$FRAMEOS_VERSION" "$FRAMEOS_RELEASE" "$WASM_COMMIT" <<'PY'
+import datetime, json, sys
+out, version, release, commit = sys.argv[1:5]
+published = lambda v: (v[1:] if v.startswith("v") else v).split("+", 1)[0] or "unknown"
+stamp = {
+    "version": published(version),
+    "release": published(release),
+    "commit": commit,
+    "built_at": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+}
+with open(out, "w") as f:
+    json.dump(stamp, f, indent=2)
+    f.write("\n")
+PY
 if [[ -f "$SCRIPT_DIR/wasm/preview-worker.js" ]]; then
     cp "$SCRIPT_DIR/wasm/preview-worker.js" "$OUT_DIR/"
 fi

--- a/frameos/tools/wasm/preview-worker.js
+++ b/frameos/tools/wasm/preview-worker.js
@@ -14,7 +14,7 @@
 //   {type: 'setFastMode', enabled}         lift (or restore) the 1 fps throttle
 //   {type: 'assets', requestId, op, ...}   browser asset folder ops, see handleAssetsRequest
 // Messages out:
-//   {type: 'ready', sceneInfo, browserAssets}
+//   {type: 'ready', sceneInfo, browserAssets, runtimeVersion}   runtimeVersion: FrameOS version of the bundle (null on older bundles)
 //   {type: 'frame', width, height, buffer, renderMs}   buffer: transferred ArrayBuffer (RGBA)
 //   {type: 'state', state}
 //   {type: 'log', message}
@@ -684,6 +684,19 @@ function renderSoonIfRequested() {
   }
 }
 
+// The FrameOS version this bundle was built from ("2026.9.0"), or null for a
+// bundle from before the export existed. The cloud installs the bundle from
+// a release rather than building it, so this is how the preview can say
+// which interpreter it is.
+function runtimeVersion() {
+  try {
+    const version = call('frameos_wasm_version', 'string', [], [])
+    return version && version !== 'unknown' ? version : null
+  } catch (e) {
+    return null
+  }
+}
+
 async function init(msg) {
   try {
     fastMode = Boolean(msg.fastMode)
@@ -745,7 +758,7 @@ async function init(msg) {
     }
     lastPostedState = null
     const sceneInfo = JSON.parse(call('frameos_wasm_scene_info', 'string', [], []))
-    post({ type: 'ready', sceneInfo, browserAssets: browserAssetsInfo() })
+    post({ type: 'ready', sceneInfo, browserAssets: browserAssetsInfo(), runtimeVersion: runtimeVersion() })
     renderNow()
   } catch (e) {
     post({ type: 'error', message: String(e && e.message ? e.message : e) })

--- a/frameos/wasm/README.md
+++ b/frameos/wasm/README.md
@@ -96,5 +96,14 @@ Helpers for building your own UI are exported too: `evaluateShowIf`, `visiblePub
 ## Development (FrameOS repo)
 
 The runtime assets are built by `frameos/tools/build_wasm.sh` into `frontend/public/frameos-wasm`
-and copied into `dist/assets` by `npm run build`. `npm run sync-version` copies the FrameOS
+(plus a `version.json` stamp: the FrameOS version the interpreter is, the release it belongs
+to, and the commit) and copied into `dist/assets` by `npm run build`. Without a runtime build
+`npm run build` still produces the TypeScript half and warns; publishing sets
+`FRAMEOS_WASM_REQUIRE_RUNTIME=1` and fails instead. `npm run sync-version` copies the FrameOS
 version out of the repo's `versions.json`; publishing refuses to run when the two disagree.
+
+Every FrameOS release also attaches the same three files as `frameos-<version>-wasm.tar.gz`
+(+ a minisign `.minisig` from the firmware signing key) — the runtime is a release artifact,
+and FrameOS Cloud installs that signed bundle rather than building from `main`, so its preview
+renders with the interpreter frames actually run. The bundle reports which version it is
+through `frameos_wasm_version()` (`runtimeInfo.version` / the third `onReady` argument here).

--- a/frameos/wasm/package.json
+++ b/frameos/wasm/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -p tsconfig.json && node scripts/build.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "sync-version": "node scripts/sync-version.mjs",
-    "prepublishOnly": "node scripts/sync-version.mjs --check && npm run build",
+    "prepublishOnly": "node scripts/sync-version.mjs --check && FRAMEOS_WASM_REQUIRE_RUNTIME=1 npm run build",
     "build:runtime": "bash ../tools/build_wasm.sh"
   },
   "devDependencies": {

--- a/frameos/wasm/scripts/build.mjs
+++ b/frameos/wasm/scripts/build.mjs
@@ -4,6 +4,12 @@
 // emscripten). When that build output is absent but dist/assets already holds
 // a previously built runtime, it is reused: the runtime only changes with the
 // nim sources, so everyday TS-only builds need no emscripten toolchain.
+//
+// With neither, the TypeScript half still builds and the runtime is simply
+// absent from dist/assets — the cloud does not read it from here (it installs
+// the release's signed bundle; see cloud/apps/auth-web/scripts/lib/
+// wasm-runtime.mjs). Publishing to npm must ship the runtime, so
+// prepublishOnly sets FRAMEOS_WASM_REQUIRE_RUNTIME=1 and that case fails.
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -13,23 +19,34 @@ const assetsSource = join(packageDir, '..', '..', 'frontend', 'public', 'frameos
 const assetsTarget = join(packageDir, 'dist', 'assets')
 
 const files = ['frameos.js', 'frameos.wasm', 'preview-worker.js']
+// Written by build_wasm.sh next to the bundle; optional for older outputs.
+const optionalFiles = ['version.json']
 const sourceComplete = files.every((file) => existsSync(join(assetsSource, file)))
 const targetComplete = files.every((file) => existsSync(join(assetsTarget, file)))
+const requireRuntime = process.env.FRAMEOS_WASM_REQUIRE_RUNTIME === '1'
 
 if (!sourceComplete) {
   if (targetComplete) {
     console.log(`No runtime build at ${assetsSource}; keeping existing dist/assets`)
     process.exit(0)
   }
-  console.error(
-    `Missing wasm runtime in ${assetsSource} and no previous copy in dist/assets — ` +
-      'build it first: turbo run build:runtime --filter=frameos-wasm (needs nim + emscripten)'
-  )
-  process.exit(1)
+  const message =
+    `No wasm runtime in ${assetsSource} and no previous copy in dist/assets — ` +
+    'build it with: turbo run build:runtime --filter=frameos-wasm (needs nim + emscripten)'
+  if (requireRuntime) {
+    console.error(message)
+    process.exit(1)
+  }
+  console.warn(`${message}; dist/assets stays empty`)
+  process.exit(0)
 }
 
 mkdirSync(assetsTarget, { recursive: true })
-for (const file of files) {
-  copyFileSync(join(assetsSource, file), join(assetsTarget, file))
+const copied = []
+for (const file of [...files, ...optionalFiles]) {
+  if (existsSync(join(assetsSource, file))) {
+    copyFileSync(join(assetsSource, file), join(assetsTarget, file))
+    copied.push(file)
+  }
 }
-console.log(`Copied ${files.join(', ')} to dist/assets`)
+console.log(`Copied ${copied.join(', ')} to dist/assets`)

--- a/frameos/wasm/src/index.ts
+++ b/frameos/wasm/src/index.ts
@@ -42,6 +42,7 @@ export {
   type PreviewAssetEntry,
   type PreviewAssetsInfo,
   type PreviewFrame,
+  type PreviewRuntimeInfo,
   type SceneEventButton,
   type SceneInfo,
   type SceneNode,

--- a/frameos/wasm/src/manager.ts
+++ b/frameos/wasm/src/manager.ts
@@ -71,10 +71,10 @@ export function mountFrameOSManager(container: HTMLElement, options: FrameOSMana
   const preview = new FrameOSPreview({
     ...options,
     canvas,
-    onReady: (sceneInfo, assets) => {
+    onReady: (sceneInfo, assets, runtime) => {
       status.textContent = ''
       renderControls()
-      options.onReady?.(sceneInfo, assets)
+      options.onReady?.(sceneInfo, assets, runtime)
     },
     onFrame: (frame) => {
       status.textContent = `Rendered ${frame.width}×${frame.height} in ${frame.renderMs} ms`

--- a/frameos/wasm/src/preview.ts
+++ b/frameos/wasm/src/preview.ts
@@ -4,7 +4,14 @@
 // a canvas, and exposes events/state as callbacks.
 import type { DeviceLimits } from './devices'
 import { ditherFrame, panelPaletteFor, type PanelPaletteKey } from './dither'
-import type { FrameOSScene, PreviewAssetEntry, PreviewAssetsInfo, PreviewFrame, SceneInfo } from './types'
+import type {
+  FrameOSScene,
+  PreviewAssetEntry,
+  PreviewAssetsInfo,
+  PreviewFrame,
+  PreviewRuntimeInfo,
+  SceneInfo,
+} from './types'
 
 /** What a render cost under a simulated device ceiling. */
 export interface DeviceMemoryUsage {
@@ -54,7 +61,7 @@ export interface FrameOSPreviewOptions {
    * inks or greys (see ./dither). Display only — the scene renders in full
    * colour either way. Null (the default) paints the frame as rendered. */
   panelPalette?: PanelPaletteKey | null
-  onReady?: (sceneInfo: SceneInfo, assets: PreviewAssetsInfo | null) => void
+  onReady?: (sceneInfo: SceneInfo, assets: PreviewAssetsInfo | null, runtime: PreviewRuntimeInfo) => void
   onFrame?: (frame: PreviewFrame) => void
   onState?: (state: Record<string, unknown>) => void
   onLog?: (message: string) => void
@@ -99,6 +106,8 @@ export class FrameOSPreview {
   sceneInfo: SceneInfo | null = null
   /** How the runtime's /srv/assets is backed (set once `ready` fires). */
   assetsInfo: PreviewAssetsInfo | null = null
+  /** Which FrameOS version the runtime is (set once `ready` fires). */
+  runtimeInfo: PreviewRuntimeInfo = { version: null }
   /** Latest public state of the current scene. */
   state: Record<string, unknown> = {}
   /** The scene currently selected in the runtime. */
@@ -148,7 +157,8 @@ export class FrameOSPreview {
         if (this.sceneInfo?.currentSceneId) {
           this.currentSceneId = this.sceneInfo.currentSceneId
         }
-        this.options.onReady?.(msg.sceneInfo, this.assetsInfo)
+        this.runtimeInfo = { version: typeof msg.runtimeVersion === 'string' ? msg.runtimeVersion : null }
+        this.options.onReady?.(msg.sceneInfo, this.assetsInfo, this.runtimeInfo)
         break
       case 'frame':
         this.pendingFrame = { width: msg.width, height: msg.height, buffer: msg.buffer }

--- a/frameos/wasm/src/types.ts
+++ b/frameos/wasm/src/types.ts
@@ -82,6 +82,15 @@ export interface PreviewAssetEntry {
   isDir: boolean
 }
 
+/** What the worker reports about the runtime itself (its `ready` message). */
+export interface PreviewRuntimeInfo {
+  /** The FrameOS version the wasm bundle was built from, in the published
+   * form a frame reports ("2026.9.0") — null for a bundle older than the
+   * export. The preview renders with this interpreter; a frame renders with
+   * its own firmware, and the two can differ between releases. */
+  version: string | null
+}
+
 /** How the runtime's /srv/assets is backed, sent with the worker's `ready` message. */
 export interface PreviewAssetsInfo {
   /** False when the wasm bundle has no filesystem export at all. */

--- a/turbo.json
+++ b/turbo.json
@@ -73,7 +73,17 @@
     },
     "@frameos-cloud/auth-web#build": {
       "dependsOn": ["^build"],
-      "env": ["NEXT_PUBLIC_POSTHOG_KEY", "NEXT_PUBLIC_POSTHOG_HOST"],
+      "env": [
+        "NEXT_PUBLIC_POSTHOG_KEY",
+        "NEXT_PUBLIC_POSTHOG_HOST",
+        "FRAMEOS_WASM_SOURCE",
+        "FRAMEOS_WASM_RELEASE_REPO"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../../versions.json",
+        "../../../release-assets/firmware-signing.pub"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",


### PR DESCRIPTION
Convergence item 4 (`docs/convergence-todo.md`): the cloud preview and headless renderer ran a wasm bundle built from `main` while frames run the last release.

## Release
- New `build-wasm-runtime` job → `frameos-<version>-wasm.tar.gz` (frameos.js, frameos.wasm, preview-worker.js, `version.json` {version, release, commit, built_at}); signed with the firmware key by the existing github-release job (`frameos-*.tar.gz` glob), both files attached.
- `publish-npm` needs it and passes `runtime_run_id`; `npm-publish.yml` downloads that artifact instead of compiling, so the npm package ships byte-for-byte the release bundle. Manual dispatch without the id still builds from source.

## Cloud
- `scripts/lib/wasm-runtime.mjs`: pin = `versions.json` → `docker` (the one place the release bump updates); download once to `node_modules/.cache/frameos-wasm/<v>/`, verify minisign (BLAKE2b-512 + Ed25519 + trusted-comment global signature) against the committed `release-assets/firmware-signing.pub` on **every** run, untar, install into `public/frameos-wasm/` and the editor's copy.
- `FRAMEOS_WASM_SOURCE=local` = workspace build (for runtime development / offline).
- cloud-ci drops the Nim + emsdk steps; path filters follow; `turbo.json` lists `versions.json` + the key as inputs.
- Version stamp: `frameos_wasm_version()` export, `runtimeVersion` on the worker's ready message, `FrameOSPreview.runtimeInfo` + third `onReady` arg, "runtime 2026.9.0" hint in the live preview controls, `rendererVersion()` → `runtime_version` in the render route JSON and `x-frameos-runtime-version` on the PNG.
- Docs: `cloud/docs/deployment.md` (new section, skew caveat, escape hatch), `mcp.md`, `frameos/wasm/README.md`.

## ⚠️ Merge window
The pinned release **2026.9.0 has no wasm asset**, so after merging, cloud-ci (deploys *and* PR runs that build auth-web) fails at prebuild with a clear 404 message until the next release attaches one. **Cut a release right after merging.** Later releases have no gap: the version-bump push never fires cloud-ci (default-token push) and the release's completion re-deploys via the existing `workflow_run` trigger. Production keeps serving the previous deploy meanwhile.

## Verified
Wasm built locally with emscripten (`frameos_wasm_version()` → `"2026.9.0"`, `version.json` correct); local-source install path end-to-end; scene-render suite renders with the new bundle; new resolver test (signature accept/refuse/forged trusted comment, pin parsing, download+verify+cache, unsigned refusal); SceneLivePreview tests; eslint; `tsc` for auth-web and frameos-wasm; workflow YAML parses. **Not verified:** the CI jobs themselves (first release proves them); `gh run download` from a still-running release run.

Self-hosted backend preview (root Dockerfile builds from source) untouched by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKnsuRU12dtVXgsHYYcLdi