### PR TITLE
esp32: a wiped /state no longer reports the cached scenes checksum; 4:4:4 JPEG clamp fix (pixie#8)

### DIFF
--- a/docs/manual-testing-todo.md
+++ b/docs/manual-testing-todo.md
@@ -5,7 +5,7 @@ Everything here shipped with green automated suites but needed a bench.
 evidence for what passed, in the original section order, because the open
 boxes point into it. Tick a box by moving its entry from Open to the matching
 Done section with the date and what was seen; delete the file when Open is
-empty. Last refreshed 2026-09-05 08:00 UTC, after release 2026.9.8.
+empty. Last refreshed 2026-09-05 10:15 UTC, after release 2026.9.8.
 
 ## Open
 
@@ -71,10 +71,27 @@ Done section for this bench below.
   `flashBytes 8388608`, `otaSlotBytes 3604480`, OTA check asks for
   `esp32-s3-generic`; "Update firmware" keeps whatever layout the board has,
   so only "Add frame" → Connect & flash exercises this. The 8 MB half of the
-  USB *update* path passed on 2026.9.5 — see the dual-console box.)* on the XTEINK X4 (16 MB C3), "Flash latest release" picks
-  `esp32-c3-16mb`, the "4MB layout / no OTA" warnings are gone, the board
-  boots and later takes an OTA; on a 13.3E6 (32 MB S3) the same with
-  `esp32-s3-32mb`.
+  USB *update* path passed on 2026.9.5 — see the dual-console box.)*
+  *(2026-09-05, the 13.3E6 half, firmware side only: SuurESP was moved from
+  the generic 8 MB layout to the signed `frameos-2026.9.8-esp32-s3-32mb.bin`
+  by hand with esptool, sparing NVS — erase old otadata 0xd000+0x2000 so it
+  reads as blank NVS pages, erase the old SPIFFS region at 0x800000, write
+  the image around 0x9000–0xf000 — so it reconnected as the SAME cloud
+  record; `storage` now reports flashBytes 33554432 / otaSlotBytes 4128768 /
+  stateBytes 25165824 / nvsBytes 24576, the SPIFFS format took ~3 min, a
+  console `ota` logged `ota:cloud up-to-date 2026.9.8` and the app carries
+  exactly one platform string, `esp32-s3-32mb` (the request itself was not
+  seen server-side). **Found:** the wiped `/state` left the board sceneless
+  for 10 min while the cloud showed it in sync — the hello reports the
+  NVS-cached `cloud_scn_sum` without checking `/state/scenes.json` exists
+  (`fos_cloud.c`), so the hub never re-pushed and `set_current_scene`
+  failed `scene not found`; recovered by reordering the assignment. Same
+  trap for a SPIFFS autoformat after corruption — in `docs/todo.md`. Still
+  open here: the browser "Add frame → Connect & flash" click-through on a
+  32 MB board, and a later OTA landing on the new layout.)* on the XTEINK
+  X4 (16 MB C3), "Flash latest release" picks `esp32-c3-16mb`, the "4MB
+  layout / no OTA" warnings are gone, the board boots and later takes an
+  OTA; on a 13.3E6 (32 MB S3) the same with `esp32-s3-32mb`.
 
 - [ ] **The backend flashes what the cloud flashes (needs firmware built
   after 2026-09-03):** on a blank board, "Flash latest release" from the
@@ -753,6 +770,26 @@ root→`frameos` migration inside that upgrade (`docs/buildroot-privileges.md`
   (`systemctl status frameos-privileged.service` settles).
 
 ### ESP32 bench
+
+- [x] **SuurESP on the 32 MB layout + the two fixes it surfaced (2026-09-05,
+  dev build 2026.9.8+471e8e3f on branch `esp32-stale-checksum-and-444-jpeg`,
+  flashed to ota_0 by esptool):** *(1) wiped-state hello:* state partition
+  erased before the boot; `cloud:session_ready` at 09:59:40, the cloud listed
+  `scenes_checksum: ""` against the assignment (out of sync, where 2026.9.8
+  had claimed in sync and stayed sceneless), a `frame_scenes_set` with the
+  unchanged list pushed, and all five scenes were back within a minute
+  (`available: 5`). The hub does not push unasked on a hello mismatch, so the
+  recovery is a deploy — noted in `docs/todo.md`. *(2) 4:4:4 photos:* the SD
+  card scene rendered `koduraam/DSC02441.jpg` (6336-wide, 4:4:4, the local
+  copy checked with PIL) in 178 s with **no `render:degraded` line** where
+  every 4:4:4 photo on 2026.9.8 logged `needs 5160K … over the 4989K memory
+  budget` and came out 600x800; the panel capture is sharp at full
+  resolution. *(3)* console `ota` prints `check requested (cloud)` and the
+  prod nginx log shows the OTA check as
+  `firmware/manifest?platform=esp32-s3-32mb` (09:18:01 UTC; the 02:02 OTA
+  had asked for `esp32-s3-generic`). Idle PSRAM after a photo render 5.91 MB,
+  after Weather 5.36 MB — the 24 MB SPIFFS costs ~0.5 MB against the old
+  8 MB-layout baseline.
 
 - [x] **E1004 first render after a cold boot (2026.9.8):** closed 2026-09-05 07:56 UTC. Every deep-sleep wake on this board is a full boot (`cloud:session_ready … uptimeSeconds: 6` at every 15-minute wake), so every render since 02:21 has been a first-render-after-boot, all full size; a commanded cloud `reboot` on the 07:55 wake (second session at 07:55:21, `uptimeSeconds: 9`) rendered at 07:56:17 with the chart filling the lower cell, and the log has never carried a `render:degraded` line. The 02:06 capture was the one render *during* the OTA boot itself; whatever it showed did not recur across ~20 boots.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -36,22 +36,50 @@ Two rules that shape most entries:
 
 ## ESP32 memory
 
-- **Verify on hardware** (docs/esp32-memory.md, 2026-08-24): the Weather
-  scene renders on the 16 MB 13.3" (frame 529463b4) after a reboot with no
-  `memory:oomAbort`; post-render idle PSRAM stays near the ~6.9 MB
-  baseline; the sky gradient shows no strip seams. The 8 MB half is done:
-  the E1004 (565 canvas, strips are the only thing that fits) renders
-  Weather with an 873 KB PSRAM low-water mark since the transpiler fix
-  (#428, measured on the board 2026-09-01).
-- **Verify on hardware** (docs/esp32-memory.md, 2026-08-23): a 24 MP photo
-  cover-rendered on the 16 MB 13.3" is sharp (no `render:degraded` in the
-  log — the cover window keeps the plan at 2.9 MB inside the RGBX canvas's
-  ~5 MB headroom); the 7.3" weather sky renders without bands (RGBX canvas
-  now; boot line `canvas: 800x480 rgbx`); the E1004's gradients are
-  band-free on its `canvas: 1200x1600 rgb565 (dithered stores)`; after a
-  text render idle PSRAM should drop ~0.5 MB, not 1.6 MB; `render:degraded`
-  and `memory:oomAbort` appear in the cloud log when provoked (force the
-  budget low with an oversized photo); the leak-percent restart fires.
+- **Weather on the 16 MB-PSRAM 13.3" (SuurESP) — verified 2026-09-05** on
+  2026.9.8 after a cold boot (first scene render after the 32 MB relayout):
+  `render:done` in 85 s (14.4 s render + 18.9 s dither/pack + refresh), no
+  `memory:oomAbort`, no `render:degraded`; idle PSRAM 5.91 MB before the
+  text-heavy render and 5.36 MB after (the ~0.5 MB drop the plan expected,
+  not 1.6 MB); the packed capture shows the sky's 6-colour dither banding
+  and no full-width strip seam (the RGBX canvas draws no strips). Idle PSRAM
+  now sits ~0.5 MB below the old ~6.9 MB baseline — the 24 MB SPIFFS state
+  partition's cache, measured 6.15 MB free at boot with no scene loaded.
+  Still to provoke deliberately: `memory:oomAbort` and the leak-percent
+  restart. The 8 MB E1004 half was done 2026-09-01 (#428).
+- **4:4:4 JPEGs degraded to half resolution on the 13.3" — fixed in the
+  pixie fork (FrameOS/pixie#8, lock bumped to fe417a0).** Found 2026-09-05
+  on SuurESP: the `koduraam` photos are 4:4:4 exports and every one logged
+  `render:degraded … needs 5160K of decode buffers, over the 4989K memory
+  budget`, rendering 600x800 stretched at 12, 24 and 60 MP alike (4:2:0
+  and 4:2:2 files passed at 60 MP). The JPEG planner's budget clamp shaved
+  the sampling grid until the channel planes fit, then the plan check added
+  the per-component band + accumulator buffers (~180 KB) and refused, and
+  the degrade ladder jumped to the divisor-2 rung instead of the ~1130x1506
+  grid the clamp had computed. The clamp now counts the same three buffers
+  and shaves in 1/64 steps until the exact plan fits (`tests/test_jpeg.nim`
+  pins it; the frameos `test_decode_degrade` suite still passes). Verified
+  on the board: see the bench entry in `docs/manual-testing-todo.md`.
+  Longer term the streamed JPEG decoder holds target-sized channel planes;
+  a banded design would cut the plan to a few MCU rows per component.
+- **A cloud frame whose `/state` was wiped stayed sceneless but "in sync"
+  — device half fixed (`fos_cloud.c` + `fos_scenes_stored()`).** The hello
+  reported the NVS-cached `cloud_scn_sum` without checking that
+  `/state/scenes.json` (or the split index) still existed, so after a
+  SPIFFS autoformat or a flash relayout the hub saw the assigned checksum,
+  never re-pushed, and every `set_current_scene` failed `scene not found`.
+  Now the hello forgets the cached checksum when the store is empty and
+  reports the store's own etag, so the frame shows **out of sync** in the
+  workspace and any deploy (or `frame_scenes_set` with the same list)
+  restores it. The hub does not push unasked on a hello mismatch by design
+  (the push is assembled on the auth-web side; the hub has no channel to
+  ask for it), so an automatic re-push for the empty-store case is a
+  possible follow-up, not a bug: it would need an internal auth-web route
+  the hub can call, and it can never lose anything because the device
+  holds nothing.
+- Console: `ota` printed `ota: UNKNOWN ERROR (cloud)` on every outcome
+  because `CONFIG_ESP_ERR_TO_NAME_LOOKUP` is off; it now prints
+  `check requested` / `request failed 0x…`.
 
 ---
 

--- a/embedded/esp32/main/fos_cloud.c
+++ b/embedded/esp32/main/fos_cloud.c
@@ -1268,6 +1268,17 @@ static void add_state_fields(cJSON *msg, nim_snapshot_t *snap)
      * for every pushed payload). Anything else resident — backend-synced or
      * locally uploaded — reports the etag, which is the truth the provider
      * should see: out of sync. */
+    if (s_applied_scenes_checksum[0] && !fos_scenes_stored()) {
+        /* NVS remembers a payload /state no longer holds — a SPIFFS
+         * autoformat after corruption, a flash relayout. Vouching for it
+         * left a frame sceneless for good: the hub saw the assigned checksum,
+         * never re-pushed, and every set_current_scene failed "scene not
+         * found" (13.3" bench, 2026-09-05). Forget it so the hello reports
+         * the store's own (empty) etag and the hub resyncs. */
+        ESP_LOGW(TAG, "hello: cached scenes checksum but no stored scenes; reporting out of sync");
+        s_applied_scenes_checksum[0] = '\0';
+        nvs_erase_key_quiet("cloud_scn_sum");
+    }
     if (fos_scenes_from_cloud() && s_applied_scenes_checksum[0]) {
         cJSON_AddStringToObject(msg, "scenes_checksum", s_applied_scenes_checksum);
     } else {

--- a/embedded/esp32/main/fos_console.c
+++ b/embedded/esp32/main/fos_console.c
@@ -1032,7 +1032,13 @@ static int cmd_ota(int argc, char **argv)
 {
     const char *plane = "backend";
     esp_err_t err = ota_request_for_control_plane(&plane);
-    printf("ota: %s (%s)\n", esp_err_to_name(err), plane);
+    /* CONFIG_ESP_ERR_TO_NAME_LOOKUP is off (flash budget), so every code —
+     * ESP_OK included — would print as "UNKNOWN ERROR" here. */
+    if (err == ESP_OK) {
+        printf("ota: check requested (%s)\n", plane);
+    } else {
+        printf("ota: request failed 0x%x (%s)\n", (unsigned)err, plane);
+    }
     return err == ESP_OK ? 0 : 1;
 }
 

--- a/embedded/esp32/main/fos_scenes.c
+++ b/embedded/esp32/main/fos_scenes.c
@@ -892,6 +892,14 @@ bool fos_scenes_apply_succeeded(void) { return s_apply_ok; }
 
 int fos_scenes_loaded(void) { return s_loaded; }
 const char *fos_scenes_etag(void) { return s_etag; }
+
+bool fos_scenes_stored(void)
+{
+    if (!s_mounted) return false;
+    struct stat st;
+    if (stat(SCENES_PATH, &st) == 0 && st.st_size > 2) return true;
+    return stat(SCENES_INDEX_PATH, &st) == 0 && st.st_size > 2;
+}
 void fos_scenes_request_sync(void) { s_sync_requested = true; }
 
 /* The whole payload, for callers that download or re-upload it (the USB API,

--- a/embedded/esp32/main/fos_scenes.h
+++ b/embedded/esp32/main/fos_scenes.h
@@ -82,3 +82,9 @@ int fos_scenes_loaded(void);
 
 /* ETag of the last synced payload ("" when none). */
 const char *fos_scenes_etag(void);
+
+/* True when /state holds a scene payload (the combined scenes.json or the
+ * per-scene index an earlier boot split it into). False on a fresh or
+ * wiped state partition — a SPIFFS autoformat after corruption, a flash
+ * relayout — even when NVS still remembers what used to be there. */
+bool fos_scenes_stored(void);

--- a/frameos/nimble.lock
+++ b/frameos/nimble.lock
@@ -161,7 +161,7 @@
     },
     "pixie": {
       "version": "6.1.0",
-      "vcsRevision": "f6c6a9b37088fd167476ded6ff15a931f131afc5",
+      "vcsRevision": "fe417a0757d35d9d1ba494cc197eb08c3aefd0be",
       "url": "https://github.com/FrameOS/pixie",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "crunchy"
       ],
       "checksums": {
-        "sha1": "2584a5e5f804ea428eb442938c4664669b30f736"
+        "sha1": "db1233396c5678d2020199326c7024f9c09b82ee"
       }
     }
   },


### PR DESCRIPTION
Two findings from the 13.3" bench on 2026-09-05, after moving SuurESP from the generic 8 MB layout to the 32 MB one with its NVS intact and its state partition erased. Both verified on the board with this branch's firmware (`docs/manual-testing-todo.md`, ESP32 bench).

**Sceneless but "in sync".** The hello reported the NVS-cached `cloud_scn_sum` whenever the scene store's source was the cloud, without checking that `/state/scenes.json` (or the split index) still existed. After a SPIFFS autoformat or a flash relayout the hub saw the assigned checksum, never re-pushed, and every `set_current_scene` failed "scene not found". `fos_scenes_stored()` answers whether `/state` holds a payload; the hello forgets the cached checksum when it does not and reports the store's own (empty) etag, so the frame shows out of sync and a deploy restores it. The hub does not push unasked on a hello mismatch by design; an automatic re-push for the empty-store case is noted in `docs/todo.md` as a possible follow-up.

**Every 4:4:4 JPEG larger than the canvas degraded to half resolution on the 13.3".** `render:degraded … needs 5160K of decode buffers, over the 4989K memory budget` on 12, 24 and 60 MP files alike (4:2:0 and 4:2:2 passed at 60 MP). The pixie planner's budget clamp shaved the sampling grid until the channel planes fit, then the plan check added the band + accumulator buffers and refused, and the degrade ladder fell to the divisor-2 rung. Fixed in FrameOS/pixie#8 (the clamp counts the same three buffers and shaves until the exact plan fits, with a regression test); `nimble.lock` pins that revision. On the board a 6336-wide 4:4:4 photo now renders full size with no `render:degraded`.

**Console.** `ota` printed `UNKNOWN ERROR` for every outcome because `CONFIG_ESP_ERR_TO_NAME_LOOKUP` is off; it now prints `check requested` / `request failed 0x…`.

Note: FrameOS/pixie#8 still needs merging (the lock pins its commit, which stays reachable after the merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139HGEK8aCrB9Ab9kDH1F7Z