### PR TITLE
Review todo: fifth cut item 3, Nim apps and the Remote shell verb

### DIFF
--- a/backend/app/tasks/deploy_remote.py
+++ b/backend/app/tasks/deploy_remote.py
@@ -41,6 +41,10 @@ REMOTE_SOURCE_BUILD_APT_PACKAGES = ("build-essential", "libssl-dev")
 REMOTE_BINARY = "frameos_remote"
 REMOTE_SERVICE = "frameos-remote"
 REPO_ROOT = Path(__file__).resolve().parents[3]
+# Runtime modules frameos_remote imports from ../src (see remote/config.nims).
+# Only std-library-dependent modules belong here: the staged copy carries no
+# other part of the runtime tree.
+REMOTE_RUNTIME_MODULES: tuple[str, ...] = ("frameos/utils/process.nim",)
 
 
 def legacy_remote_cleanup_script(delay_seconds: int = 0) -> str:
@@ -294,13 +298,21 @@ class RemoteDeployer(FrameDeployer):
         Return `(build_dir, source_dir)`.
 
         * ``build_dir`` holds the Nim intermediate artefacts.
-        * ``source_dir`` is a fresh copy of `../remote`.
+        * ``source_dir`` is a fresh copy of `../remote`, with the one runtime
+          module it imports staged next to it: remote/config.nims puts
+          ``../src`` on the Nim path so the `shell` verb can spawn through
+          ``frameos/utils/process.nim`` (the runtime's bounded process
+          wrapper) instead of raw osproc.
         """
         build_dir = os.path.join(self.temp_dir, f"remote_{self.build_id}")
         source_dir = os.path.join(self.temp_dir, "remote")
 
         os.makedirs(source_dir, exist_ok=True)
         shutil.copytree(REPO_ROOT / "frameos" / "remote", source_dir, dirs_exist_ok=True)  # idempotent copy
+        for relative in REMOTE_RUNTIME_MODULES:
+            target = os.path.join(self.temp_dir, "src", relative)
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            shutil.copy(REPO_ROOT / "frameos" / "src" / relative, target)
         os.makedirs(build_dir, exist_ok=True)
 
         return build_dir, source_dir

--- a/backend/app/tasks/tests/test_deploy_remote.py
+++ b/backend/app/tasks/tests/test_deploy_remote.py
@@ -8,6 +8,8 @@ from typing import Any
 import pytest
 
 from app.tasks.deploy_remote import (
+    REMOTE_RUNTIME_MODULES,
+    REPO_ROOT,
     RemoteDeployer,
     delayed_remote_restart_command,
     deploy_remote,
@@ -723,3 +725,23 @@ async def test_remote_source_build_requires_gcc_on_buildroot(tmp_path: Path):
 
     with pytest.raises(RuntimeError, match="Cannot source-build FrameOS Remote on buildroot"):
         await deployer._ensure_remote_source_build_dependencies("buildroot")
+
+
+def test_remote_build_folders_stage_the_runtime_modules_the_remote_imports(tmp_path: Path):
+    # remote/config.nims puts ../src on the Nim path so the `shell` verb can
+    # spawn through frameos/utils/process.nim; a copy of remote/ alone would
+    # fail to compile on the frame, so the staging has to carry that module.
+    deployer = FakeRemoteDeployer(tmp_path)
+    deployer.build_id = "abc"
+
+    build_dir, source_dir = RemoteDeployer._create_remote_build_folders(deployer)
+
+    assert Path(build_dir) == tmp_path / "remote_abc"
+    assert Path(source_dir) == tmp_path / "remote"
+    assert (Path(source_dir) / "config.nims").is_file()
+    assert (Path(source_dir) / "src" / "frameos_remote.nim").is_file()
+    assert "frameos/utils/process.nim" in REMOTE_RUNTIME_MODULES
+    for relative in REMOTE_RUNTIME_MODULES:
+        staged = tmp_path / "src" / relative
+        assert staged.is_file(), relative
+        assert staged.read_bytes() == (REPO_ROOT / "frameos" / "src" / relative).read_bytes()

--- a/frameos/remote/config.nims
+++ b/frameos/remote/config.nims
@@ -3,3 +3,17 @@
 when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config
+
+import std/os
+
+# The Remote spawns its `shell` children through the runtime's process
+# wrapper (frameos/utils/process.nim) instead of raw osproc, so the runtime
+# tree's src/ goes on the path. A repo checkout and bin/cross both keep
+# remote/ next to src/; the backend's source deploy copies remote/ alone and
+# stages that one module under ../src itself (deploy_remote.py,
+# REMOTE_RUNTIME_MODULES). Conditional so `nimble setup` on a bare
+# dependency-only copy (the Dockerfile) still works; a real build without it
+# fails on the import with a clear "cannot open file".
+let frameosRuntimeSrc = thisDir() / ".." / "src"
+if dirExists(frameosRuntimeSrc / "frameos" / "utils"):
+  switch("path", frameosRuntimeSrc)

--- a/frameos/remote/src/frameos_remote.nim
+++ b/frameos/remote/src/frameos_remote.nim
@@ -1,5 +1,5 @@
 import std/[algorithm, segfaults, strformat, strutils, asyncdispatch,
-            terminal, times, os, httpclient, osproc, streams, unicode,
+            terminal, times, os, httpclient, osproc, unicode,
             monotimes, tables]
 import checksums/md5
 import json, jsony
@@ -7,6 +7,7 @@ import ws
 import nimcrypto
 import nimcrypto/hmac
 import zippy
+import frameos/utils/process
 
 const
   DefaultConfigPath* = "./frame.json" # secure location
@@ -273,21 +274,107 @@ proc recvBinary(ws: WebSocket): Future[string] {.async.} =
       discard # ignore text, pong …
 
 # TODO: split stdout and stderr
+const
+  ## The backend's longest single step over the Remote is an 1800 s apt /
+  ## compile run (deploy_remote.py); a `shell` command that outlives this is
+  ## killed and reported as timed out instead of holding the Remote forever.
+  ShellDefaultTimeoutSeconds* = 1800
+  ShellMaxTimeoutSeconds* = 4 * 3600
+  ## Output is streamed line by line; past this much the child keeps running
+  ## but its output is dropped, so a runaway `yes` cannot fill the websocket.
+  ShellMaxOutputBytes* = 8 * 1024 * 1024
+  ShellPollMs = 50
+  ## How long an exited-pipe child gets to be reaped before it is stopped.
+  ShellExitGraceMs = 5000
+
+type
+  ShellRunResult* = object
+    exitCode*: int
+    timedOut*: bool
+    outputTruncated*: bool
+
+proc shellTimeoutMs*(args: JsonNode): int =
+  ## `args.timeout` (seconds) when the backend sends one, clamped to a sane
+  ## range; the deploy-step default otherwise.
+  var seconds = args{"timeout"}.getInt(0)
+  if seconds <= 0:
+    seconds = ShellDefaultTimeoutSeconds
+  min(seconds, ShellMaxTimeoutSeconds) * 1000
+
+proc runShellStreaming*(rawCmd: string;
+                        timeoutMs: int;
+                        onLine: proc(line: string): Future[void] {.closure, gcsafe.}
+                       ): Future[ShellRunResult] {.async.} =
+  ## Runs `rawCmd` through the runtime's process wrapper (frameos/utils/process:
+  ## serialized spawn, non-blocking pipe reads, terminate-then-kill stop) and
+  ## hands every complete output line to `onLine` as it arrives. The wait is a
+  ## polling loop with `sleepAsync`, so the websocket heartbeat keeps running
+  ## while a long command works; at `timeoutMs` the child is stopped.
+  let shell = if fileExists("/bin/bash"): "bash" else: "sh"
+  var p = startProcessSerialized("/usr/bin/env",
+                                 args = @[shell, "-c", rawCmd],
+                                 options = {poUsePath, poStdErrToStdOut}) # <- merge stderr
+  var reader = initProcessOutputReader(p)
+  let deadline = getMonoTime() + initDuration(milliseconds = timeoutMs)
+  var outputBytes = 0
+  try:
+    while true:
+      for line in reader.readAvailableLines():
+        outputBytes += line.len + 1
+        if outputBytes > ShellMaxOutputBytes:
+          result.outputTruncated = true
+        else:
+          await onLine(line & '\n')
+      if reader.eof:
+        break
+      if getMonoTime() >= deadline:
+        result.timedOut = true
+        p.stopProcess()
+        # whatever the child managed to write before it was stopped
+        for line in reader.readAvailableLines():
+          if not result.outputTruncated:
+            await onLine(line & '\n')
+        break
+      await sleepAsync(ShellPollMs)
+
+    # The pipe is closed (or the child was stopped): reap it, bounded.
+    let graceDeadline = getMonoTime() + initDuration(milliseconds = ShellExitGraceMs)
+    var exitCode = p.peekExitCode()
+    while exitCode == -1 and getMonoTime() < graceDeadline:
+      await sleepAsync(ShellPollMs)
+      exitCode = p.peekExitCode()
+    if exitCode == -1:
+      # closed its stdout but never exited (a stuck child): stop it
+      p.stopProcess()
+      exitCode = p.peekExitCode()
+    result.exitCode = if result.timedOut: -1 else: exitCode
+  finally:
+    p.close()
+
 proc execShellSimple(rawCmd: string;
                      ws: WebSocket;
                      cfg: FrameConfig;
-                     id: string): Future[void] {.async.} =
-  let shell = if fileExists("/bin/bash"): "bash" else: "sh"
-  var p = startProcess("/usr/bin/env",
-                       args = [shell, "-c", rawCmd],
-                       options = {poUsePath, poStdErrToStdOut}) # <- merge stderr
-
-  var line: string
-  while p.outputStream.readLine(line):
-    await streamChunk(ws, cfg, id, "stdout", line & '\n')
-
-  let rc = p.waitForExit() # closes pipe & reaps the child
-  await sendResp(ws, cfg, id, rc == 0, %*{"exit": rc})
+                     id: string;
+                     timeoutMs: int): Future[void] {.async.} =
+  var run: ShellRunResult
+  try:
+    run = await runShellStreaming(rawCmd, timeoutMs,
+      proc(line: string): Future[void] {.closure, gcsafe.} =
+        streamChunk(ws, cfg, id, "stdout", line))
+  except CatchableError as e:
+    await sendResp(ws, cfg, id, false, %*{"exit": -1, "error": "shell failed to start: " & e.msg})
+    return
+  if run.timedOut:
+    await sendResp(ws, cfg, id, false, %*{
+      "exit": -1,
+      "timedOut": true,
+      "error": &"command timed out after {timeoutMs div 1000}s and was stopped"
+    })
+  else:
+    var res = %*{"exit": run.exitCode}
+    if run.outputTruncated:
+      res["outputTruncated"] = %*true
+    await sendResp(ws, cfg, id, run.exitCode == 0, res)
 
 # ----------------------------------------------------------------------------
 # All command handlers
@@ -361,7 +448,7 @@ proc handleCmd(cmd: JsonNode; ws: WebSocket; cfg: FrameConfig): Future[void] {.a
       if not args.hasKey("cmd"):
         await sendResp(ws, cfg, id, false, %*{"error": "`cmd` missing"})
       else:
-        asyncCheck execShellSimple(args["cmd"].getStr(), ws, cfg, id)
+        asyncCheck execShellSimple(args["cmd"].getStr(), ws, cfg, id, shellTimeoutMs(args))
 
     of "file_md5":
       let path = args{"path"}.getStr("")

--- a/frameos/remote/tests/test_shell.nim
+++ b/frameos/remote/tests/test_shell.nim
@@ -1,0 +1,73 @@
+import std/[asyncdispatch, json, monotimes, os, strutils, times]
+import ../src/frameos_remote
+
+## The `shell` verb runs through frameos/utils/process (serialized spawn,
+## non-blocking pipe reads, terminate-then-kill stop) with a deadline, and
+## the wait yields to the async loop instead of blocking it.
+
+proc collect(lines: ref seq[string]): proc(line: string): Future[void] {.closure, gcsafe.} =
+  result = proc(line: string): Future[void] {.closure, gcsafe.} =
+    {.gcsafe.}:
+      lines[].add(line)
+    result = newFuture[void]()
+    result.complete()
+
+block test_shell_timeout_from_args_is_clamped_with_a_default:
+  doAssert shellTimeoutMs(%*{}) == ShellDefaultTimeoutSeconds * 1000
+  doAssert shellTimeoutMs(%*{"timeout": 0}) == ShellDefaultTimeoutSeconds * 1000
+  doAssert shellTimeoutMs(%*{"timeout": -5}) == ShellDefaultTimeoutSeconds * 1000
+  doAssert shellTimeoutMs(%*{"timeout": 30}) == 30_000
+  doAssert shellTimeoutMs(%*{"timeout": 10_000_000}) == ShellMaxTimeoutSeconds * 1000
+
+block test_shell_streams_lines_and_reports_the_exit_code:
+  var lines = new seq[string]
+  let run = waitFor runShellStreaming("echo one; echo two >&2; echo three; exit 3", 10_000, collect(lines))
+  doAssert run.exitCode == 3, $run
+  doAssert not run.timedOut
+  doAssert not run.outputTruncated
+  doAssert lines[] == @["one\n", "two\n", "three\n"], $lines[]
+
+block test_shell_success_is_exit_zero:
+  var lines = new seq[string]
+  let run = waitFor runShellStreaming("true", 10_000, collect(lines))
+  doAssert run.exitCode == 0
+  doAssert lines[].len == 0
+
+block test_shell_is_stopped_at_the_deadline_and_reported_as_timed_out:
+  var lines = new seq[string]
+  let started = getMonoTime()
+  let run = waitFor runShellStreaming("echo started; sleep 30; echo never", 500, collect(lines))
+  let elapsedMs = (getMonoTime() - started).inMilliseconds
+  doAssert run.timedOut, $run
+  doAssert run.exitCode == -1
+  doAssert lines[] == @["started\n"], $lines[]
+  # 500 ms deadline + terminate/kill grace, never the child's 30 s
+  doAssert elapsedMs < 10_000, $elapsedMs
+
+block test_shell_wait_yields_to_the_async_loop:
+  # A timer scheduled on the dispatcher fires while the command is running,
+  # which it could not when the old implementation blocked on readLine.
+  var ticks = 0
+  proc ticker() {.async.} =
+    for _ in 0 ..< 3:
+      await sleepAsync(50)
+      inc ticks
+  let tickerFuture = ticker()
+  var lines = new seq[string]
+  let run = waitFor runShellStreaming("sleep 0.5; echo done", 10_000, collect(lines))
+  waitFor tickerFuture
+  doAssert run.exitCode == 0
+  doAssert lines[] == @["done\n"]
+  doAssert ticks == 3, $ticks
+
+block test_shell_output_past_the_cap_is_dropped_not_buffered:
+  var lines = new seq[string]
+  # ~9 MB of output against the 8 MB cap
+  let run = waitFor runShellStreaming("head -c 9437184 /dev/zero | tr '\\0' 'x' | fold -w 1024", 60_000, collect(lines))
+  doAssert run.exitCode == 0, $run
+  doAssert run.outputTruncated
+  var streamed = 0
+  for line in lines[]:
+    streamed += line.len
+  doAssert streamed <= ShellMaxOutputBytes + 2048, $streamed
+  doAssert streamed > ShellMaxOutputBytes - 2048, $streamed

--- a/frameos/src/apps/data/beRecycle/app.nim
+++ b/frameos/src/apps/data/beRecycle/app.nim
@@ -3,6 +3,7 @@ import times
 import options
 import json
 import strutils
+import std/uri
 import chrono
 import frameos/apps
 import frameos/types
@@ -41,6 +42,25 @@ var
   beRecycleAuthenticateHook*: BeRecycleAuthenticateHook = nil
   beRecycleFetchCollectionsHook*: BeRecycleFetchCollectionsHook = nil
 
+proc queryParam(value: string): string =
+  ## Percent-encodes one query value. Street names carry spaces and accents;
+  ## the runtime's HTTP client refuses a request line with either in it.
+  encodeUrl(value, usePlus = false)
+
+proc zipcodesUrl*(postalCode: int): string =
+  API_ENDPOINT & "/zipcodes?q=" & queryParam($postalCode)
+
+proc streetsUrl*(streetName: string, zipId: string): string =
+  API_ENDPOINT & "/streets?q=" & queryParam(streetName) & "&zipcodes=" & queryParam(zipId)
+
+proc collectionsUrl*(zipId: string, streetId: string, houseNumber: int,
+                     fromDate: string, toDate: string): string =
+  API_ENDPOINT & "/collections?zipcodeId=" & queryParam(zipId) &
+    "&streetId=" & queryParam(streetId) &
+    "&houseNumber=" & queryParam($houseNumber) &
+    "&fromDate=" & queryParam(fromDate) &
+    "&untilDate=" & queryParam(toDate) & "&size=200"
+
 proc fetchBody(self: App, url: string, httpMethod = "GET", body = ""): string =
   let response = boundedRequestWithHeaders(url,
     httpMethod = httpMethod,
@@ -68,7 +88,7 @@ proc authenticate(self: App) =
     raise newException(ValueError, "Error occurred while requesting access-token.")
 
 proc fetchAddressIds(self: App): AddressIds =
-  let url = API_ENDPOINT & "/zipcodes?q=" & $self.appConfig.postalCode
+  let url = zipcodesUrl(self.appConfig.postalCode)
   let zipResp = self.fetchBody(url)
   let zipJson = parseJson(zipResp)
   var zipId = ""
@@ -81,7 +101,7 @@ proc fetchAddressIds(self: App): AddressIds =
   if zipId == "":
     raise newException(ValueError, "Could not find the right zip code.")
 
-  let streetUrl = API_ENDPOINT & "/streets?q=" & self.appConfig.streetName & "&zipcodes=" & zipId
+  let streetUrl = streetsUrl(self.appConfig.streetName, zipId)
   let streetResp = self.fetchBody(streetUrl, httpMethod = "POST")
   let streetJson = parseJson(streetResp)
   var streetId = ""
@@ -96,8 +116,7 @@ proc fetchAddressIds(self: App): AddressIds =
   result = AddressIds(zip: zipId, street: streetId, housenumber: self.appConfig.number)
 
 proc fetchCollections(self: App, addressIds: AddressIds, fromDate: string, toDate: string): JsonNode =
-  let url = API_ENDPOINT & "/collections?zipcodeId=" & addressIds.zip & "&streetId=" & addressIds.street &
-      "&houseNumber=" & $addressIds.housenumber & "&fromDate=" & fromDate & "&untilDate=" & toDate & "&size=200"
+  let url = collectionsUrl(addressIds.zip, addressIds.street, addressIds.housenumber, fromDate, toDate)
   let collectionResp = self.fetchBody(url)
   let collections = parseJson(collectionResp)
 

--- a/frameos/src/apps/data/beRecycle/tests/test_app.nim
+++ b/frameos/src/apps/data/beRecycle/tests/test_app.nim
@@ -1,7 +1,8 @@
-import std/[json, unittest]
+import std/[json, strutils, unittest]
 
 import ../app
 import frameos/types
+import frameos/utils/http_client
 
 type LogStore = ref object
   items: seq[JsonNode]
@@ -87,3 +88,22 @@ suite "data/beRecycle app":
     check capturedToDay == "2026-01-07"
     check output.len == 1
     check output[0]["summary"].getStr() == "Trash: Paper"
+
+  test "query parameters are percent-encoded so the runtime client accepts them":
+    # "Rue de la Loi" used to go out unencoded; validateHttpRequestUrl refuses a
+    # request line with a space, so every street with one failed to resolve.
+    let streets = streetsUrl("Rue de la Loi", "zip-1")
+    validateHttpRequestUrl(streets)
+    check streets.contains("/streets?q=Rue%20de%20la%20Loi&zipcodes=zip-1")
+    check not streets.contains(" ")
+    check not streets.contains("+")
+
+    let accented = streetsUrl("Sint-Jorisstraat & Co/é", "z&1")
+    validateHttpRequestUrl(accented)
+    check accented.contains("q=Sint-Jorisstraat%20%26%20Co%2F%C3%A9&zipcodes=z%261")
+
+    check zipcodesUrl(1000).endsWith("/zipcodes?q=1000")
+    let collections = collectionsUrl("zip 1", "street/2", 12, "2026-01-05", "2026-01-07")
+    validateHttpRequestUrl(collections)
+    check collections.contains("zipcodeId=zip%201&streetId=street%2F2&houseNumber=12" &
+      "&fromDate=2026-01-05&untilDate=2026-01-07&size=200")

--- a/frameos/src/drivers/httpUpload/httpUpload.nim
+++ b/frameos/src/drivers/httpUpload/httpUpload.nim
@@ -2,13 +2,19 @@ import pixie
 import pixie/fileformats/png
 import std/httpclient
 import std/json
-import std/net
 import std/strutils
-import std/uri
 import checksums/md5
 import frameos/driver_context
+import frameos/utils/http_client
 
-const DEFAULT_TIMEOUT_MS = 30000
+const
+  DEFAULT_TIMEOUT_MS = 30000
+  ## The upload is bounded end to end: DNS, connect, TLS, the PNG going out
+  ## and the reply coming back all fit inside this budget.
+  UPLOAD_MAX_SECONDS = 90.0
+  ## The reply is only ever logged (truncated to 512 bytes), so a receiver
+  ## that answers with a page is cut off here rather than buffered whole.
+  UPLOAD_MAX_RESPONSE_BYTES = 256 * 1024
 
 type
   Driver* = ref object of FrameOSDriver
@@ -41,11 +47,22 @@ proc addDefaultHeader(headers: var HttpHeaders, name: string, value: string) =
   if not headers.hasKey(name):
     headers[name] = value
 
-proc buildHeaders(self: Driver, image: Image, bodyBytes: int, hashValue: string): HttpHeaders =
+proc buildHeaders*(self: Driver, image: Image, bodyBytes: int, hashValue: string): HttpHeaders =
+  ## Configured headers first, then the driver's own defaults where the user
+  ## set nothing. Every configured header goes through the runtime client's
+  ## validator: a name that is not an RFC 9110 token or a value carrying CR,
+  ## LF or another control byte would otherwise become a second header on the
+  ## wire. Hop-by-hop and framing headers (Host, Content-Length, Connection…)
+  ## belong to the client and are dropped rather than sent twice.
   var headers = newHttpHeaders()
   for header in self.headers:
-    if header.name.len > 0:
-      headers.add(header.name, header.value)
+    let name = header.name.strip()
+    if name.len == 0:
+      continue
+    if isReservedHttpHeader(name):
+      continue
+    validateHttpHeader(name, header.value)
+    headers.add(name, header.value)
   headers.addDefaultHeader("Content-Type", "image/png")
   headers.addDefaultHeader("X-FrameOS-Driver", self.name)
   headers.addDefaultHeader("X-FrameOS-Image-Hash", hashValue)
@@ -54,88 +71,22 @@ proc buildHeaders(self: Driver, image: Image, bodyBytes: int, hashValue: string)
   headers.addDefaultHeader("X-FrameOS-Image-Bytes", $bodyBytes)
   return headers
 
-proc isManagedPlainHttpHeader(name: string): bool =
-  cmpIgnoreCase(name, "Host") == 0 or
-    cmpIgnoreCase(name, "Connection") == 0 or
-    cmpIgnoreCase(name, "Content-Length") == 0
-
-proc plainHttpRequest(url: string, body: string, headers: HttpHeaders): tuple[status: int, body: string] =
-  let parsed = parseUri(url)
-  if cmpIgnoreCase(parsed.scheme, "http") != 0:
-    raise newException(ValueError, "plainHttpRequest only supports http URLs")
-  if parsed.hostname.len == 0:
-    raise newException(ValueError, "HTTP upload URL is missing a host")
-
-  let port =
-    if parsed.port.len > 0:
-      Port(parseInt(parsed.port))
-    else:
-      Port(80)
-  var path =
-    if parsed.path.len > 0:
-      parsed.path
-    else:
-      "/"
-  if parsed.query.len > 0:
-    path &= "?" & parsed.query
-
-  var request = "POST " & path & " HTTP/1.1\r\n"
-  request &= "Host: " & parsed.hostname
-  if parsed.port.len > 0:
-    request &= ":" & parsed.port
-  request &= "\r\n"
-  request &= "Connection: close\r\n"
-  request &= "Content-Length: " & $body.len & "\r\n"
-  for key, value in headers:
-    if not isManagedPlainHttpHeader(key):
-      request &= key & ": " & value & "\r\n"
-  request &= "\r\n"
-  request &= body
-
-  var socket = newSocket()
-  try:
-    socket.connect(parsed.hostname, port, timeout = DEFAULT_TIMEOUT_MS)
-    socket.send(request)
-
-    var response = ""
-    while true:
-      let chunk = socket.recv(8192, timeout = DEFAULT_TIMEOUT_MS)
-      if chunk.len == 0:
-        break
-      response &= chunk
-
-    let headerEnd = response.find("\r\n\r\n")
-    let responseHeaders =
-      if headerEnd >= 0:
-        response[0 ..< headerEnd]
-      else:
-        response
-    result.body =
-      if headerEnd >= 0 and headerEnd + 4 < response.len:
-        response[(headerEnd + 4) .. ^1]
-      else:
-        ""
-
-    let lines = responseHeaders.splitLines()
-    if lines.len == 0:
-      raise newException(ValueError, "HTTP upload response is empty")
-    let statusParts = lines[0].splitWhitespace()
-    if statusParts.len < 2:
-      raise newException(ValueError, "HTTP upload response is missing a status code")
-    result.status = parseInt(statusParts[1])
-  finally:
-    socket.close()
-
 proc defaultRequest(url: string, body: string, headers: HttpHeaders): tuple[status: int, body: string] =
-  if cmpIgnoreCase(parseUri(url).scheme, "http") == 0:
-    return plainHttpRequest(url, body, headers)
-
-  var client = newHttpClient(timeout = DEFAULT_TIMEOUT_MS)
-  try:
-    let response = client.request(url, httpMethod = HttpPost, body = body, headers = headers)
-    result = (response.code.int, response.body)
-  finally:
-    client.close()
+  ## One POST on the runtime's bounded client (frameos/utils/http_client):
+  ## resolve-once, connect and socket timeouts, TLS, a response cap and no
+  ## redirect following — an upload target is a literal endpoint, and a
+  ## 301/302 would turn the POST into a bodiless GET that "succeeds".
+  let response = boundedRequest(
+    url,
+    httpMethod = HttpPost,
+    body = body,
+    headers = headers,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxBytes = UPLOAD_MAX_RESPONSE_BYTES,
+    maxSeconds = UPLOAD_MAX_SECONDS,
+    maxRedirects = 0,
+  )
+  (response.code, response.body)
 
 proc logSuccess(self: Driver, status: int, hashValue: string) =
   self.logger.log(%*{

--- a/frameos/src/drivers/httpUpload/tests/test_http_upload.nim
+++ b/frameos/src/drivers/httpUpload/tests/test_http_upload.nim
@@ -1,9 +1,10 @@
-import std/[json, strutils, unittest]
+import std/[json, net, os, strutils, unittest]
 import pixie
 import std/httpclient
 
 import ../httpUpload
 import frameos/driver_context
+import frameos/utils/http_client
 
 type LogSink = ref object
   entries: seq[JsonNode]
@@ -119,3 +120,166 @@ suite "httpUpload driver":
     check sink.entries[1]["event"].getStr() == "driver:httpUpload:error"
     check sink.entries[1].hasKey("status") == false
     check sink.entries[1]["error"].getStr() == "request failed"
+
+## A tiny blocking HTTP server on a thread: it reads one POST, then answers
+## with a 500 whose body describes what it saw, so the driver's error log
+## carries the request the bounded client actually sent.
+var uploadServerPort: Port
+var uploadServerThread: Thread[void]
+
+proc uploadServerLoop() {.thread.} =
+  var server = newSocket()
+  server.setSockOpt(OptReuseAddr, true)
+  server.bindAddr(Port(0), "127.0.0.1")
+  server.listen()
+  var boundAddr: string
+  var boundPort: Port
+  (boundAddr, boundPort) = server.getLocalAddr()
+  uploadServerPort = boundPort
+
+  while true:
+    var client: Socket
+    server.accept(client)
+    var requestLine = ""
+    var contentType = ""
+    var extra = ""
+    var contentLength = 0
+    var hostSeen = 0
+    try:
+      requestLine = client.recvLine(timeout = 5000)
+      while true:
+        let line = client.recvLine(timeout = 5000)
+        if line == "\r\n" or line.len == 0:
+          break
+        let lowered = line.toLowerAscii()
+        if lowered.startsWith("content-type:"):
+          contentType = line.split(':', 1)[1].strip()
+        elif lowered.startsWith("content-length:"):
+          contentLength = parseInt(line.split(':', 1)[1].strip())
+        elif lowered.startsWith("x-test:"):
+          extra = line.split(':', 1)[1].strip()
+        elif lowered.startsWith("host:"):
+          inc hostSeen
+      var body = ""
+      while body.len < contentLength:
+        let chunk = client.recv(contentLength - body.len, timeout = 5000)
+        if chunk.len == 0:
+          break
+        body.add(chunk)
+      let parts = requestLine.splitWhitespace()
+      let summary = (if parts.len > 0: parts[0] else: "?") & "|" & contentType & "|" & extra &
+        "|" & $body.len & "|hosts=" & $hostSeen & "|png=" & $(body.startsWith("\x89PNG"))
+      if parts.len >= 2 and parts[1] == "/quit":
+        client.send("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        client.close()
+        break
+      client.send("HTTP/1.1 500 Internal Server Error\r\nContent-Length: " & $summary.len &
+        "\r\n\r\n" & summary)
+    except CatchableError:
+      discard
+    client.close()
+
+suite "httpUpload driver on the bounded client":
+  teardown:
+    requestHook = nil
+
+  test "a configured header carrying CRLF is refused before any request goes out":
+    let sink = LogSink(entries: @[])
+    var requestCount = 0
+    requestHook = proc(url: string, body: string, headers: HttpHeaders): tuple[status: int, body: string] =
+      requestCount.inc
+      (200, "")
+
+    let driver = Driver(
+      name: "httpUpload",
+      logger: makeLogger(sink),
+      url: "https://example.com/upload",
+      headers: @[HttpHeaderPair(name: "X-Test", value: "1\r\nX-Injected: yes")],
+      lastHash: ""
+    )
+    driver.render(makeImage())
+    check requestCount == 0
+    check sink.entries.len == 1
+    check sink.entries[0]["event"].getStr() == "driver:httpUpload:error"
+    check "control character" in sink.entries[0]["error"].getStr()
+
+    # A header name that is not a token is refused the same way.
+    driver.headers = @[HttpHeaderPair(name: "X Test", value: "1")]
+    driver.lastHash = ""
+    driver.render(makeImage())
+    check requestCount == 0
+    check sink.entries.len == 2
+    check "header name" in sink.entries[1]["error"].getStr()
+
+  test "hop-by-hop and framing headers belong to the client and are dropped":
+    let sink = LogSink(entries: @[])
+    requestHook = proc(url: string, body: string, headers: HttpHeaders): tuple[status: int, body: string] =
+      check not headers.hasKey("Host")
+      check not headers.hasKey("Content-Length")
+      check not headers.hasKey("Connection")
+      check headers["X-Kept"] == "yes"
+      (204, "")
+
+    let driver = Driver(
+      name: "httpUpload",
+      logger: makeLogger(sink),
+      url: "https://example.com/upload",
+      headers: @[
+        HttpHeaderPair(name: "Host", value: "evil.example"),
+        HttpHeaderPair(name: "content-length", value: "1"),
+        HttpHeaderPair(name: "Connection", value: "keep-alive"),
+        HttpHeaderPair(name: "X-Kept", value: "yes"),
+      ],
+      lastHash: ""
+    )
+    driver.render(makeImage())
+    check sink.entries.len == 1
+    check sink.entries[0]["event"].getStr() == "driver:httpUpload"
+
+  test "the default request is one bounded POST with the PNG body and headers":
+    createThread(uploadServerThread, uploadServerLoop)
+    while uploadServerPort == Port(0):
+      sleep(10)
+    defer:
+      try:
+        discard boundedRequest("http://127.0.0.1:" & $int(uploadServerPort) & "/quit",
+                               timeoutMs = 2000, maxSeconds = 5.0)
+      except CatchableError:
+        discard
+      joinThread(uploadServerThread)
+
+    let sink = LogSink(entries: @[])
+    let driver = Driver(
+      name: "httpUpload",
+      logger: makeLogger(sink),
+      url: "http://127.0.0.1:" & $int(uploadServerPort) & "/upload",
+      headers: @[HttpHeaderPair(name: "X-Test", value: "seen")],
+      lastHash: ""
+    )
+    driver.render(makeImage())
+    check sink.entries.len == 1
+    check sink.entries[0]["event"].getStr() == "driver:httpUpload:error"
+    check sink.entries[0]["status"].getInt() == 500
+    let summary = sink.entries[0]["error"].getStr()
+    let parts = summary.split('|')
+    check parts.len == 6
+    check parts[0] == "POST"
+    check parts[1] == "image/png"
+    check parts[2] == "seen"
+    check parseInt(parts[3]) > 0
+    check parts[4] == "hosts=1"
+    check parts[5] == "png=true"
+
+  test "an unresolvable host fails inside the driver's budget instead of hanging":
+    let sink = LogSink(entries: @[])
+    let driver = Driver(
+      name: "httpUpload",
+      logger: makeLogger(sink),
+      url: "http://127.0.0.1:1/upload", # nothing listens on port 1
+      headers: @[],
+      lastHash: ""
+    )
+    driver.render(makeImage())
+    check sink.entries.len == 1
+    check sink.entries[0]["event"].getStr() == "driver:httpUpload:error"
+    check not sink.entries[0].hasKey("status")


### PR DESCRIPTION
Fifth cut item 3 from `docs/review-todo.md` (§13 Mediums).

## beRecycle URL encoding
- Every query parameter goes through `encodeUrl(usePlus = false)` via three exported builders (`zipcodesUrl`, `streetsUrl`, `collectionsUrl`). A street name with a space or an accent now passes the runtime's `validateHttpRequestUrl` instead of being refused.
- Tests pin `%20` (no `+`), accents, `&` and `/` in values, and the collections URL.

## httpUpload on the runtime's bounded client
- The hand-rolled http socket reader and the stdlib https client are deleted. One POST on `boundedRequest`: 30 s socket timeout, 90 s total budget, 256 KB response cap, `maxRedirects = 0` (a 301/302 would otherwise turn the upload into a bodiless GET that "succeeds").
- `buildHeaders` drops reserved hop-by-hop/framing headers (Host, Content-Length, Connection…) and runs every configured header through `validateHttpHeader`, so a CRLF in a value or a non-token name is a logged driver error and nothing is sent.
- Config surface and the `requestHook` test seam unchanged. Four new tests including an end-to-end POST against a loopback server thread.

## Remote `shell` through `utils/process.nim` with a timeout
- `execShellSimple` runs on `startProcessSerialized` + `ProcessOutputReader`, polled with `sleepAsync(50)` so the websocket heartbeat keeps running; `stopProcess` at the deadline.
- Timeout from `args.timeout` (seconds) clamped to 4 h, default 1800 s (the backend's longest step). Output past 8 MB is dropped, not buffered.
- Wire format kept: stream chunks as before, final `{"exit": rc}`; a timeout answers `ok=false, {"exit": -1, "timedOut": true, "error": …}`.
- `remote/config.nims` adds `../src` to the Nim path when it exists (conditional so the Dockerfile's dependency-only `nimble setup` copy still works). The backend's source deploy copies `frameos/remote` alone, so `deploy_remote.py` now stages `frameos/utils/process.nim` (std-only) under `<temp>/src/` too, with a test.
- New `frameos/remote/tests/test_shell.nim`: clamp/default, line streaming + exit codes, a `sleep 30` stopped at a 500 ms deadline, an async ticker firing during the command, 9 MB output truncated.

## Verified
```
nim c -r src/apps/data/beRecycle/tests/test_app.nim            3/3 OK
nim c -r src/drivers/httpUpload/tests/test_http_upload.nim      8/8 OK
nim c -r frameos/remote/tests/test_shell.nim                    OK
nim c -o:/tmp/… -d:ssl src/frameos.nim                          links
nim c --app:lib -d:frameosDriverLibrary … httpUpload.nim        compiles
nim c --useMalloc --panics:on -d:ssl frameos_remote.nim         builds
TEST=1 pytest app/tasks/tests/test_deploy_remote.py test_cross_bin.py   33 passed
```

Not done here: the Remote's `tests/` directory is not discovered by any CI job (`run_test_shard.sh` only walks `src/**/tests/`), and the backend does not yet forward `timeout` on the `shell` payload, so the Remote uses its 1800 s default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrbChngvqARbcdbkrYF7sb