### PR TITLE
Shell-less frame upgrade from the backend: five papercuts

### DIFF
--- a/backend/app/api/frame_sync.py
+++ b/backend/app/api/frame_sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import copy
+import hashlib
 from datetime import datetime, timezone
 from http import HTTPStatus
 import json
@@ -748,7 +749,15 @@ def _frame_sync_snapshot(frame: Frame) -> dict[str, Any]:
     snapshot.pop("last_successful_deploy", None)
     snapshot.pop("last_successful_deploy_at", None)
     frameos_version = current_frameos_version()
-    if isinstance(frameos_version, str) and frameos_version:
+    previous = frame.last_successful_deploy if isinstance(frame.last_successful_deploy, dict) else {}
+    device_reported = previous.get("frameos_version")
+    if not frame_has_shell_access(frame) and isinstance(device_reported, str) and device_reported:
+        # A sync over the admin API installs no FrameOS: the baseline keeps
+        # the version the device last reported (upgrade status, bootup line)
+        # rather than claiming the backend's own — after one fast deploy a
+        # 2026.9.11 card read as 2026.9.12 here.
+        snapshot["frameos_version"] = device_reported
+    elif isinstance(frameos_version, str) and frameos_version:
         snapshot["frameos_version"] = frameos_version
     return snapshot
 
@@ -816,11 +825,10 @@ def _restore_write_only_secrets(remote_frame: dict[str, Any], backend_frame: Fra
 async def _load_live_frame_api_payload(
     frame: Frame, redis: Redis, fetch_frame_http_bytes: FrameFetch
 ) -> dict[str, Any]:
-    headers = await _frame_admin_session_headers(frame, redis, fetch_frame_http_bytes)
     last_status = 0
     last_body = b""
     for path in ("/api/frames/1", f"/api/frames/{frame.id}", "/api/frames"):
-        status, body, _headers = await fetch_frame_http_bytes(frame, redis, path=path, headers=headers)
+        status, body, _headers = await _frame_admin_request(frame, redis, fetch_frame_http_bytes, path=path)
         last_status = status
         last_body = body
         if status != 200:
@@ -852,9 +860,32 @@ def _frame_error_detail(body: bytes) -> str:
     return ""
 
 
+# A device admin session lives a day (frameos/server/auth.nim
+# ADMIN_SESSION_TTL_SECONDS); the cached cookie is kept well under that and
+# dropped the moment the device answers 401/403 (a rotated password, a
+# restarted device with a new session key), see _frame_admin_request.
+FRAME_ADMIN_SESSION_CACHE_TTL_SECONDS = 6 * 60 * 60
+
+
+def _frame_admin_session_cache_key(frame: Frame) -> str:
+    auth = normalize_frame_admin_auth(frame.frame_admin_auth)
+    # The credentials are part of the key so a changed login never reuses the
+    # session the old one opened.
+    fingerprint = hashlib.sha256(
+        json.dumps([frame.frame_host, frame.frame_port, auth.get("user"), auth.get("pass")], default=str).encode()
+    ).hexdigest()[:16]
+    return f"frame:{frame.id}:admin_session:{fingerprint}"
+
+
 async def _frame_admin_session_headers(
-    frame: Frame, redis: Redis, fetch_frame_http_bytes: FrameFetch
+    frame: Frame, redis: Redis, fetch_frame_http_bytes: FrameFetch, *, fresh: bool = False
 ) -> dict[str, str]:
+    """The Cookie header for the frame's admin API. One login opens a
+    session the device honours for a day, so the cookie is cached: the deploy
+    drawer polls an upgrade every few seconds, the device allows ten logins
+    per five minutes per client address, and logging in on every poll ran
+    into that limiter ("Frame admin login failed: 429 Too many login
+    attempts") about a minute into every upgrade. `fresh` skips the cache."""
     auth = normalize_frame_admin_auth(frame.frame_admin_auth)
     username = str(auth.get("user") or "").strip()
     password = str(auth.get("pass") or "").strip()
@@ -863,6 +894,15 @@ async def _frame_admin_session_headers(
             status_code=HTTPStatus.BAD_REQUEST,
             detail="Frame admin credentials are required before syncing from the backend",
         )
+    cache_key = _frame_admin_session_cache_key(frame)
+    if not fresh:
+        try:
+            cached = await redis.get(cache_key)
+        except Exception:  # noqa: BLE001 - the cache is an optimisation
+            cached = None
+        if isinstance(cached, (bytes, str)) and cached:
+            cookie = cached.decode("utf-8") if isinstance(cached, bytes) else cached
+            return {"Cookie": cookie}
     status, body, headers = await fetch_frame_http_bytes(
         frame,
         redis,
@@ -880,7 +920,43 @@ async def _frame_admin_session_headers(
     if not set_cookie:
         raise HTTPException(status_code=HTTPStatus.BAD_GATEWAY, detail="Frame admin login did not return a session")
     cookie = set_cookie.split(";", 1)[0]
+    try:
+        await redis.set(cache_key, cookie, ex=FRAME_ADMIN_SESSION_CACHE_TTL_SECONDS)
+    except Exception:  # noqa: BLE001 - the cache is an optimisation
+        pass
     return {"Cookie": cookie}
+
+
+async def _forget_frame_admin_session(frame: Frame, redis: Redis) -> None:
+    try:
+        await redis.delete(_frame_admin_session_cache_key(frame))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def _frame_admin_request(
+    frame: Frame,
+    redis: Redis,
+    fetch_frame_http_bytes: FrameFetch,
+    *,
+    path: str,
+    method: str = "GET",
+    body: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, bytes, dict[str, str]]:
+    """One request against the frame's admin API with the cached session; a
+    401/403 drops the cached cookie, logs in again and retries once."""
+    auth_headers = await _frame_admin_session_headers(frame, redis, fetch_frame_http_bytes)
+    status, response_body, response_headers = await fetch_frame_http_bytes(
+        frame, redis, path=path, method=method, body=body, headers={**(headers or {}), **auth_headers}
+    )
+    if status in (401, 403):
+        await _forget_frame_admin_session(frame, redis)
+        auth_headers = await _frame_admin_session_headers(frame, redis, fetch_frame_http_bytes, fresh=True)
+        status, response_body, response_headers = await fetch_frame_http_bytes(
+            frame, redis, path=path, method=method, body=body, headers={**(headers or {}), **auth_headers}
+        )
+    return status, response_body, response_headers
 
 
 def _frame_sync_baseline(frame: Frame, backend_frame: dict[str, Any]) -> dict[str, Any]:
@@ -1233,14 +1309,14 @@ async def _push_frame_sync_payload(
             **({"skip_runtime_reload": True} if not reload_runtime else {}),
         }
     )
-    auth_headers = await _frame_admin_session_headers(frame, redis, fetch_frame_http_bytes)
-    status, response_body, _headers = await fetch_frame_http_bytes(
+    status, response_body, _headers = await _frame_admin_request(
         frame,
         redis,
+        fetch_frame_http_bytes,
         path="/api/frames/1",
         method="POST",
         body=body,
-        headers={**auth_headers, "Content-Type": "application/json"},
+        headers={"Content-Type": "application/json"},
     )
     if status != 200:
         raise HTTPException(

--- a/backend/app/api/frames.py
+++ b/backend/app/api/frames.py
@@ -60,6 +60,7 @@ from app.models.frame import (
     normalize_https_proxy,
     refresh_tls_certificate_validity_dates,
     record_successful_deploy,
+    remember_device_reported_frameos_version,
     update_frame,
 )
 from app.models.log import FRAME_ACTIVITY_LOG_TYPES, Log, new_log as log
@@ -114,7 +115,7 @@ from app.utils.frame_http import (
 )
 from app.utils import embedded_assets, virtual_assets
 from app.api.frame_sync import (
-    _frame_admin_session_headers,
+    _frame_admin_request,
     frame_has_shell_access,
     adopt_standalone_frame,
     apply_frame_sync,
@@ -3407,16 +3408,34 @@ async def api_frame_embedded_firmware_ota(
     return {"message": "Firmware update requested", "device": device_payload}
 
 
+async def _record_device_reported_frameos_version(db: Session, redis: Redis, frame: Frame, payload: dict) -> None:
+    """A frame the backend cannot deploy FrameOS to updates itself, so the
+    version in its deploy baseline (what the drawer's "FrameOS a -> b" line
+    and the change indicator compare against) is only ever learnt from the
+    device: here from the upgrade status it just answered, and from the
+    version its bootup log carries (models/log.py)."""
+    if frame_has_shell_access(frame):
+        return
+    version = payload.get("current_version") if isinstance(payload, dict) else None
+    if not isinstance(version, str) or not re.fullmatch(r"\d+\.\d+\.\d+", version.strip()):
+        return
+    if remember_device_reported_frameos_version(frame, version.strip()):
+        await update_frame(db, redis, frame)
+
+
 async def _relay_device_admin(
     frame: Frame, redis: Redis, path: str, *, method: str = "GET", body: dict | None = None
 ) -> dict:
     """One request against the frame's admin API with the stored admin login;
     the device's JSON comes back as-is, its errors as a 502 with the detail."""
-    headers = await _frame_admin_session_headers(frame, redis, _fetch_frame_http_bytes)
-    if body is not None:
-        headers = {**headers, "Content-Type": "application/json"}
-    status, raw, _headers = await _fetch_frame_http_bytes(
-        frame, redis, path=path, method=method, body=json.dumps(body) if body is not None else None, headers=headers
+    status, raw, _headers = await _frame_admin_request(
+        frame,
+        redis,
+        _fetch_frame_http_bytes,
+        path=path,
+        method=method,
+        body=json.dumps(body) if body is not None else None,
+        headers={"Content-Type": "application/json"} if body is not None else None,
     )
     try:
         payload = json.loads(raw.decode("utf-8")) if raw else {}
@@ -3445,6 +3464,7 @@ async def api_frame_device_upgrade_status(
         _not_found()
     payload = await _relay_device_admin(frame, redis, "/api/upgrade/status" + ("?check=1" if check else ""))
     payload["shell_access"] = frame_has_shell_access(frame)
+    await _record_device_reported_frameos_version(db, redis, frame, payload)
     return payload
 
 
@@ -3468,6 +3488,7 @@ async def api_frame_device_upgrade(
     dry_run = bool(isinstance(body, dict) and body.get("dry_run"))
     payload = await _relay_device_admin(frame, redis, "/api/upgrade", method="POST", body={"dry_run": dry_run})
     payload["shell_access"] = frame_has_shell_access(frame)
+    await _record_device_reported_frameos_version(db, redis, frame, payload)
     return payload
 
 

--- a/backend/app/api/tests/test_frames.py
+++ b/backend/app/api/tests/test_frames.py
@@ -3646,6 +3646,102 @@ async def test_api_frame_device_upgrade_relays_the_frames_own_upgrade(async_clie
 
 
 @pytest.mark.asyncio
+async def test_api_frame_device_admin_session_is_cached_and_reopened_on_401(async_client, db, redis):
+    """The deploy drawer polls an upgrade every 5 s and the device allows ten
+    admin logins per five minutes: one login must serve every poll, and a
+    session the device no longer honours is reopened once, not surfaced."""
+    payload = {**_standalone_device_payload(), 'mode': 'buildroot', 'buildroot': {'platform': 'raspberry-pi-64'}}
+    logins = []
+    reject_next = {'count': 0}
+
+    async def mock_fetch(frame_obj, redis_obj, *, path, method="GET", body=None, headers=None):
+        if path == '/api/admin/login':
+            logins.append(json.loads(body))
+            return 200, b'{"status":"ok"}', {'set-cookie': f'frame_admin_session=s{len(logins)}; Path=/'}
+        if path.startswith('/api/upgrade/status'):
+            if reject_next['count'] > 0:
+                reject_next['count'] -= 1
+                return 401, b'{"detail":"Not authenticated"}', {'content-type': 'application/json'}
+            assert headers and headers.get('Cookie', '').startswith('frame_admin_session=s')
+            return 200, json.dumps({'status': 'running', 'current_version': '2026.9.11'}).encode(), {}
+        if method == 'POST':
+            return 200, b'{"message":"ok"}', {'content-type': 'application/json'}
+        return 200, json.dumps({'frame': payload}).encode(), {'content-type': 'application/json'}
+
+    with patch('app.api.frames._fetch_frame_http_bytes', new=AsyncMock(side_effect=mock_fetch)):
+        adopted = await async_client.post('/api/frames/adopt', json=_adopt_request_body())
+        assert adopted.status_code == 200, adopted.text
+        frame_id = adopted.json()['frame']['id']
+        logins_after_adopt = len(logins)
+
+        for _ in range(12):
+            status = await async_client.get(f'/api/frames/{frame_id}/device/upgrade')
+            assert status.status_code == 200, status.text
+        assert len(logins) == logins_after_adopt, "twelve polls reused the session the adoption opened"
+
+        reject_next['count'] = 1
+        status = await async_client.get(f'/api/frames/{frame_id}/device/upgrade')
+        assert status.status_code == 200, status.text
+        assert len(logins) == logins_after_adopt + 1, "a 401 reopens the session exactly once"
+
+        # A rotated password never reuses the old session.
+        db.expire_all()
+        frame = db.get(Frame, frame_id)
+        frame.frame_admin_auth = {**frame.frame_admin_auth, 'pass': 'rotated'}
+        db.commit()
+        status = await async_client.get(f'/api/frames/{frame_id}/device/upgrade')
+        assert status.status_code == 200, status.text
+        assert logins[-1]['password'] == 'rotated'
+
+
+@pytest.mark.asyncio
+async def test_api_frame_device_upgrade_status_records_the_version_the_frame_reports(async_client, db, redis):
+    """A shell-less card upgrades itself; the row's deploy baseline learns
+    the new version from the status it answers, so the drawer stops saying
+    "2026.9.11 -> 2026.9.12" once the frame is on 2026.9.12. A fast deploy
+    over the admin API must not overwrite it with the backend's version."""
+    payload = {**_standalone_device_payload(), 'mode': 'buildroot', 'buildroot': {'platform': 'raspberry-pi-64'}}
+    device_version = {'value': '2026.9.11'}
+
+    async def mock_fetch(frame_obj, redis_obj, *, path, method="GET", body=None, headers=None):
+        if path == '/api/admin/login':
+            return _sync_admin_login_response()
+        if path.startswith('/api/upgrade/status'):
+            return 200, json.dumps({'status': 'success', 'current_version': device_version['value'],
+                                    'update_available': False}).encode(), {}
+        if method == 'POST':
+            return 200, b'{"message":"ok"}', {'content-type': 'application/json'}
+        return 200, json.dumps({'frame': payload}).encode(), {'content-type': 'application/json'}
+
+    with patch('app.api.frames._fetch_frame_http_bytes', new=AsyncMock(side_effect=mock_fetch)):
+        adopted = await async_client.post('/api/frames/adopt', json=_adopt_request_body())
+        assert adopted.status_code == 200, adopted.text
+        frame_id = adopted.json()['frame']['id']
+        db.expire_all()
+        frame = db.get(Frame, frame_id)
+        frame.last_successful_deploy = {**(frame.last_successful_deploy or {}), 'frameos_version': '2026.9.11'}
+        db.commit()
+
+        device_version['value'] = '2026.9.12'
+        status = await async_client.get(f'/api/frames/{frame_id}/device/upgrade')
+        assert status.status_code == 200, status.text
+        db.expire_all()
+        frame = db.get(Frame, frame_id)
+        assert frame.last_successful_deploy['frameos_version'] == '2026.9.12'
+        # The rest of the baseline is untouched by a version report.
+        assert frame.last_successful_deploy['name'] == 'Kitchen frame'
+
+        from app.api.frame_sync import _frame_sync_snapshot
+        assert _frame_sync_snapshot(frame)['frameos_version'] == '2026.9.12'
+
+        # A frame the backend deploys FrameOS to keeps the backend's version.
+        frame.ssh_pass = 'raspberry'
+        db.commit()
+        from app.utils.versions import current_frameos_version
+        assert _frame_sync_snapshot(frame)['frameos_version'] == current_frameos_version()
+
+
+@pytest.mark.asyncio
 async def test_push_backend_state_to_device_is_the_http_fast_deploy(async_client, db, redis):
     from app.api.frame_sync import push_backend_state_to_device
 

--- a/backend/app/api/tests/test_log.py
+++ b/backend/app/api/tests/test_log.py
@@ -251,3 +251,36 @@ async def test_gzip_body_over_the_cap_is_rejected_before_decompression(async_cli
     monkeypatch.setattr(middleware, "MAX_DECOMPRESSED_BODY", len(body) - 1)
     response = await async_client.post('/api/log', content=body, headers=headers)
     assert response.status_code == 413
+
+
+
+@pytest.mark.asyncio
+async def test_api_log_bootup_version_updates_a_shell_less_frames_baseline(async_client, db, redis):
+    """An adopted generic card upgrades itself and the runtime says which
+    FrameOS it booted; the deploy baseline's version follows, nothing else
+    in the baseline moves, and a frame the backend can deploy to ignores it."""
+    frame = await new_frame(db, redis, 'AdoptedCard', 'localhost', 'localhost')
+    frame.mode = 'buildroot'
+    frame.buildroot = {'adopted': True, 'platform': 'raspberry-pi-64'}
+    frame.ssh_keys = []
+    frame.ssh_pass = None
+    frame.server_api_key = 'testkey'
+    frame.last_successful_deploy = {'name': 'AdoptedCard', 'frameos_version': '2026.9.11'}
+    await update_frame(db, redis, frame)
+
+    headers = {'Authorization': 'Bearer testkey'}
+    response = await async_client.post('/api/log', json={'log': {'event': 'bootup', 'version': '2026.9.12'}}, headers=headers)
+    assert response.status_code == 200
+    db.refresh(frame)
+    assert frame.last_successful_deploy == {'name': 'AdoptedCard', 'frameos_version': '2026.9.12'}
+
+    shell = await new_frame(db, redis, 'SshFrame', 'localhost', 'localhost')
+    shell.server_api_key = 'sshkey'
+    shell.ssh_pass = 'raspberry'
+    shell.last_successful_deploy = {'name': 'SshFrame', 'frameos_version': '2026.9.11'}
+    await update_frame(db, redis, shell)
+    response = await async_client.post('/api/log', json={'log': {'event': 'bootup', 'version': '2026.9.12'}},
+                                       headers={'Authorization': 'Bearer sshkey'})
+    assert response.status_code == 200
+    db.refresh(shell)
+    assert shell.last_successful_deploy['frameos_version'] == '2026.9.11'

--- a/backend/app/models/frame.py
+++ b/backend/app/models/frame.py
@@ -629,6 +629,23 @@ def frame_has_shell_access(frame: Any) -> bool:
     return not bool((getattr(frame, "buildroot", None) or {}).get("adopted"))
 
 
+def remember_device_reported_frameos_version(frame: Frame, version: str) -> bool:
+    """Set the deploy baseline's `frameos_version` to what the device says it
+    runs, leaving the rest of the baseline (scenes, settings, fingerprints)
+    exactly as deployed. For a frame the backend cannot install FrameOS on —
+    an adopted shell-less card, which upgrades itself — this is the only way
+    the row ever learns a new version; without it the deploy drawer kept
+    showing "2026.9.11 -> 2026.9.12" after the frame had upgraded. Returns
+    whether anything changed."""
+    snapshot = frame.last_successful_deploy if isinstance(frame.last_successful_deploy, dict) else None
+    if not snapshot or not version:
+        return False
+    if snapshot.get("frameos_version") == version:
+        return False
+    frame.last_successful_deploy = {**snapshot, "frameos_version": version}
+    return True
+
+
 def record_successful_deploy(frame: Frame, frame_dict: dict, deployed_at: Optional[datetime] = None) -> None:
     """Store ``frame_dict`` as the frame's deploy baseline, minus its secrets."""
     frame.last_successful_deploy = deploy_snapshot(frame_dict)

--- a/backend/app/models/log.py
+++ b/backend/app/models/log.py
@@ -7,7 +7,7 @@ from ipaddress import ip_address
 from typing import Any, Optional
 from arq import ArqRedis as Redis
 
-from .frame import Frame, record_successful_deploy, update_frame
+from .frame import Frame, frame_has_shell_access, record_successful_deploy, remember_device_reported_frameos_version, update_frame
 from .metrics import new_metrics
 from app.database import Base
 from app.utils.timezone import stored_timezone
@@ -297,6 +297,13 @@ async def process_log(
         )
 
         marked_buildroot_sd_image_booted = await mark_buildroot_sd_image_booted(db, redis, frame)
+        if (frame.mode or "rpios") != "embedded" and not frame_has_shell_access(frame):
+            # A shell-less card upgrades itself; its bootup line is where the
+            # backend learns which FrameOS it now runs (the runtime sends
+            # `version` since 2026.9.13). The baseline keeps everything else.
+            boot_version = _frameos_version_from_boot(log.get("version"))
+            if boot_version and remember_device_reported_frameos_version(frame, boot_version):
+                changes["last_successful_deploy"] = frame.last_successful_deploy
         if (frame.mode or "rpios") == "embedded":
             embedded_boot_metadata = _embedded_boot_metadata(log, timestamp, ip=ip)
             embedded = dict(frame.embedded or {})

--- a/cloud/apps/auth-web/src/test/shared-spa/frame-secrets-mirror.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/frame-secrets-mirror.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SECRET_PATHS, restoreDeployedSecrets } from "../../../../../../frontend/src/utils/frameSecrets";
+
+// The frontend's secret-path list is a hand-copied mirror of the backend's
+// (backend/app/utils/frame_secrets.py). When the backend gained the two
+// network passwords (PR #460) the mirror did not, so the deploy baseline
+// (fingerprints only) never equalled the live row and "Network settings"
+// stayed pending after every fast deploy. This reads the backend list out
+// of the Python source so the two cannot drift apart again.
+const backendSource = readFileSync(
+  resolve(__dirname, "../../../../../../backend/app/utils/frame_secrets.py"),
+  "utf8",
+);
+
+function tupleBlock(name: string): string[][] {
+  // TOP_LEVEL_SECRET_KEYS is one line of strings; NESTED_SECRET_PATHS is a
+  // block of one tuple per line, closed by ")" at the start of a line.
+  const match = backendSource.match(new RegExp(`${name} = \\(([^\\n]*|[\\s\\S]*?\\n)\\)`));
+  if (!match?.[1]) {
+    throw new Error(`${name} not found in frame_secrets.py`);
+  }
+  const body = match[1].replace(/#[^\n]*/g, "");
+  const tuples = [...body.matchAll(/\(([^()]*)\)/g)].map((m) =>
+    [...(m[1] ?? "").matchAll(/"([^"]+)"/g)].map((q) => q[1] ?? ""),
+  );
+  if (tuples.length > 0) {
+    return tuples;
+  }
+  return [...body.matchAll(/"([^"]+)"/g)].map((q) => [q[1] ?? ""]);
+}
+
+describe("frameSecrets mirrors the backend secret paths", () => {
+  it("lists every top-level and nested secret path the backend fingerprints", () => {
+    const backend = [...tupleBlock("TOP_LEVEL_SECRET_KEYS"), ...tupleBlock("NESTED_SECRET_PATHS")]
+      .map((path) => path.join("."))
+      .sort();
+    const frontend = SECRET_PATHS.map((path) => path.join(".")).sort();
+    expect(frontend).toEqual(backend);
+  });
+
+  it("fills an unchanged Wi-Fi password back into the baseline so network compares equal", () => {
+    const baseline = {
+      network: { wifiSSID: "home", wifiHotspotPassword: undefined },
+      secret_fingerprints: { "network.wifiPassword": "fp-1" },
+    };
+    const frame = {
+      network: { wifiSSID: "home", wifiPassword: "hunter2" },
+      secret_fingerprints: { "network.wifiPassword": "fp-1" },
+    };
+    const restored = restoreDeployedSecrets(baseline as never, frame as never) as {
+      network?: Record<string, unknown>;
+    };
+    expect(restored.network?.wifiPassword).toBe("hunter2");
+  });
+});

--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -24,6 +24,7 @@
     // Imports frontend/src/utils/duplicateScenes, whose FrameEvent typing
     // predates exactOptionalPropertyTypes. Vitest still runs it.
     "src/test/shared-spa/duplicate-scenes.test.ts",
+    "src/test/shared-spa/frame-secrets-mirror.test.ts",
     // Same story: mounts the real framesModel, whose import graph reaches
     // the legacy workspace components (bare JSX namespace, pre-strict
     // typing). Vitest still runs it; only tsc leaves it out.

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -23,6 +23,7 @@ export default tseslint.config(
       // package tsconfig for its pre-strict FrameEvent typing; the project
       // service therefore cannot parse it. Vitest still runs it.
       "**/src/test/shared-spa/duplicate-scenes.test.ts",
+      "**/src/test/shared-spa/frame-secrets-mirror.test.ts",
       // Same exclusion, same reason: mounts the real framesModel, whose
       // import graph reaches the legacy workspace components.
       "**/src/test/shared-spa/cloud-scene-deploy.test.ts",

--- a/docs/manual-testing-todo.md
+++ b/docs/manual-testing-todo.md
@@ -5,7 +5,7 @@ Everything here shipped with green automated suites but needed a bench.
 evidence for what passed, in the original section order, because the open
 boxes point into it. Tick a box by moving its entry from Open to the matching
 Done section with the date and what was seen; delete the file when Open is
-empty. Last refreshed 2026-09-08 (setup portal round two + adopt #380 closed on 2026.9.11), after release 2026.9.11.
+empty. Last refreshed 2026-09-09 (shell-less "Update FrameOS" closed on 2026.9.12, five papercuts fixed on main), after release 2026.9.12.
 
 ## Open
 
@@ -21,17 +21,14 @@ empty. Last refreshed 2026-09-08 (setup portal round two + adopt #380 closed on 
 
 ### Backend (self-hosted) bench
 
-- [ ] **"Update FrameOS" on a shell-less card (needs a release newer than
-  2026.9.11):** on frame-2c2ea9 (or any adopted generic card) press Update
-  FrameOS in the deploy drawer: the frame downloads the release for its
-  target, verifies the minisign signature and installs through the
-  privileged door; the drawer polls the status to `success` /
-  `reboot_required` and the frame comes back on the new version. The rest of
-  that box passed 2026-09-08 (see Done). Watch the door's file modes on the
-  way — the 9.5 OTA left `drivers/*.so` 0640 and loaded no drivers.
-
 - [ ] **Adopted card, round two (2026-09-08 findings on frame-2c2ea9, all
-  fixed on main the same day, needs the next backend release):** re-adopt
+  fixed on main the same day, needs the next backend release):** *(2026-09-09
+  on the 2026.9.12 add-on: "Pending changes" did NOT open clean — "Network
+  settings" came back after every fast deploy. Cause found and fixed on main
+  (`ha-upgrade-papercuts`): the frontend's secret-path mirror lacked the two
+  `network.*` passwords PR #460 fingerprinted, so the baseline never equalled
+  the row; a shared-spa test now reads the backend list. Re-check with the
+  next add-on.)* re-adopt
   a fresh generic card (or the same one, un-adopted) and check: logs arrive
   without touching the device (the adopt log line says it restarted
   FrameOS); "Current image" shows the panel and the scene gets its
@@ -391,6 +388,37 @@ empty. Last refreshed 2026-09-08 (setup portal round two + adopt #380 closed on 
   evidenced by the release dir, the service restart and the activity feed.)
 
 ### Backend (self-hosted) bench
+
+- [x] **"Update FrameOS" on a shell-less card** — PASSED 2026-09-09 on
+  frame-2c2ea9 (adopted generic card, 2026.9.11 → 2026.9.12, from the
+  2026.9.12 Home Assistant add-on): Check for updates saw 2026.9.12, Update
+  FrameOS queued → `running` → "installing the staged release 2026.9.12" →
+  `success: FrameOS upgraded to 2026.9.12. Restarting services.`, and the
+  frame came back rendering on 2026.9.12. **Papercuts, all fixed on main
+  2026-09-09 (`ha-upgrade-papercuts`), need the next add-on:** (1) the frame
+  rail icon stayed gray although a release was waiting — the change details
+  skipped the version gap for shell-less frames; it is now a change of its
+  own ("the frame installs it itself: Update FrameOS"), so the icon goes
+  brass and the drawer names it. (2) "Check for updates" showed "update
+  available" and, under it, `up_to_date: FrameOS is already on the latest
+  stable GitHub release.` — the device's `upgrade-status.json` is the record
+  of its LAST run and was rendered as if it were the answer; finished runs
+  now show as a dated "Last upgrade: …" line and a stale `up_to_date` is
+  dropped once a newer release exists. (3) About a minute in: `Frame admin
+  login failed: 429 {"detail":"Too many login attempts"}` and the watch
+  ended — the backend logged into the frame on every 5 s poll against the
+  device's 10-logins-per-5-minutes limiter; the admin session cookie is now
+  cached (6 h, reopened once on 401, keyed by the credentials) and the poll
+  survives the runtime restart instead of stopping on the first failed
+  request. (4) After success the drawer's bottom still said
+  `2026.9.11 -> 2026.9.12` and the status line stayed on "Restarting
+  services" — the row never learnt the device's version; the backend now
+  records `current_version` from the upgrade status (and, from 2026.9.13,
+  the `version` the runtime puts on its bootup line) into the deploy
+  baseline, the fast/sync path keeps that device-reported version instead of
+  stamping the backend's, and the drawer re-reads the frame and plan once
+  the upgrade finishes. (5) "Pending changes: Network settings" after every
+  fast deploy — see the open "round two" box (secret-path mirror).
 
 - [x] **Shell-less frame from the deploy drawer** — everything but the update
   itself PASSED 2026-09-08 on frame-2c2ea9 (adopted generic 2026.9.11 card,

--- a/frameos/src/frameos/frameos.nim
+++ b/frameos/src/frameos/frameos.nim
@@ -17,7 +17,7 @@ import frameos/timezone_updater
 import frameos/types
 import frameos/utils/memory
 import frameos/portal as netportal
-from frameos/upgrade import reconcileInterruptedUpgradeStatus
+from frameos/upgrade import reconcileInterruptedUpgradeStatus, installedFrameOSVersion
 import frameos/cloud/hub_client
 import frameos/tls_proxy
 import frameos/setup_proxy
@@ -263,7 +263,9 @@ proc newFrameOS*(): FrameOS =
   startTimezoneUpdater(result)
 
 proc start*(self: FrameOS) {.async.} =
-  var message = %*{"event": "bootup", "config": {
+  # `version` is what a backend that cannot deploy FrameOS to this frame
+  # (an adopted shell-less card) uses to learn the release it now runs.
+  var message = %*{"event": "bootup", "version": installedFrameOSVersion(), "config": {
     "frameHost": self.frameConfig.frameHost,
     "framePort": self.frameConfig.framePort,
     "frameAccess": self.frameConfig.frameAccess,

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -213,7 +213,14 @@ export interface DeviceUpgradeStatus {
 }
 
 // frameos/upgrade.nim UpgradeTerminalStatuses: anything else is in flight.
-const DEVICE_UPGRADE_TERMINAL_STATUSES = ['success', 'reboot_required', 'failed', 'up_to_date', 'idle']
+export const DEVICE_UPGRADE_TERMINAL_STATUSES = ['success', 'reboot_required', 'failed', 'up_to_date', 'idle']
+// 5 s polls: how long a running upgrade may go unanswered (the runtime
+// restarting, a reboot) before the watch gives up.
+const DEVICE_UPGRADE_MAX_POLL_FAILURES = 36
+
+export function deviceUpgradeInFlight(status: DeviceUpgradeStatus | null | undefined): boolean {
+  return Boolean(status?.status) && !DEVICE_UPGRADE_TERMINAL_STATUSES.includes(String(status?.status))
+}
 
 function frameHasSyncCredentials(frame: FrameType | null): boolean {
   const frameAdminAuth = frame?.frame_admin_auth
@@ -893,7 +900,7 @@ function withServiceKeyFingerprints(
   const fingerprints = frame?.settings_fingerprints
   return fingerprints && !frameForm?.settings_fingerprints
     ? { ...(frameForm ?? {}), settings_fingerprints: fingerprints }
-    : (frameForm ?? {})
+    : frameForm ?? {}
 }
 
 export function serviceKeysChangeDetail(
@@ -921,6 +928,14 @@ function computeChangeDetails(
     includeFrameosVersion = false
   }
   const previousFrameosVersion = includeFrameosVersion ? deployedFrameosVersion(previous) : null
+  // ...but a release the frame has not installed yet is still something
+  // waiting on it, so the change indicator lights up and the drawer names
+  // it — the frame installs it itself ("Update FrameOS" in the drawer), and
+  // the row learns the new version from the device (the upgrade status it
+  // answers, its bootup line), never from a fast deploy.
+  const shellLessDeviceVersion = shellLess ? deployedFrameosVersion(previous) : null
+  const shellLessUpdateWaiting =
+    shellLess && Boolean(shellLessDeviceVersion) && frameosVersionRequiresDeploy(shellLessDeviceVersion)
 
   for (const key of frameDiffKeys().filter((k) => k !== 'scenes')) {
     if (shellLess && SHELL_LESS_BACKEND_ONLY_KEYS.has(key)) {
@@ -947,6 +962,18 @@ function computeChangeDetails(
       frameosVersionChange: {
         kind: 'upgrade',
         previousVersion: previousFrameosVersion,
+        currentVersion: CURRENT_FRAMEOS_VERSION,
+      },
+    })
+  }
+
+  if (shellLessUpdateWaiting) {
+    details.push({
+      label: `FrameOS ${shellLessDeviceVersion} -> ${CURRENT_FRAMEOS_VERSION} (the frame installs it itself: Update FrameOS)`,
+      requiresFullDeploy: false,
+      frameosVersionChange: {
+        kind: 'upgrade',
+        previousVersion: shellLessDeviceVersion,
         currentVersion: CURRENT_FRAMEOS_VERSION,
       },
     })
@@ -1965,6 +1992,7 @@ export interface frameLogicValues {
   deployWithAgent: boolean
   deviceUpgradeError: string | null
   deviceUpgradeLoading: boolean
+  deviceUpgradePollFailures: number
   deviceUpgradeStatus: DeviceUpgradeStatus | null
   fastDeployPlan: DeployPlanResponse | null
   fastDeployPlanSummary: SummaryItem[]
@@ -2059,6 +2087,9 @@ export interface frameLogicActions {
   ) => {
     recompile: boolean
     transport: RemoteTaskTransport
+  }
+  deviceUpgradePollFailed: () => {
+    value: true
   }
   fastDeployFrame: () => {
     value: true
@@ -2404,6 +2435,7 @@ export const frameLogic = kea<frameLogicType>([
     loadDeviceUpgradeStatus: (check: boolean = false) => ({ check }),
     loadDeviceUpgradeStatusSuccess: (status: DeviceUpgradeStatus) => ({ status }),
     loadDeviceUpgradeStatusFailure: (error: string) => ({ error }),
+    deviceUpgradePollFailed: true,
     startDeviceUpgrade: true,
     startDeviceUpgradeSuccess: (status: DeviceUpgradeStatus) => ({ status }),
     startDeviceUpgradeFailure: (error: string) => ({ error }),
@@ -2520,6 +2552,14 @@ export const frameLogic = kea<frameLogicType>([
       {
         loadDeviceUpgradeStatusSuccess: (_, { status }) => status,
         startDeviceUpgradeSuccess: (_, { status }) => status,
+      },
+    ],
+    deviceUpgradePollFailures: [
+      0,
+      {
+        deviceUpgradePollFailed: (state) => state + 1,
+        loadDeviceUpgradeStatusSuccess: () => 0,
+        startDeviceUpgrade: () => 0,
       },
     ],
     deviceUpgradeLoading: [
@@ -2807,17 +2847,42 @@ export const frameLogic = kea<frameLogicType>([
       }
     },
     loadDeviceUpgradeStatus: async ({ check }, breakpoint) => {
-      const response = await apiFetch(`/api/frames/${values.frameId}/device/upgrade${check ? '?check=1' : ''}`)
-      const payload = await response.json().catch(() => ({}))
-      if (!response.ok) {
-        actions.loadDeviceUpgradeStatusFailure(getResponseDetail(payload) ?? 'Could not read the upgrade status')
+      const wasInFlight = deviceUpgradeInFlight(values.deviceUpgradeStatus)
+      let response: Response | null = null
+      let payload: Record<string, unknown> = {}
+      try {
+        response = await apiFetch(`/api/frames/${values.frameId}/device/upgrade${check ? '?check=1' : ''}`)
+        payload = await response.json().catch(() => ({}))
+      } catch {
+        response = null
+      }
+      if (!response || !response.ok) {
+        // While an upgrade runs the frame restarts its services (a refused
+        // connection for a few seconds) and the backend may answer 502 for
+        // the same reason: keep watching for a couple of minutes before
+        // giving up, instead of ending the watch on the first blip.
+        if (wasInFlight && values.deviceUpgradePollFailures < DEVICE_UPGRADE_MAX_POLL_FAILURES) {
+          actions.deviceUpgradePollFailed()
+          await breakpoint(5000)
+          actions.loadDeviceUpgradeStatus(false)
+          return
+        }
+        actions.loadDeviceUpgradeStatusFailure(
+          (payload && getResponseDetail(payload)) ?? 'Could not read the upgrade status'
+        )
         return
       }
       actions.loadDeviceUpgradeStatusSuccess(payload as DeviceUpgradeStatus)
-      if (!DEVICE_UPGRADE_TERMINAL_STATUSES.includes(String(payload?.status ?? 'idle'))) {
+      if (deviceUpgradeInFlight(payload as DeviceUpgradeStatus)) {
         // Still downloading / verifying / installing: keep watching.
         await breakpoint(5000)
         actions.loadDeviceUpgradeStatus(false)
+      } else if (wasInFlight) {
+        // The upgrade just finished: the backend recorded the version the
+        // frame now reports, so the row and the deploy plan (its "FrameOS
+        // a -> b" line, the change indicator) must be re-read.
+        framesModel.actions.loadFrame(values.frameId)
+        actions.loadDeployPlans()
       }
     },
     startDeviceUpgrade: async (_, breakpoint) => {
@@ -3058,10 +3123,8 @@ export const frameLogic = kea<frameLogicType>([
         isFrameAdminMode
           ? []
           : lastDeploy
-            ? sortDeployChangeDetails(
-                deployChangeDetails(lastDeploy, withServiceKeyFingerprints(frameForm, frame), mode)
-              )
-            : firstDeployChangeDetails(frameForm, mode),
+          ? sortDeployChangeDetails(deployChangeDetails(lastDeploy, withServiceKeyFingerprints(frameForm, frame), mode))
+          : firstDeployChangeDetails(frameForm, mode),
     ],
     undeployedSummaryItems: [
       (s) => [s.lastDeploy, s.frame, s.frameForm, s.requiresRecompilation, s.isFrameAdminMode],

--- a/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
+++ b/frontend/src/scenes/workspace/FrameDeployPlanDrawer.tsx
@@ -73,6 +73,7 @@ import {
   type FrameSyncChoices,
   type SummaryItem,
   frameSyncChangeKey,
+  deviceUpgradeInFlight,
 } from '../frame/frameLogic'
 import {
   buildRemoteUpgradeNotice,
@@ -937,10 +938,23 @@ function ShellLessFrameSection({
   onCheck: () => void
   onUpgrade: () => void
 }): JSX.Element {
-  const inFlight =
-    Boolean(status?.status) &&
-    !['success', 'reboot_required', 'failed', 'up_to_date', 'idle'].includes(String(status?.status))
+  const inFlight = deviceUpgradeInFlight(status)
   const updateAvailable = status?.update_available === true
+  // upgrade-status.json on the device is the record of its LAST upgrade run
+  // and stays there for good, so a finished run is history, not the answer
+  // to "Check for updates": it is shown dated, below the current
+  // up-to-date / update-available line, and an "up_to_date" record from a
+  // past check is dropped once a newer release exists (the two would
+  // contradict each other on one screen).
+  const finishedRun =
+    status &&
+    !inFlight &&
+    status.status &&
+    status.status !== 'idle' &&
+    !(status.status === 'up_to_date' && updateAvailable)
+      ? status
+      : null
+  const finishedAt = finishedRun ? String(finishedRun.finished_at ?? finishedRun.updated_at ?? '') : ''
   const buttonClass =
     'frameos-secondary-button rounded-lg px-3 py-2 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:opacity-40'
   return (
@@ -960,13 +974,19 @@ function ShellLessFrameSection({
               <span className="frame-tool-muted">
                 {' '}
                 · latest {status.latest_version}
-                {updateAvailable ? ' — update available' : status.status === 'idle' ? ' — up to date' : ''}
+                {updateAvailable ? ' — update available' : inFlight ? '' : ' — up to date'}
               </span>
             ) : null}
-            {status.status && status.status !== 'idle' ? (
+            {inFlight ? (
               <div className="frame-tool-muted mt-1">
                 {status.status}
                 {status.message ? `: ${status.message}` : ''}
+              </div>
+            ) : finishedRun ? (
+              <div className="frame-tool-muted mt-1">
+                Last upgrade{finishedAt ? ` (${finishedAt.replace('T', ' ').replace(/Z$/, ' UTC')})` : ''}:{' '}
+                {finishedRun.status}
+                {finishedRun.message ? ` — ${finishedRun.message}` : ''}
               </div>
             ) : null}
             {status.latest_error ? <div className="mt-1 text-amber-600">{status.latest_error}</div> : null}

--- a/frontend/src/utils/frameSecrets.ts
+++ b/frontend/src/utils/frameSecrets.ts
@@ -13,8 +13,12 @@ import type { FrameType } from '../types'
  */
 
 // Mirrors TOP_LEVEL_SECRET_KEYS + NESTED_SECRET_PATHS on the backend; "*"
-// walks a list.
-const SECRET_PATHS: readonly (readonly string[])[] = [
+// walks a list. A path the backend fingerprints but this list lacks makes
+// that leaf "changed since deploy" forever (the baseline has no value, the
+// row does), which is how "Network settings" stayed pending after every
+// fast deploy once the Wi-Fi passwords became secrets — the shared-spa
+// `frame-secrets-mirror` test reads the backend list and fails on drift.
+export const SECRET_PATHS: readonly (readonly string[])[] = [
   ['ssh_pass'],
   ['server_api_key'],
   ['frame_access_key'],
@@ -22,6 +26,8 @@ const SECRET_PATHS: readonly (readonly string[])[] = [
   ['agent', 'agentSharedSecret'],
   ['frame_admin_auth', 'pass'],
   ['mountpoints', 'items', '*', 'password'],
+  ['network', 'wifiPassword'],
+  ['network', 'wifiHotspotPassword'],
 ]
 
 const FINGERPRINTS_KEY = 'secret_fingerprints'


### PR DESCRIPTION
Seen on frame-2c2ea9 (adopted generic card) upgrading 2026.9.11 → 2026.9.12 from the 2026.9.12 Home Assistant add-on. The upgrade itself worked; everything around it did not.

## What was wrong, and the fix
1. **"Network settings" pending after every fast deploy.** The backend fingerprints `network.wifiPassword` / `network.wifiHotspotPassword` in the deploy baseline since #460, but the frontend's hand-copied secret-path mirror (`utils/frameSecrets.ts`) was never updated, so the baseline could never equal the live row. Added the two paths, plus a shared-spa test that parses the backend's list out of `frame_secrets.py` so the two cannot drift again.
2. **`Frame admin login failed: 429 Too many login attempts` a minute into the upgrade.** The backend logged into the frame's admin API on every 5 s poll; the device allows ten logins per five minutes per address. The admin session cookie is now cached in redis (keyed by frame + credentials, 6 h, the device honours it for 24 h) and reopened once on a 401/403 through one `_frame_admin_request` helper used by the relay, the sync read and the sync write. The drawer's poll also rides out the runtime restart (up to 3 min of unanswered polls while an upgrade is in flight) instead of ending on the first failed request.
3. **The drawer kept saying `2026.9.11 -> 2026.9.12` after the upgrade.** The row's deploy baseline only ever carried the backend's own version. A shell-less frame now reports its version: the backend records `current_version` from the upgrade status into `last_successful_deploy.frameos_version` (nothing else in the baseline moves), and the runtime's bootup line now carries `version` so the backend also learns it on every boot (from the next runtime release). The sync/fast-deploy baseline keeps the device-reported version instead of stamping the backend's. Once the poll reaches a terminal status the frame and deploy plan are re-read.
4. **"Check for updates" showed `update available` and, under it, `up_to_date: already on the latest stable release`; after the upgrade "success … Restarting services" stuck forever.** The device's `upgrade-status.json` is the record of its last run and was rendered as the current answer. Finished runs are now a dated "Last upgrade: …" line, in-flight statuses stay live, and a stale `up_to_date` is dropped once a newer release exists.
5. **Gray frame icon with a release waiting.** The change details skipped the version gap for shell-less frames entirely. It is now a change of its own ("FrameOS a -> b (the frame installs it itself: Update FrameOS)"), so the rail icon goes brass and the drawer names it; it clears when the device reports the new version.

`docs/manual-testing-todo.md`: the shell-less "Update FrameOS" box moved to Done with these findings; the "round two" box notes the network-settings cause.

## Verified
Backend: 136 tests across `test_frames.py` (sync/adopt/upgrade, three new tests: cached session + 401 reopen + credential rotation, version recorded from the upgrade status and kept by the sync snapshot) and `test_log.py` (bootup version updates a shell-less baseline, SSH frames ignore it). Frontend `tsc`, kea-typegen, prettier; shared-spa vitest for frame change details, the deploy dialog, frame settings and the new mirror test (39). Nim runtime compiles. Not run on hardware: needs the next add-on and runtime release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaUJwpd41L3VeQQGgAHWHY