### PR TITLE
Backend: the smaller security list closed; contract: single-plane settings must say why

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Optional
+from urllib.parse import urlparse
 
 from fastapi import Depends, HTTPException, status, Request, Response, WebSocket
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
@@ -177,22 +178,37 @@ async def get_current_user_from_request(
     return db.query(User).filter(User.email == email).first()
 
 
+def websocket_origin_allowed(websocket: WebSocket) -> bool:
+    """Whether a WebSocket handshake comes from a page on this backend.
+
+    Browsers always send `Origin` on a WebSocket handshake and it cannot be
+    set by page script, so a mismatch against the `Host` the browser dialled
+    is a cross-site page opening a socket with the user's cookie (SameSite=Lax
+    does not cover WebSockets). Non-browser clients send no Origin and pass;
+    the cookie check that follows still applies to them. Compared as host:port
+    (case-insensitive), scheme ignored — a TLS-terminating proxy changes the
+    scheme the browser sees, never the host it dialled.
+    """
+    origin = websocket.headers.get("origin")
+    if not origin:
+        return True
+    host = websocket.headers.get("host", "")
+    try:
+        origin_host = urlparse(origin).netloc
+    except ValueError:
+        return False
+    return bool(origin_host) and origin_host.lower() == host.lower()
+
+
 def get_current_user_from_websocket(
     websocket: WebSocket,
     db: Session,
 ) -> tuple[User | None, str | None]:
-    token = websocket.query_params.get("token")
-    if token:
-        try:
-            email, session_id = _decode_jwt_claims(token)
-        except JWTError:
-            return None, "Invalid token"
-        if not session_is_active(db, session_id):
-            return None, "Session revoked"
-        user = db.query(User).filter(User.email == email).first()
-        if user is None:
-            return None, "User not found"
-        return user, None
+    # Cookie only. The `?token=<jwt>` query form nothing in the SPA ever sent
+    # is gone: a bearer in a URL lands in proxy and browser logs, and the
+    # session cookie already rides every handshake from the same origin.
+    if not websocket_origin_allowed(websocket):
+        return None, "Origin not allowed"
 
     cookie_value = websocket.cookies.get(SESSION_COOKIE_NAME)
     claims = decode_session_cookie_claims(cookie_value)
@@ -381,7 +397,7 @@ async def logout(request: Request, response: Response, db: Session = Depends(get
     if cookie_claims is not None:
         revoke_user_session(db, cookie_claims[1])
     if user is not None:
-        from urllib.parse import quote
+        from urllib.parse import quote, urlparse
 
         from app.api.cloud import _browser_origin, _connected_link, _link_has_scope
         from app.models.cloud import CloudIdentity

--- a/backend/app/api/cloud.py
+++ b/backend/app/api/cloud.py
@@ -617,9 +617,52 @@ SETUP_CLAIM_COOKIE = "frameos_setup_claim"
 SETUP_CLAIM_TTL_SECONDS = 60 * 60
 
 
-def _require_setup_mode(db: Session) -> None:
+# Hostname suffixes that only resolve on a LAN. A fresh install is set up
+# from the same network it lives on, by IP or a local name; a public DNS name
+# in the Host header of a setup request means a browser was pointed at a
+# domain the attacker controls that resolves to this backend's LAN address
+# (DNS rebinding) — the one way the unauthenticated setup routes could be
+# driven from outside before a user exists.
+LOCAL_HOST_SUFFIXES = (".local", ".localhost", ".lan", ".home", ".internal", ".localdomain", ".home.arpa", ".fritz.box")
+
+
+def setup_host_allowed(host_header: str | None) -> bool:
+    host = (host_header or "").strip().lower()
+    if not host:
+        return False
+    if host.startswith("["):
+        host = host[1 : host.find("]")] if "]" in host else host[1:]
+    elif host.count(":") == 1:
+        host = host.rsplit(":", 1)[0]
+    if not host:
+        return False
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        pass
+    if "." not in host or host == "localhost":
+        return True
+    if any(host.endswith(suffix) for suffix in LOCAL_HOST_SUFFIXES):
+        return True
+    allowed = {entry.strip().lower() for entry in app_config.config.FRAMEOS_SETUP_ALLOWED_HOSTS.split(",") if entry.strip()}
+    return host in allowed
+
+
+def _require_setup_mode(request: Request, db: Session) -> None:
     if db.query(User).first() is not None:
         raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Setup is complete; log in first")
+    # Behind Home Assistant's ingress the Supervisor's proxy is the only peer
+    # (IngressPeerGuard) and the Host is Home Assistant's own, so the name
+    # check does not apply there.
+    if app_config.config.HASSIO_RUN_MODE != "ingress" and not setup_host_allowed(request.headers.get("host")):
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail=(
+                "First-run setup is served on the local network only: open this backend by its IP address or a "
+                ".local name, or list this hostname in FRAMEOS_SETUP_ALLOWED_HOSTS."
+            ),
+        )
 
 
 def _setup_claim_matches(request: Request, link: CloudBackendLink | None) -> bool:
@@ -655,7 +698,7 @@ def _require_setup_claim(request: Request, db: Session) -> CloudBackendLink | No
 
 @api_open.get("/cloud/setup/status", response_model=CloudStatusResponse)
 async def setup_cloud_status(request: Request, db: Session = Depends(get_db)):
-    _require_setup_mode(db)
+    _require_setup_mode(request, db)
     link = current_cloud_backend_link(db)
     payload = _status_payload(db, link)
     if not _setup_claim_matches(request, link):
@@ -671,7 +714,7 @@ async def setup_cloud_status(request: Request, db: Session = Depends(get_db)):
 async def setup_cloud_provider(
     request: Request, data: CloudProviderUpdateRequest, db: Session = Depends(get_db)
 ):
-    _require_setup_mode(db)
+    _require_setup_mode(request, db)
     _require_setup_claim(request, db)
     return await _update_provider(data, db)
 
@@ -680,7 +723,7 @@ async def setup_cloud_provider(
 async def setup_cloud_connect(
     request: Request, response: Response, data: CloudConnectRequest, db: Session = Depends(get_db)
 ):
-    _require_setup_mode(db)
+    _require_setup_mode(request, db)
     _require_setup_claim(request, db)
     payload = await _start_connect(request, data, db)
     # Claim the flow for this browser. Issued per connect, so a takeover after
@@ -696,14 +739,14 @@ async def setup_cloud_connect(
 
 @api_open.post("/cloud/setup/poll", response_model=CloudStatusResponse)
 async def setup_cloud_poll(request: Request, db: Session = Depends(get_db)):
-    _require_setup_mode(db)
+    _require_setup_mode(request, db)
     _require_setup_claim(request, db)
     return await _poll_link(db)
 
 
 @api_open.post("/cloud/setup/disconnect", response_model=CloudStatusResponse)
 async def setup_cloud_disconnect(request: Request, db: Session = Depends(get_db)):
-    _require_setup_mode(db)
+    _require_setup_mode(request, db)
     # Deliberately not claim-gated: a browser that lost its cookie (or a second
     # one taking over) must be able to clear a half-finished link, and on an
     # install with no users there is nothing yet to protect.

--- a/backend/app/api/frame_sync.py
+++ b/backend/app/api/frame_sync.py
@@ -122,10 +122,19 @@ async def store_frame_sync_hint_headers(redis: Redis, frame_id: int, frame_heade
     return _sync_hint_headers_from_payload(payload)
 
 
+# Backend-owned: the device holds a copy of these only because the backend
+# wrote it there, and importing the device's view back would let a
+# compromised (or merely stale) frame rewrite how the backend reaches and
+# runs it — which control mode it is in, whether FrameOS Remote may run
+# commands and with what shared secret, and the admin login the backend uses
+# against it. They never appear in the sync diff (docs/security-todo.md).
+FRAME_SYNC_BACKEND_OWNED_KEYS = frozenset({"mode", "agent", "frame_admin_auth"})
+
 FRAME_SYNC_FRAME_KEYS = tuple(
     key
     for key in FrameUpdateRequest.model_fields.keys()
-    if key
+    if key not in FRAME_SYNC_BACKEND_OWNED_KEYS
+    and key
     not in {
         "archived",
         "buildroot",
@@ -271,15 +280,13 @@ def _sync_https_proxy(value: Any) -> dict[str, Any] | None:
         return None
     if not _sync_bool(value.get("enable"), False):
         return None
-    certs = value.get("certs") if isinstance(value.get("certs"), dict) else {}
+    # No certs: the backend mints the frame's TLS pair and pushes it, so the
+    # device's copy is never the source of truth — and importing a certificate
+    # without its (write-only, blanked) key would leave a mismatched pair.
     proxy = {
         "enable": True,
         "port": _sync_number(value.get("port") or 8443),
         "expose_only_port": _sync_bool(value.get("expose_only_port"), True),
-        "certs": {
-            "server": certs.get("server"),
-            "server_key": certs.get("server_key"),
-        },
     }
     return _sync_prune_empty(proxy)
 

--- a/backend/app/api/tests/test_cloud_setup_claim.py
+++ b/backend/app/api/tests/test_cloud_setup_claim.py
@@ -105,3 +105,52 @@ def test_plain_http_to_a_public_provider_is_refused(url):
     # http an on-path attacker can forge any of them.
     with pytest.raises(ValueError):
         cloud_link.normalize_cloud_provider_url(url)
+
+
+@pytest.mark.parametrize(
+    "host, allowed",
+    [
+        ("192.168.1.20:8989", True),
+        ("[fe80::1]:8989", True),
+        ("frameos:8989", True),
+        ("localhost", True),
+        ("frameos.local:8989", True),
+        ("nas.lan", True),
+        ("homeassistant.home.arpa:8123", True),
+        ("evil.example.com", False),
+        ("192.168.1.20.evil.example.com", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_setup_host_rule(host, allowed):
+    from app.api.cloud import setup_host_allowed
+
+    assert setup_host_allowed(host) is allowed
+
+
+def test_setup_host_rule_honours_the_allowlist(monkeypatch):
+    from app.api.cloud import setup_host_allowed
+    from app import config
+
+    monkeypatch.setattr(config.config, "FRAMEOS_SETUP_ALLOWED_HOSTS", "frames.example.com, Other.Example.org")
+    assert setup_host_allowed("frames.example.com:8989") is True
+    assert setup_host_allowed("other.example.org") is True
+    assert setup_host_allowed("third.example.net") is False
+
+
+@pytest.mark.asyncio
+async def test_setup_routes_refuse_a_public_hostname_on_a_fresh_install(db, monkeypatch):
+    from app import config
+
+    monkeypatch.setattr(config.config, "HASSIO_RUN_MODE", "")
+    # DNS rebinding: the attacker's page is on a domain that resolves to this
+    # backend's LAN address, so the browser sends that domain as Host.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://rebind.evil.example") as client:
+        response = await client.get("/api/cloud/setup/status")
+    assert response.status_code == 403
+    assert "local network" in response.json()["detail"]
+    # The same request from a LAN address is served.
+    async with _client() as client:
+        response = await client.get("/api/cloud/setup/status")
+    assert response.status_code == 200

--- a/backend/app/api/tests/test_frame_sync_secrets.py
+++ b/backend/app/api/tests/test_frame_sync_secrets.py
@@ -8,6 +8,8 @@ the backend's copy and the next deploy would push the blank to the device.
 """
 
 from app.api.frame_sync import (
+    FRAME_SYNC_BACKEND_OWNED_KEYS,
+    FRAME_SYNC_FRAME_KEYS,
     _build_frame_sync_section,
     _restore_write_only_secrets,
     _sync_frame_value,
@@ -94,16 +96,16 @@ def test_blanked_secrets_do_not_show_as_changes_once_restored():
     assert section["changes"] == []
 
 
-def test_without_restore_the_blanks_would_read_as_changes():
-    # The guard the test above depends on: the raw payload really differs.
+def test_blanked_secret_leaves_are_not_sync_choices_at_all():
+    # Every leaf the device blanks (admin password, TLS key, API key, Wi-Fi
+    # passphrase) is either backend-owned and never pulled
+    # (FRAME_SYNC_BACKEND_OWNED_KEYS), outside the pull list, or dropped by the
+    # per-key compaction — so even the raw, un-restored payload shows nothing to
+    # choose. The restore helper is what keeps the backend's copy intact when
+    # such a payload is written back; the two tests above cover that.
     backend = _backend_frame()
     section = _build_frame_sync_section(backend, _device_frame(), backend)
-    paths = {change["path"] for change in section["changes"]}
-    assert "frame_admin_auth" in paths
-    assert "https_proxy" in paths
-    assert _sync_frame_value("frame_admin_auth", _device_frame()["frame_admin_auth"]) != _sync_frame_value(
-        "frame_admin_auth", backend["frame_admin_auth"]
-    )
+    assert section["changes"] == []
 
 
 def test_restore_reads_the_backend_copy_off_a_frame_row():
@@ -124,3 +126,29 @@ def test_restore_reads_the_backend_copy_off_a_frame_row():
     assert restored["frame_admin_auth"]["pass"] == "row-admin-secret"
     assert restored["https_proxy"]["certs"]["server_key"] == "ROW-KEY"
     assert restored["network"]["wifiPassword"] == "row-wifi-secret"
+
+
+def test_backend_owned_keys_are_never_pulled_from_the_device():
+    # A device that claims another control mode, a Remote that may run
+    # commands under a secret of its choosing, or a different admin login
+    # must never even appear as a sync choice.
+    for key in ("mode", "agent", "frame_admin_auth"):
+        assert key in FRAME_SYNC_BACKEND_OWNED_KEYS
+        assert key not in FRAME_SYNC_FRAME_KEYS
+    backend = _backend_frame()
+    backend["mode"] = "rpios"
+    backend["agent"] = {"agentEnabled": True, "agentRunCommands": False, "agentSharedSecret": "ours"}
+    device = _device_frame()
+    device["mode"] = "buildroot"
+    device["agent"] = {"agentEnabled": True, "agentRunCommands": True, "agentSharedSecret": "theirs"}
+    device["frame_admin_auth"] = {"enabled": False, "user": "root", "pass": "pwned"}
+    section = _build_frame_sync_section(backend, device)
+    paths = {change["path"] for change in section.get("changes", [])}
+    assert not paths & {"mode", "agent", "frame_admin_auth"}
+
+
+def test_https_proxy_sync_carries_no_certificate_material():
+    # The backend mints and pushes the pair; the device's copy is not a
+    # source, and a cert imported without its blanked key would mismatch.
+    value = _sync_frame_value("https_proxy", _device_frame()["https_proxy"])
+    assert value == {"enable": True, "port": 8443, "expose_only_port": True}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -138,6 +138,10 @@ class Config:
     # Socket peers the ingress uvicorn (HASSIO_RUN_MODE=ingress) answers to;
     # empty = the Supervisor's ingress proxy only (app/utils/ingress_guard.py).
     FRAMEOS_INGRESS_TRUSTED_PEERS = os.environ.get('FRAMEOS_INGRESS_TRUSTED_PEERS') or ''
+    # Host names (no port) on which the unauthenticated first-run setup routes
+    # (/api/cloud/setup/*) answer, beyond IP literals and local names. See
+    # app/api/cloud.py setup_host_allowed.
+    FRAMEOS_SETUP_ALLOWED_HOSTS = os.environ.get('FRAMEOS_SETUP_ALLOWED_HOSTS') or ''
     HASSIO_RUN_MODE = os.environ.get('HASSIO_RUN_MODE', None)
     HASSIO_TOKEN = os.environ.get('HASSIO_TOKEN', None)
     SUPERVISOR_TOKEN = os.environ.get('SUPERVISOR_TOKEN', None)

--- a/backend/app/ha/sync.py
+++ b/backend/app/ha/sync.py
@@ -36,6 +36,33 @@ SCENE_CHANGE_EVENTS = ("render:scene", "render:sceneChange", "event:setCurrentSc
 IMAGE_PUBLISH_MIN_INTERVAL = 2.0
 
 
+def partition_projects_by_broker(
+    resolved: dict[int, Optional[MqttConfig]],
+) -> tuple[Optional[MqttConfig], list[int], list[int]]:
+    """Pick the broker this run connects to and split projects by it.
+
+    Returns (broker, project ids on that broker, project ids on any other
+    broker). The broker is the first project's (dict order = load order); a
+    project that resolved to no broker at all counts as skipped too, since
+    nothing could be published for it. Pure, so the leak rule is unit-tested
+    without a broker or a Redis.
+    """
+    chosen: Optional[MqttConfig] = None
+    kept: list[int] = []
+    skipped: list[int] = []
+    for project_id, broker in resolved.items():
+        if broker is None:
+            skipped.append(project_id)
+            continue
+        if chosen is None:
+            chosen = broker
+        if broker == chosen:
+            kept.append(project_id)
+        else:
+            skipped.append(project_id)
+    return chosen, kept, skipped
+
+
 class HomeAssistantSync:
     def __init__(self):
         self._mqtt: Any = None  # aiomqtt.Client while connected
@@ -84,10 +111,28 @@ class HomeAssistantSync:
 
                 mqtt_config = None
                 if self._enabled:
-                    # One broker for the whole install: the Supervisor's Mosquitto
-                    # service as an add-on, or the settings-configured broker.
-                    any_settings = next(iter(self._enabled.values()))
-                    mqtt_config = await resolve_mqtt_config(http, any_settings)
+                    # One broker per run. As an add-on every project resolves to
+                    # the Supervisor's Mosquitto; self-hosted, each project may
+                    # name its own broker — and frames must only ever be
+                    # published to the broker their own project configured, or
+                    # project A's frames land on project B's MQTT (a
+                    # cross-project leak, docs/security-todo.md). Projects on
+                    # any other broker are left out of this run and said so.
+                    resolved = {
+                        project_id: await resolve_mqtt_config(http, ha_settings)
+                        for project_id, ha_settings in self._enabled.items()
+                    }
+                    mqtt_config, kept, skipped = partition_projects_by_broker(resolved)
+                    if skipped:
+                        print(
+                            "🟡 Home Assistant sync: projects "
+                            + ", ".join(str(project_id) for project_id in skipped)
+                            + " configure a different MQTT broker than the one this run connects to "
+                            + (f"({mqtt_config.host}:{mqtt_config.port})" if mqtt_config else "")
+                            + "; their frames are not shared. One broker per install is supported."
+                        )
+                        self._enabled = {project_id: self._enabled[project_id] for project_id in kept}
+                        self._rest = {project_id: rest for project_id, rest in self._rest.items() if project_id in kept}
 
                 if mqtt_config:
                     import aiomqtt

--- a/backend/app/ha/tests/test_sync.py
+++ b/backend/app/ha/tests/test_sync.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient, MockTransport, Response
 
 from app.ha import HA_SYNC_REQUEST_KEY, discovery
 from app.ha.client import MqttConfig, RestConfig
-from app.ha.sync import HomeAssistantSync
+from app.ha.sync import HomeAssistantSync, partition_projects_by_broker
 from app.models import new_frame, update_frame
 from app.models.settings import Settings
 
@@ -285,3 +285,25 @@ async def test_render_publishes_latest_image(db, redis, service):
     service._mqtt.messages.clear()
     await service._handle_broadcast("new_scene_image", {"project_id": project_id, "frameId": frame.id})
     assert service._mqtt.messages == []
+
+
+def test_projects_are_only_shared_over_their_own_broker():
+    # Two projects, two brokers: the run connects to the first project's
+    # broker and the second project's frames stay off it. Before this, every
+    # enabled project's frames were published to whichever broker the
+    # first-loaded project configured.
+    home = MqttConfig(host="mqtt.home", port=1883, username="a", password="x")
+    office = MqttConfig(host="mqtt.office", port=1883, username="b", password="y")
+    broker, kept, skipped = partition_projects_by_broker({1: home, 2: office, 3: home})
+    assert broker == home
+    assert kept == [1, 3]
+    assert skipped == [2]
+
+    # The add-on case: the Supervisor's Mosquitto for everyone.
+    broker, kept, skipped = partition_projects_by_broker({1: home, 2: home})
+    assert (broker, kept, skipped) == (home, [1, 2], [])
+
+    # A project with no broker at all is skipped, not silently attached.
+    broker, kept, skipped = partition_projects_by_broker({1: None, 2: home})
+    assert (broker, kept, skipped) == (home, [2], [1])
+    assert partition_projects_by_broker({}) == (None, [], [])

--- a/backend/app/tasks/precompiled_frameos.py
+++ b/backend/app/tasks/precompiled_frameos.py
@@ -21,6 +21,7 @@ from app.models.frame import Frame
 from app.utils.scene_execution import scene_is_interpreted
 from app.tasks._frame_deployer import FrameDeployer
 from app.utils.versions import get_versions
+from app.utils.release_signing import verify_release_archive_signature
 
 RELEASE_BASE_URL = os.environ.get(
     "FRAMEOS_PRECOMPILED_RELEASE_BASE_URL",
@@ -148,6 +149,37 @@ def precompiled_frameos_cache_path(url: str) -> Path:
     return precompiled_frameos_cache_dir() / f"{digest}-{safe_filename}"
 
 
+def precompiled_frameos_signature_path(cache_path: Path) -> Path:
+    return cache_path.with_name(cache_path.name + ".minisig")
+
+
+def _cached_archive_verifies(cache_path: Path) -> bool:
+    """A cache hit is only a hit if the archive still matches its signature.
+
+    The cache lives under tempfile.gettempdir() by default — a path every
+    local user can write to and predict (sha256 of the URL) — so the check
+    that runs when the archive is downloaded has to run again before the
+    bytes are handed to a frame. A miss here is treated as no cache at all:
+    both files are removed and the release is fetched afresh.
+    """
+    signature_path = precompiled_frameos_signature_path(cache_path)
+    if not _has_cached_archive(cache_path) or not _has_cached_archive(signature_path):
+        return False
+    try:
+        verify_release_archive_signature(cache_path, signature_path.read_text(encoding="utf-8"))
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def _discard_cached_archive(cache_path: Path) -> None:
+    for path in (cache_path, precompiled_frameos_signature_path(cache_path)):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 async def _cached_release_archive(
     url: str,
     target: str,
@@ -156,17 +188,22 @@ async def _cached_release_archive(
     label: str = "FrameOS",
 ) -> tuple[Path, bool]:
     cache_path = precompiled_frameos_cache_path(url)
+    signature_path = precompiled_frameos_signature_path(cache_path)
     if _has_cached_archive(cache_path):
-        await logger("stdout", f"Using cached precompiled {label} release for {target}")
-        return cache_path, True
+        if _cached_archive_verifies(cache_path):
+            await logger("stdout", f"Using cached precompiled {label} release for {target} (signature verified)")
+            return cache_path, True
+        await logger(
+            "stdout",
+            f"Cached precompiled {label} release for {target} fails its signature check; downloading it again",
+        )
+        _discard_cached_archive(cache_path)
 
     await logger("stdout", f"Downloading precompiled {label} release for {target}")
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    if _has_cached_archive(cache_path):
-        await logger("stdout", f"Using cached precompiled {label} release for {target}")
-        return cache_path, True
 
     temp_path: Path | None = None
+    temp_signature_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
             prefix=f".{cache_path.name}.",
@@ -175,13 +212,33 @@ async def _cached_release_archive(
             delete=False,
         ) as temp_file:
             temp_path = Path(temp_file.name)
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{signature_path.name}.",
+            suffix=".part",
+            dir=cache_path.parent,
+            delete=False,
+        ) as temp_file:
+            temp_signature_path = Path(temp_file.name)
         await _download(url, temp_path, timeout)
         if not _has_cached_archive(temp_path):
             raise RuntimeError("Downloaded precompiled FrameOS release was empty")
+        # The detached minisign signature published beside every release
+        # asset; verified against the key baked into the device runtimes
+        # (app/utils/release_signing.py) before anything trusts the archive.
+        await _download(f"{url}.minisig", temp_signature_path, timeout)
+        minisig = temp_signature_path.read_text(encoding="utf-8", errors="replace")
+        try:
+            verify_release_archive_signature(temp_path, minisig)
+        except ValueError as exc:
+            raise RuntimeError(f"Precompiled {label} release for {target} failed its signature check: {exc}") from exc
+        os.replace(temp_signature_path, signature_path)
+        temp_signature_path = None
         os.replace(temp_path, cache_path)
+        temp_path = None
     finally:
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
+        for leftover in (temp_path, temp_signature_path):
+            if leftover is not None:
+                leftover.unlink(missing_ok=True)
     return cache_path, False
 
 

--- a/backend/app/tasks/tests/release_signing_helpers.py
+++ b/backend/app/tasks/tests/release_signing_helpers.py
@@ -1,0 +1,46 @@
+"""Test-side release signing: mint a key, sign a fake archive the way the
+release pipeline does (minisign prehashed Ed25519 over BLAKE2b-512), and point
+the module's trusted key at it. The precompiled-release cache verifies every
+archive it downloads or reuses, so any test that fakes `_download` must hand
+out a signature too."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import shutil
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from app.utils import release_signing
+
+TEST_SIGNING_KEY = ed25519.Ed25519PrivateKey.generate()
+TEST_SIGNING_PUBLIC_KEY_BASE64 = base64.b64encode(
+    TEST_SIGNING_KEY.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+).decode()
+
+
+def minisig_for(archive: Path, key: ed25519.Ed25519PrivateKey = TEST_SIGNING_KEY) -> str:
+    digest = hashlib.blake2b(archive.read_bytes(), digest_size=64).digest()
+    blob = b"ED" + b"\x01" * 8 + key.sign(digest)
+    return "untrusted comment: test\n" + base64.b64encode(blob).decode() + "\n"
+
+
+def trust_test_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(release_signing, "RELEASE_SIGNING_PUBLIC_KEY_BASE64", TEST_SIGNING_PUBLIC_KEY_BASE64)
+
+
+def signing_download(archive: Path, calls: list[str] | None = None):
+    """A `_download` fake: the archive for the asset URL, its signature for the .minisig URL."""
+
+    async def fake_download(url: str, destination: Path, _timeout: float) -> None:
+        if calls is not None:
+            calls.append(url)
+        if url.endswith(".minisig"):
+            destination.write_text(minisig_for(archive), encoding="utf-8")
+        else:
+            shutil.copy2(archive, destination)
+
+    return fake_download

--- a/backend/app/tasks/tests/test_esp32_cloud_contract.py
+++ b/backend/app/tasks/tests/test_esp32_cloud_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import os
 import shutil
 import subprocess
@@ -72,3 +74,26 @@ def test_fos_cloud_contract_fixtures_pass(tmp_path: Path):
     run_result = subprocess.run([str(binary), str(FIXTURES)], capture_output=True, text=True)
     assert run_result.returncode == 0, run_result.stdout + run_result.stderr
     assert "0 failures" in run_result.stdout
+
+
+def test_single_plane_settings_carry_a_parity_reason():
+    """docs/convergence-todo.md item 6: the linux-only / esp32-only split is the
+    measured parity gap, and no key may be single-plane without saying why."""
+    doc = json.loads((REPO_ROOT / "docs" / "cloud-frames-contract.json").read_text(encoding="utf-8"))
+    every = set(doc["profiles"])
+    single = {name: spec for name, spec in doc["settings"].items() if set(spec["profiles"]) != every}
+    both = {name for name, spec in doc["settings"].items() if set(spec["profiles"]) == every}
+    for name, spec in single.items():
+        parity = spec.get("parity")
+        assert isinstance(parity, dict), f"{name} is single-plane and carries no parity entry"
+        assert set(spec["profiles"]) == {parity["only"]}, name
+        assert len(parity["why"].strip()) >= 20, name
+    for name in both:
+        assert "parity" not in doc["settings"][name], f"{name} is accepted on both planes; drop its parity entry"
+    # The gap as measured today. Shrinking is progress and needs no ceremony;
+    # growing it is a decision that belongs in the contract, not here.
+    by_plane = {}
+    for spec in single.values():
+        by_plane[spec["parity"]["only"]] = by_plane.get(spec["parity"]["only"], 0) + 1
+    assert by_plane.get("linux", 0) <= 8, by_plane
+    assert by_plane.get("esp32", 0) <= 7, by_plane

--- a/backend/app/tasks/tests/test_precompiled_frameos.py
+++ b/backend/app/tasks/tests/test_precompiled_frameos.py
@@ -7,8 +7,50 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.tasks import precompiled_frameos
 from app.tasks.prebuilt_deps import resolve_prebuilt_target
 from app.tasks.precompiled_frameos import download_precompiled_frameos_release, frame_compiled_scene_count
+
+
+import base64
+import hashlib
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from app.utils import release_signing
+
+
+# Every archive the fakes hand out is signed with a key minted here, and the
+# module's trusted key is pointed at it: the cache verifies the signature both
+# on download and on every hit (the cache dir is world-writable /tmp by
+# default), so an unsigned fake would never be used.
+_TEST_SIGNING_KEY = ed25519.Ed25519PrivateKey.generate()
+_TEST_SIGNING_PUBLIC_KEY_BASE64 = base64.b64encode(
+    _TEST_SIGNING_KEY.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+).decode()
+
+
+def _minisig_for(archive: Path) -> str:
+    digest = hashlib.blake2b(archive.read_bytes(), digest_size=64).digest()
+    blob = b"ED" + b"\x01" * 8 + _TEST_SIGNING_KEY.sign(digest)
+    return "untrusted comment: test\n" + base64.b64encode(blob).decode() + "\n"
+
+
+def _trust_test_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(release_signing, "RELEASE_SIGNING_PUBLIC_KEY_BASE64", _TEST_SIGNING_PUBLIC_KEY_BASE64)
+
+
+def _signing_download(archive: Path, calls: list[str] | None = None):
+    async def fake_download(url: str, destination: Path, _timeout: float) -> None:
+        if calls is not None:
+            calls.append(url)
+        if url.endswith(".minisig"):
+            destination.write_text(_minisig_for(archive), encoding="utf-8")
+        else:
+            shutil.copy2(archive, destination)
+
+    return fake_download
 
 
 def test_frame_compiled_scene_count_treats_missing_execution_as_interpreted():
@@ -45,14 +87,14 @@ async def test_download_precompiled_frameos_release_extracts_required_files(
     with tarfile.open(archive, "w:gz") as tar:
         tar.add(source_root, arcname=source_root.name)
 
-    async def fake_download(_url: str, destination: Path, _timeout: float) -> None:
-        shutil.copy2(archive, destination)
+    fake_download = _signing_download(archive)
 
     logs: list[tuple[str, str]] = []
 
     async def logger(level: str, message: str) -> None:
         logs.append((level, message))
 
+    _trust_test_key(monkeypatch)
     monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr("app.tasks.precompiled_frameos._download", fake_download)
 
@@ -101,12 +143,9 @@ async def test_download_precompiled_frameos_release_reuses_cached_archive(
     with tarfile.open(archive, "w:gz") as tar:
         tar.add(source_root, arcname=source_root.name)
 
-    download_count = 0
-
-    async def fake_download(_url: str, destination: Path, _timeout: float) -> None:
-        nonlocal download_count
-        download_count += 1
-        shutil.copy2(archive, destination)
+    download_calls: list[str] = []
+    fake_download = _signing_download(archive, download_calls)
+    _trust_test_key(monkeypatch)
 
     logs: list[tuple[str, str]] = []
 
@@ -133,7 +172,7 @@ async def test_download_precompiled_frameos_release_reuses_cached_archive(
         logger=logger,
     )
 
-    assert download_count == 1
+    assert len([url for url in download_calls if not url.endswith(".minisig")]) == 1
     assert first.cache_hit is False
     assert second.cache_hit is True
     assert Path(second.binary_path).read_bytes() == b"frameos"
@@ -268,3 +307,70 @@ async def test_download_gives_up_after_the_last_attempt(
         )
 
     assert not outcomes
+
+
+@pytest.mark.asyncio
+async def test_a_tampered_cached_archive_is_not_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The cache dir is predictable and (by default) under /tmp: bytes planted
+    there must fail the signature check and be fetched again, not deployed."""
+    source_root = tmp_path / "source" / "frameos-2026.5.14-debian-trixie-arm64"
+    (source_root / "drivers").mkdir(parents=True)
+    (source_root / "frameos").write_bytes(b"frameos")
+    (source_root / "metadata.json").write_text('{"slug":"debian-trixie-arm64","driver_libraries":[]}\n', encoding="utf-8")
+    archive = tmp_path / "release.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(source_root, arcname=source_root.name)
+
+    calls: list[str] = []
+    _trust_test_key(monkeypatch)
+    monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr("app.tasks.precompiled_frameos._download", _signing_download(archive, calls))
+
+    async def logger(level: str, message: str) -> None:
+        pass
+
+    url = precompiled_frameos.precompiled_frameos_release_url("debian-trixie-arm64", "2026.5.14")
+    assert url
+    cache_path, hit = await precompiled_frameos._cached_release_archive(url, "debian-trixie-arm64", 1.0, logger)
+    assert hit is False
+    assert precompiled_frameos.precompiled_frameos_signature_path(cache_path).is_file()
+
+    # Plant other bytes under the cached name: the signature no longer matches.
+    planted = tmp_path / "planted.tar.gz"
+    with tarfile.open(planted, "w:gz") as tar:
+        tar.add(source_root, arcname="evil")
+    shutil.copy2(planted, cache_path)
+    before = len(calls)
+    cache_path_again, hit = await precompiled_frameos._cached_release_archive(url, "debian-trixie-arm64", 1.0, logger)
+    assert hit is False, "a cached archive that fails its signature must not count as a hit"
+    assert len(calls) == before + 2
+    assert cache_path_again.read_bytes() == archive.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_a_release_with_a_bad_signature_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    archive = tmp_path / "release.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        pass
+    other_key = ed25519.Ed25519PrivateKey.generate()
+
+    async def fake_download(url: str, destination: Path, _timeout: float) -> None:
+        if url.endswith(".minisig"):
+            digest = hashlib.blake2b(archive.read_bytes(), digest_size=64).digest()
+            blob = b"ED" + b"\x01" * 8 + other_key.sign(digest)
+            destination.write_text("untrusted comment: x\n" + base64.b64encode(blob).decode() + "\n")
+        else:
+            shutil.copy2(archive, destination)
+
+    _trust_test_key(monkeypatch)
+    monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr("app.tasks.precompiled_frameos._download", fake_download)
+
+    async def logger(level: str, message: str) -> None:
+        pass
+
+    url = precompiled_frameos.precompiled_frameos_release_url("debian-trixie-arm64", "2026.5.14")
+    assert url
+    with pytest.raises(RuntimeError, match="signature"):
+        await precompiled_frameos._cached_release_archive(url, "debian-trixie-arm64", 1.0, logger)
+    assert not precompiled_frameos.precompiled_frameos_cache_path(url).exists()

--- a/backend/app/tasks/tests/test_precompiled_frameos.py
+++ b/backend/app/tasks/tests/test_precompiled_frameos.py
@@ -15,42 +15,10 @@ from app.tasks.precompiled_frameos import download_precompiled_frameos_release, 
 import base64
 import hashlib
 
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
-from app.utils import release_signing
+from app.tasks.tests.release_signing_helpers import signing_download as _signing_download, trust_test_key as _trust_test_key
 
-
-# Every archive the fakes hand out is signed with a key minted here, and the
-# module's trusted key is pointed at it: the cache verifies the signature both
-# on download and on every hit (the cache dir is world-writable /tmp by
-# default), so an unsigned fake would never be used.
-_TEST_SIGNING_KEY = ed25519.Ed25519PrivateKey.generate()
-_TEST_SIGNING_PUBLIC_KEY_BASE64 = base64.b64encode(
-    _TEST_SIGNING_KEY.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
-).decode()
-
-
-def _minisig_for(archive: Path) -> str:
-    digest = hashlib.blake2b(archive.read_bytes(), digest_size=64).digest()
-    blob = b"ED" + b"\x01" * 8 + _TEST_SIGNING_KEY.sign(digest)
-    return "untrusted comment: test\n" + base64.b64encode(blob).decode() + "\n"
-
-
-def _trust_test_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(release_signing, "RELEASE_SIGNING_PUBLIC_KEY_BASE64", _TEST_SIGNING_PUBLIC_KEY_BASE64)
-
-
-def _signing_download(archive: Path, calls: list[str] | None = None):
-    async def fake_download(url: str, destination: Path, _timeout: float) -> None:
-        if calls is not None:
-            calls.append(url)
-        if url.endswith(".minisig"):
-            destination.write_text(_minisig_for(archive), encoding="utf-8")
-        else:
-            shutil.copy2(archive, destination)
-
-    return fake_download
 
 
 def test_frame_compiled_scene_count_treats_missing_execution_as_interpreted():

--- a/backend/app/tasks/tests/test_precompiled_remote.py
+++ b/backend/app/tasks/tests/test_precompiled_remote.py
@@ -11,6 +11,7 @@ from app.tasks.precompiled_remote import (
     precompiled_remote_release_url,
 )
 from app.tasks.precompiled_frameos import release_version
+from app.tasks.tests.release_signing_helpers import signing_download, trust_test_key
 
 
 def test_precompiled_remote_release_url_uses_release_version():
@@ -39,14 +40,14 @@ async def test_download_precompiled_remote_release_extracts_binary(
     with tarfile.open(archive, "w:gz") as tar:
         tar.add(source_root, arcname=source_root.name)
 
-    async def fake_download(_url: str, destination: Path, _timeout: float) -> None:
-        shutil.copy2(archive, destination)
+    fake_download = signing_download(archive)
 
     logs: list[tuple[str, str]] = []
 
     async def logger(level: str, message: str) -> None:
         logs.append((level, message))
 
+    trust_test_key(monkeypatch)
     monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr("app.tasks.precompiled_frameos._download", fake_download)
 

--- a/backend/app/tasks/tests/test_real_ssh_deploy_e2e.py
+++ b/backend/app/tasks/tests/test_real_ssh_deploy_e2e.py
@@ -27,6 +27,7 @@ from app.tasks._frame_deployer import FrameDeployer
 from app.tasks import precompiled_frameos
 from app.tasks.frame_deploy_workflow import FrameDeployPlan, FrameDeployWorkflow
 from app.tasks.precompiled_frameos import release_version
+from app.tasks.tests.release_signing_helpers import minisig_for, trust_test_key
 from app.tasks.utils import find_nim_v2
 from app.tenancy import ensure_default_project
 
@@ -431,7 +432,11 @@ def _build_precompiled_release_archive(
     archive_path = release_dir / f"frameos-{version}-{precompiled_target}.tar.gz"
     with tarfile.open(archive_path, "w:gz") as archive:
         archive.add(artifact_root, arcname=archive_root_name)
-    _say(f"packaged local precompiled release archive {archive_path}")
+    # The release pipeline publishes a detached minisign signature beside every
+    # archive and the backend refuses an archive without one; this local
+    # release is signed with the test key the test trusts (trust_test_key).
+    archive_path.with_name(archive_path.name + ".minisig").write_text(minisig_for(archive_path), encoding="utf-8")
+    _say(f"packaged and signed local precompiled release archive {archive_path}")
     return archive_path
 
 
@@ -486,6 +491,7 @@ async def test_real_ssh_full_fast_cross_and_precompiled_deploy(
         os.environ.get("FRAMEOS_CROSS_MAKE_JOBS") or str(os.cpu_count() or 2),
     )
     monkeypatch.setenv("FRAMEOS_PRECOMPILED_CACHE_DIR", str(tmp_path / "precompiled-cache"))
+    trust_test_key(monkeypatch)
 
     with _phase("full deploy with compile on device"):
         remote_frame = _frame(

--- a/backend/app/utils/release_signing.py
+++ b/backend/app/utils/release_signing.py
@@ -15,6 +15,8 @@ Nim one, so a key rotation cannot leave the two halves disagreeing.
 from __future__ import annotations
 
 import base64
+import hashlib
+from pathlib import Path
 
 # Raw 32-byte Ed25519 public key, base64 — byte-for-byte
 # OtaSigningPublicKeyBase64 in frameos/src/frameos/ota_pubkey.nim.
@@ -32,3 +34,58 @@ def release_signing_public_key_spki_base64() -> str:
     if len(raw) != 32:
         raise ValueError("release signing key is not a 32-byte Ed25519 key")
     return base64.b64encode(_ED25519_SPKI_PREFIX + raw).decode("ascii")
+
+
+def parse_minisig_signature(minisig: str) -> bytes:
+    """The 64 signature bytes from a .minisig file.
+
+    The first non-comment line is base64(ED || keyid8 || sig64): "ED" marks
+    minisign's prehashed mode (the signature is over BLAKE2b-512 of the file).
+    The trusted-comment line and its global signature are ignored on purpose
+    — the backend trusts a KEY, not a comment — mirroring parseMinisigSignature
+    in frameos/src/frameos/upgrade.nim and parse_minisig in fos_ota.c.
+    """
+    for raw_line in minisig.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("untrusted comment:") or line.startswith("trusted comment:"):
+            continue
+        try:
+            blob = base64.b64decode(line, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise ValueError("Release signature is not valid base64") from exc
+        if len(blob) != 74:
+            raise ValueError(f"Release signature blob has the wrong length ({len(blob)}, expected 74)")
+        if blob[:2] != b"ED":
+            raise ValueError("Release signature is not the prehashed Ed25519 form FrameOS uses")
+        return blob[10:74]
+    raise ValueError("Release signature file contained no signature line")
+
+
+def verify_release_archive_signature(
+    archive_path: str | Path,
+    minisig: str,
+    public_key_base64: str | None = None,
+) -> None:
+    """Raise ValueError unless `archive_path` was signed by the release key.
+
+    Same check the device runtimes make before installing an OTA: BLAKE2b-512
+    over the whole file, Ed25519 over that digest. The backend runs no release
+    bytes itself, but it hands the archive to frames — and the download cache
+    it keeps under the system temp dir is writable by every local user, so a
+    cached archive is verified again on every use, not only when downloaded.
+    """
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    signature = parse_minisig_signature(minisig)
+    raw_key = base64.b64decode(public_key_base64 or RELEASE_SIGNING_PUBLIC_KEY_BASE64)
+    digest = hashlib.blake2b(digest_size=64)
+    with open(archive_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    try:
+        ed25519.Ed25519PublicKey.from_public_bytes(raw_key).verify(signature, digest.digest())
+    except InvalidSignature as exc:
+        raise ValueError(
+            f"Release signature does not verify against the FrameOS signing key: {archive_path}"
+        ) from exc

--- a/backend/app/ws/tests/test_websockets.py
+++ b/backend/app/ws/tests/test_websockets.py
@@ -97,22 +97,62 @@ def test_ws_missing_token(client: TestClient) -> None:
     assert exc.value.reason == "Missing token"
 
 
-def test_ws_invalid_token(client: TestClient) -> None:
+def test_ws_query_token_is_not_a_credential(client: TestClient) -> None:
+    # The `?token=` form is gone: a bearer in a URL lands in logs, and the SPA
+    # never sent one. It is simply ignored, so the cookie check speaks.
     with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/ws?token=bad"):
             pass
     assert exc.value.code == 1008
-    assert exc.value.reason == "Invalid token"
+    assert exc.value.reason == "Missing token"
 
 
-def test_ws_valid_token_echo(client: TestClient) -> None:
+def test_ws_refuses_a_cross_site_origin_before_looking_at_the_cookie(client: TestClient) -> None:
+    create_user()
+    login_resp = client.post("/api/login", data={"username": "test@example.com", "password": "testpassword"})
+    assert login_resp.status_code == 200
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/ws", headers={"origin": "https://evil.example"}):
+            pass
+    assert exc.value.code == 1008
+    assert exc.value.reason == "Origin not allowed"
+
+
+def test_ws_accepts_the_same_origin(client: TestClient) -> None:
+    create_user()
+    login_resp = client.post("/api/login", data={"username": "test@example.com", "password": "testpassword"})
+    assert login_resp.status_code == 200
+    # TestClient dials host "testserver"; a page served from it says so.
+    with client.websocket_connect("/ws", headers={"origin": "http://testserver"}) as ws:
+        ws.send_text("ping")
+        assert json.loads(ws.receive_text())["event"] == "pong"
+
+
+def test_terminal_ws_refuses_a_cross_site_origin(client: TestClient) -> None:
+    project_id = create_user()
+    login_resp = client.post("/api/login", data={"username": "test@example.com", "password": "testpassword"})
+    assert login_resp.status_code == 200
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(
+            f"/ws/projects/{project_id}/terminal/1", headers={"origin": "https://evil.example"}
+        ):
+            pass
+    assert exc.value.code == 1008
+    assert exc.value.reason == "Origin not allowed"
+
+
+def test_ws_valid_jwt_in_the_query_string_is_ignored(client: TestClient) -> None:
+    # Even a genuine access token does nothing in the URL: only the session
+    # cookie authenticates a socket. Clearing the cookie jar proves it.
     create_user()
     login_resp = client.post("/api/login", data={"username": "test@example.com", "password": "testpassword"})
     token = login_resp.json()["access_token"]
-    with client.websocket_connect(f"/ws?token={token}") as ws:
-        ws.send_text("ping")
-        data = ws.receive_json()
-    assert data == {"event": "pong", "payload": "ping"}
+    client.cookies.clear()
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f"/ws?token={token}"):
+            pass
+    assert exc.value.code == 1008
+    assert exc.value.reason == "Missing token"
 
 
 def test_ws_session_cookie_echo(client: TestClient) -> None:
@@ -153,7 +193,8 @@ def test_terminal_ws_invalid_token(client: TestClient) -> None:
         with client.websocket_connect("/ws/projects/1/terminal/1?token=bad"):
             pass
     assert exc.value.code == 1008
-    assert exc.value.reason == "Invalid token"
+    # The query token is ignored (cookie only), so the cookie check speaks.
+    assert exc.value.reason == "Missing token"
 
 
 def test_terminal_ws_frame_not_found(client: TestClient) -> None:

--- a/cloud/apps/auth-web/src/test/cloud-frames-contract.test.ts
+++ b/cloud/apps/auth-web/src/test/cloud-frames-contract.test.ts
@@ -27,6 +27,42 @@ const fixtures = JSON.parse(
   readFileSync(new URL("../../../../../docs/cloud-frames-fixtures.json", import.meta.url), "utf8"),
 ) as { settings: SettingsFixture[]; verbs: { name: string; type: string; expect: string }[] };
 
+interface ContractSettingSpec {
+  profiles: Record<string, unknown>;
+  parity?: { only: string; why: string };
+}
+const contract = JSON.parse(
+  readFileSync(new URL("../../../../../docs/cloud-frames-contract.json", import.meta.url), "utf8"),
+) as { profiles: string[]; settings: Record<string, ContractSettingSpec> };
+
+describe("settings parity between the device planes", () => {
+  // docs/convergence-todo.md item 6: a key one plane accepts and the other
+  // does not is the measured parity gap, and every such key must say why.
+  it("every single-plane key carries a parity reason, and no both-planes key does", () => {
+    const every = new Set(contract.profiles);
+    for (const [name, spec] of Object.entries(contract.settings)) {
+      const present = Object.keys(spec.profiles);
+      const isSingle = present.length !== every.size;
+      if (isSingle) {
+        expect(spec.parity, `${name} is single-plane without a parity entry`).toBeDefined();
+        expect(present, name).toEqual([spec.parity!.only]);
+        expect(spec.parity!.why.trim().length, name).toBeGreaterThanOrEqual(20);
+      } else {
+        expect(spec.parity, `${name} is both-planes and must not carry parity`).toBeUndefined();
+      }
+    }
+  });
+
+  it("the gap does not grow past today's measurement", () => {
+    const counts: Record<string, number> = {};
+    for (const spec of Object.values(contract.settings)) {
+      if (spec.parity) counts[spec.parity.only] = (counts[spec.parity.only] ?? 0) + 1;
+    }
+    expect(counts.linux ?? 0).toBeLessThanOrEqual(8);
+    expect(counts.esp32 ?? 0).toBeLessThanOrEqual(7);
+  });
+});
+
 describe("cloud verb contract fixtures", () => {
   it("has cases", () => {
     expect(fixtures.settings.length).toBeGreaterThan(50);

--- a/docs/cloud-frames-contract.json
+++ b/docs/cloud-frames-contract.json
@@ -30,7 +30,14 @@
     "WHOLE verb on a key it does not know). `rule` inside a profile overrides",
     "the top-level rule for that profile. `restart` = applying it restarts the",
     "runtime (Linux) or reboots the chip (ESP32). `companion` = only valid next",
-    "to that other key in the same push."
+    "to that other key in the same push.",
+    "",
+    "`parity` (2026-09-06): a key accepted by one profile only MUST carry",
+    "`parity: {only, why}` naming the plane and the reason the other cannot",
+    "take it; a key both accept must not. The generator refuses the file",
+    "otherwise, so no new key ships single-plane silently. Each key that",
+    "goes both-planes deletes its parity entry; the count of entries IS the",
+    "measured parity gap (docs/convergence-todo.md item 6)."
   ],
   "version": 1,
   "profiles": ["linux", "esp32"],
@@ -59,7 +66,8 @@
       "$comment": "The zone's tzdata slice for a chip without a tz database; command payload only, never a stored setting. null = fetch it yourself.",
       "rule": {"anyOf": [{"type": "object", "open": true}, {"type": "null"}]},
       "companion": "timezone",
-      "profiles": {"esp32": {"since": "2026.8.34"}}
+      "profiles": {"esp32": {"since": "2026.8.34"}},
+      "parity": {"only": "esp32", "why": "The POSIX TZ string for the chip's libc; the Pi has tzdata and takes `timezone` alone."}
     },
     "debug": {
       "rule": {"type": "bool"},
@@ -67,7 +75,8 @@
     },
     "flip": {
       "rule": {"type": "string", "enum": ["", "horizontal", "vertical", "both"]},
-      "profiles": {"linux": {"since": "2026.8.30"}}
+      "profiles": {"linux": {"since": "2026.8.30"}},
+      "parity": {"only": "linux", "why": "The Pi runtime flips the framebuffer in pixie; the ESP32 render path has rotate only, no flip stage (fos_http.c reports \"\")."}
     },
     "error_behavior": {
       "$comment": "The frontend/backend spelling; the runtime maps it onto errorBehavior in frame.json.",
@@ -82,7 +91,8 @@
           "silent_window_minutes": {"type": "number", "min": 1, "max": 10080}
         }
       },
-      "profiles": {"linux": {"since": "2026.8.30"}}
+      "profiles": {"linux": {"since": "2026.8.30"}},
+      "parity": {"only": "linux", "why": "The Pi runtime's scene-error retry policy (safe mode, retry windows); the ESP32 restarts the scene on an error and has no such state machine."}
     },
     "control_code": {
       "$comment": "The runtime's controlCode shape: a bool, numbers and #rrggbb colours — not the SPA form's string spellings.",
@@ -99,12 +109,14 @@
           "backgroundColor": {"type": "string", "format": "html_hex_color"}
         }
       },
-      "profiles": {"linux": {"since": "2026.8.30"}}
+      "profiles": {"linux": {"since": "2026.8.30"}},
+      "parity": {"only": "linux", "why": "Renders the local-presence pairing code overlay on the Pi; the ESP32 has no on-device pairing UI (its console prints what it needs)."}
     },
     "metrics_interval": {
       "$comment": "0 disables the sampler; anything else is a period in seconds.",
       "rule": {"type": "number", "min": 0, "max": 86400},
-      "profiles": {"linux": {"since": "2026.8.30"}}
+      "profiles": {"linux": {"since": "2026.8.30"}},
+      "parity": {"only": "linux", "why": "The Pi runtime pushes metrics on its own timer; the ESP32 pushes them on its render cadence and reports a fixed 60 (fos_http.c)."}
     },
     "max_http_response_bytes": {
       "$comment": "A per-request memory bound. The Linux ceiling is the runtime's own default (64 MiB) so a push can only lower it; the chip takes 1 KiB up.",
@@ -120,12 +132,14 @@
         {"type": "bool"},
         {"type": "map", "values": {"type": "bool"}, "maxEntries": 64, "keyMinLen": 1, "keyMaxLen": 64}
       ]},
-      "profiles": {"linux": {"since": "2026.8.30"}}
+      "profiles": {"linux": {"since": "2026.8.30"}},
+      "parity": {"only": "linux", "why": "Caches downloaded images into the Pi's assets directory; the ESP32 has no writable assets cache beyond the optional SD card."}
     },
     "timezone_updater": {
       "$comment": "enabled/hour only: the download URL is never a provider's to set.",
       "rule": {"type": "object", "keys": {"enabled": {"type": "bool"}, "hour": {"type": "int", "min": 0, "max": 23}}},
-      "profiles": {"linux": {"since": "2026.8.30"}}
+      "profiles": {"linux": {"since": "2026.8.30"}},
+      "parity": {"only": "linux", "why": "A Pi cron/systemd timer refreshing tzdata; the ESP32 receives its zone as timezone_data instead."}
     },
     "palette": {
       "$comment": "frame.json's palette: #rrggbb colours plus optional display name and per-colour names. An empty colour list hands the panel back its built-in palette.",
@@ -139,7 +153,8 @@
         "required": ["colors"]
       },
       "extraChecks": ["colorNames, when present, has exactly as many entries as colors"],
-      "profiles": {"linux": {"since": "2026.8.31", "restart": true}}
+      "profiles": {"linux": {"since": "2026.8.31", "restart": true}},
+      "parity": {"only": "linux", "why": "Custom dithering palette for the Pi renderer; ESP32 panels dither to their driver's fixed palette."}
     },
     "device_config": {
       "$comment": "STRICTLY the partial-refresh policy; the rest of deviceConfig is hardware wiring and stays the device's own (the persist path patches).",
@@ -152,7 +167,8 @@
         },
         "minKeys": 1
       },
-      "profiles": {"linux": {"since": "2026.8.31", "restart": true}}
+      "profiles": {"linux": {"since": "2026.8.31", "restart": true}},
+      "parity": {"only": "linux", "why": "Pi driver knobs (partial refresh, VCOM, …); on the ESP32 the panel table carries them per board."}
     },
     "gpio_buttons": {
       "$comment": "[{pin, label}] — the whole list, replaced; an empty list unbinds every button. The chip's table is smaller, and the firmware refuses (invalid_settings) any pin that is an SPI flash / PSRAM pad or already a driver's on that chip (fos_config_gpio_pin_reserved): the range here is chip-agnostic, the reservation is not.",
@@ -173,30 +189,36 @@
     },
     "deep_sleep": {
       "rule": {"type": "bool"},
-      "profiles": {"esp32": {"since": null}}
+      "profiles": {"esp32": {"since": null}},
+      "parity": {"only": "esp32", "why": "ESP32 power management; a Pi has no deep sleep."}
     },
     "deep_sleep_on_battery": {
       "rule": {"type": "bool"},
-      "profiles": {"esp32": {"since": null}}
+      "profiles": {"esp32": {"since": null}},
+      "parity": {"only": "esp32", "why": "ESP32 power management; a Pi has no deep sleep or battery sense."}
     },
     "wake_check_seconds": {
       "$comment": "0 = only wake to render; the firmware clamps 1..59 up to 60 (sub-minute check-ins drain a battery for nothing).",
       "rule": {"type": "int", "min": 0, "max": 86400},
-      "profiles": {"esp32": {"since": null}}
+      "profiles": {"esp32": {"since": null}},
+      "parity": {"only": "esp32", "why": "ESP32 deep-sleep wake cadence; a Pi never sleeps."}
     },
     "battery_pin": {
       "$comment": "ADC GPIO; -1 = no battery sense. Read at boot. The firmware refuses (invalid_settings) an SPI flash / PSRAM pad or a driver-claimed pin for its chip.",
       "rule": {"type": "int", "min": -1, "max": 48},
-      "profiles": {"esp32": {"since": null, "restart": true}}
+      "profiles": {"esp32": {"since": null, "restart": true}},
+      "parity": {"only": "esp32", "why": "ESP32 ADC battery sense; a Pi has no ADC."}
     },
     "battery_divider": {
       "rule": {"type": "number", "min": 0.5, "max": 20},
-      "profiles": {"esp32": {"since": null, "restart": true}}
+      "profiles": {"esp32": {"since": null, "restart": true}},
+      "parity": {"only": "esp32", "why": "ESP32 ADC battery sense; a Pi has no ADC."}
     },
     "battery_enable_pin": {
       "$comment": "GPIO driven high to switch the divider on while sampling (reTerminal E1004: 21); -1 = always on. Same reserved-pin refusal as battery_pin.",
       "rule": {"type": "int", "min": -1, "max": 48},
-      "profiles": {"esp32": {"since": "2026.8.39", "restart": true}}
+      "profiles": {"esp32": {"since": "2026.8.39", "restart": true}},
+      "parity": {"only": "esp32", "why": "ESP32 ADC battery sense; a Pi has no ADC."}
     }
   },
   "formats": {

--- a/docs/cloud-link.md
+++ b/docs/cloud-link.md
@@ -41,6 +41,7 @@ Behind a reverse proxy, also set:
 |---|---|
 | `FRAMEOS_PUBLIC_URL` | The origin this install is reached at, e.g. `https://frameos.example`. It becomes the login `redirect_uri` and the logout `return_to`, so setting it explicitly is what stops a caller choosing them through `X-Forwarded-Host` |
 | `FRAMEOS_TRUSTED_PROXIES` | Comma-separated proxy addresses whose `X-Forwarded-*` headers are honoured. Empty means loopback and private-range peers only |
+| `FRAMEOS_SETUP_ALLOWED_HOSTS` | Comma-separated hostnames on which the unauthenticated first-run setup (`/api/cloud/setup/*`, before any user exists) answers. IP literals, single-label names and local suffixes (`.local`, `.lan`, `.home.arpa`, …) always do; a public DNS name is refused unless listed, which is what a DNS-rebinding page cannot present |
 
 (`FRAMEOS_AUTH_PROVIDER_URL` is accepted as a fallback name.) The provider URL
 can also be edited in the UI while disconnected; the edited value is stored

--- a/docs/convergence-todo.md
+++ b/docs/convergence-todo.md
@@ -175,10 +175,16 @@ is *not* pinned elsewhere it already matters:
   list in one runner). Its first run found a drift: the SPA read an
   unknown `settings.execution` stamp as compiled while the backend read
   it as interpreted. New cases go in the JSON first.
-- [ ] The 8-both / 8-linux / 7-esp32 settings-key split is the measured
-  parity gap between the device planes. Each key that goes
-  both-planes deletes a row; no new key ships single-plane without a
-  contract entry saying so.
+- [x] The 8-both / 8-linux / 7-esp32 settings-key split is pinned
+  (2026-09-06): every single-plane key in `docs/cloud-frames-contract.json`
+  carries `parity: {only, why}` and the generator refuses the file
+  otherwise; pytest and the auth-web contract test assert the rule and cap
+  the count at today's 8 / 7. Each key that goes both-planes deletes its
+  parity entry (and the cap can only go down). Of the 15, none is a cheap
+  port: the linux-only eight are Pi-runtime features (flip stage, error
+  state machine, pairing overlay, metrics timer, assets cache, tzdata
+  timer, custom palette, driver knobs) and the esp32-only seven are power
+  management and ADC battery sense a Pi does not have.
 - [ ] `fos_cloud.c` (3,259) beside `hub_client.nim` (2,049) is the
   accepted cost of the C decision — hold the line: new verbs land as
   contract entry + fixtures + both walkers in one PR, and any helper

--- a/docs/security-todo.md
+++ b/docs/security-todo.md
@@ -47,16 +47,22 @@ medium / low list below.
   the API answers `plain_http` + a warning the drawer shows when the
   script URL is `http://` (the key and Remote secret cross the LAN in
   clear, once).
-- Smaller: cross-project leak via the first-loaded project's MQTT broker in
-  `ha/sync.py`; `replayEnrollment`-style sync pulls `mode` / `agent` /
-  `frame_admin_auth` / `https_proxy.server_key` from the device; `?token=`
-  JWT in WebSocket query strings (dormant); no Origin check on WebSocket
-  handshakes (SameSite=Lax is the only defence); `TrustedHostMiddleware`
-  absent (DNS rebinding reaches `/api/cloud/setup/*` on a fresh install);
-  predictable unverified precompiled cache under `/tmp`; a device `bootup`
-  event may still move `frame_host` on embedded frames when the claimed IP
-  matches the request peer or `embedded.followBootIp` is set (deliberate:
-  ESP32 DHCP follow).
+- Smaller, what is left: a device `bootup` event may still move
+  `frame_host` on embedded frames when the claimed IP matches the request
+  peer or `embedded.followBootIp` is set (deliberate: ESP32 DHCP follow).
+  Closed 2026-09-06 — the HA sync connects to one broker per run and shares
+  only the projects that configured that broker (others are logged and
+  skipped; `partition_projects_by_broker`); the frame sync never pulls
+  `mode`, `agent` or `frame_admin_auth` from a device and drops certificate
+  material from `https_proxy` (`FRAME_SYNC_BACKEND_OWNED_KEYS`); WebSocket
+  handshakes are cookie-only (the dormant `?token=` JWT form is gone) and
+  refuse a cross-site `Origin` before reading the cookie; the unauthenticated
+  `/api/cloud/setup/*` routes answer only on IP literals and local names
+  (`.local`, `.lan`, `.home.arpa`, …) or `FRAMEOS_SETUP_ALLOWED_HOSTS`, which
+  is what a DNS-rebinding page cannot present; the precompiled release cache
+  under `/tmp` keeps each archive's `.minisig` beside it and verifies the
+  signature on download and on every hit (a planted archive is discarded and
+  fetched again).
 
 ### Device runtime (Nim) and ESP32
 

--- a/frameos/tools/generate_cloud_contract.py
+++ b/frameos/tools/generate_cloud_contract.py
@@ -46,10 +46,37 @@ def load():
             if profile not in doc["profiles"]:
                 raise SystemExit(f"setting {name!r}: unknown profile {profile!r}")
         validate_rule(spec["rule"], f"settings.{name}")
+        validate_parity(doc, name, spec)
         for profile, pspec in spec["profiles"].items():
             if "rule" in pspec:
                 validate_rule(pspec["rule"], f"settings.{name}.profiles.{profile}")
     return doc
+
+
+def validate_parity(doc, name, spec):
+    """A single-plane key must say why it is single-plane; a both-planes key must not.
+
+    The point (docs/convergence-todo.md item 6): the 8-linux / 7-esp32 split
+    is the measured parity gap between the device planes, and no new key may
+    widen it without a contract entry saying so. `parity` is documentation for
+    the generated tables' readers; none of the walkers consumes it.
+    """
+    present = set(spec["profiles"])
+    every = set(doc["profiles"])
+    parity = spec.get("parity")
+    if present == every:
+        if parity is not None:
+            raise SystemExit(f"settings.{name}: accepted by every profile, so it must not carry `parity`")
+        return
+    if not isinstance(parity, dict) or set(parity) != {"only", "why"}:
+        raise SystemExit(
+            f"settings.{name}: accepted by {sorted(present)} only — add "
+            f'`parity: {{"only": "<profile>", "why": "<reason the other plane cannot take it>"}}`'
+        )
+    if len(present) != 1 or parity["only"] not in present:
+        raise SystemExit(f"settings.{name}: parity.only must name the one profile that accepts the key ({sorted(present)})")
+    if not isinstance(parity["why"], str) or len(parity["why"].strip()) < 20:
+        raise SystemExit(f"settings.{name}: parity.why must be a sentence, not {parity['why']!r}")
 
 
 def validate_rule(rule, where):


### PR DESCRIPTION
Two items from the post-#453 pass.

**Self-hosted backend, the "Smaller" security list** (`docs/security-todo.md`):
- WebSocket handshakes are cookie-only (the dormant `?token=` JWT form is gone) and refuse a cross-site `Origin` before reading the cookie, on `/ws` and the terminal socket.
- `/api/cloud/setup/*` on a fresh install answers only on IP literals, single-label and local-suffix names, or `FRAMEOS_SETUP_ALLOWED_HOSTS` (new, documented in `docs/cloud-link.md`), which is what a DNS-rebinding page cannot present. Skipped under HA ingress.
- The precompiled release cache under `/tmp` keeps each archive's `.minisig` beside it and verifies the release signature on download and on every hit; planted bytes are discarded and re-fetched.
- The frame sync never pulls `mode`, `agent` or `frame_admin_auth` from a device and drops certificate material from `https_proxy`.
- Home Assistant sync connects to one broker per run and shares only the projects that configured it; others are logged and skipped rather than published to a foreign MQTT.

**Contract discipline** (`docs/convergence-todo.md` item 6): every single-plane setting in the contract carries `parity: {only, why}`; the generator refuses the file otherwise; pytest and the auth-web contract test assert the rule and cap the gap at today's 8 / 7. None of the 15 is a cheap port, reasons are in the file.

Verified locally: 563 backend tests across the touched areas (plus the new ones), the generator `--check`, the auth-web contract test and lint. The one local failure is the stale wasm e2e fixture test that passed in CI on #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un8Q6ih58FbBd7WoDQtZ24
