### PR TITLE
Review todo: fifth cut item 1, scene editor correctness and the first editor tests

### DIFF
--- a/cloud/apps/auth-web/src/test/shared-spa/app-node-logic.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/app-node-logic.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+//
+// appNodeLogic — the per-node view over diagramLogic that every node
+// component reads (its node, its edges, the field inputs and outputs wired
+// through handles) — built headlessly against the embedded editor's
+// frameLogic shim. The 2026-09 review found it had no tests; this also pins
+// `deleteCodeField`, which replaced a rename branch that wrote a key the node
+// data does not have: deleting a code argument takes its edge, and the code
+// node that existed only to feed it, but never a shared source node.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initKea } from "../../../../../../frontend/src/initKea";
+import type { DiagramEdge, DiagramNode, FrameScene, FrameType } from "../../../../../../frontend/src/types";
+
+vi.mock("../../../../../../frontend/src/scenes/frame/frameLogic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../../../frontend/src/scenes/frame/frameLogic")>();
+  const { embedFrameLogic } = await import("../../../../../../frontend/src/embed/embedFrameLogic");
+  return { ...actual, frameLogic: embedFrameLogic };
+});
+vi.mock("../../../../../../frontend/src/scenes/frame/panels/Logs/logsLogic", async () => {
+  return await import("../../../../../../frontend/src/embed/logsLogicShim");
+});
+
+import { embedFrameLogic } from "../../../../../../frontend/src/embed/embedFrameLogic";
+import { appNodeLogic } from "../../../../../../frontend/src/scenes/frame/panels/Diagram/appNodeLogic";
+import { diagramLogic } from "../../../../../../frontend/src/scenes/frame/panels/Diagram/diagramLogic";
+
+const frameId = 1 as unknown as FrameType["id"];
+const sceneId = "app-node-scene";
+
+const node = (id: string, type: string, data: Record<string, unknown>, x = 0): DiagramNode =>
+  ({ id, type, position: { x, y: 0 }, data }) as DiagramNode;
+
+const edge = (id: string, source: string, sourceHandle: string, target: string, targetHandle: string): DiagramEdge =>
+  ({ id, source, sourceHandle, target, targetHandle }) as DiagramEdge;
+
+// render → weather (app) → target (code, arguments a and b)
+//   a  ← "onlyA"  (a code node with no other connection: dedicated)
+//   b  ← "weather" (which also feeds "other": shared)
+const scene = {
+  id: sceneId,
+  name: "App node",
+  nodes: [
+    node("render", "event", { keyword: "render" }),
+    node("weather", "app", { keyword: "weather", config: { city: "Tallinn" } }, 100),
+    node("target", "code", { code: "a + b", codeArgs: [{ name: "a", type: "string" }, { name: "b", type: "string" }] }, 200),
+    node("onlyA", "code", { code: "'A'" }, 300),
+    node("other", "code", { code: "shared", codeArgs: [{ name: "shared", type: "string" }] }, 400),
+  ],
+  edges: [
+    edge("e-render-weather", "render", "next", "weather", "prev"),
+    edge("e-weather-city", "onlyA", "fieldOutput", "weather", "fieldInput/city"),
+    edge("e-a", "onlyA", "fieldOutput", "target", "codeField/a"),
+    edge("e-b", "weather", "fieldOutput", "target", "codeField/b"),
+    edge("e-shared", "weather", "fieldOutput", "other", "codeField/shared"),
+    edge("e-out", "weather", "field/city", "render", "prev"),
+  ],
+  fields: [],
+  customEvents: [],
+  settings: { execution: "interpreted" },
+} as unknown as FrameScene;
+
+type EmbedTestWindow = Window & { FRAMEOS_EMBEDDED_NO_BACKEND?: boolean };
+const testWindow = window as EmbedTestWindow;
+
+let unmount: (() => void)[] = [];
+
+function mountNode(nodeId: string): ReturnType<typeof appNodeLogic> {
+  const logic = appNodeLogic({ frameId, sceneId, nodeId });
+  unmount.push(logic.mount());
+  return logic;
+}
+
+function sceneInForm(): FrameScene {
+  return embedFrameLogic({ frameId }).values.frameForm.scenes!.find((candidate) => candidate.id === sceneId)!;
+}
+
+beforeEach(() => {
+  testWindow.FRAMEOS_EMBEDDED_NO_BACKEND = true;
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("null", { status: 404 })));
+  initKea({ memoryRouter: true });
+  embedFrameLogic({ frameId }).mount();
+  embedFrameLogic({ frameId }).actions.initEmbedFrame({
+    id: frameId,
+    name: "Embedded",
+    scenes: [scene],
+    width: 800,
+    height: 480,
+  } as Partial<FrameType>);
+  unmount = [diagramLogic({ frameId, sceneId }).mount()];
+});
+
+afterEach(() => {
+  for (const fn of unmount.reverse()) {
+    fn();
+  }
+  vi.unstubAllGlobals();
+  delete testWindow.FRAMEOS_EMBEDDED_NO_BACKEND;
+});
+
+describe("appNodeLogic selectors", () => {
+  it("finds its node and only the edges touching it", () => {
+    const logic = mountNode("weather");
+    expect(logic.values.nodeId).toBe("weather");
+    expect(logic.values.node?.type).toBe("app");
+    expect(logic.values.nodeConfig).toEqual({ city: "Tallinn" });
+    expect(logic.values.nodeEdges.map((e) => e.id).sort()).toEqual([
+      "e-b",
+      "e-out",
+      "e-render-weather",
+      "e-shared",
+      "e-weather-city",
+    ]);
+    expect(mountNode("missing").values.node).toBeNull();
+  });
+
+  it("lists the fields wired in through fieldInput handles and out through field handles", () => {
+    const logic = mountNode("weather");
+    expect(logic.values.codeArgs).toEqual(["city"]);
+    expect(logic.values.fieldInputFields).toEqual(["city"]);
+    expect(logic.values.nodeOutputFields).toEqual(["city"]);
+    const target = mountNode("target");
+    // codeField/ handles are the code node's own arguments, not field inputs.
+    expect(target.values.fieldInputFields).toEqual([]);
+    expect(target.values.nodeOutputFields).toEqual([]);
+  });
+
+  it("follows the diagram's selection", () => {
+    const logic = mountNode("weather");
+    expect(logic.values.isSelected).toBe(false);
+    logic.actions.select();
+    expect(logic.values.isSelected).toBe(true);
+    expect(diagramLogic({ frameId, sceneId }).values.selectedNode?.id).toBe("weather");
+    mountNode("render").actions.select();
+    expect(logic.values.isSelected).toBe(false);
+  });
+});
+
+describe("appNodeLogic deleteCodeField", () => {
+  it("removes the argument, its edge and the code node that existed only for it", () => {
+    const logic = mountNode("target");
+    logic.actions.deleteCodeField("a");
+    const diagram = diagramLogic({ frameId, sceneId });
+    expect((logic.values.node?.data as { codeArgs: { name: string }[] }).codeArgs.map((a) => a.name)).toEqual(["b"]);
+    expect(diagram.values.rawEdges.map((e) => e.id).sort()).toEqual([
+      "e-b",
+      "e-out",
+      "e-render-weather",
+      "e-shared",
+      "e-weather-city",
+    ]);
+    // "onlyA" also feeds weather's city, so it is not dedicated to `a`.
+    expect(diagram.values.nodes.map((n) => n.id)).toContain("onlyA");
+  });
+
+  it("deletes a code node whose only connection was the argument", () => {
+    const diagram = diagramLogic({ frameId, sceneId });
+    diagram.actions.setEdges(diagram.values.rawEdges.filter((e) => e.id !== "e-weather-city"));
+    const logic = mountNode("target");
+    logic.actions.deleteCodeField("a");
+    expect(diagram.values.nodes.map((n) => n.id)).not.toContain("onlyA");
+    expect(diagram.values.rawEdges.find((e) => e.id === "e-a")).toBeUndefined();
+    expect(sceneInForm().nodes.map((n) => n.id)).not.toContain("onlyA");
+    expect(sceneInForm().edges.map((e) => e.id)).not.toContain("e-a");
+  });
+
+  it("keeps a shared source node and only drops the edge", () => {
+    const logic = mountNode("target");
+    logic.actions.deleteCodeField("b");
+    const diagram = diagramLogic({ frameId, sceneId });
+    expect((logic.values.node?.data as { codeArgs: { name: string }[] }).codeArgs.map((a) => a.name)).toEqual(["a"]);
+    expect(diagram.values.nodes.map((n) => n.id)).toContain("weather");
+    expect(diagram.values.rawEdges.find((e) => e.id === "e-b")).toBeUndefined();
+    expect(diagram.values.rawEdges.find((e) => e.id === "e-shared")).toBeDefined();
+    expect((sceneInForm().nodes.find((n) => n.id === "target")?.data as { codeArgs: unknown[] }).codeArgs).toHaveLength(
+      1
+    );
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/diagram-clipboard.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/diagram-clipboard.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+//
+// The scene editor's copy, paste and "has this scene changed" logic, built
+// headlessly against the embedded editor's frameLogic shim (the same alias
+// frontend/build.mjs applies). The 2026-09 review found diagramLogic had no
+// tests at all; this pins the clipboard payload shapes (a bare node for one
+// node, {nodes, edges} for a selection, secrets stripped either way), the
+// same-tab paste fallback used when navigator.clipboard is missing (the
+// default http://<ip>:8989 self-hosted deployment), id remapping on paste,
+// and that hasChanges compares against the stored frame, not the form.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initKea } from "../../../../../../frontend/src/initKea";
+import type { AppConfig, DiagramNode, FrameScene, FrameType } from "../../../../../../frontend/src/types";
+
+vi.mock("../../../../../../frontend/src/scenes/frame/frameLogic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../../../frontend/src/scenes/frame/frameLogic")>();
+  const { embedFrameLogic } = await import("../../../../../../frontend/src/embed/embedFrameLogic");
+  return { ...actual, frameLogic: embedFrameLogic };
+});
+vi.mock("../../../../../../frontend/src/scenes/frame/panels/Logs/logsLogic", async () => {
+  return await import("../../../../../../frontend/src/embed/logsLogicShim");
+});
+// The package lives only in frontend/node_modules (this workspace does not
+// depend on it), so the mock names the resolved file.
+const copyToClipboard = vi.fn();
+vi.mock("../../../../../../frontend/node_modules/copy-to-clipboard/index.js", () => ({
+  default: (text: string) => copyToClipboard(text),
+}));
+
+import { embedFrameLogic } from "../../../../../../frontend/src/embed/embedFrameLogic";
+import { appsModel } from "../../../../../../frontend/src/models/appsModel";
+import { framesModel } from "../../../../../../frontend/src/models/framesModel";
+import { diagramLogic } from "../../../../../../frontend/src/scenes/frame/panels/Diagram/diagramLogic";
+
+const frameId = 1 as unknown as FrameType["id"];
+const sceneId = "clipboard-scene";
+
+const renderNode: DiagramNode = {
+  id: "render",
+  type: "event",
+  position: { x: 0, y: 0 },
+  data: { keyword: "render" },
+} as DiagramNode;
+
+// A catalog app with one secret field, the way an API key is declared.
+const weatherApp: AppConfig = {
+  name: "Weather",
+  category: "data",
+  fields: [
+    { name: "city", type: "string", label: "City", value: "" },
+    { name: "apiKey", type: "string", label: "API key", value: "", secret: true },
+  ],
+} as unknown as AppConfig;
+
+const weatherNode: DiagramNode = {
+  id: "weather",
+  type: "app",
+  position: { x: 100, y: 100 },
+  data: { keyword: "weather", config: { city: "Tallinn", apiKey: "sk-secret" } },
+} as DiagramNode;
+
+const scene = {
+  id: sceneId,
+  name: "Clipboard",
+  nodes: [renderNode, weatherNode],
+  // No `type` on the edge, as in a hand-written, imported or AI-built scene:
+  // the editor only stamps its render type in the `edges` selector, and
+  // hasChanges used to compare those decorated edges with the stored ones, so
+  // such a scene showed as changed from the moment it opened.
+  edges: [
+    {
+      id: "e-render-weather",
+      source: "render",
+      sourceHandle: "next",
+      target: "weather",
+      targetHandle: "prev",
+    },
+  ],
+  fields: [],
+  customEvents: [],
+  settings: { execution: "interpreted" },
+} as unknown as FrameScene;
+
+const frame = { id: frameId, name: "Embedded", scenes: [scene], width: 800, height: 480 } as Partial<FrameType>;
+
+type EmbedTestWindow = Window & { FRAMEOS_EMBEDDED_NO_BACKEND?: boolean };
+const testWindow = window as EmbedTestWindow;
+
+function sceneInForm(): FrameScene {
+  return embedFrameLogic({ frameId }).values.frameForm.scenes!.find((candidate) => candidate.id === sceneId)!;
+}
+
+function lastCopied(): unknown {
+  return JSON.parse(copyToClipboard.mock.calls.at(-1)?.[0] as string);
+}
+
+let unmountDiagram: () => void = () => {};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  copyToClipboard.mockClear();
+  testWindow.FRAMEOS_EMBEDDED_NO_BACKEND = true;
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("null", { status: 404 })));
+  initKea({ memoryRouter: true });
+  appsModel.mount();
+  appsModel.actions.loadAppsSuccess({ weather: weatherApp });
+  framesModel.mount();
+  framesModel.actions.addFrame(frame as FrameType);
+  embedFrameLogic({ frameId }).mount();
+  embedFrameLogic({ frameId }).actions.initEmbedFrame(frame);
+  unmountDiagram = diagramLogic({ frameId, sceneId }).mount();
+});
+
+afterEach(() => {
+  unmountDiagram();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  delete testWindow.FRAMEOS_EMBEDDED_NO_BACKEND;
+});
+
+describe("diagramLogic hasChanges", () => {
+  it("is false while the diagram matches the stored frame and true once a node is added", () => {
+    const logic = diagramLogic({ frameId, sceneId });
+    expect(logic.values.hasChanges).toBe(false);
+    logic.actions.setNodes([...logic.values.nodes, { ...renderNode, id: "second", position: { x: 10, y: 10 } }]);
+    expect(logic.values.hasChanges).toBe(true);
+    // Selection is a view concern, not a change.
+    logic.actions.setNodes(logic.values.nodes.filter((node) => node.id !== "second"));
+    expect(logic.values.hasChanges).toBe(false);
+    logic.actions.selectNode("render");
+    expect(logic.values.nodes.find((node) => node.id === "render")?.selected).toBe(true);
+    expect(logic.values.hasChanges).toBe(false);
+  });
+
+  it("clears once the stored frame catches up with the form", () => {
+    const logic = diagramLogic({ frameId, sceneId });
+    logic.actions.setNodes([...logic.values.nodes, { ...renderNode, id: "second", position: { x: 10, y: 10 } }]);
+    expect(logic.values.hasChanges).toBe(true);
+    framesModel.actions.addFrame({ ...frame, scenes: [sceneInForm()] } as FrameType);
+    expect(logic.values.hasChanges).toBe(false);
+  });
+});
+
+describe("diagramLogic copy", () => {
+  it("copies one unselected node as a bare node, without its secrets or view state", () => {
+    const logic = diagramLogic({ frameId, sceneId });
+    logic.actions.setNodes(logic.values.nodes.map((node) => ({ ...node, selected: false })));
+    logic.actions.copyAppJSON("weather");
+    const copied = lastCopied() as DiagramNode;
+    expect(copied.id).toBe("weather");
+    expect("nodes" in copied).toBe(false);
+    expect((copied.data as { config: Record<string, unknown> }).config).toEqual({ city: "Tallinn" });
+    expect("selected" in copied).toBe(false);
+  });
+
+  it("copies a selection as {nodes, edges} keeping only edges inside the selection", () => {
+    const logic = diagramLogic({ frameId, sceneId });
+    const stray = { ...renderNode, id: "stray", selected: false, position: { x: 300, y: 300 } };
+    logic.actions.setNodesAndEdges(
+      [...logic.values.nodes.map((node) => ({ ...node, selected: true })), stray],
+      [...logic.values.rawEdges, { id: "e-stray", source: "weather", sourceHandle: "next", target: "stray", targetHandle: "prev" }]
+    );
+    logic.actions.copySelectedNodes();
+    const copied = lastCopied() as { nodes: DiagramNode[]; edges: { id: string }[] };
+    expect(copied.nodes.map((node) => node.id).sort()).toEqual(["render", "weather"]);
+    expect(copied.edges.map((edge) => edge.id)).toEqual(["e-render-weather"]);
+    expect((copied.nodes.find((node) => node.id === "weather")!.data as { config: unknown }).config).toEqual({
+      city: "Tallinn",
+    });
+  });
+});
+
+describe("diagramLogic paste", () => {
+  it("falls back to the last copied payload and pastes fresh, selected, remapped copies", async () => {
+    const logic = diagramLogic({ frameId, sceneId });
+    expect(navigator.clipboard).toBeUndefined();
+    logic.actions.setNodes(logic.values.nodes.map((node) => ({ ...node, selected: true })));
+    logic.actions.copySelectedNodes();
+    await logic.asyncActions.pasteFromClipboard();
+    vi.advanceTimersByTime(300);
+
+    const nodes = logic.values.nodes;
+    expect(nodes).toHaveLength(4);
+    const pasted = nodes.filter((node) => !["render", "weather"].includes(node.id));
+    expect(pasted).toHaveLength(2);
+    for (const node of pasted) {
+      expect(node.selected).toBe(true);
+      expect(node.id).not.toMatch(/^(render|weather)$/);
+    }
+    for (const node of nodes.filter((node) => ["render", "weather"].includes(node.id))) {
+      expect(node.selected).toBeFalsy();
+    }
+    // Pasted copies land offset from the originals, not on top of them.
+    const pastedRender = pasted.find((node) => node.type === "event")!;
+    expect(pastedRender.position).toEqual({ x: 40, y: 40 });
+
+    const edges = logic.values.rawEdges;
+    expect(edges).toHaveLength(2);
+    const pastedIds = new Set(pasted.map((node) => node.id));
+    const pastedEdge = edges.find((edge) => edge.id !== "e-render-weather")!;
+    expect(pastedIds.has(pastedEdge.source)).toBe(true);
+    expect(pastedIds.has(pastedEdge.target)).toBe(true);
+    expect(pastedEdge.selected).toBeFalsy();
+
+    expect(sceneInForm().nodes).toHaveLength(4);
+    expect(sceneInForm().edges).toHaveLength(2);
+    expect(logic.values.hasChanges).toBe(true);
+  });
+
+  it("pastes a bare node payload as one new node", async () => {
+    const logic = diagramLogic({ frameId, sceneId });
+    logic.actions.setNodes(logic.values.nodes.map((node) => ({ ...node, selected: false })));
+    logic.actions.copyAppJSON("weather");
+    await logic.asyncActions.pasteFromClipboard();
+    vi.advanceTimersByTime(300);
+    expect(logic.values.nodes).toHaveLength(3);
+    const pasted = logic.values.nodes.find((node) => node.selected)!;
+    expect(pasted.id).not.toBe("weather");
+    expect(pasted.type).toBe("app");
+    expect((pasted.data as { config: Record<string, unknown> }).config).toEqual({ city: "Tallinn" });
+    expect(logic.values.rawEdges).toHaveLength(1);
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/scene-json-logic.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/scene-json-logic.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+//
+// The scene JSON editor's logic, built headlessly against the embedded
+// editor's frameLogic shim (the alias frontend/build.mjs applies). Pins how a
+// scene is printed, when the editor counts as changed or broken, and that a
+// save goes through sanitizeScene: the embed's updateScene does not sanitize,
+// so hand-typed JSON with a node lacking `position` used to take reactflow
+// down — the exact crash sanitizeIncomingScenes guards against inbound
+// (2026-09 review).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initKea } from "../../../../../../frontend/src/initKea";
+import type { FrameScene, FrameType } from "../../../../../../frontend/src/types";
+
+vi.mock("../../../../../../frontend/src/scenes/frame/frameLogic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../../../frontend/src/scenes/frame/frameLogic")>();
+  const { embedFrameLogic } = await import("../../../../../../frontend/src/embed/embedFrameLogic");
+  return { ...actual, frameLogic: embedFrameLogic };
+});
+vi.mock("../../../../../../frontend/src/scenes/frame/panels/Logs/logsLogic", async () => {
+  return await import("../../../../../../frontend/src/embed/logsLogicShim");
+});
+
+import { embedFrameLogic } from "../../../../../../frontend/src/embed/embedFrameLogic";
+import { sceneJSONLogic } from "../../../../../../frontend/src/scenes/frame/panels/SceneJSON/sceneJSONLogic";
+
+const frameId = 1 as unknown as FrameType["id"];
+const sceneId = "json-scene";
+
+const scene = {
+  id: sceneId,
+  name: "JSON",
+  nodes: [{ id: "render", type: "event", position: { x: 0, y: 0 }, data: { keyword: "render" } }],
+  edges: [],
+  fields: [],
+  customEvents: [],
+  settings: { execution: "interpreted", refreshInterval: 60, backgroundColor: "#000000" },
+} as unknown as FrameScene;
+
+type EmbedTestWindow = Window & { FRAMEOS_EMBEDDED_NO_BACKEND?: boolean };
+const testWindow = window as EmbedTestWindow;
+
+function sceneInForm(): FrameScene {
+  return embedFrameLogic({ frameId }).values.frameForm.scenes!.find((candidate) => candidate.id === sceneId)!;
+}
+
+function logic() {
+  return sceneJSONLogic({ frameId, sceneId });
+}
+
+let unmount: () => void = () => {};
+
+beforeEach(() => {
+  testWindow.FRAMEOS_EMBEDDED_NO_BACKEND = true;
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("null", { status: 404 })));
+  initKea({ memoryRouter: true });
+  embedFrameLogic({ frameId }).mount();
+  embedFrameLogic({ frameId }).actions.initEmbedFrame({
+    id: frameId,
+    name: "Embedded",
+    scenes: [scene],
+    width: 800,
+    height: 480,
+  } as Partial<FrameType>);
+  unmount = logic().mount();
+});
+
+afterEach(() => {
+  unmount();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete testWindow.FRAMEOS_EMBEDDED_NO_BACKEND;
+});
+
+describe("sceneJSONLogic", () => {
+  it("prints the scene with id, name, settings, fields, nodes, edges first and no default key", () => {
+    const printed = JSON.parse(logic().values.sceneJSON) as Record<string, unknown>;
+    expect(Object.keys(printed).slice(0, 6)).toEqual(["id", "name", "settings", "fields", "nodes", "edges"]);
+    expect("default" in printed).toBe(false);
+    expect(printed.name).toBe("JSON");
+    expect(logic().values.sceneName).toBe("JSON");
+  });
+
+  it("counts as changed only while the text differs from the printed scene", () => {
+    expect(logic().values.hasChanges).toBe(false);
+    const printed = logic().values.sceneJSON;
+    logic().actions.setEditedSceneJSON(printed.replace('"JSON"', '"Renamed"'));
+    expect(logic().values.hasChanges).toBe(true);
+    logic().actions.setEditedSceneJSON(printed);
+    expect(logic().values.hasChanges).toBe(false);
+  });
+
+  it("flags unparsable text", () => {
+    expect(logic().values.hasError).toBe(false);
+    logic().actions.setEditedSceneJSON("{ not json");
+    expect(logic().values.hasError).toBe(true);
+    expect(logic().values.hasChanges).toBe(true);
+  });
+
+  it("saves valid JSON into the frame form, keeping the scene id, and clears the draft", async () => {
+    const edited = { ...JSON.parse(logic().values.sceneJSON), id: "someone-else", name: "Renamed" };
+    logic().actions.setEditedSceneJSON(JSON.stringify(edited));
+    await logic().asyncActions.saveChanges();
+    expect(sceneInForm().name).toBe("Renamed");
+    expect(sceneInForm().id).toBe(sceneId);
+    expect(embedFrameLogic({ frameId }).values.frameForm.scenes).toHaveLength(1);
+    expect(logic().values.editedSceneJSON).toBe(null);
+    expect(logic().values.hasChanges).toBe(false);
+  });
+
+  it("gives a saved node without a position somewhere to be", async () => {
+    const edited = JSON.parse(logic().values.sceneJSON) as FrameScene;
+    edited.nodes = [...edited.nodes, { id: "code", type: "code", data: { code: "1 + 1" } } as FrameScene["nodes"][number]];
+    logic().actions.setEditedSceneJSON(JSON.stringify(edited));
+    await logic().asyncActions.saveChanges();
+    const saved = sceneInForm().nodes.find((node) => node.id === "code");
+    expect(saved).toBeDefined();
+    expect(Number.isFinite(saved?.position?.x)).toBe(true);
+    expect(Number.isFinite(saved?.position?.y)).toBe(true);
+  });
+
+  it("leaves the scene untouched on a JSON array or invalid JSON", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const before = sceneInForm();
+    logic().actions.setEditedSceneJSON("[1, 2]");
+    await logic().asyncActions.saveChanges();
+    expect(sceneInForm()).toBe(before);
+    logic().actions.setEditedSceneJSON("{ nope");
+    await logic().asyncActions.saveChanges();
+    expect(sceneInForm()).toBe(before);
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(logic().values.editedSceneJSON).toBe("{ nope");
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/select-missing-value.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/select-missing-value.test.tsx
@@ -1,0 +1,86 @@
+// <Select> (frontend/src/components/Select.tsx) with a value that is not
+// among its options. A native <select> then shows the first option while the
+// form still holds the stored value — a field pointing at a renamed scene or
+// state key looked like it had picked the first entry and saved the stale
+// one (2026-09 review). The component now renders the stored value as an
+// extra first option so what is shown is what gets saved.
+
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Select } from "../../../../../../frontend/src/components/Select";
+
+const options = [
+  { value: "one", label: "One" },
+  { value: "two", label: "Two" },
+];
+
+function optionValues(html: string): string[] {
+  return Array.from(html.matchAll(/<option[^>]*value="([^"]*)"/g)).map((m) => m[1] ?? "");
+}
+
+function selectedValue(html: string): string | null {
+  const match = html.match(/<option[^>]*\bselected=""[^>]*value="([^"]*)"|<option[^>]*value="([^"]*)"[^>]*\bselected=""/);
+  return match ? (match[1] ?? match[2] ?? null) : null;
+}
+
+describe("<Select> with a value outside its options", () => {
+  it("renders nothing extra when the value is an option", () => {
+    const html = renderToStaticMarkup(<Select value="two" options={options} onChange={() => {}} />);
+    expect(optionValues(html)).toEqual(["one", "two"]);
+    expect(selectedValue(html)).toBe("two");
+  });
+
+  it("renders the stored value as a marked first option and keeps it selected", () => {
+    const html = renderToStaticMarkup(<Select value="gone" options={options} onChange={() => {}} />);
+    expect(optionValues(html)).toEqual(["gone", "one", "two"]);
+    expect(html).toContain(">gone (not an option)</option>");
+    expect(selectedValue(html)).toBe("gone");
+  });
+
+  it("leaves the empty string to the browser (placeholder idiom)", () => {
+    const html = renderToStaticMarkup(<Select value="" options={options} onChange={() => {}} />);
+    expect(optionValues(html)).toEqual(["one", "two"]);
+    expect(html).not.toContain("not an option");
+    const nullHtml = renderToStaticMarkup(<Select value={null as unknown as string} options={options} />);
+    expect(optionValues(nullHtml)).toEqual(["one", "two"]);
+  });
+
+  it("finds a value inside an optgroup", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        value="deep"
+        options={[{ label: "Group", options: [{ value: "deep", label: "Deep" }] }, ...options]}
+        onChange={() => {}}
+      />,
+    );
+    expect(optionValues(html)).toEqual(["deep", "one", "two"]);
+    expect(html).not.toContain("not an option");
+    expect(selectedValue(html)).toBe("deep");
+  });
+
+  it("matches numeric option values against a string value", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        value="2"
+        options={[
+          { value: 1, label: "One" },
+          { value: 2, label: "Two" },
+        ]}
+        onChange={() => {}}
+      />,
+    );
+    expect(optionValues(html)).toEqual(["1", "2"]);
+    expect(html).not.toContain("not an option");
+  });
+
+  it("does not throw on a non-string label", () => {
+    const html = renderToStaticMarkup(
+      <Select
+        value="x"
+        options={[{ value: "x", label: { nested: true } as unknown as string }, { value: "y", label: 3 as unknown as string }]}
+      />,
+    );
+    expect(optionValues(html)).toEqual(["x", "y"]);
+    expect(html).toContain(">3</option>");
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/select-options.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/select-options.test.ts
@@ -1,0 +1,114 @@
+// The select-field option helpers (frontend/src/utils/selectOptions.ts):
+// every reader of `field.options` goes through them because scenes are
+// hand-edited, imported and AI-written, so options arrive as strings,
+// numbers, `{ value, label }` pairs or half-filled objects. Pins the
+// canonical storage shape, the reference-preserving normalizer the save
+// path relies on, and the `value | Label` textarea round-trip.
+
+import { describe, expect, it } from "vitest";
+import {
+  normalizeFieldOptions,
+  normalizeSelectOptions,
+  selectFieldOptions,
+  selectFieldValues,
+  selectOptionsFromText,
+  selectOptionsToText,
+} from "../../../../../../frontend/src/utils/selectOptions";
+
+describe("selectFieldOptions", () => {
+  it("reads strings, numbers, booleans and labelled pairs, dropping garbage", () => {
+    expect(
+      selectFieldOptions([
+        "a",
+        2,
+        true,
+        { value: "b", label: "Bee" },
+        { value: 3 },
+        { label: "no value" },
+        null,
+        undefined,
+        ["nested"],
+        { value: { deep: true } },
+      ]),
+    ).toEqual([
+      { value: "a", label: "a" },
+      { value: "2", label: "2" },
+      { value: "true", label: "true" },
+      { value: "b", label: "Bee" },
+      { value: "3", label: "3" },
+    ]);
+  });
+
+  it("falls back to the value when a label is not a scalar", () => {
+    expect(selectFieldOptions([{ value: "x", label: { nested: true } }, { value: "y", label: 7 }])).toEqual([
+      { value: "x", label: "x" },
+      { value: "y", label: "7" },
+    ]);
+  });
+
+  it("returns nothing for a non-array", () => {
+    expect(selectFieldOptions("a,b")).toEqual([]);
+    expect(selectFieldOptions(undefined)).toEqual([]);
+    expect(selectFieldValues(null)).toEqual([]);
+  });
+
+  it("selectFieldValues is just the values", () => {
+    expect(selectFieldValues(["a", { value: "b", label: "Bee" }, 4])).toEqual(["a", "b", "4"]);
+  });
+});
+
+describe("normalizeSelectOptions", () => {
+  it("stores a plain string unless the option carries its own label", () => {
+    expect(normalizeSelectOptions(["a", { value: "b", label: "Bee" }, { value: "c", label: "c" }, 4])).toEqual([
+      "a",
+      { value: "b", label: "Bee" },
+      "c",
+      "4",
+    ]);
+  });
+});
+
+describe("normalizeFieldOptions", () => {
+  it("returns the same object when the options are already canonical", () => {
+    const field = { name: "size", type: "select", options: ["s", { value: "m", label: "Medium" }] };
+    expect(normalizeFieldOptions(field)).toBe(field);
+  });
+
+  it("returns a canonicalized copy otherwise, leaving the input alone", () => {
+    const field = { name: "size", type: "select", options: [1, { value: "m", label: "m" }, { value: "l", label: "Large", extra: 1 }] };
+    const normalized = normalizeFieldOptions(field);
+    expect(normalized).not.toBe(field);
+    expect(normalized.options).toEqual(["1", "m", { value: "l", label: "Large" }]);
+    expect(field.options).toHaveLength(3);
+    expect(field.options[0]).toBe(1);
+  });
+
+  it("leaves a field without options untouched", () => {
+    const field = { name: "city", type: "string" };
+    expect(normalizeFieldOptions(field)).toBe(field);
+    expect(normalizeFieldOptions(null)).toBe(null);
+    expect(normalizeFieldOptions(undefined)).toBe(undefined);
+  });
+});
+
+describe("options textarea round-trip", () => {
+  it("prints one option per line, `value | Label` when labelled", () => {
+    expect(selectOptionsToText(["a", { value: "b", label: "Bee" }])).toBe("a\nb | Bee");
+  });
+
+  it("parses back to the canonical shape", () => {
+    const text = selectOptionsToText(["a", { value: "b", label: "Bee" }]);
+    expect(selectOptionsFromText(text)).toEqual(["a", { value: "b", label: "Bee" }]);
+  });
+
+  it("collapses a label equal to its value, and trims around the separator", () => {
+    expect(selectOptionsFromText("b | b\n c |  Sea ")).toEqual(["b", { value: "c", label: "Sea" }]);
+  });
+
+  it("cannot express a label containing `|` (known limitation, 2026-09 review)", () => {
+    // The first `|` is the separator, so the rest of the line is the label:
+    // a label that itself holds a `|` survives a round-trip but a value never can.
+    expect(selectOptionsFromText("x | y | z")).toEqual([{ value: "x", label: "y | z" }]);
+    expect(selectOptionsToText(selectOptionsFromText("x | y | z"))).toBe("x | y | z");
+  });
+});

--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -95,6 +95,14 @@
     // reach frameLogic / duplicateScenes. Vitest still runs both; only tsc
     // leaves them out.
     "src/test/shared-spa/diagram-history.test.ts",
-    "src/test/shared-spa/editor-export-secrets.test.ts"
+    "src/test/shared-spa/editor-export-secrets.test.ts",
+    // The first scene-editor logic tests (2026-09 review §11): diagramLogic
+    // clipboard, appNodeLogic, sceneJSONLogic against the embed shim, and the
+    // shared <Select>, all reaching frontend/src.
+    "src/test/shared-spa/diagram-clipboard.test.ts",
+    "src/test/shared-spa/app-node-logic.test.ts",
+    "src/test/shared-spa/scene-json-logic.test.ts",
+    "src/test/shared-spa/select-options.test.ts",
+    "src/test/shared-spa/select-missing-value.test.tsx"
   ]
 }

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -75,6 +75,12 @@ export default tseslint.config(
       "**/src/test/shared-spa/diagram-history.test.ts",
       "**/src/test/shared-spa/editor-export-secrets.test.ts",
       "**/src/test/shared-spa/preview-key-consent.test.ts",
+      // The scene-editor logic tests (2026-09 review §11), same reason.
+      "**/src/test/shared-spa/diagram-clipboard.test.ts",
+      "**/src/test/shared-spa/app-node-logic.test.ts",
+      "**/src/test/shared-spa/scene-json-logic.test.ts",
+      "**/src/test/shared-spa/select-options.test.ts",
+      "**/src/test/shared-spa/select-missing-value.test.tsx",
     ],
   },
   js.configs.recommended,

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -42,7 +42,28 @@ function renderOption(option: SelectOption): JSX.Element {
   )
 }
 
+function optionValues(options: SelectOptionEntry[]): Set<string> {
+  const values = new Set<string>()
+  for (const option of options) {
+    if (isOptionGroup(option)) {
+      option.options.forEach((entry) => values.add(String(entry.value)))
+    } else {
+      values.add(String(option.value))
+    }
+  }
+  return values
+}
+
 export function Select({ className, onChange, options, theme, value, ...props }: SelectProps) {
+  // A native <select> whose value matches no <option> shows the first option
+  // while the form still holds the old value: a field pointing at a scene or
+  // state key that was renamed looked like it had picked the first entry, and
+  // saving kept the stale one. Show the stored value instead, so what the user
+  // sees is what gets saved.
+  // An empty string is the placeholder idiom ("nothing chosen") and is left
+  // to the browser.
+  const stored = value === null || value === undefined || Array.isArray(value) ? '' : String(value)
+  const missing = stored !== '' && !optionValues(options).has(stored)
   return (
     <select
       className={clsx(
@@ -56,6 +77,11 @@ export function Select({ className, onChange, options, theme, value, ...props }:
       {...(value === null ? { value: '' } : value !== undefined ? { value } : {})}
       {...props}
     >
+      {missing ? (
+        <option key={`missing:${stored}`} value={stored}>
+          {`${stored} (not an option)`}
+        </option>
+      ) : null}
       {options.map((option) =>
         isOptionGroup(option) ? (
           <optgroup key={option.label} label={option.label}>

--- a/frontend/src/scenes/frame/frameEditorsLogic.ts
+++ b/frontend/src/scenes/frame/frameEditorsLogic.ts
@@ -1,4 +1,17 @@
-import { MakeLogicType, actions, BuiltLogic, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import {
+  MakeLogicType,
+  actions,
+  beforeUnmount,
+  BuiltLogic,
+  connect,
+  kea,
+  key,
+  listeners,
+  path,
+  props,
+  reducers,
+  selectors,
+} from 'kea'
 import { AppNodeData, FrameId } from '../../types'
 
 import { frameLogic } from './frameLogic'
@@ -120,6 +133,28 @@ export type frameEditorsLogicType = MakeLogicType<
 > &
   frameEditorsLogicMeta
 
+/** The editor logics each mounted workspace keeps alive, by editor key —
+ * module state keyed by logic path rather than `cache`, because under
+ * StrictMode / Fast Refresh kea can run afterMount on one built object and
+ * beforeUnmount on another for the same path (see diagramLogic). */
+const persistedEditors = new Map<string, Map<string, () => void>>()
+
+function unmountPersistedEditors(pathString: string, matches: (editorKey: string) => boolean): void {
+  const persisted = persistedEditors.get(pathString)
+  if (!persisted) {
+    return
+  }
+  for (const [editorKey, unmount] of Array.from(persisted.entries())) {
+    if (matches(editorKey)) {
+      persisted.delete(editorKey)
+      unmount()
+    }
+  }
+  if (persisted.size === 0) {
+    persistedEditors.delete(pathString)
+  }
+}
+
 export const frameEditorsLogic = kea<frameEditorsLogicType>([
   path(['src', 'scenes', 'frame', 'frameEditorsLogic']),
   props({} as FrameEditorsLogicProps),
@@ -234,34 +269,33 @@ export const frameEditorsLogic = kea<frameEditorsLogicType>([
         ) === 'interpreted',
     ],
   })),
-  listeners(({ cache }) => ({
+  listeners(({ pathString }) => ({
     persistUntilClosed: ({ editorKey, logic }) => {
-      if (!cache.closeListeners) {
-        cache.closeListeners = {} as Record<string, () => void>
-      }
-      if (!cache.closeListeners[editorKey]) {
-        cache.closeListeners[editorKey] = logic.mount()
+      const persisted = persistedEditors.get(pathString) ?? new Map<string, () => void>()
+      if (!persisted.has(editorKey)) {
+        persisted.set(editorKey, logic.mount())
+        persistedEditors.set(pathString, persisted)
       }
     },
     closeEditor: ({ editorKey }) => {
-      if (cache.closeListeners?.[editorKey]) {
-        cache.closeListeners[editorKey]()
-        delete cache.closeListeners[editorKey]
-      }
+      unmountPersistedEditors(pathString, (key) => key === editorKey)
     },
     closeSceneEditors: ({ sceneIds }) => {
-      for (const sceneId of sceneIds) {
-        for (const editorKey of Object.keys(cache.closeListeners ?? {})) {
-          if (
+      unmountPersistedEditors(pathString, (editorKey) =>
+        sceneIds.some(
+          (sceneId) =>
             editorKey === diagramEditorKey(sceneId) ||
             editorKey === sceneJSONEditorKey(sceneId) ||
             editorKey.startsWith(`editApp:${sceneId}.`)
-          ) {
-            cache.closeListeners[editorKey]()
-            delete cache.closeListeners[editorKey]
-          }
-        }
-      }
+        )
+      )
     },
   })),
+  // Leaving the workspace (another frame, the dashboard) unmounts this logic
+  // but nothing closes the editors: every diagram/app/JSON logic they kept
+  // mounted, and through kea's connect the whole frameLogic behind them, used
+  // to live on until the page reloaded.
+  beforeUnmount(({ pathString }) => {
+    unmountPersistedEditors(pathString, () => true)
+  }),
 ])

--- a/frontend/src/scenes/frame/frameLogic.ts
+++ b/frontend/src/scenes/frame/frameLogic.ts
@@ -1934,6 +1934,9 @@ function trimFieldName<T extends { name?: string }>(field: T): T {
   return { ...field, name: field.name.trim() }
 }
 
+/** The Cmd+S window listener of each mounted frameLogic, by logic path — see afterMount. */
+const saveKeydownHandlers = new Map<string, (event: KeyboardEvent) => void>()
+
 export function sanitizeScene(scene: Partial<FrameScene>, frame: Partial<FrameType>): FrameScene {
   // AI-generated scenes used to carry the user's prompt here. It was never
   // needed to run the scene and could hold more than the user meant to share
@@ -3593,7 +3596,7 @@ export const frameLogic = kea<frameLogicType>([
       },
     }
   }),
-  afterMount(({ actions, values, cache, props }) => {
+  afterMount(({ actions, values, props, pathString }) => {
     const defaultScene = values.frame?.scenes?.find((scene) => scene.id === 'default' && !scene.default)
     if (defaultScene) {
       const { name, id, default: _def, ...rest } = defaultScene
@@ -3606,7 +3609,15 @@ export const frameLogic = kea<frameLogicType>([
       actions.loadFrameSyncStatus()
     }
 
-    cache.keydownHandler = (event: KeyboardEvent) => {
+    // Keyed by path in module state, not `cache`: under StrictMode / Fast
+    // Refresh afterMount can run on one built object and beforeUnmount on
+    // another for the same path, which left a Cmd+S listener behind that
+    // saved through a dead logic (diagramLogic's keydown handler, same fix).
+    const previousHandler = saveKeydownHandlers.get(pathString)
+    if (previousHandler) {
+      window.removeEventListener('keydown', previousHandler)
+    }
+    const keydownHandler = (event: KeyboardEvent) => {
       const key = event.key.toLowerCase()
       if (!(event.metaKey || event.ctrlKey) || key !== 's') {
         return
@@ -3623,12 +3634,14 @@ export const frameLogic = kea<frameLogicType>([
       event.preventDefault()
       actions.saveFrame()
     }
-    window.addEventListener('keydown', cache.keydownHandler)
+    saveKeydownHandlers.set(pathString, keydownHandler)
+    window.addEventListener('keydown', keydownHandler)
   }),
-  beforeUnmount(({ cache }) => {
-    if (cache.keydownHandler) {
-      window.removeEventListener('keydown', cache.keydownHandler)
-      cache.keydownHandler = null
+  beforeUnmount(({ pathString }) => {
+    const keydownHandler = saveKeydownHandlers.get(pathString)
+    if (keydownHandler) {
+      window.removeEventListener('keydown', keydownHandler)
+      saveKeydownHandlers.delete(pathString)
     }
   }),
 ])

--- a/frontend/src/scenes/frame/panels/Diagram/CodeArg.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/CodeArg.tsx
@@ -30,6 +30,18 @@ export function CodeArg({ codeArg, onChange, onDelete }: CodeArgProps): JSX.Elem
   if (!node) {
     return <div />
   }
+  const trimmedName = name.trim()
+  const otherNames = ((node.data as { codeArgs?: CodeArg[] }).codeArgs ?? [])
+    .map((arg) => arg.name)
+    .filter((existing) => existing !== codeArg.name)
+  // An argument needs a name the code can reference, and two arguments with
+  // one name would share a `codeField/<name>` handle and overwrite each other.
+  const nameError = !trimmedName
+    ? 'The field needs a name'
+    : otherNames.includes(trimmedName)
+    ? `"${trimmedName}" is already an argument of this node`
+    : null
+  const changed = type !== codeArg.type || trimmedName !== codeArg.name
   const codeNode = (
     <div className={clsx('flex items-center gap-1', onChange && 'hover:underline cursor-pointer')}>
       <div>{codeArg.name}</div>
@@ -49,6 +61,7 @@ export function CodeArg({ codeArg, onChange, onDelete }: CodeArgProps): JSX.Elem
           <div className="space-y-1">
             <Label>Field name</Label>
             <TextInput value={name} onChange={(value) => setName(value)} placeholder="name" />
+            {nameError ? <div className="text-xs text-red-400">{nameError}</div> : null}
           </div>
           <div className="space-y-1">
             <Label>Data type</Label>
@@ -60,9 +73,14 @@ export function CodeArg({ codeArg, onChange, onDelete }: CodeArgProps): JSX.Elem
           </div>
           <div className="flex gap-2">
             <Button
-              color={type !== codeArg.type || name !== codeArg.name ? 'primary' : 'secondary'}
+              color={changed && !nameError ? 'primary' : 'secondary'}
               size="small"
-              onClick={() => onChange?.({ name, type })}
+              disabled={!!nameError}
+              onClick={() => {
+                if (!nameError) {
+                  onChange?.({ name: trimmedName, type })
+                }
+              }}
             >
               Update
             </Button>

--- a/frontend/src/scenes/frame/panels/Diagram/CodeNode.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/CodeNode.tsx
@@ -32,7 +32,7 @@ export function CodeNode({ id, isConnectable }: NodeProps<CodeNodeData>): JSX.El
     appNodeLogic(appNodeLogicProps)
   )
   const data: CodeNodeData = (node?.data as CodeNodeData) ?? ({ code: '' } satisfies CodeNodeData)
-  const { select, editCodeField } = useActions(appNodeLogic(appNodeLogicProps))
+  const { select, deleteCodeField } = useActions(appNodeLogic(appNodeLogicProps))
   const { openNewNodePicker } = useActions(newNodePickerLogic({ sceneId, frameId }))
   const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null)
   // State, not a ref: the declarations effect below has to re-run once the
@@ -202,17 +202,26 @@ export function CodeNode({ id, isConnectable }: NodeProps<CodeNodeData>): JSX.El
                       key={`${codeField.type}/${codeField.name}`}
                       codeArg={codeField}
                       onChange={(value) => {
+                        // CodeArg refuses these in its form; guard here too so no
+                        // caller can write an argument the code cannot reference or
+                        // two arguments sharing one `codeField/<name>` handle.
+                        const name = typeof value.name === 'string' ? value.name.trim() : codeField.name
+                        if (!name || data.codeArgs?.some((c, j) => j !== i && c.name === name)) {
+                          return
+                        }
                         updateNodeData(id, {
-                          codeArgs: data.codeArgs?.map((c, j) => (i === j ? { ...c, ...value } : c)),
+                          codeArgs: data.codeArgs?.map((c, j) => (i === j ? { ...c, ...value, name } : c)),
                         })
-                        nodeEdges.forEach((edge) => {
-                          if (edge.target === id && edge.targetHandle === `codeField/${codeField.name}`) {
-                            updateEdge({ ...edge, targetHandle: `codeField/${value.name}` })
-                          }
-                        })
+                        if (name !== codeField.name) {
+                          nodeEdges.forEach((edge) => {
+                            if (edge.target === id && edge.targetHandle === `codeField/${codeField.name}`) {
+                              updateEdge({ ...edge, targetHandle: `codeField/${name}` })
+                            }
+                          })
+                        }
                         updateNodeInternals(id)
                       }}
-                      onDelete={() => editCodeField(codeField.name, '')}
+                      onDelete={() => deleteCodeField(codeField.name)}
                     />
                   </div>
                 ) : null}

--- a/frontend/src/scenes/frame/panels/Diagram/appNodeLogic.ts
+++ b/frontend/src/scenes/frame/panels/Diagram/appNodeLogic.ts
@@ -113,19 +113,8 @@ export interface appNodeLogicActions {
     data: Record<string, any>
     id: string
   } // diagramLogic
-  editCodeField: (
-    field: string,
-    newField: string
-  ) => {
+  deleteCodeField: (field: string) => {
     field: string
-    newField: string
-  }
-  editCodeFieldOutput: (
-    field: string,
-    newField: string
-  ) => {
-    field: string
-    newField: string
   }
   select: () => {
     value: true
@@ -246,9 +235,9 @@ export const appNodeLogic = kea<appNodeLogicType>([
   })),
   actions({
     select: true,
-    editCodeField: (field: string, newField: string) => ({ field, newField }),
-    editCodeFieldOutput: (field: string, newField: string) => ({ field, newField }),
-    // updateCodeOutput: (index: number, codeArg: CodeArg) => ({ field, newField }),
+    // Renaming an argument lives in CodeNode (CodeArg's Update button): it
+    // rewrites the node's codeArgs and the edges' target handles in place.
+    deleteCodeField: (field: string) => ({ field }),
   }),
   selectors({
     nodeId: [() => [(_, props) => props.nodeId], (nodeId): string => nodeId],
@@ -679,104 +668,38 @@ export const appNodeLogic = kea<appNodeLogicType>([
         actions.selectNode(values.nodeId)
       }
     },
-    editCodeField: ({ field, newField }) => {
+    deleteCodeField: ({ field }) => {
       const { nodeId, node, nodeEdges, edges } = values
       const codeFieldEdges = nodeEdges.filter(
         (edge) =>
           edge.target === nodeId && edge.sourceHandle === 'fieldOutput' && edge.targetHandle === `codeField/${field}`
       )
       const codeArgs = (node?.data as CodeNodeData)?.codeArgs ?? []
-      if (newField) {
-        actions.setEdges(
-          edges.map((edge) =>
-            edge.target === nodeId && edge.sourceHandle === 'fieldOutput' && edge.targetHandle === `codeField/${field}`
-              ? { ...edge, targetHandle: `codeField/${newField}` }
-              : edge
+      // `fieldOutput` is the output handle of EVERY data app and code node,
+      // so the node behind this argument may be a shared weather or OpenAI
+      // node feeding other targets too. Only a node that exists for this
+      // argument alone (a code node with no other connections) goes with
+      // it; anything else keeps its node and loses just the edge.
+      const nodes = values.nodes ?? []
+      const removedEdgeIds = new Set(codeFieldEdges.map((edge) => edge.id))
+      let remainingEdges = edges.filter((edge) => !removedEdgeIds.has(edge.id))
+      for (const edge of codeFieldEdges) {
+        const source = nodes.find((n) => n.id === edge.source)
+        const dedicated =
+          source?.type === 'code' &&
+          !remainingEdges.some((other) => other.source === edge.source || other.target === edge.source)
+        if (dedicated) {
+          actions.deleteApp(edge.source)
+          remainingEdges = remainingEdges.filter(
+            (other) => other.source !== edge.source && other.target !== edge.source
           )
-        )
-        actions.updateNodeData(nodeId, {
-          codeFields: codeArgs.find((a) => a.name === newField)
-            ? codeArgs.filter((f) => f.name !== field)
-            : codeArgs.map((f) => (f.name === field ? newField : f)),
-        })
-        window.requestAnimationFrame(() => {
-          props.updateNodeInternals?.(nodeId)
-        })
-      } else {
-        // `fieldOutput` is the output handle of EVERY data app and code node,
-        // so the node behind this argument may be a shared weather or OpenAI
-        // node feeding other targets too. Only a node that exists for this
-        // argument alone (a code node with no other connections) goes with
-        // it; anything else keeps its node and loses just the edge.
-        const nodes = values.nodes ?? []
-        const removedEdgeIds = new Set(codeFieldEdges.map((edge) => edge.id))
-        let remainingEdges = edges.filter((edge) => !removedEdgeIds.has(edge.id))
-        for (const edge of codeFieldEdges) {
-          const source = nodes.find((n) => n.id === edge.source)
-          const dedicated =
-            source?.type === 'code' &&
-            !remainingEdges.some((other) => other.source === edge.source || other.target === edge.source)
-          if (dedicated) {
-            actions.deleteApp(edge.source)
-            remainingEdges = remainingEdges.filter((other) => other.source !== edge.source && other.target !== edge.source)
-          }
-        }
-        actions.setEdges(remainingEdges)
-        actions.updateNodeData(nodeId, { codeArgs: codeArgs.filter((f) => f.name !== field) })
-        window.requestAnimationFrame(() => {
-          props.updateNodeInternals?.(nodeId)
-        })
-      }
-    },
-    editCodeFieldOutput: ({ field, newField }) => {
-      const { nodeId, node, nodes, nodeEdges, edges } = values
-      const codeOutputEdges = nodeEdges.filter(
-        (edge) =>
-          edge.source === nodeId && edge.sourceHandle === `fieldOutput` && edge.targetHandle === `codeField/${field}`
-      )
-
-      const updatedNodes: Record<string, DiagramNode | false> = {}
-      const updatedEdges: Record<string, DiagramEdge | false> = {}
-      for (const edge of codeOutputEdges) {
-        const otherNode = nodes.find((n) => n.id === edge.target)
-        if (!otherNode) {
-          continue
-        }
-        const codeArgs = (otherNode?.data as CodeNodeData)?.codeArgs ?? []
-
-        if (newField) {
-          updatedEdges[edge.id] = { ...edge, targetHandle: `codeField/${newField}` }
-          updatedNodes[edge.target] = {
-            ...otherNode,
-            data: {
-              ...otherNode.data,
-              codeArgs: codeArgs.map((f) => (f.name === field ? { ...f, name: newField } : f)),
-            },
-          }
-        } else {
-          updatedEdges[edge.id] = false
-          updatedNodes[edge.source] = false
-          updatedNodes[edge.target] = {
-            ...otherNode,
-            data: {
-              ...otherNode.data,
-              codeArgs: codeArgs.filter((f) => f.name !== field),
-            },
-          }
         }
       }
-
-      const newEdges = edges.map((edge) => updatedEdges[edge.id] ?? edge).filter((e): e is DiagramEdge => e !== false)
-      const newNodes = nodes.map((node) => updatedNodes[node.id] ?? node).filter((n): n is DiagramNode => n !== false)
-      actions.setEdges(newEdges)
-      actions.setNodes(newNodes)
-      if (newNodes.length > 0) {
-        window.setTimeout(() => {
-          window.requestAnimationFrame(() => {
-            props.updateNodeInternals?.(newNodes.map((n) => n.id))
-          })
-        }, 100)
-      }
+      actions.setEdges(remainingEdges)
+      actions.updateNodeData(nodeId, { codeArgs: codeArgs.filter((f) => f.name !== field) })
+      window.requestAnimationFrame(() => {
+        props.updateNodeInternals?.(nodeId)
+      })
     },
   })),
 ])

--- a/frontend/src/scenes/frame/panels/Diagram/diagramLogic.tsx
+++ b/frontend/src/scenes/frame/panels/Diagram/diagramLogic.tsx
@@ -420,6 +420,20 @@ const collectSceneAppsForNodes = (
 // paste used to be silently dead there. Same-tab paste falls back to this.
 let lastCopiedPayload: string | null = null
 
+/** The render `type` reactflow picks a component by: app-flow edges (prev/next)
+ * against data edges into code and field handles. Stamped on read, so a stored
+ * scene never needs to carry it. */
+const decorateEdges = (edges: DiagramEdge[]): DiagramEdge[] =>
+  edges.map((edge) =>
+    edge.targetHandle === 'prev' || edge.sourceHandle === 'next'
+      ? edge.type !== 'appNodeEdge'
+        ? { ...edge, type: 'appNodeEdge' }
+        : edge
+      : edge.type !== 'codeNodeEdge'
+      ? { ...edge, type: 'codeNodeEdge' }
+      : edge
+  )
+
 const clipboardPayloadForNodes = (
   nodes: DiagramNode[],
   edges: DiagramEdge[],
@@ -1154,21 +1168,7 @@ export const diagramLogic = kea<diagramLogicType>([
       (nodes: diagramLogicValues['nodes']): string[] => nodes.filter((node) => node.selected).map((node) => node.id),
     ],
     selectedNodes: [(s) => [s.nodes], (nodes: DiagramNode[]): DiagramNode[] => nodes.filter((node) => node.selected)],
-    edges: [
-      (s) => [s.rawEdges],
-      (rawEdges: diagramLogicValues['rawEdges']): DiagramEdge[] =>
-        rawEdges.map((edge) => {
-          const newEdge =
-            edge.targetHandle === 'prev' || edge.sourceHandle === 'next'
-              ? edge.type !== 'appNodeEdge'
-                ? { ...edge, type: 'appNodeEdge' }
-                : edge
-              : edge.type !== 'codeNodeEdge'
-              ? { ...edge, type: 'codeNodeEdge' }
-              : edge
-          return newEdge
-        }),
-    ],
+    edges: [(s) => [s.rawEdges], (rawEdges: diagramLogicValues['rawEdges']): DiagramEdge[] => decorateEdges(rawEdges)],
     selectedEdge: [
       (s) => [s.edges],
       (edges: diagramLogicValues['edges']): DiagramEdge | null => edges.find((edge) => edge.selected) ?? null,
@@ -1207,11 +1207,14 @@ export const diagramLogic = kea<diagramLogicType>([
         originalFrame: diagramLogicValues['originalFrame']
       ) => {
         const scene = originalFrame?.scenes?.find((s) => s.id === sceneId)
+        // The stored edges are decorated too: a scene whose edges never had a
+        // render `type` (hand written, imported, AI-built) used to show as
+        // changed from the moment it opened, until a save wrote the type back.
         return (
           !equal(normalizeNodes(nodes), scene?.nodes) ||
           !equal(
             edges?.map((e) => (e.selected ? { ...e, selected: false } : e)),
-            scene?.edges
+            scene?.edges ? decorateEdges(scene.edges) : scene?.edges
           ) ||
           !equal(sceneApps, normalizeSceneApps(scene?.apps))
         )

--- a/frontend/src/scenes/frame/panels/SceneJSON/sceneJSONLogic.tsx
+++ b/frontend/src/scenes/frame/panels/SceneJSON/sceneJSONLogic.tsx
@@ -1,6 +1,6 @@
 import { MakeLogicType, actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
-import { frameLogic } from '../../frameLogic'
+import { frameLogic, sanitizeScene } from '../../frameLogic'
 import { FrameScene, FrameId } from '../../../../types'
 import type { FrameType } from '../../../../types'
 
@@ -145,16 +145,30 @@ export const sceneJSONLogic = kea<sceneJSONLogicType>([
         if (!props.sceneId) {
           return
         }
-        const { id: _, default: __, name, ...scene } = JSON.parse(values.sceneJSON)
-        actions.updateScene(props.sceneId, {
-          id: props.sceneId,
-          name,
-          ...(values.scene?.default ? { default: true } : {}),
-          ...scene,
-        })
+        const parsed: unknown = JSON.parse(values.sceneJSON)
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('A scene is a JSON object')
+        }
+        const { id: _, default: __, name, ...scene } = parsed as Partial<FrameScene>
+        // Hand-typed JSON is as untrusted as an imported file: a node without a
+        // `position` takes reactflow down, so it goes through the same
+        // sanitizer inbound scenes do. The backend's frameLogic sanitizes in
+        // updateScene as well; the embedded editor's shim does not.
+        actions.updateScene(
+          props.sceneId,
+          sanitizeScene(
+            {
+              id: props.sceneId,
+              name,
+              ...(values.scene?.default ? { default: true } : {}),
+              ...scene,
+            },
+            values.frameForm
+          )
+        )
         actions.setEditedSceneJSON(null)
-      } catch {
-        console.error('Cannot save invalid JSON')
+      } catch (error) {
+        console.error('Cannot save invalid JSON', error)
       }
     },
   })),


### PR DESCRIPTION
Fifth cut, item 1 of `docs/review-todo.md` (§11, the scene editor). One PR as the doc asks.

## Fixes

- **`<Select>` showed the wrong value** when the stored value matched no option: a native select falls back to the first entry while the form keeps the stale value. It now renders the stored value as a marked first option (`… (not an option)`), so what is shown is what gets saved. The empty string stays the placeholder idiom.
- **CodeNode argument rename** refuses empty and duplicate names: `CodeArg` shows why and disables Update, and the `CodeNode` handler guards too. Edge handles are only rewritten when the name actually changed. `appNodeLogic`'s dead `editCodeField` rename branch (it wrote a `codeFields` key that does not exist) and the caller-less `editCodeFieldOutput` are gone; the delete path is `deleteCodeField`.
- **SceneJSON Save goes through `sanitizeScene`**, so hand-typed JSON with a node lacking `position` no longer takes reactflow down in the embedded editor, whose frameLogic shim does not sanitize in `updateScene`.
- **`persistUntilClosed` editors are unmounted with the workspace**: `frameEditorsLogic` keeps them in module state keyed by logic path and closes them all in `beforeUnmount`. Before, leaving the workspace left every editor logic (and through kea's `connect`, the frameLogic behind them) mounted until reload.
- **Cmd+S handler off the `cache` pattern** in `frameLogic`, onto the same path-keyed map `diagramLogic` uses, so StrictMode / Fast Refresh cannot leave a save listener behind on a dead logic.
- Found while writing the tests: **`hasChanges` reported a change on open** for any scene whose edges carry no render `type` (hand-written, imported, AI-built scenes), because it compared the decorated `edges` selector with the raw stored edges. Both sides are decorated now through one shared function.

## Tests

First scene-editor logic tests in the shared-spa suite, all against the embed shim like `diagram-history.test.ts`:

- `diagram-clipboard.test.ts` — copy (bare node vs `{nodes, edges}`, secrets and view state stripped), paste (same-tab fallback without `navigator.clipboard`, new ids, remapped edges, selection), `hasChanges` including the no-`type` edge case.
- `app-node-logic.test.ts` — selectors and `deleteCodeField` (dedicated code node goes with the argument, shared source keeps its node).
- `scene-json-logic.test.ts` — printing, `hasChanges`, `hasError`, save keeps the scene id, the sanitize regression, invalid input leaves the scene alone.
- `select-options.test.ts` — the `selectOptions` round-trips, pinning the known `|`-in-label limitation.
- `select-missing-value.test.tsx` — the `<Select>` missing-value option.

Registered in the auth-web `tsconfig.json` exclude and the cloud eslint ignores like the existing frontend-reaching tests.

## Verified

- `frontend` tsc, `build:kea:check`, prettier; `cloud-frontend` tsc; auth-web tsc.
- Full shared-spa suite: 66 files, 643 tests pass (serially, Node 26 local run).

Left in §11: the "Save means three different things" Medium and the Low list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X77rYdZ5CvsDSh4NpaEu55
