### PR TITLE
cloud: the C3 watchdog test typechecks under auth-web's strict indexed access

### DIFF
--- a/cloud/apps/auth-web/src/test/shared-spa/esp32-watchdog-reset.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/esp32-watchdog-reset.test.ts
@@ -23,16 +23,16 @@ describe('watchdogResetAfterFlash', () => {
     expect(await watchdogResetAfterFlash(loader)).toBe(true)
     expect(writes.map(([addr]) => addr)).toEqual([0x6000812c, 0x600080b0, 0x6000809c, 0x60008098, 0x600080b0])
     expect(writes[0]).toEqual([0x6000812c, 0, 0x1])
-    expect(writes[1][1]).toBe(0x50d83aa1)
-    expect(writes[4][1]).toBe(0)
+    expect(writes[1]?.[1]).toBe(0x50d83aa1)
+    expect(writes[4]?.[1]).toBe(0)
   })
 
   it('arms the C3 watchdog at its own register block, with no latch to clear', async () => {
     const { loader, writes } = loaderFor('ESP32-C3')
     expect(await watchdogResetAfterFlash(loader)).toBe(true)
     expect(writes.map(([addr]) => addr)).toEqual([0x600080a8, 0x60008094, 0x60008090, 0x600080a8])
-    expect(writes[1][1]).toBe(2000)
-    expect(writes[2][1]).toBe((0x80000000 | (5 << 28) | (1 << 8) | 2) >>> 0)
+    expect(writes[1]?.[1]).toBe(2000)
+    expect(writes[2]?.[1]).toBe((0x80000000 | (5 << 28) | (1 << 8) | 2) >>> 0)
   })
 
   it('leaves other chips to the DTR/RTS fallback', async () => {


### PR DESCRIPTION
Four `writes[n][1]` reads in `esp32-watchdog-reset.test.ts` (from 97c8c750) fail `noUncheckedIndexedAccess` in auth-web's tsconfig, which failed Cloud CI's verify job on main and skipped the deploy of #451. `writes[n]?.[1]` keeps the assertions and typechecks; the test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GEcUE6p3UpnPxiwXuWw8h