### PR TITLE
Release: the runtime always carries the release version

### DIFF
--- a/.github/workflows/docker-publish-multi.yml
+++ b/.github/workflows/docker-publish-multi.yml
@@ -48,9 +48,19 @@ jobs:
         env:
           NEXT_VERSION: ${{ inputs.next_version }}
         run: |
-          args=(--force-project docker)
+          # `docker` is the release itself. `frameos` rides along on purpose:
+          # the runtime binary is compiled with versions.json's `frameos` entry
+          # (frameos/Makefile -> -d:frameosVersion) and reports it to the cloud,
+          # the hub and its own upgrade check. Left to its content hash, a
+          # release that touched nothing under frameos/ (2026.9.2 changed only
+          # this workflow) ships a runtime still stamped with the previous
+          # version: every frame that installed "2026.9.2" came back reporting
+          # 2026.9.1, the cloud kept offering the update, and the upgrade
+          # re-ran to nowhere. The release tag and the runtime's version must
+          # be the same number.
+          args=(--force-project docker --force-project frameos)
           if [ -n "$NEXT_VERSION" ]; then
-            args+=(--force-project frameos --next-version "$NEXT_VERSION")
+            args+=(--next-version "$NEXT_VERSION")
           fi
           python3 tools/update_versions.py "${args[@]}"
 


### PR DESCRIPTION
## Why

Frames upgrading 2026.9.1 → 2026.9.2 from the cloud "succeed" and then still report 2026.9.1, so the cloud keeps offering the update. On `cloud-w` the upgrade log shows two complete, successful installs of the same binary three minutes apart.

`versions.json` versions each component by content hash and the release tag is the `docker` entry; the runtime binary is compiled with the `frameos` entry (`frameos/Makefile` → `-d:frameosVersion`) and reports that. 2026.9.2 touched nothing under `frameos/`, so its archive shipped a runtime stamped `2026.9.1+ced9d7ce…`:

```
$ strings /srv/frameos/current/frameos | grep 2026.9
@2026.9.1+ced9d7ce2d6f25a3b091d6a357c27de6aefaffc6
```

## What

The release workflow forces `frameos` to the release version alongside `docker`. The content hash still only changes when the runtime changes; the base version is always the tag. Nothing else reads differently: the self-hosted backend, the SD image composer, the frontend and the Makefile all take the `frameos` entry and now agree with the tag. `frameos-wasm` follows `frameos` and npm-publish already skips versions that exist.

Dry run of the bump on main today: `frameos` goes `2026.9.1+ced9d7ce…` → `2026.9.3+ced9d7ce…` (same hash), `docker` → `2026.9.3`.

## For the frames already on "9.2"

Nothing to do: the next release (2026.9.3, first one with #415) ships a runtime stamped 2026.9.3, the frames install it, report 2026.9.3, and the cloud stops offering the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNoEbYgrQYsVugVp8hFsRS