### PR TITLE
Release: talk HTTP/1.1 to github.com in the prebuilt-cross matrix too

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -159,6 +159,16 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.determine-release-targets.outputs.targets) }}
     steps:
+      # Anonymous git over HTTP/2 is throttled by GitHub from the self-hosted
+      # runner pool's address: nimble's fetch of QRgen died with "expected
+      # flush after ref listing" on all six epyc-8 legs of the 2026.9.1 run
+      # while the GitHub-hosted ARM legs sailed through. HTTP/1.1 from the
+      # same host succeeds every time (frameos-cross.yml and
+      # pull-request-tests.yml carry the same step). Harmless on GitHub-hosted
+      # runners.
+      - name: Use HTTP/1.1 toward github.com
+        run: git config --global http.https://github.com/.version HTTP/1.1
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
All six epyc-8 legs of the 2026.9.1 release run (amd64 and armv6 for
every distro) failed in nimble's fetch of QRgen with "expected flush
after ref listing" — GitHub's throttling of anonymous git over HTTP/2
from the runner pool's address, the same failure frameos-cross.yml and
pull-request-tests.yml already work around. The GitHub-hosted ARM legs
were unaffected. Same step, same place: before checkout.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GKnsuRU12dtVXgsHYYcLdi
