### PR TITLE
Interpreter robustness: wall-clock render deadline, per-scene heap budget, per-run dispatch budget

### DIFF
--- a/docs/js-apps-and-code-nodes.md
+++ b/docs/js-apps-and-code-nodes.md
@@ -186,6 +186,21 @@ viewBox units, numeric stop offsets 0–1, no percentages, no
 `gradientTransform`. For a whole-screen gradient the `render/gradient` app
 (`startColor`, `endColor`, `angle`) is the simpler choice.
 
+## What the runtime will not let a scene do
+
+Scene JS is untrusted on every frame — it is anyone's store scene at worst
+and your own typo at best — and it runs on the thread that draws the panel.
+Four ceilings turn "this frame never renders again" into one logged scene
+error. All of them are set in `frame.json` under `js`; `-1` or an absent key
+keeps the build's default, `0` disables the ceiling.
+
+| Key | Default | What it bounds |
+|---|---|---|
+| `executionTimeoutMs` | 30 000 (Pi), 20 000 (ESP32) | Interpreter time per entry into JS. The clock stops while a native binding (`httpRequest`, an asset read) runs, so a slow fetch is not mistaken for a runaway loop. |
+| `renderDeadlineMs` | 120 000 (Pi), 90 000 (ESP32), 60 000 (preview) | Wall-clock time per render or event, native calls **included**. Every HTTP request made during the run is capped to what is left of it; the script is stopped when it passes. This is what a tarpit URL costs a scene: one render, not the watchdog window. |
+| `memoryLimitMb` | 256 (Pi), 8 (ESP32) | JS heap **per scene**, shared by the scene's code-node context and every JS app node's runtime. One node hoarding the heap fails with `out of memory`; the frame's other scenes are unaffected. |
+| `dispatchBudget` | 64 | Events a single render or event may fire through dispatch nodes. A handler that dispatches its own event is an unbounded chain; past the budget the run's dispatches are dropped, once with an `interpreter:dispatch:ignored` log line (`reason: dispatchBudget`). The ESP32, which runs events synchronously, also refuses events nested more than four deep. |
+
 ## Checklist before shipping a scene
 
 - Every `data.config` key is a field of the app; select values are one of the options.

--- a/docs/security-todo.md
+++ b/docs/security-todo.md
@@ -127,13 +127,21 @@ medium / low list below.
   GitHub metadata, so anyone with release-upload rights (no signing key) can
   attach an older or other-arch signed archive under a new tag. Verify the
   global signature / trusted comment naming version + target.
-- **Interpreter robustness, what is left** (the node depth / self-reference
-  guard and the SVG / canvas dimension cap are in): the interpreter time
-  budget excludes native calls (`httpRequest` tarpit up to 600 s wedges the
-  render thread until the 900 s watchdog, forever); 256 MB JS heap per
-  runtime, one per JS app node; self-dispatching event loops starve
-  rendering (Pi) or recurse synchronously (ESP32). Wall-clock render
-  deadline, per-scene heap budget, per-render dispatch budget.
+- **Interpreter robustness — closed 2026-09-06** (the node depth /
+  self-reference guard and the SVG / canvas dimension cap were already in):
+  every run of a scene now arms a wall-clock deadline that counts native
+  calls (`js.renderDeadlineMs`, 120 s Pi / 90 s ESP32; the HTTP client caps
+  each request to what is left and the interrupt handler stops the script
+  when it passes — a 600 s `httpRequest` tarpit costs one render, not the
+  900 s watchdog), the JS heap ceiling is per scene and shared by all of the
+  scene's runtimes (`js.memoryLimitMb`, 256 MB Pi / 8 MB ESP32, through
+  budgeted QuickJS allocators on both planes), and a run may fire at most
+  `js.dispatchBudget` (64) events — the Pi's message loop also yields to the
+  render loop every 32 events, and the ESP32 refuses events nested more
+  than four deep. Reference: `docs/js-apps-and-code-nodes.md`, "What the
+  runtime will not let a scene do". Left: the budgets are per run, not per
+  scene per minute — a scene that spends its whole deadline on every render
+  is slow, not stopped.
 - Smaller: the frame's TLS material and admin login now ride the
   `/embedded/settings` pull (bearer-authenticated, but in clear on an http
   backend — same exposure as the API keys that pull already carried; an

--- a/embedded/esp32/components/frameos_quickjs/fos_qjs_glue.c
+++ b/embedded/esp32/components/frameos_quickjs/fos_qjs_glue.c
@@ -7,6 +7,7 @@
 // js_def_malloc so JS_ComputeMemoryUsage and the malloc limit keep working.
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -40,6 +41,31 @@ static size_t fos_js_usable_size(const void *ptr)
     return heap_caps_get_allocated_size((void *)ptr);
 }
 
+/* The scene-wide ceiling shared by every runtime of one scene (its context
+ * plus one per JS app node), handed in as the malloc state's opaque by
+ * fos_js_new_runtime_budgeted. The per-runtime malloc_limit still applies;
+ * this stops N runtimes from claiming N × that limit of PSRAM. */
+static inline fos_js_heap_budget_t *fos_js_budget(JSMallocState *s)
+{
+    return (fos_js_heap_budget_t *)s->opaque;
+}
+
+static inline bool fos_js_budget_allows(fos_js_heap_budget_t *b, size_t extra)
+{
+    return b == NULL || b->limit_bytes == 0 || b->used_bytes + extra <= b->limit_bytes;
+}
+
+static inline void fos_js_budget_charge(fos_js_heap_budget_t *b, size_t bytes)
+{
+    if (b != NULL) b->used_bytes += bytes;
+}
+
+static inline void fos_js_budget_release(fos_js_heap_budget_t *b, size_t bytes)
+{
+    if (b == NULL) return;
+    b->used_bytes = b->used_bytes > bytes ? b->used_bytes - bytes : 0;
+}
+
 static void *fos_js_malloc(JSMallocState *s, size_t size)
 {
     void *ptr;
@@ -47,11 +73,15 @@ static void *fos_js_malloc(JSMallocState *s, size_t size)
     assert(size != 0);
     if (s->malloc_size + size > s->malloc_limit)
         return NULL;
+    if (!fos_js_budget_allows(fos_js_budget(s), size))
+        return NULL;
     ptr = fos_js_alloc(size);
     if (ptr == NULL)
         return NULL;
     s->malloc_count++;
-    s->malloc_size += fos_js_usable_size(ptr) + FOS_JS_MALLOC_OVERHEAD;
+    size_t charged = fos_js_usable_size(ptr) + FOS_JS_MALLOC_OVERHEAD;
+    s->malloc_size += charged;
+    fos_js_budget_charge(fos_js_budget(s), charged);
     return ptr;
 }
 
@@ -60,7 +90,9 @@ static void fos_js_free(JSMallocState *s, void *ptr)
     if (ptr == NULL)
         return;
     s->malloc_count--;
-    s->malloc_size -= fos_js_usable_size(ptr) + FOS_JS_MALLOC_OVERHEAD;
+    size_t charged = fos_js_usable_size(ptr) + FOS_JS_MALLOC_OVERHEAD;
+    s->malloc_size -= charged;
+    fos_js_budget_release(fos_js_budget(s), charged);
     heap_caps_free(ptr);
 }
 
@@ -81,6 +113,8 @@ static void *fos_js_realloc(JSMallocState *s, void *ptr, size_t size)
     }
     if (s->malloc_size + size - old_size > s->malloc_limit)
         return NULL;
+    if (size > old_size && !fos_js_budget_allows(fos_js_budget(s), size - old_size))
+        return NULL;
 
     // No heap_caps_realloc with caps fallback chain: realloc keeps the
     // original heap, which is what we want (stays in PSRAM).
@@ -89,7 +123,12 @@ static void *fos_js_realloc(JSMallocState *s, void *ptr, size_t size)
         new_ptr = heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT);
     if (new_ptr == NULL)
         return NULL;
-    s->malloc_size += fos_js_usable_size(new_ptr) - old_size;
+    size_t new_size = fos_js_usable_size(new_ptr);
+    s->malloc_size += new_size - old_size;
+    if (new_size >= old_size)
+        fos_js_budget_charge(fos_js_budget(s), new_size - old_size);
+    else
+        fos_js_budget_release(fos_js_budget(s), old_size - new_size);
     return new_ptr;
 }
 
@@ -100,12 +139,17 @@ static const JSMallocFunctions fos_js_malloc_funcs = {
     .js_malloc_usable_size = fos_js_usable_size,
 };
 
-struct JSRuntime *fos_js_new_runtime(void)
+struct JSRuntime *fos_js_new_runtime_budgeted(fos_js_heap_budget_t *budget)
 {
-    JSRuntime *rt = JS_NewRuntime2(&fos_js_malloc_funcs, NULL);
+    JSRuntime *rt = JS_NewRuntime2(&fos_js_malloc_funcs, budget);
     if (rt == NULL)
         return NULL;
     JS_SetMemoryLimit(rt, FOS_JS_MEMORY_LIMIT);
     JS_SetMaxStackSize(rt, FOS_JS_STACK_SIZE);
     return rt;
+}
+
+struct JSRuntime *fos_js_new_runtime(void)
+{
+    return fos_js_new_runtime_budgeted(NULL);
 }

--- a/embedded/esp32/components/frameos_quickjs/include/fos_qjs_glue.h
+++ b/embedded/esp32/components/frameos_quickjs/include/fos_qjs_glue.h
@@ -5,7 +5,21 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+
 struct JSRuntime;
+
+/* One scene's shared JS heap ceiling, drawn on by every runtime the scene
+ * creates. Layout matches JsHeapBudget in frameos/src/frameos/js_runtime/
+ * burrito.nim (two size_t: limit, then used); the Nim side owns the memory
+ * for the process lifetime. limit_bytes 0 = no shared ceiling. */
+typedef struct fos_js_heap_budget {
+    size_t limit_bytes;
+    size_t used_bytes;
+} fos_js_heap_budget_t;
+
+/* fos_js_new_runtime, plus the scene's shared budget (NULL for none). */
+struct JSRuntime *fos_js_new_runtime_budgeted(fos_js_heap_budget_t *budget);
 
 // Create a JSRuntime whose allocations go to PSRAM (8-bit capable SPIRAM,
 // falling back to internal RAM when PSRAM is absent), with a memory limit

--- a/frameos/src/embedded/embedded_runtime.nim
+++ b/frameos/src/embedded/embedded_runtime.nim
@@ -38,6 +38,10 @@ var
   defaultSceneId: Option[SceneId] = none(SceneId)
   scenesLoadedCount = 0
   renderRequested = false
+  # Nesting of synchronously dispatched scene events (see the event hook).
+  embeddedEventDepth = 0
+
+const MaxEmbeddedEventDepth = 4
 
 type
   SceneCatalogEntry* = object
@@ -259,12 +263,23 @@ proc initRuntime*(width, height: int, name: string, maxHttpResponseBytes: int,
       if event == "render":
         renderRequested = true
       elif not currentScene.isNil:
-        try:
-          let context = ExecutionContext(scene: currentScene, event: event,
-              payload: if payload.isNil: %*{} else: payload, loopIndex: 0, loopKey: ".")
-          runEvent(currentScene, context)
-        except Exception as e:
-          log("event " & event & " failed: " & e.msg)
+        # Events run synchronously here (one task, no queue), so a handler that
+        # dispatches its own event recurses on the render task's stack. The
+        # per-run dispatch budget (interpreter, run_budget.nim) caps the fan-out;
+        # this caps the depth, and names the loop instead of overflowing.
+        if embeddedEventDepth >= MaxEmbeddedEventDepth:
+          log("event " & event & " dropped: " & $embeddedEventDepth &
+              " events deep — a scene is re-dispatching its own event")
+        else:
+          inc embeddedEventDepth
+          try:
+            let context = ExecutionContext(scene: currentScene, event: event,
+                payload: if payload.isNil: %*{} else: payload, loopIndex: 0, loopKey: ".")
+            runEvent(currentScene, context)
+          except Exception as e:
+            log("event " & event & " failed: " & e.msg)
+          finally:
+            dec embeddedEventDepth
 
 proc cleanupScene(scene: FrameScene) =
   ## Break ORC cycles and close the scene's QuickJS context before dropping

--- a/frameos/src/frameos/config.nim
+++ b/frameos/src/frameos/config.nim
@@ -197,7 +197,8 @@ proc newHook*(v: var NetworkConfig) =
 proc newHook*(v: var JsRuntimeConfig) =
   ## Defaults live in js_runtime/burrito.nim (DefaultJs*); -1 means "keep what
   ## this build target chose", so an unset frame.json changes nothing.
-  v = JsRuntimeConfig(executionTimeoutMs: -1, memoryLimitMb: -1, maxStackKb: -1, assetSandbox: "frame")
+  v = JsRuntimeConfig(executionTimeoutMs: -1, memoryLimitMb: -1, maxStackKb: -1, assetSandbox: "frame",
+                      renderDeadlineMs: -1, dispatchBudget: -1)
 
 proc postHook*(v: var JsRuntimeConfig) =
   if v.assetSandbox notin ["frame", "scene"]:

--- a/frameos/src/frameos/interpreter.nim
+++ b/frameos/src/frameos/interpreter.nim
@@ -9,6 +9,7 @@ when defined(memProbe): import frameos/utils/memory
 import frameos/js_runtime/app_runtime
 import frameos/js_runtime/runtime
 import frameos/channels
+import frameos/js_runtime/run_budget
 import frameos/node_config
 import frameos/planner
 import frameos/runtime_diagnostics
@@ -845,7 +846,23 @@ proc runNode*(self: FrameScene, nodeId: NodeId, context: ExecutionContext, asDat
           "reason": "runtimeVerb"
         })
       else:
-        sendEvent(eventName, finalPayload)
+        # One run may fire only so many events (run_budget.nim): a handler that
+        # dispatches its own event is an unbounded chain that starves rendering
+        # on the Pi and recurses on the ESP32. Logged once per run, then dropped.
+        case takeDispatchBudget()
+        of dvAllowed:
+          sendEvent(eventName, finalPayload)
+        of dvRefusedFirst:
+          self.logger.log(%*{
+            "event": "interpreter:dispatch:ignored",
+            "sceneId": self.id.string,
+            "nodeId": currentNodeId.int,
+            "eventName": eventName,
+            "reason": "dispatchBudget",
+            "budget": dispatchBudgetTotalNow()
+          })
+        of dvRefused:
+          discard
       if asDataNode:
         result = VJson(copy(finalPayload))
     of "code":
@@ -1558,7 +1575,7 @@ proc eventNodeMatchesPayload(node: DiagramNode, payload: JsonNode): bool =
 
   true
 
-proc runEvent*(self: FrameScene, context: ExecutionContext) =
+proc runEventInner(self: FrameScene, context: ExecutionContext) =
   var scene: InterpretedFrameScene = InterpretedFrameScene(self)
   markRuntimeCheckpoint("event:start", currentSceneId = self.id.string, contextEvent = context.event,
     clearNode = true)
@@ -1633,6 +1650,32 @@ proc runEvent*(self: FrameScene, context: ExecutionContext) =
         "error": "\"" & context.event & "\" reached the scene but every listener filtered it out" &
           (if expectedFilters.len > 0: " (nodes want " & expectedFilters.join(", ") & ")" else: "")
       })
+
+proc resolvedRenderDeadlineMs(frameConfig: FrameConfig): int =
+  if frameConfig != nil and frameConfig.js != nil and frameConfig.js.renderDeadlineMs >= 0:
+    return frameConfig.js.renderDeadlineMs
+  DefaultRenderDeadlineMs
+
+proc resolvedDispatchBudget(frameConfig: FrameConfig): int =
+  if frameConfig != nil and frameConfig.js != nil and frameConfig.js.dispatchBudget >= 0:
+    return frameConfig.js.dispatchBudget
+  DefaultDispatchBudget
+
+proc runEvent*(self: FrameScene, context: ExecutionContext) =
+  ## Every run of a scene — a render, an event, a child scene's init — enters
+  ## here on every host (runner.nim, embedded_runtime.nim, wasm_main.nim), so
+  ## this is where the run's budgets are armed: the wall-clock deadline that
+  ## counts native calls too, and the dispatch budget. Re-entrant: a nested run
+  ## rides on the outer one's budgets (run_budget.nim).
+  let armedHere = armRenderDeadline(resolvedRenderDeadlineMs(self.frameConfig))
+  if armedHere:
+    setDispatchBudget(resolvedDispatchBudget(self.frameConfig))
+  try:
+    runEventInner(self, context)
+  finally:
+    if armedHere:
+      disarmRenderDeadline()
+      setDispatchBudget(0)
 
 proc render*(self: FrameScene, context: ExecutionContext): Image =
   if TRACING:

--- a/frameos/src/frameos/js_runtime/app_runtime.nim
+++ b/frameos/src/frameos/js_runtime/app_runtime.nim
@@ -4,6 +4,7 @@ import pixie
 
 import frameos/apps as frameos_apps
 import frameos/js_runtime/runtime
+import frameos/js_runtime/run_budget
 import frameos/types
 import frameos/values
 import frameos/utils/http_client
@@ -218,8 +219,11 @@ proc jsHttpRequest(ctx: ptr JSContext, url: JSValue, optionsJson: JSValue): JSVa
     if not headersNode.isNil and headersNode.kind == JObject:
       for name, value in headersNode.pairs:
         headers.add((name, value.getStr($value)))
-    let timeoutMs = clamp(options{"timeoutMs"}.getInt(DefaultFetchTimeoutMs), 1000, JsHttpMaxTimeoutMs)
-    let maxSeconds = max(DefaultFetchMaxSeconds, timeoutMs.float / 1000.0 + 30.0)
+    # The scene's own ceiling for this request, then the run's wall-clock
+    # deadline (run_budget.nim): a 600 s tarpit used to hold the render
+    # thread until the systemd watchdog fired.
+    let timeoutMs = capToRenderDeadline(clamp(options{"timeoutMs"}.getInt(DefaultFetchTimeoutMs), 1000, JsHttpMaxTimeoutMs))
+    let maxSeconds = capToRenderDeadline(int(max(DefaultFetchMaxSeconds, timeoutMs.float / 1000.0 + 30.0) * 1000)).float / 1000.0
     let res = boundedRequestWithHeaders(
       urlStr,
       httpMethod = options{"method"}.getStr("GET").toUpperAscii(),
@@ -1113,7 +1117,10 @@ proc setDynamicJsAppField*(app: AppRoot, field: string, value: Value) =
     dynamicApp.runtime.releaseReplacedImageRef(dynamicApp.configJson[field], nextValue)
   dynamicApp.configJson[field] = nextValue
 
-proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig) =
+proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig, sceneId: string = "") =
+  ## `sceneId` joins this runtime to the owning scene's shared heap budget
+  ## (runtime.sceneHeapBudgetFor): every JS app node of a scene draws on one
+  ## ceiling instead of each getting the full per-runtime limit.
   if runtime.ready:
     return
 
@@ -1124,7 +1131,7 @@ proc ensureReady(runtime: JsAppRuntime, frameConfig: FrameConfig) =
       liveJsRuntimes.add(runtime)
 
   when defined(memProbe): memProbe("    newQuickJS BEFORE")
-  runtime.js = newQuickJS(sceneJsConfig(frameConfig))
+  runtime.js = newQuickJS(sceneJsConfig(frameConfig, sceneId))
   when defined(memProbe): memProbe("    newQuickJS AFTER")
   jsAppRuntimeByCtx[runtime.js.context] = runtime
   runtime.js.setModuleLoader(jsAppModuleLoader, jsAppModuleNormalize)
@@ -1526,7 +1533,7 @@ proc toValue(runtime: JsAppRuntime, owner: AppRoot, context: ExecutionContext, p
   runtime.toValue(owner, context, jsValueToJson(ctx, payload), expectedType)
 
 proc invoke(runtime: JsAppRuntime, owner: AppRoot, configJson: JsonNode, context: ExecutionContext, fnName: string): JSValue =
-  ensureReady(runtime, owner.frameConfig)
+  ensureReady(runtime, owner.frameConfig, if owner.scene.isNil: "" else: owner.scene.id.string)
   let ctx = runtime.js.context
   let fnNameValue = nimStringToJS(ctx, fnName)
   defer: JS_FreeValue(ctx, fnNameValue)

--- a/frameos/src/frameos/js_runtime/burrito.nim
+++ b/frameos/src/frameos/js_runtime/burrito.nim
@@ -81,6 +81,7 @@
 ##
 
 import std/[tables, macros, json, strutils, os, monotimes, times]
+import frameos/js_runtime/run_budget
 
 when defined(frameosEmbedded):
   # The ESP-IDF build compiles QuickJS as the frameos_quickjs component and
@@ -118,6 +119,19 @@ type
   JSRuntime* {.importc: "struct JSRuntime", header: "quickjs/quickjs.h".} = object
   JSContext* {.importc: "struct JSContext", header: "quickjs/quickjs.h".} = object
   JSModuleDef* {.importc: "struct JSModuleDef", header: "quickjs/quickjs.h".} = object
+  JSMallocState* {.importc: "JSMallocState", header: "quickjs/quickjs.h", bycopy.} = object
+    malloc_count*: csize_t
+    malloc_size*: csize_t
+    malloc_limit*: csize_t
+    opaque*: pointer
+  ## `const void *` as C spells it: the usable-size callback's parameter type
+  ## in JSMallocFunctions, which clang refuses to take a plain `void *` for.
+  ConstPointer* {.importc: "const void *", nodecl.} = distinct pointer
+  JSMallocFunctions* {.importc: "JSMallocFunctions", header: "quickjs/quickjs.h", bycopy.} = object
+    js_malloc*: proc(s: ptr JSMallocState, size: csize_t): pointer {.cdecl.}
+    js_free*: proc(s: ptr JSMallocState, p: pointer) {.cdecl.}
+    js_realloc*: proc(s: ptr JSMallocState, p: pointer, size: csize_t): pointer {.cdecl.}
+    js_malloc_usable_size*: proc(p: ConstPointer): csize_t {.cdecl.}
   JSAtom* = uint32
   JSClassID* = uint32
 
@@ -162,6 +176,7 @@ when not defined(frameosEmbedded) and not defined(frameosWasm):
 {.push importc, header: "quickjs/quickjs.h".}
 
 proc JS_NewRuntime*(): ptr JSRuntime
+proc JS_NewRuntime2*(mf: ptr JSMallocFunctions, opaque: pointer): ptr JSRuntime
 proc JS_FreeRuntime*(rt: ptr JSRuntime)
 proc JS_NewContext*(rt: ptr JSRuntime): ptr JSContext
 proc JS_FreeContext*(ctx: ptr JSContext)
@@ -212,6 +227,7 @@ proc JS_ThrowTypeError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 proc JS_ThrowReferenceError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 proc JS_ThrowRangeError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 proc JS_ThrowInternalError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
+proc JS_SetUncatchableException*(ctx: ptr JSContext, flag: cint)
 proc JS_ThrowSyntaxError*(ctx: ptr JSContext, fmt: cstring): JSValue {.varargs.}
 
 # Global object
@@ -415,11 +431,22 @@ type
     ## loop.
     armed*: bool
     tripped*: bool
+    ## The trip was the run's wall-clock deadline (run_budget.nim), not this
+    ## guard's interpreter-time budget; the error message names which.
+    wallTripped*: bool
     deadline*: MonoTime
     budgetMs*: int
     defaultBudgetMs*: int
     nativeDepth*: int
     nativeEnteredAt*: MonoTime
+
+  JsHeapBudget* = object
+    ## One scene's JS heap ceiling, shared by every runtime the scene creates
+    ## (its scene context and one per JS app node). Raw memory the allocator
+    ## callbacks read on the C stack; layout matches fos_js_heap_budget_t in
+    ## embedded/esp32/components/frameos_quickjs/fos_qjs_glue.h.
+    limitBytes*: csize_t
+    usedBytes*: csize_t
 
   # Context data to pass to C callbacks
   BurritoContextData* = object
@@ -432,9 +459,10 @@ type
     includeStdLib*: bool     ## Include std module (default: false)
     includeOsLib*: bool      ## Include os module (default: false)
     enableStdHandlers*: bool ## Enable std event handlers (default: false)
-    memoryLimitBytes*: int   ## JS heap ceiling; 0 leaves it unlimited
+    memoryLimitBytes*: int   ## JS heap ceiling per runtime; 0 leaves it unlimited
     maxStackSizeBytes*: int  ## JS stack ceiling; 0 keeps QuickJS's default
     executionTimeoutMs*: int ## Interpreter-time ceiling per entry; 0 disables
+    heapBudget*: ptr JsHeapBudget ## Shared per-scene heap ceiling (nil: only the per-runtime limit)
 
   QuickJS* = object
     ## QuickJS wrapper object containing runtime and context
@@ -482,6 +510,99 @@ const
     else:
       30_000
 
+const
+  # Matches MALLOC_OVERHEAD in quickjs.c for the accounting the budget sees.
+  BudgetMallocOverhead = 8
+  # The scene-wide ceiling. Non-embedded: the same 256 MB one runtime used to
+  # get on its own, now shared — a scene with six JS nodes no longer holds
+  # 1.5 GB of headroom. Embedded: twice the glue's per-runtime cap, so a
+  # scene cannot claim the whole PSRAM by having many nodes while a single
+  # runtime keeps the room it has today.
+  DefaultJsSceneHeapBytes* = when defined(frameosEmbedded):
+      8 * 1024 * 1024
+    else:
+      256 * 1024 * 1024
+
+when not defined(frameosEmbedded):
+  # Budgeted allocators for JS_NewRuntime2: QuickJS's own def_malloc functions
+  # (per-runtime limit only) with one more check against the scene's shared
+  # JsHeapBudget. Sizes are kept in a 16-byte header so usable-size needs no
+  # platform call (macOS malloc_size vs glibc malloc_usable_size vs emscripten).
+  const BudgetHeaderBytes = 16
+  proc c_malloc(size: csize_t): pointer {.importc: "malloc", header: "<stdlib.h>".}
+  proc c_free(p: pointer) {.importc: "free", header: "<stdlib.h>".}
+  proc c_realloc(p: pointer, size: csize_t): pointer {.importc: "realloc", header: "<stdlib.h>".}
+
+  proc budgetRaw(p: pointer): pointer {.inline.} =
+    cast[pointer](cast[uint](p) - BudgetHeaderBytes.uint)
+
+  proc budgetedUsableSize(p: ConstPointer): csize_t {.cdecl.} =
+    let raw = cast[pointer](p)
+    if raw == nil: 0 else: cast[ptr csize_t](budgetRaw(raw))[]
+
+  proc budgetedMalloc(s: ptr JSMallocState, size: csize_t): pointer {.cdecl.} =
+    if size == 0:
+      return nil
+    if s.malloc_size + size > s.malloc_limit:
+      return nil
+    let budget = cast[ptr JsHeapBudget](s.opaque)
+    if budget != nil and budget.limitBytes > 0 and budget.usedBytes + size > budget.limitBytes:
+      return nil
+    let raw = c_malloc(size + BudgetHeaderBytes.csize_t)
+    if raw == nil:
+      return nil
+    cast[ptr csize_t](raw)[] = size
+    inc s.malloc_count
+    s.malloc_size += size + BudgetMallocOverhead.csize_t
+    if budget != nil:
+      budget.usedBytes += size + BudgetMallocOverhead.csize_t
+    cast[pointer](cast[uint](raw) + BudgetHeaderBytes.uint)
+
+  proc budgetedFree(s: ptr JSMallocState, p: pointer) {.cdecl.} =
+    if p == nil:
+      return
+    let size = budgetedUsableSize(cast[ConstPointer](p))
+    dec s.malloc_count
+    s.malloc_size -= size + BudgetMallocOverhead.csize_t
+    let budget = cast[ptr JsHeapBudget](s.opaque)
+    if budget != nil:
+      let charged = size + BudgetMallocOverhead.csize_t
+      budget.usedBytes = if budget.usedBytes > charged: budget.usedBytes - charged else: 0
+    c_free(budgetRaw(p))
+
+  proc budgetedRealloc(s: ptr JSMallocState, p: pointer, size: csize_t): pointer {.cdecl.} =
+    if p == nil:
+      return budgetedMalloc(s, size)
+    if size == 0:
+      budgetedFree(s, p)
+      return nil
+    let oldSize = budgetedUsableSize(cast[ConstPointer](p))
+    if s.malloc_size + size - oldSize > s.malloc_limit:
+      return nil
+    let budget = cast[ptr JsHeapBudget](s.opaque)
+    if budget != nil and budget.limitBytes > 0 and size > oldSize and
+        budget.usedBytes + (size - oldSize) > budget.limitBytes:
+      return nil
+    let raw = c_realloc(budgetRaw(p), size + BudgetHeaderBytes.csize_t)
+    if raw == nil:
+      return nil
+    cast[ptr csize_t](raw)[] = size
+    s.malloc_size = s.malloc_size + size - oldSize
+    if budget != nil:
+      if size >= oldSize:
+        budget.usedBytes += size - oldSize
+      else:
+        let shrink = oldSize - size
+        budget.usedBytes = if budget.usedBytes > shrink: budget.usedBytes - shrink else: 0
+    cast[pointer](cast[uint](raw) + BudgetHeaderBytes.uint)
+
+  var budgetedMallocFuncs = JSMallocFunctions(
+    js_malloc: budgetedMalloc,
+    js_free: budgetedFree,
+    js_realloc: budgetedRealloc,
+    js_malloc_usable_size: budgetedUsableSize,
+  )
+
 proc burritoInterruptHandler(rt: ptr JSRuntime, opaque: pointer): cint {.cdecl.} =
   ## Runs on the interpreter's own stack every few thousand bytecode steps.
   ## Must not allocate, raise, or re-enter QuickJS.
@@ -495,7 +616,15 @@ proc burritoInterruptHandler(rt: ptr JSRuntime, opaque: pointer): cint {.cdecl.}
   ## gets its own runtime, and therefore its own guard and its own budget — so
   ## the case this gives up on does not currently exist.
   let guard = cast[ptr JsExecutionGuard](opaque)
-  if guard == nil or not guard.armed or guard.nativeDepth > 0:
+  if guard == nil:
+    return 0
+  # The run's wall clock (run_budget.nim) counts everything and applies even
+  # when the interpreter-time budget is disabled or paused for a native call.
+  if renderDeadlinePassed():
+    guard.tripped = true
+    guard.wallTripped = true
+    return 1
+  if not guard.armed or guard.nativeDepth > 0:
     return 0
   if getMonoTime() < guard.deadline:
     return 0
@@ -516,6 +645,11 @@ proc leaveNativeCall*(guard: ptr JsExecutionGuard) =
   dec guard.nativeDepth
   if guard.nativeDepth == 0:
     guard.deadline = guard.deadline + (getMonoTime() - guard.nativeEnteredAt)
+  # A binding that came back after the render deadline: the interrupt handler
+  # will stop the script at its next check; say why when it does.
+  if renderDeadlinePassed():
+    guard.tripped = true
+    guard.wallTripped = true
 
 proc armGuard(guard: ptr JsExecutionGuard, timeoutMs: int): bool =
   ## Start (or leave running) the interpreter-time budget for one entry into
@@ -529,6 +663,7 @@ proc armGuard(guard: ptr JsExecutionGuard, timeoutMs: int): bool =
     return false
   guard.armed = true
   guard.tripped = false
+  guard.wallTripped = false
   guard.budgetMs = budget
   guard.nativeDepth = 0
   guard.deadline = getMonoTime() + initDuration(milliseconds = budget)
@@ -563,14 +698,39 @@ proc contextDeadlineTripped*(ctx: ptr JSContext): bool =
   let guard = guardForContext(ctx)
   guard != nil and guard.tripped
 
-proc clearContextDeadlineTrip*(ctx: ptr JSContext): int {.discardable.} =
-  ## Consume the tripped flag and report the budget that was blown, so the
-  ## caller can raise a message that names the real cause.
+proc takeContextDeadlineTrip*(ctx: ptr JSContext): tuple[budgetMs: int, wallClock: bool] =
+  ## Consume the tripped flag and report which ceiling was blown — the
+  ## interpreter-time budget, or the run's wall-clock deadline — and how big it
+  ## was, so the caller can raise a message that names the real cause.
   let guard = guardForContext(ctx)
   if guard == nil or not guard.tripped:
-    return 0
+    return (0, false)
+  let wall = guard.wallTripped
   guard.tripped = false
-  return guard.budgetMs
+  guard.wallTripped = false
+  if wall:
+    return (max(1, renderDeadlineBudgetMs()), true)
+  (guard.budgetMs, false)
+
+proc clearContextDeadlineTrip*(ctx: ptr JSContext): int {.discardable.} =
+  ## The blown budget in ms (either ceiling), 0 when nothing tripped.
+  takeContextDeadlineTrip(ctx).budgetMs
+
+const SceneHeapBudgetNote* = " (the scene's JS heap budget is shared by all of its code nodes and apps)"
+
+proc describeJsError*(errorMsg: string): string =
+  ## QuickJS's own text, plus what it means on a frame where that text is
+  ## easy to misread: `out of memory` is the SCENE's shared ceiling
+  ## (JsHeapBudget), not the device running dry. Idempotent.
+  if errorMsg.contains("out of memory") and not errorMsg.contains(SceneHeapBudgetNote):
+    return errorMsg & SceneHeapBudgetNote
+  errorMsg
+
+proc deadlineTripMessage*(budgetMs: int, wallClock: bool): string =
+  if wallClock:
+    "render exceeded its " & $budgetMs & "ms wall-clock deadline (native calls such as HTTP included) and was interrupted"
+  else:
+    "JavaScript execution exceeded its " & $budgetMs & "ms time budget and was interrupted"
 
 template withContextDeadline*(ctx: ptr JSContext, body: untyped): untyped =
   ## Bound one entry into the interpreter from a call site that only holds a
@@ -587,10 +747,11 @@ proc raiseIfDeadlineTripped(js: QuickJS) =
   ## QuickJS reports an interrupt as a bare InternalError; say what really
   ## happened so the scene log names the runaway script instead of "interrupted".
   if js.deadlineTripped():
-    let budget = js.deadlineBudgetMs()
+    let wall = js.guard.wallTripped
+    let budget = if wall: max(1, renderDeadlineBudgetMs()) else: js.deadlineBudgetMs()
     js.guard.tripped = false
-    raise newException(JSException,
-      "JavaScript execution exceeded its " & $budget & "ms time budget and was interrupted")
+    js.guard.wallTripped = false
+    raise newException(JSException, deadlineTripMessage(budget, wall))
 
 template withDeadline*(js: QuickJS, body: untyped): untyped =
   ## Bound one entry into the interpreter. Re-entrant: nested uses are no-ops.
@@ -1099,24 +1260,12 @@ proc jsArgsToSeq*(ctx: ptr JSContext, argc: cint, argv: ptr JSValueConst): seq[J
     result[i] = JS_DupValue(ctx, cast[ptr UncheckedArray[JSValueConst]](argv)[i])
 
 # Generic C function trampoline for Nim function calls
-proc nimFunctionTrampoline(ctx: ptr JSContext, thisVal: JSValueConst, argc: cint, argv: ptr JSValueConst,
-    magic: cint): JSValue {.cdecl.} =
-  ## Generic trampoline that calls registered Nim functions from JavaScript
-  ## Uses magic parameter as function ID to lookup the actual Nim function
+proc nimFunctionTrampolineInner(ctx: ptr JSContext, contextData: ptr BurritoContextData, argc: cint,
+    argv: ptr JSValueConst, magic: cint): JSValue =
+  ## Calls the registered Nim function the magic id names and maps Nim
+  ## exceptions onto JavaScript ones. The budget bookkeeping around the call
+  ## lives in nimFunctionTrampoline.
   try:
-    let contextData = cast[ptr BurritoContextData](JS_GetContextOpaque(ctx))
-    if contextData == nil:
-      return jsUndefined(ctx)
-
-    if magic notin contextData.functions:
-      return jsUndefined(ctx)
-
-    # Time spent in a binding (an HTTP fetch, an asset read) is not the script
-    # spinning, so it must not eat the interpreter-time budget.
-    let guard = contextData.guard
-    enterNativeCall(guard)
-    defer: leaveNativeCall(guard)
-
     let funcEntry = contextData.functions[magic]
 
     case funcEntry.kind
@@ -1173,6 +1322,36 @@ proc nimFunctionTrampoline(ctx: ptr JSContext, thisVal: JSValueConst, argc: cint
     let errorObj = nimStringToJS(ctx, "Nim Error: " & e.msg)
     return JS_Throw(ctx, errorObj)
 
+
+proc nimFunctionTrampoline(ctx: ptr JSContext, thisVal: JSValueConst, argc: cint, argv: ptr JSValueConst,
+    magic: cint): JSValue {.cdecl.} =
+  ## Generic trampoline that calls registered Nim functions from JavaScript.
+  ## Uses magic parameter as function ID to lookup the actual Nim function.
+  let contextData = cast[ptr BurritoContextData](JS_GetContextOpaque(ctx))
+  if contextData == nil:
+    return jsUndefined(ctx)
+  if magic notin contextData.functions:
+    return jsUndefined(ctx)
+
+  # Time spent in a binding (an HTTP fetch, an asset read) is not the script
+  # spinning, so it must not eat the interpreter-time budget…
+  let guard = contextData.guard
+  enterNativeCall(guard)
+  result = nimFunctionTrampolineInner(ctx, contextData, argc, argv, magic)
+  leaveNativeCall(guard)
+  # …but it does count against the run's wall-clock deadline. A binding that
+  # came back after it has passed fails right here, so a script whose last
+  # statement was that slow fetch does not finish as if nothing happened; the
+  # interrupt handler backs this up on the next bytecode batch, try/catch or
+  # not, because the deadline stays passed.
+  if guard != nil and guard.wallTripped:
+    JS_FreeValue(ctx, result)
+    result = JS_ThrowInternalError(ctx, "%s",
+      deadlineTripMessage(max(1, renderDeadlineBudgetMs()), true).cstring)
+    # Same standing as the interrupt handler's own error: scene code cannot
+    # catch its way past the deadline.
+    JS_SetUncatchableException(ctx, 1)
+
 # Configuration helpers
 proc defaultConfig*(): QuickJSConfig =
   ## Create default configuration (no std/os modules)
@@ -1211,12 +1390,17 @@ proc newQuickJS*(config: QuickJSConfig = defaultConfig()): QuickJS =
   ## - config: Configuration specifying which modules to include
   when defined(frameosEmbedded):
     # Created by the frameos_quickjs IDF component: allocators backed by
-    # PSRAM (heap_caps_malloc) and a stack limit sized for the render task.
-    proc fos_js_new_runtime(): ptr JSRuntime {.importc: "fos_js_new_runtime",
+    # PSRAM (heap_caps_malloc), a stack limit sized for the render task, and
+    # the scene's shared heap budget when the caller has one.
+    proc fos_js_new_runtime_budgeted(budget: pointer): ptr JSRuntime {.importc: "fos_js_new_runtime_budgeted",
         header: "fos_qjs_glue.h".}
-    let rt = fos_js_new_runtime()
+    let rt = fos_js_new_runtime_budgeted(cast[pointer](config.heapBudget))
   else:
-    let rt = JS_NewRuntime()
+    let rt =
+      if config.heapBudget != nil:
+        JS_NewRuntime2(addr budgetedMallocFuncs, cast[pointer](config.heapBudget))
+      else:
+        JS_NewRuntime()
   if rt == nil:
     raise newException(JSException, "Failed to create QuickJS runtime")
 
@@ -1325,7 +1509,7 @@ proc eval*(js: QuickJS, code: string, filename: string = "<eval>", flags: cint =
       defer: JS_FreeValue(js.context, exception)
       let errorMsg = toNimString(js.context, exception)
       js.raiseIfDeadlineTripped()
-      raise newException(JSException, "Evaluation failed: " & errorMsg)
+      raise newException(JSException, "Evaluation failed: " & describeJsError(errorMsg))
 
     result = toNimString(js.context, val)
 
@@ -1365,7 +1549,7 @@ proc evalModule*(js: QuickJS, code: string, filename: string = "<module>"): stri
       let errorMsg = toNimString(js.context, exception)
       JS_FreeValue(js.context, val)
       js.raiseIfDeadlineTripped()
-      raise newException(JSException, "Module evaluation failed: " & errorMsg)
+      raise newException(JSException, "Module evaluation failed: " & describeJsError(errorMsg))
 
     # Modules return promises, but we just return a string representation
     # Using js_std_await here causes reference counting issues on cleanup
@@ -1434,7 +1618,7 @@ proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module
     defer: JS_FreeValue(ctx, exception)
     let errorMsg = toNimString(ctx, exception)
     JS_FreeValue(ctx, compiled)
-    raise newException(JSException, errorMsg)
+    raise newException(JSException, describeJsError(errorMsg))
 
   let moduleDef = moduleDefOf(compiled)
   if moduleDef == nil:
@@ -1453,7 +1637,7 @@ proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module
       let errorMsg = toNimString(ctx, exception)
       JS_FreeValue(ctx, evaluated)
       js.raiseIfDeadlineTripped()
-      raise newException(JSException, errorMsg)
+      raise newException(JSException, describeJsError(errorMsg))
     JS_FreeValue(ctx, evaluated)
 
   result = JS_GetModuleNamespace(ctx, moduleDef)
@@ -1462,7 +1646,7 @@ proc evalModuleNamespace*(js: QuickJS, code: string, filename: string = "<module
     defer: JS_FreeValue(ctx, exception)
     let errorMsg = toNimString(ctx, exception)
     JS_FreeValue(ctx, result)
-    raise newException(JSException, errorMsg)
+    raise newException(JSException, describeJsError(errorMsg))
 
 proc compileToBytecode*(js: QuickJS, code: string, filename: string = "<input>", isModule: bool = false): seq[byte] =
   ## Compile JavaScript code to bytecode format

--- a/frameos/src/frameos/js_runtime/run_budget.nim
+++ b/frameos/src/frameos/js_runtime/run_budget.nim
@@ -1,0 +1,111 @@
+## The budgets one scene run (a render or an event) spends against, shared by
+## every host that drives the interpreter — the Pi runner, the ESP32 firmware
+## and the browser preview — because they all arrive at interpreter.runEvent.
+##
+## Two ceilings live here; the third (the per-scene JS heap) is in burrito.nim
+## next to the allocator that enforces it.
+##
+## * The wall-clock render deadline. The interpreter-time budget in
+##   burrito.nim deliberately stops its clock while a Nim binding runs, so an
+##   honest 30 s fetch is not mistaken for a runaway loop. The flip side was a
+##   scene that never finished: `httpRequest` against a tarpit could hold the
+##   render thread for its full 600 s ceiling, node after node, until the
+##   900 s systemd watchdog shot the service (docs/security-todo.md). This
+##   deadline counts everything — script, bindings, HTTP — and is read from
+##   three places: the QuickJS interrupt handler (trips the script), the HTTP
+##   client (caps every request's timeout to what is left), and the binding
+##   wrapper (marks the trip as soon as a slow call returns).
+## * The per-run dispatch budget. A dispatch node fires an event; an event
+##   whose handler dispatches again is an unbounded chain — on the Pi it
+##   floods the event queue and starves rendering, on the ESP32 it recurses
+##   on the render task's stack. Past the budget a run's dispatches are
+##   dropped, once with a log line naming the budget.
+##
+## Thread-local on purpose: the runner renders on its own thread and the
+## budgets belong to the run in progress there; the embedded and wasm hosts
+## have one task. Re-entrant: a nested run (a child scene's init event) rides
+## on the outer run's budgets and does not re-arm them.
+
+import std/monotimes
+import std/times
+
+const
+  DefaultRenderDeadlineMs* = when defined(frameosEmbedded):
+      90_000       # a few 30 s fetches; well under anything the firmware's own watchdogs allow to pile up
+    elif defined(frameosWasm):
+      60_000
+    else:
+      120_000      # under the 900 s systemd WatchdogSec with room for the driver's refresh
+  DefaultDispatchBudget* = 64
+
+var
+  renderDeadlineArmed {.threadvar.}: bool
+  renderDeadlineAt {.threadvar.}: MonoTime
+  renderDeadlineBudget {.threadvar.}: int
+  dispatchBudgetRemaining {.threadvar.}: int
+  dispatchBudgetTotal {.threadvar.}: int
+  dispatchBudgetExhaustedLogged {.threadvar.}: bool
+
+proc armRenderDeadline*(budgetMs: int): bool =
+  ## Start the wall clock for this run. Returns true when this call armed it
+  ## (so the matching disarm belongs to this caller); false when a run is
+  ## already in progress on this thread or the budget disables the ceiling.
+  if renderDeadlineArmed or budgetMs <= 0:
+    return false
+  renderDeadlineArmed = true
+  renderDeadlineBudget = budgetMs
+  renderDeadlineAt = getMonoTime() + initDuration(milliseconds = budgetMs)
+  true
+
+proc disarmRenderDeadline*() =
+  renderDeadlineArmed = false
+
+proc renderDeadlineArmedNow*(): bool = renderDeadlineArmed
+
+proc renderDeadlineBudgetMs*(): int =
+  if renderDeadlineArmed: renderDeadlineBudget else: 0
+
+proc renderDeadlinePassed*(): bool =
+  ## Safe to call from the QuickJS interrupt handler: no allocation, no raise.
+  renderDeadlineArmed and getMonoTime() >= renderDeadlineAt
+
+proc renderDeadlineRemainingMs*(): int =
+  ## -1 when no deadline is armed; 0 once it has passed; otherwise what is left.
+  if not renderDeadlineArmed:
+    return -1
+  let remaining = (renderDeadlineAt - getMonoTime()).inMilliseconds
+  if remaining <= 0: 0 else: int(remaining)
+
+proc capToRenderDeadline*(timeoutMs: int): int =
+  ## The timeout a blocking call may use: its own, or the remainder of the
+  ## render deadline when that is shorter. Never below 1 ms so a call that
+  ## starts right at the deadline fails fast instead of never.
+  let remaining = renderDeadlineRemainingMs()
+  if remaining < 0 or timeoutMs <= remaining:
+    return timeoutMs
+  max(1, remaining)
+
+type
+  DispatchVerdict* = enum
+    dvAllowed        ## within budget
+    dvRefusedFirst   ## the first dispatch over budget this run — log this one
+    dvRefused        ## further dispatches over budget — drop silently
+
+proc setDispatchBudget*(budget: int) =
+  ## Called by whoever armed the render deadline; <= 0 leaves dispatch unbounded.
+  dispatchBudgetTotal = budget
+  dispatchBudgetRemaining = budget
+  dispatchBudgetExhaustedLogged = false
+
+proc dispatchBudgetTotalNow*(): int = dispatchBudgetTotal
+
+proc takeDispatchBudget*(): DispatchVerdict =
+  if dispatchBudgetTotal <= 0:
+    return dvAllowed
+  if dispatchBudgetRemaining > 0:
+    dec dispatchBudgetRemaining
+    return dvAllowed
+  if not dispatchBudgetExhaustedLogged:
+    dispatchBudgetExhaustedLogged = true
+    return dvRefusedFirst
+  dvRefused

--- a/frameos/src/frameos/js_runtime/runtime.nim
+++ b/frameos/src/frameos/js_runtime/runtime.nim
@@ -638,11 +638,15 @@ proc jsExceptionDetails*(ctx: ptr JSContext): tuple[message: string, stack: stri
   if result.message.len == 0:
     result.message = "JavaScript error"
   # An interrupted script reports a bare "InternalError: interrupted", which
-  # tells nobody why the scene died. Name the real cause.
-  let blownBudgetMs = clearContextDeadlineTrip(ctx)
-  if blownBudgetMs > 0:
-    result.message = "execution exceeded its " & $blownBudgetMs & "ms time budget"
+  # tells nobody why the scene died. Name the real cause — and which of the
+  # two clocks (interpreter time, or the run's wall-clock deadline) ran out.
+  let trip = takeContextDeadlineTrip(ctx)
+  if trip.budgetMs > 0:
+    result.message = deadlineTripMessage(trip.budgetMs, trip.wallClock)
     result.stack = result.message
+  else:
+    # `out of memory` is the scene's shared ceiling, not the device's; say so.
+    result.message = describeJsError(result.message)
 
 proc mappedJsExceptionDetails*(ctx: ptr JSContext): tuple[message: string, stack: string] =
   result = jsExceptionDetails(ctx)
@@ -667,18 +671,67 @@ proc callGlobalFunction*(ctx: ptr JSContext, fnName: string, args: openArray[JSV
         argv[i] = arg
       result = JS_Call(ctx, fn, globalObj, args.len.cint, addr argv[0])
 
-proc sceneJsConfig*(frameConfig: FrameConfig): QuickJSConfig =
+# ---- per-scene heap budgets ------------------------------------------------
+# One JsHeapBudget per scene id, shared by the scene's own context and by the
+# runtime of every JS app node in it (app_runtime.ensureReady). QuickJS's
+# memory limit is per runtime, so before this a scene with N JS nodes could
+# hold N × 256 MB; now the N runtimes draw on one ceiling. Budgets are raw
+# memory the allocator callbacks read on the C stack and are kept for the
+# process lifetime — a few dozen 16-byte records at most — so a runtime that
+# outlives a scene reload (evicted and rebuilt, or torn down late) never
+# dereferences a freed budget.
+var
+  sceneHeapBudgets = initTable[string, ptr JsHeapBudget]()
+  sceneHeapBudgetsLock: Lock
+
+initLock(sceneHeapBudgetsLock)
+
+proc sceneHeapBudgetFor*(sceneId: string, limitBytes: int): ptr JsHeapBudget =
+  ## The scene's budget, created on first use; the limit follows the latest
+  ## frame.json on every call so a config reload applies to new runtimes.
+  {.gcsafe.}:
+    withLock sceneHeapBudgetsLock:
+      if sceneHeapBudgets.hasKey(sceneId):
+        result = sceneHeapBudgets[sceneId]
+      else:
+        result = cast[ptr JsHeapBudget](alloc0(sizeof(JsHeapBudget)))
+        sceneHeapBudgets[sceneId] = result
+      result.limitBytes = max(0, limitBytes).csize_t
+
+proc sceneHeapBudgetUsedBytes*(sceneId: string): int =
+  ## Bytes the scene's runtimes currently hold, as the allocator accounts them.
+  {.gcsafe.}:
+    withLock sceneHeapBudgetsLock:
+      if sceneHeapBudgets.hasKey(sceneId):
+        return sceneHeapBudgets[sceneId].usedBytes.int
+  0
+
+proc sceneJsHeapLimitBytes*(frameConfig: FrameConfig): int =
+  ## The scene-wide ceiling: frame.json's js.memoryLimitMb (0 = unlimited) or
+  ## the build target's default.
+  if frameConfig != nil and frameConfig.js != nil and frameConfig.js.memoryLimitMb >= 0:
+    return frameConfig.js.memoryLimitMb * 1024 * 1024
+  DefaultJsSceneHeapBytes
+
+proc sceneJsConfig*(frameConfig: FrameConfig, sceneId: string = ""): QuickJSConfig =
   ## Per-frame overrides for the interpreter ceilings. Anything left at -1 (or
-  ## absent from frame.json) keeps the build target's default.
+  ## absent from frame.json) keeps the build target's default. With a scene id
+  ## the runtime also joins that scene's shared heap budget.
   result = defaultConfig()
-  if frameConfig == nil or frameConfig.js == nil:
-    return
-  if frameConfig.js.executionTimeoutMs >= 0:
-    result.executionTimeoutMs = frameConfig.js.executionTimeoutMs
-  if frameConfig.js.memoryLimitMb >= 0:
-    result.memoryLimitBytes = frameConfig.js.memoryLimitMb * 1024 * 1024
-  if frameConfig.js.maxStackKb >= 0:
-    result.maxStackSizeBytes = frameConfig.js.maxStackKb * 1024
+  if frameConfig != nil and frameConfig.js != nil:
+    if frameConfig.js.executionTimeoutMs >= 0:
+      result.executionTimeoutMs = frameConfig.js.executionTimeoutMs
+    if frameConfig.js.memoryLimitMb >= 0:
+      # The per-runtime cap follows the scene ceiling on hosts that set one;
+      # embedded keeps the glue's own per-runtime cap (config default 0).
+      when not defined(frameosEmbedded):
+        result.memoryLimitBytes = frameConfig.js.memoryLimitMb * 1024 * 1024
+    if frameConfig.js.maxStackKb >= 0:
+      result.maxStackSizeBytes = frameConfig.js.maxStackKb * 1024
+  if sceneId.len > 0:
+    let sceneLimit = sceneJsHeapLimitBytes(frameConfig)
+    if sceneLimit > 0:
+      result.heapBudget = sceneHeapBudgetFor(sceneId, sceneLimit)
 
 # -------------------------
 # Scene JS context
@@ -730,7 +783,7 @@ proc ensureSceneJs*(scene: InterpretedFrameScene) =
       evictIdleSceneJs(scene)
       if not liveSceneJsScenes.contains(scene):
         liveSceneJsScenes.add(scene)
-    scene.js = newQuickJS(sceneJsConfig(scene.frameConfig))
+    scene.js = newQuickJS(sceneJsConfig(scene.frameConfig, scene.id.string))
     # Register bridge functions ONCE per scene/context
     scene.js.registerFunction("getState", jsGetState)
     scene.js.registerFunction("getArg", jsGetArg)
@@ -912,7 +965,9 @@ proc callCompiledFn*(scene: InterpretedFrameScene,
 
   let kind = parsed{"k"}.getStr()
   if kind == "error":
-    var message = mapJsErrorText(scene.js.context, parsed{"v"}{"message"}.getStr())
+    # The JS-side envelope caught the error, so QuickJS's text arrives raw;
+    # an `out of memory` here is the scene's shared heap ceiling.
+    var message = describeJsError(mapJsErrorText(scene.js.context, parsed{"v"}{"message"}.getStr()))
     let stack = mapJsErrorText(scene.js.context, parsed{"v"}{"stack"}.getStr())
     var errorPayload = %*{
       "event": "interpreter:jsError",

--- a/frameos/src/frameos/js_runtime/tests/test_js_resource_limits.nim
+++ b/frameos/src/frameos/js_runtime/tests/test_js_resource_limits.nim
@@ -4,6 +4,7 @@
 import std/[json, monotimes, os, sequtils, strutils, times, unittest]
 
 import frameos/js_runtime/burrito
+import frameos/js_runtime/run_budget
 import frameos/js_runtime/runtime
 import frameos/types
 import frameos/values
@@ -131,3 +132,140 @@ suite "js memory ceiling":
     var js = newQuickJS()
     defer: js.close()
     check js.eval("new Array(1000).fill(1).length") == "1000"
+
+suite "wall-clock render deadline":
+  test "time inside native bindings counts against the render deadline":
+    # The interpreter budget stops its clock in a binding (previous suite);
+    # the run's wall-clock deadline does not. Three 300ms native calls against
+    # a 500ms deadline must end the script, and the message must say which
+    # clock ran out.
+    var config = defaultConfig()
+    config.executionTimeoutMs = 5_000
+    var js = newQuickJS(config)
+    defer: js.close()
+    js.registerFunction("slowNativeCall", sleepingBinding)
+
+    check armRenderDeadline(500)
+    defer: disarmRenderDeadline()
+    var message = ""
+    try:
+      discard js.eval("slowNativeCall(); slowNativeCall(); slowNativeCall(); 1")
+    except JSException as err:
+      message = err.msg
+    check message.contains("wall-clock")
+    check message.contains("500ms")
+    check renderDeadlinePassed()
+
+  test "a run that finishes inside the deadline is untouched":
+    var js = newQuickJS()
+    defer: js.close()
+    check armRenderDeadline(5_000)
+    defer: disarmRenderDeadline()
+    check js.eval("let n = 0; for (let i = 0; i < 1000; i++) n += i; n") == "499500"
+    check not js.deadlineTripped()
+    check renderDeadlineRemainingMs() > 0
+
+  test "the deadline applies even when the interpreter-time budget is off":
+    var config = defaultConfig()
+    config.executionTimeoutMs = 0
+    var js = newQuickJS(config)
+    defer: js.close()
+    check armRenderDeadline(150)
+    defer: disarmRenderDeadline()
+    var message = ""
+    try:
+      discard js.eval("for (;;) {}")
+    except JSException as err:
+      message = err.msg
+    check message.contains("wall-clock")
+
+  test "arming is re-entrant and a nested run does not reset the clock":
+    check armRenderDeadline(1_000)
+    check not armRenderDeadline(50)
+    check renderDeadlineBudgetMs() == 1_000
+    disarmRenderDeadline()
+    check renderDeadlineRemainingMs() == -1
+    check not renderDeadlinePassed()
+    check capToRenderDeadline(30_000) == 30_000
+
+  test "capToRenderDeadline shortens a timeout to what is left":
+    check armRenderDeadline(200)
+    defer: disarmRenderDeadline()
+    let capped = capToRenderDeadline(30_000)
+    check capped > 0
+    check capped <= 200
+    sleep(250)
+    check capToRenderDeadline(30_000) == 1
+    check renderDeadlineRemainingMs() == 0
+
+suite "dispatch budget":
+  test "a run may dispatch only so many events, and the first refusal is flagged once":
+    setDispatchBudget(3)
+    check takeDispatchBudget() == dvAllowed
+    check takeDispatchBudget() == dvAllowed
+    check takeDispatchBudget() == dvAllowed
+    check takeDispatchBudget() == dvRefusedFirst
+    check takeDispatchBudget() == dvRefused
+    check dispatchBudgetTotalNow() == 3
+    setDispatchBudget(0)
+    check takeDispatchBudget() == dvAllowed
+
+suite "per-scene heap budget":
+  test "the runtimes of one scene draw on one ceiling":
+    # Two runtimes, each allowed 4 MB on its own, share a 3 MB scene budget:
+    # what the first holds is not available to the second.
+    let budget = sceneHeapBudgetFor("tests/js-heap-budget", 3 * 1024 * 1024)
+    var config = defaultConfig()
+    config.memoryLimitBytes = 4 * 1024 * 1024
+    config.heapBudget = budget
+    var first = newQuickJS(config)
+    var second = newQuickJS(config)
+    # ~1.6 MB of JSValues, well inside 4 MB on its own.
+    check first.eval("globalThis.hog = new Array(100000).fill(7); hog.length") == "100000"
+    check sceneHeapBudgetUsedBytes("tests/js-heap-budget") > 1_500_000
+    var message = ""
+    try:
+      discard second.eval("globalThis.hog = new Array(100000).fill(7); hog.length")
+    except JSException as err:
+      message = err.msg
+    check message.contains("out of memory")
+    first.close()
+    second.close()
+    # Everything the two runtimes charged was released with them.
+    check sceneHeapBudgetUsedBytes("tests/js-heap-budget") == 0
+
+  test "a second scene's budget is its own":
+    let budgetA = sceneHeapBudgetFor("tests/js-heap-a", 3 * 1024 * 1024)
+    let budgetB = sceneHeapBudgetFor("tests/js-heap-b", 3 * 1024 * 1024)
+    check budgetA != budgetB
+    var configA = defaultConfig()
+    configA.heapBudget = budgetA
+    var configB = defaultConfig()
+    configB.heapBudget = budgetB
+    var a = newQuickJS(configA)
+    var b = newQuickJS(configB)
+    defer:
+      a.close()
+      b.close()
+    check a.eval("globalThis.hog = new Array(100000).fill(7); 1") == "1"
+    check b.eval("globalThis.hog = new Array(100000).fill(7); 1") == "1"
+
+  test "scene code nodes run under the scene's budget":
+    var scene = testScene()
+    scene.frameConfig.js.memoryLimitMb = 2
+    var logs: seq[JsonNode] = @[]
+    scene.logger.log = proc(payload: JsonNode) =
+      logs.add(payload)
+    let value = evalSnippet(
+      scene,
+      testContext(scene),
+      1.NodeId,
+      "(() => { const hog = []; for (;;) hog.push(new Array(10000).fill(1)); })()"
+    )
+    check value.kind == fkNone
+    let logged = logs.mapIt($it).join(" ")
+    check logged.contains("out of memory")
+    check logged.contains("heap budget")
+    cleanupSceneJs(scene)
+    cleanupCompilerJs()
+    check sceneHeapBudgetUsedBytes("tests/js-limits") == 0

--- a/frameos/src/frameos/runner.nim
+++ b/frameos/src/frameos/runner.nim
@@ -592,12 +592,19 @@ proc dispatchSceneEvent*(self: RunnerThread, sceneId: Option[SceneId], event: st
   finally:
     markRuntimeDone()
 
+const MessageLoopYieldEvery = 32
+
 proc startMessageLoop*(self: RunnerThread, maxIterations = -1): Future[void] {.async.} =
   var waitTime = 10
   var iterations = 0
   # Holds the first non-mouseMove event pulled out while coalescing a burst
   # of queued mouse moves, so ordering is preserved.
   var pendingEvent = none((Option[SceneId], string, JsonNode))
+  # Scene events handled since this loop last let the render loop run. Both
+  # loops share one thread, and a scene whose event handler re-dispatches
+  # keeps this queue non-empty forever — so after a burst the loop yields even
+  # though more is queued, and a frame under such a scene still refreshes.
+  var handledSinceYield = 0
 
   while true:
     # Heartbeat for systemd's WatchdogSec: stops when this thread hangs in a
@@ -724,9 +731,16 @@ proc startMessageLoop*(self: RunnerThread, maxIterations = -1): Future[void] {.a
         self.dispatchSceneEvent(sceneId, event, payload)
       except Exception as e:
         self.logSignal(%*{"event": "event:error", "error": $e.msg, "stacktrace": e.getStackTrace()})
+      inc handledSinceYield
+      if handledSinceYield >= MessageLoopYieldEvery:
+        handledSinceYield = 0
+        if self.triggerRenderNext and not self.isRendering:
+          self.triggerRender()
+        await sleepAsync(1)
 
     # after we have processed all queued messages
     if not success:
+      handledSinceYield = 0
       let droppedEvents = eventsDroppedCounter.exchange(0)
       if droppedEvents > 0:
         self.logSignal(%*{"event": "events:dropped", "count": droppedEvents})

--- a/frameos/src/frameos/tests/test_interpreter_errors.nim
+++ b/frameos/src/frameos/tests/test_interpreter_errors.nim
@@ -353,6 +353,56 @@ suite "interpreter error paths":
       check ignored["reason"].getStr() == "renderSelfDispatch"
     clearEventChannel()
 
+  test "a run's dispatch nodes are capped by the dispatch budget":
+    # Five chained dispatch nodes, a budget of three: three events reach the
+    # queue, the fourth is refused with one log line naming the budget, the
+    # fifth is dropped silently. A self-dispatching handler is the same chain
+    # spread over runs; this is what keeps it from starving the render loop.
+    clearEventChannel()
+    let sceneId = "tests/interpreter-errors/dispatch-budget".SceneId
+    let exported = ExportedInterpretedScene(
+      name: "dispatch budget",
+      backgroundColor: parseHtmlColor("#000000"),
+      refreshInterval: 1.0,
+      publicStateFields: @[],
+      nodes: @[
+        node(10, "event", %*{"keyword": "tick"}),
+        node(21, "dispatch", %*{"keyword": "ping", "config": {}}),
+        node(22, "dispatch", %*{"keyword": "ping", "config": {}}),
+        node(23, "dispatch", %*{"keyword": "ping", "config": {}}),
+        node(24, "dispatch", %*{"keyword": "ping", "config": {}}),
+        node(25, "dispatch", %*{"keyword": "ping", "config": {}})
+      ],
+      edges: @[
+        edge(100, 10, "next", 21, "prev"),
+        edge(101, 21, "next", 22, "prev"),
+        edge(102, 22, "next", 23, "prev"),
+        edge(103, 23, "next", 24, "prev"),
+        edge(104, 24, "next", 25, "prev")
+      ]
+    )
+
+    withUploadedScene(sceneId, exported) do (store: LogStore, scene: FrameScene):
+      scene.frameConfig.js = JsRuntimeConfig(executionTimeoutMs: -1, memoryLimitMb: -1, maxStackKb: -1,
+                                             assetSandbox: "frame", renderDeadlineMs: -1, dispatchBudget: 3)
+      runEvent(scene, ctx(scene, "tick"))
+      var delivered = 0
+      while true:
+        let (ok, msg) = eventChannel.tryRecv()
+        if not ok:
+          break
+        check msg[1] == "ping"
+        inc delivered
+      check delivered == 3
+      var refusals = 0
+      for entry in store.entries:
+        if entry{"event"}.getStr() == "interpreter:dispatch:ignored" and entry{"reason"}.getStr() == "dispatchBudget":
+          inc refusals
+          check entry["budget"].getInt() == 3
+          check entry["nodeId"].getInt() == 24
+      check refusals == 1
+    clearEventChannel()
+
   test "a scene's dispatch node cannot fire runtime verbs":
     # Scene code is untrusted: dispatching uploadScenes would replace the
     # installed scenes past every guard, and reboot on every render is a loop.

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -61,9 +61,11 @@ type
     ## "sandbox posture"). Scene JS is user-authored at best and provider-pushed
     ## at worst, and it runs on the render thread.
     executionTimeoutMs*: int ## interpreter time per entry; 0 disables
-    memoryLimitMb*: int      ## JS heap ceiling; 0 leaves it unlimited
+    memoryLimitMb*: int      ## JS heap ceiling PER SCENE, shared by every runtime the scene creates; 0 leaves it unlimited
     maxStackKb*: int         ## JS stack ceiling; 0 keeps QuickJS's default
     assetSandbox*: string    ## "frame" (shared, default) or "scene" (per-scene subtree)
+    renderDeadlineMs*: int   ## wall-clock ceiling per render/event, native calls included; 0 disables
+    dispatchBudget*: int     ## dispatch nodes one render/event may fire; 0 leaves it unbounded
 
   # Part of FrameConfig
   TimeZoneUpdatesConfig* = ref object

--- a/frameos/src/frameos/utils/http_client.nim
+++ b/frameos/src/frameos/utils/http_client.nim
@@ -25,6 +25,7 @@ const
   DefaultFetchMaxRedirects* = 5
 
 import std/strutils
+import frameos/js_runtime/run_budget
 import frameos/spool
 
 type
@@ -380,6 +381,13 @@ when defined(frameosEmbedded) or defined(frameosWasm):
     ## Callers must release it with freeHttpBufferResponse once they have
     ## decoded or copied the bytes they need.
     validateHttpRequestUrl(url)
+    # The run's wall-clock deadline (js_runtime/run_budget.nim) bounds every
+    # request made while a scene renders — built-in apps and scene JS alike —
+    # so a slow upstream costs the render its remaining time, not the whole
+    # watchdog window. Refused outright once the deadline has passed.
+    if renderDeadlineRemainingMs() == 0:
+      raise newException(IOError, &"HTTP request refused: the render's wall-clock deadline has passed ({url})")
+    let effectiveTimeoutMs = capToRenderDeadline(timeoutMs)
     var status: cint = 0
     let bodyPtr = if body.len > 0: unsafeAddr body[0] else: nil
     let headerBlock = encodeSimpleHeaders(headers)
@@ -391,7 +399,7 @@ when defined(frameosEmbedded) or defined(frameosWasm):
       let rawChunks = fos_nim_http_request_chunked_spill(httpMethod.cstring, url.cstring,
                                      bodyPtr, body.len.csize_t,
                                      headerPtr, headerBlock.len.csize_t,
-                                     timeoutMs.cint, maxBytes.csize_t,
+                                     effectiveTimeoutMs.cint, maxBytes.csize_t,
                                      addr status, addr chunkCount,
                                      addr spillPath, addr spillLen)
       if rawChunks == nil and status == 0:
@@ -425,7 +433,7 @@ when defined(frameosEmbedded) or defined(frameosWasm):
       let buf = fos_nim_http_request(httpMethod.cstring, url.cstring,
                                      bodyPtr, body.len.csize_t,
                                      headerPtr, headerBlock.len.csize_t,
-                                     timeoutMs.cint, maxBytes.csize_t,
+                                     effectiveTimeoutMs.cint, maxBytes.csize_t,
                                      addr status, addr outLen)
       if buf == nil and status == 0:
         raise newException(IOError, &"HTTP request failed: {url}")


### PR DESCRIPTION
Closes the "Interpreter robustness" item in `docs/security-todo.md` on all three hosts (Pi runner, ESP32 firmware, wasm preview).

- **Wall-clock render deadline** (`js.renderDeadlineMs`: 120 s Pi / 90 s ESP32 / 60 s preview). Armed per scene run in `interpreter.runEvent`; counts native calls. The QuickJS interrupt handler trips on it, the HTTP client caps every request on the render thread to what is left (and refuses once passed), and a binding returning after the deadline throws an uncatchable error naming the clock. A 600 s tarpit now costs one render instead of the 900 s watchdog window.
- **Per-scene heap budget** (`js.memoryLimitMb`: 256 MB Pi / 8 MB ESP32, shared by the scene's context and every JS app node runtime). Budgeted `JS_NewRuntime2` allocators charge one budget per scene id — Nim allocators on Pi/wasm, the PSRAM allocators in `fos_qjs_glue.c` on the ESP32. `out of memory` messages say it is the scene's shared ceiling.
- **Per-run dispatch budget** (`js.dispatchBudget`: 64) with a one-time log line on refusal; the Pi message loop yields to the render loop every 32 events; the ESP32 event hook refuses nesting deeper than four.

New `frame.json` keys are documented in `docs/js-apps-and-code-nodes.md`.

Verified locally: `nim check` of the Pi runtime; Nim suites (resource limits incl. 9 new tests, interpreter errors incl. the dispatch-budget test, runner loop, app runtime, scene cleanup, channels, config); ESP32-S3 firmware build with regenerated nimcache (22% OTA slot free); wasm bundle build.

Not verified on hardware: the ESP32 budget on a real board (the E1004 weather scene is the one to watch for the 8 MB shared ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un8Q6ih58FbBd7WoDQtZ24
