### PR TITLE
Review todo: fifth cut item 2, device runtime plumbing

### DIFF
--- a/frameos/src/frameos/metrics.nim
+++ b/frameos/src/frameos/metrics.nim
@@ -228,18 +228,12 @@ var metricsMemoryUsageHook: MemoryUsageHook = proc(): tuple[total, used: int64, 
 var metricsDiskUsageHook: DiskUsageHook = proc(): JsonNode = defaultDiskUsage()
 
 proc getLoadAverage(self: MetricsLoggerThread): seq[float] =
-  try:
-    let cpuTempLine = metricsReadFileHook("/proc/loadavg")
-    result = cpuTempLine.split(" ")[0..2].map(parseFloat)
-  except IOError:
-    result = @[]
+  let loadLine = metricsReadFileHook("/proc/loadavg")
+  loadLine.split(" ")[0..2].map(parseFloat)
 
 proc getCPUTemperature(self: MetricsLoggerThread): float =
-  try:
-    let cpuTempLine = metricsReadFileHook("/sys/class/thermal/thermal_zone0/temp")
-    result = parseFloat(cpuTempLine.strip()) / 1000.0
-  except IOError:
-    result = 0.0
+  let cpuTempLine = metricsReadFileHook("/sys/class/thermal/thermal_zone0/temp")
+  parseFloat(cpuTempLine.strip()) / 1000.0
 
 proc getMemoryUsage(self: MetricsLoggerThread): JsonNode =
   let memoryInfo = metricsMemoryUsageHook()
@@ -264,20 +258,36 @@ proc getOpenFileDescriptors(self: MetricsLoggerThread): int =
 proc getProcessMemoryUsage*(self: MetricsLoggerThread): JsonNode =
   defaultProcessMemoryUsage()
 
+# Every probe runs on its own: a `/proc` line that fails to parse, a thermal
+# zone that is missing, or a hook that raises leaves that one field `null`
+# (and names itself under `errors`) while the rest of the sample still goes
+# out. Building the sample as one expression meant one ValueError — a
+# "cpu_temp not available" board, a loadavg with an unexpected field — threw
+# away every metric the frame would ever have logged.
+template probe(payload: JsonNode, errors: JsonNode, key: string, body: untyped) =
+  try:
+    payload[key] = %(body)
+  except CatchableError as e:
+    payload[key] = newJNull()
+    errors[key] = %e.msg
+
+proc buildMetricsSample(self: MetricsLoggerThread): JsonNode =
+  result = %*{"event": "metrics"}
+  var errors = newJObject()
+  probe(result, errors, "load"): self.getLoadAverage()
+  probe(result, errors, "cpuTemperature"): self.getCPUTemperature()
+  probe(result, errors, "memoryUsage"): self.getMemoryUsage()
+  probe(result, errors, "diskUsage"): self.getDiskUsage()
+  probe(result, errors, "processMemory"): self.getProcessMemoryUsage()
+  probe(result, errors, "cpuUsage"): self.getCPUUsage()
+  probe(result, errors, "cpuCount"): self.getCPUCount()
+  probe(result, errors, "openFileDescriptors"): self.getOpenFileDescriptors()
+  probe(result, errors, "runtime"): runtimeDiagnosticsSnapshot()
+  if errors.len > 0:
+    result["errors"] = errors
+
 proc logMetrics(self: MetricsLoggerThread) =
-  var payload = %*{
-    "event": "metrics",
-    "load": self.getLoadAverage(),
-    "cpuTemperature": self.getCPUTemperature(),
-    "memoryUsage": self.getMemoryUsage(),
-    "diskUsage": self.getDiskUsage(),
-    "processMemory": self.getProcessMemoryUsage(),
-    "cpuUsage": self.getCPUUsage(),
-    "cpuCount": self.getCPUCount(),
-    "openFileDescriptors": self.getOpenFileDescriptors(),
-    "runtime": runtimeDiagnosticsSnapshot(),
-  }
-  log(payload)
+  log(self.buildMetricsSample())
 
 proc logMetricsSample(self: MetricsLoggerThread) =
   try:

--- a/frameos/src/frameos/portal.nim
+++ b/frameos/src/frameos/portal.nim
@@ -142,7 +142,22 @@ proc defaultPortalReadFileHook(path: string): string {.gcsafe, nimcall.} =
 proc defaultPortalPathExistsHook(path: string): bool {.gcsafe, nimcall.} =
   fileExists(path) or dirExists(path)
 
-proc hotspotAutoTimeoutLoop(frameOS: FrameOS, startedAt: MonoTime) {.gcsafe, nimcall.}
+# What crosses to a threadpool worker. `spawn` copies its arguments into the
+# task: a `ref` would carry ORC's non-atomic refcount across threads (the
+# same class of race that took the admin panel down on 2026-09-06,
+# server/auth.nim). The runtime's one FrameOS outlives every thread the
+# portal starts, so the worker gets its raw address and reads it back through
+# a cursor — no refcount traffic on either side. Everything else that rides
+# along (a MonoTime, an object of strings) is a plain value and is copied.
+type RuntimeHandle* = distinct pointer
+
+proc runtimeHandle*(frameOS: FrameOS): RuntimeHandle =
+  RuntimeHandle(cast[pointer](frameOS))
+
+template frameOSOf(handle: RuntimeHandle): FrameOS =
+  cast[FrameOS](pointer(handle))
+
+proc hotspotAutoTimeoutLoop(handle: RuntimeHandle, startedAt: MonoTime) {.gcsafe, nimcall.}
 
 var portalRunHook: PortalRunHook = defaultPortalRunHook
 var portalNmcliConnectHook: PortalNmcliConnectHook = defaultPortalNmcliConnectHook
@@ -1311,7 +1326,7 @@ proc finishStartedHotspot(frameOS: FrameOS): bool {.gcsafe.} =
   pLog("portal:startAp:done")
   sendEvent("setCurrentScene", %*{"sceneId": "system/wifiHotspot".SceneId})
   if portalAutoTimeoutEnabledHook():
-    spawn hotspotAutoTimeoutLoop(frameOS, hotspotStarted)
+    spawn hotspotAutoTimeoutLoop(runtimeHandle(frameOS), hotspotStarted)
   true
 
 proc startApSupplicant(frameOS: FrameOS) {.gcsafe.} =
@@ -1445,7 +1460,8 @@ proc startAp*(frameOS: FrameOS) {.gcsafe.} =
   pLog("portal:startAp:error")
 
 
-proc hotspotAutoTimeoutLoop(frameOS: FrameOS, startedAt: MonoTime) {.gcsafe, nimcall.} =
+proc hotspotAutoTimeoutLoop(handle: RuntimeHandle, startedAt: MonoTime) {.gcsafe, nimcall.} =
+  let frameOS {.cursor.} = frameOSOf(handle)
   while true:
     portalSleepHook(1000)
     if frameOS.network.hotspotStatus != HotspotStatus.enabled:
@@ -1661,6 +1677,12 @@ proc connectToWifi*(frameOS: FrameOS, options: PortalSetupOptions) {.gcsafe.} =
     noteNetworkCheck(NetworkStatus.error, "Wi-Fi join failed")
     rememberError("Wifi connection failed. Check your credentials.")
     startAp(frameOS)
+
+proc connectToWifiDetached*(handle: RuntimeHandle, options: PortalSetupOptions) {.gcsafe, nimcall.} =
+  ## The `spawn` entry point for POST /setup: the runtime by handle (see
+  ## RuntimeHandle), the form as a value.
+  let frameOS {.cursor.} = frameOSOf(handle)
+  connectToWifi(frameOS, options)
 
 proc checkNetwork*(self: FrameOS): bool =
   # A "bootOnly" hotspot needs the connectivity probe even when networkCheck

--- a/frameos/src/frameos/server/api.nim
+++ b/frameos/src/frameos/server/api.nim
@@ -397,8 +397,11 @@ proc frontendFramePayloadToRuntimeConfig*(payload: JsonNode, existing: JsonNode)
     result["errorBehavior"] = frontendErrorBehaviorToRuntime(payload["error_behavior"], result{"errorBehavior"})
 
   var frameApi = if result{"frameApi"} != nil and result{"frameApi"}.kind == JObject: copy(result["frameApi"]) else: %*{}
+  # `settings` lives once, under its own key: the echo must not keep a
+  # second copy of the service keys that GET then has to strip again.
   for key in payload.keys:
-    if key != "next_action" and key != "skip_runtime_reload" and key != frameSyncMarkDeployedKey:
+    if key != "next_action" and key != "skip_runtime_reload" and key != frameSyncMarkDeployedKey and
+        key != "settings":
       frameApi[key] = copy(payload[key])
   # The echo is what GET prefers for these fields, so it carries what was
   # actually kept — never the blank a secret-less form sent back.
@@ -755,7 +758,6 @@ proc frameApiPayload*(connectionsState: ConnectionsState, exposeSecrets = false)
   result["interval"] = storedConfigValue(configJson, "interval", %300)
   result["background_color"] = storedConfigValue(configJson, "backgroundColor", %"#000000")
   result["upload_fonts"] = storedApiOrConfigValue(configJson, storedFrameApi, "upload_fonts", "uploadFonts", %"")
-  result.delete("settings") # app secrets never ride the frame payload; see /api/settings
   result["https_proxy"] = apiHttpsProxy(live{"httpsProxy"}, exposeSecrets)
   result["error_behavior"] = apiErrorBehavior(live{"errorBehavior"})
   result["device_config"] = apiDeviceConfig(configJson{"deviceConfig"}, live{"deviceConfig"})
@@ -816,6 +818,11 @@ proc frameApiPayload*(connectionsState: ConnectionsState, exposeSecrets = false)
   for key in storedFrameApi.keys:
     if exposeSecrets or not result.hasKey(key):
       result[key] = copy(storedFrameApi[key])
+  # App service keys never ride the frame payload (see /api/settings, the
+  # admin-only reader). This has to come LAST: the echo loop above used to
+  # put `settings` back after an earlier delete — for a masked reader
+  # precisely because the delete had made the key "absent".
+  result.delete("settings")
 
 const frameSyncExposeHeaders = "X-Scene-Id, X-FrameOS-Sync-Changed, X-FrameOS-Sync-Revision, X-FrameOS-Deployed-Revision, X-FrameOS-Frame-Config-Modified-At, X-FrameOS-Scenes-Modified-At, X-FrameOS-Last-Successful-Deploy-At"
 

--- a/frameos/src/frameos/server/routes/repository_api_routes.nim
+++ b/frameos/src/frameos/server/routes/repository_api_routes.nim
@@ -1,10 +1,11 @@
-import std/[algorithm, httpclient, json, locks, monotimes, strutils, tables, times]
+import std/[algorithm, json, locks, monotimes, strutils, tables, times]
 import mummy
 import mummy/routers
 import httpcore
 import frameos/version
 import frameos/channels
 import frameos/cloud/link_state
+import frameos/utils/http_client
 import ../api
 import ../auth
 import ../embedded_assets
@@ -163,7 +164,7 @@ proc loadSystemRepository(repositorySlug: string): JsonNode {.gcsafe.} =
   result["id"] = %("system-" & repositorySlug)
   result["name"] = %(metadata{"name"}.getStr(repositorySlug))
   result["description"] =
-    if metadata{"description"}.kind == JString: %(metadata{"description"}.getStr()) else: newJNull()
+    if metadata{"description"} != nil and metadata["description"].kind == JString: %(metadata["description"].getStr()) else: newJNull()
   result["url"] = %("/api/repositories/system/" & repositorySlug & "/repository.json")
   result["last_updated_at"] = newJNull()
   result["templates"] = templates
@@ -206,43 +207,65 @@ const
   CloudStoreRepositoryId* = "system-cloud-store"
   CloudStoreScenesRoutePrefix = "/api/repositories/cloud-store/scenes/"
   cloudStoreIndexTtlSeconds = 300
+  ## A provider that is down or answering garbage is not asked again on the
+  ## very next request: with four worker threads and the SPA polling, that
+  ## was a fetch per request, each one waiting out the timeout.
+  cloudStoreFailureTtlSeconds = 30
   cloudStoreFetchTimeoutMs = 10_000
+  cloudStoreFetchMaxSeconds = 15.0
+  ## The index is a catalog (names, ids, image and zip URLs); a scene's
+  ## scenes.json carries app sources and can be far larger.
+  CloudStoreIndexMaxBytes* = 2 * 1024 * 1024
+  CloudStoreScenesMaxBytes* = 8 * 1024 * 1024
 
-type CloudStoreFetchHook* = proc(url: string): tuple[body: string, status: int] {.gcsafe, nimcall.}
+type CloudStoreFetchHook* = proc(url: string, maxBytes: int): tuple[body: string, status: int] {.gcsafe, nimcall.}
 
-proc defaultCloudStoreFetch(url: string): tuple[body: string, status: int] {.gcsafe, nimcall.} =
-  let client = newHttpClient(timeout = cloudStoreFetchTimeoutMs, maxRedirects = 2)
+proc defaultCloudStoreFetch(url: string, maxBytes: int): tuple[body: string, status: int] {.gcsafe, nimcall.} =
+  ## The runtime's own client: connect, TLS and send are bounded, not just
+  ## the read (utils/http_client.nim), the body is capped at maxBytes, and
+  ## redirects are counted. The stdlib client this replaced bounded none of
+  ## those and let the provider size the frame's heap.
   try:
-    let response = client.get(url)
-    let status = try: parseInt(response.status.split(' ')[0]) except ValueError: 0
-    (body: response.body, status: status)
+    let response = boundedRequestWithHeaders(url, timeoutMs = cloudStoreFetchTimeoutMs,
+                                             maxBytes = maxBytes, maxSeconds = cloudStoreFetchMaxSeconds,
+                                             maxRedirects = 2)
+    (body: response.body, status: response.code)
   except CatchableError as e:
     (body: e.msg, status: 0)
-  finally:
-    client.close()
 
 var cloudStoreFetchHook: CloudStoreFetchHook = defaultCloudStoreFetch
 
 proc setCloudStoreFetchHookForTest*(hook: CloudStoreFetchHook) =
   cloudStoreFetchHook = if hook == nil: defaultCloudStoreFetch else: hook
 
-# The cached index is kept as its raw body (a string, copied out under the
-# lock) and parsed per request: a JsonNode shared across the worker threads
-# is what took the admin panel down on 2026-09-06 (server/auth.nim).
+# The index is fetched and shaped ONCE per TTL and kept as the serialized
+# repository entry (a string, copied out under the lock): a JsonNode shared
+# across the worker threads is what took the admin panel down on 2026-09-06
+# (server/auth.nim), and re-parsing the provider's whole index on every
+# request was the other half of the cost. `cloudStoreFetchLock` is the
+# single-flight: the first request past a stale cache holds it while it
+# fetches, the others queue on it and find the fresh entry when they wake.
 var
   cloudStoreCacheLock: Lock
+  cloudStoreFetchLock: Lock
   cloudStoreCacheUrl: string
-  cloudStoreCacheBody: string
+  cloudStoreCacheEntry: string
   cloudStoreCacheAt: MonoTime
   cloudStoreCacheValid: bool
+  cloudStoreFailedUrl: string
+  cloudStoreFailedAt: MonoTime
+  cloudStoreFailedValid: bool
 
 initLock(cloudStoreCacheLock)
+initLock(cloudStoreFetchLock)
 
 proc resetCloudStoreCacheForTest*() =
   withLock cloudStoreCacheLock:
     cloudStoreCacheValid = false
-    cloudStoreCacheBody = ""
+    cloudStoreCacheEntry = ""
     cloudStoreCacheUrl = ""
+    cloudStoreFailedValid = false
+    cloudStoreFailedUrl = ""
 
 proc cloudStoreProviderUrl(): string {.gcsafe.} =
   providerUrlFromState(loadCloudLinkState()).strip(chars = {'/'})
@@ -255,26 +278,6 @@ proc cloudStoreRepositoryUrl*(): string {.gcsafe.} =
   if version.len == 0 or version == "unknown": base & "repository.json"
   else: base & version & "/repository.json"
 
-proc cloudStoreIndexBody(): string {.gcsafe.} =
-  ## The store index as served by the provider, or "" when it cannot be had.
-  let url = cloudStoreRepositoryUrl()
-  {.gcsafe.}:
-    withLock cloudStoreCacheLock:
-      if cloudStoreCacheValid and cloudStoreCacheUrl == url and
-          (getMonoTime() - cloudStoreCacheAt) < initDuration(seconds = cloudStoreIndexTtlSeconds):
-        return cloudStoreCacheBody
-    let fetched = cloudStoreFetchHook(url)
-    if fetched.status != 200:
-      log(%*{"event": "repositories:cloudStore:unavailable", "url": url, "status": fetched.status,
-             "error": (if fetched.status == 0: fetched.body else: "")})
-      return ""
-    withLock cloudStoreCacheLock:
-      cloudStoreCacheUrl = url
-      cloudStoreCacheBody = fetched.body
-      cloudStoreCacheAt = getMonoTime()
-      cloudStoreCacheValid = true
-    fetched.body
-
 proc resolveAgainst(repositoryUrl: string, value: string): string =
   ## "./x" is relative to the index's directory, as the backend and the cloud
   ## SPA both resolve it (backend/app/models/repository.py).
@@ -286,12 +289,9 @@ proc resolveAgainst(repositoryUrl: string, value: string): string =
 proc validStoreSceneId(value: string): bool =
   value.len == 36 and value.allCharsInSet({'0'..'9', 'a'..'f', 'A'..'F', '-'})
 
-proc cloudStoreRepositoryPayload*(): JsonNode {.gcsafe.} =
-  ## The store as one repository entry, or nil when the index is unavailable.
-  let url = cloudStoreRepositoryUrl()
-  let body = cloudStoreIndexBody()
-  if body.len == 0:
-    return nil
+proc shapeCloudStoreRepository(url: string, body: string): JsonNode {.gcsafe.} =
+  ## The provider's index as one repository entry, or nil when the body is
+  ## not an index.
   let data =
     try:
       parseJson(body)
@@ -324,14 +324,71 @@ proc cloudStoreRepositoryPayload*(): JsonNode {.gcsafe.} =
   result["id"] = %CloudStoreRepositoryId
   result["name"] = %(data{"name"}.getStr("FrameOS Cloud store"))
   result["description"] =
-    if data{"description"}.kind == JString: %(data["description"].getStr()) else: newJNull()
+    if data{"description"} != nil and data["description"].kind == JString: %(data["description"].getStr()) else: newJNull()
   result["url"] = %url
   result["last_updated_at"] = newJNull()
   result["templates"] = templates
 
+proc cachedCloudStoreEntry(url: string, now: MonoTime): tuple[hit: bool, entry: string] {.gcsafe.} =
+  ## Under the cache lock: the serialized entry when it is fresh, "" (as a
+  ## hit) inside the failure window, and a miss otherwise.
+  {.gcsafe.}:
+    withLock cloudStoreCacheLock:
+      if cloudStoreCacheValid and cloudStoreCacheUrl == url and
+          (now - cloudStoreCacheAt) < initDuration(seconds = cloudStoreIndexTtlSeconds):
+        return (hit: true, entry: cloudStoreCacheEntry)
+      if cloudStoreFailedValid and cloudStoreFailedUrl == url and
+          (now - cloudStoreFailedAt) < initDuration(seconds = cloudStoreFailureTtlSeconds):
+        return (hit: true, entry: "")
+  (hit: false, entry: "")
+
+proc cloudStoreRepositoryEntry*(): string {.gcsafe.} =
+  ## The store as one serialized repository entry, or "" when the index
+  ## cannot be had. One fetch and one parse per TTL, shared by every worker.
+  let url = cloudStoreRepositoryUrl()
+  let cached = cachedCloudStoreEntry(url, getMonoTime())
+  if cached.hit:
+    return cached.entry
+  result = ""
+  {.gcsafe.}:
+    withLock cloudStoreFetchLock:
+      # Whoever held the lock before us may have filled the cache.
+      let again = cachedCloudStoreEntry(url, getMonoTime())
+      if again.hit:
+        return again.entry
+      let fetched = cloudStoreFetchHook(url, CloudStoreIndexMaxBytes)
+      var shaped: JsonNode = nil
+      if fetched.status != 200:
+        log(%*{"event": "repositories:cloudStore:unavailable", "url": url, "status": fetched.status,
+               "error": (if fetched.status == 0: fetched.body else: "")})
+      else:
+        shaped = shapeCloudStoreRepository(url, fetched.body)
+      let entry = if shaped == nil: "" else: $shaped
+      withLock cloudStoreCacheLock:
+        if shaped == nil:
+          cloudStoreFailedUrl = url
+          cloudStoreFailedAt = getMonoTime()
+          cloudStoreFailedValid = true
+        else:
+          cloudStoreCacheUrl = url
+          cloudStoreCacheEntry = entry
+          cloudStoreCacheAt = getMonoTime()
+          cloudStoreCacheValid = true
+          cloudStoreFailedValid = false
+      result = entry
+
+proc cloudStoreRepositoryPayload*(): JsonNode {.gcsafe.} =
+  ## The store as one repository entry, or nil when the index is unavailable.
+  ## A fresh node per caller — never the cached one.
+  let entry = cloudStoreRepositoryEntry()
+  if entry.len == 0:
+    return nil
+  parseJson(entry)
+
 proc cloudStoreSceneScenesJson(sceneId: string): tuple[body: string, status: int] {.gcsafe.} =
   {.gcsafe.}:
-    cloudStoreFetchHook(cloudStoreProviderUrl() & "/api/store/scenes/" & sceneId & "/scenes.json")
+    cloudStoreFetchHook(cloudStoreProviderUrl() & "/api/store/scenes/" & sceneId & "/scenes.json",
+                        CloudStoreScenesMaxBytes)
 
 proc requireRepositoryReadAccess(request: Request): bool {.gcsafe.} =
   if not hasAdminAccess(request):
@@ -351,11 +408,11 @@ proc addRepositoryApiRoutes*(router: var Router) =
     if not requireRepositoryReadAccess(request):
       return
     {.gcsafe.}:
-      var repositories = newJArray()
-      let cloudStore = cloudStoreRepositoryPayload()
-      if cloudStore != nil:
-        repositories.add(cloudStore)
-      jsonResponse(request, Http200, repositories)
+      # The cached entry is served as-is: no parse per request.
+      let cloudStore = cloudStoreRepositoryEntry()
+      var headers: mummy.HttpHeaders
+      headers["Content-Type"] = "application/json"
+      request.respond(Http200, headers, "[" & cloudStore & "]")
   )
 
   router.get("/api/repositories/cloud-store/scenes/@sceneId/scenes.json", proc(request: Request) {.gcsafe.} =

--- a/frameos/src/frameos/server/routes/web_routes.nim
+++ b/frameos/src/frameos/server/routes/web_routes.nim
@@ -201,7 +201,7 @@ proc addWebRoutes*(router: var Router, connectionsState: ConnectionsState, admin
       if not netportal.persistPortalSetup(globalFrameOS, options):
         request.respond(Http500, body = netportal.setupHtml(globalFrameOS))
         return
-      spawn netportal.connectToWifi(globalFrameOS, options)
+      spawn netportal.connectToWifiDetached(netportal.runtimeHandle(globalFrameOS), options)
       request.respond(Http200, body = netportal.confirmHtml(globalFrameOS, ssid = options.ssid))
   )
 

--- a/frameos/src/frameos/server/tests/test_api.nim
+++ b/frameos/src/frameos/server/tests/test_api.nim
@@ -1,4 +1,5 @@
 import unittest
+import strutils
 import times
 import os
 import mummy
@@ -336,3 +337,30 @@ suite "the frame payload round-trips what the device stores":
     let privileged = frameApiPayload(state, exposeSecrets = true)
     check privileged{"network"}{"wifiHotspotPassword"}.getStr() == "hotspot-secret"
     check privileged{"agent"}{"agentSharedSecret"}.getStr() == "agent-secret"
+
+  test "service settings never ride the frame payload, masked or not":
+    # `settings` (OpenAI / Immich / Home Assistant keys) is in frameApiKeyMap
+    # so the SPA form round-trips it on POST, but the GET payload drops it on
+    # BOTH branches: a masked payload that carried it would hand every
+    # service key to whoever holds only the frame access key. /api/settings
+    # is the admin-only reader.
+    let tempRoot = getTempDir() / "frameos-api-settings-off-payload"
+    createDir(tempRoot)
+    writeFile(tempRoot / "frame.json", $(%*{
+      "settings": {"openAI": {"apiKey": "sk-stored-openai"}},
+      "frameApi": {"settings": {"immich": {"apiKey": "immich-echoed"}}},
+    }))
+    putEnv("FRAMEOS_CONFIG", tempRoot / "frame.json")
+    var config = baseConfig(tempRoot)
+    setConfigDefaults(config)
+    config.settings = %*{"openAI": {"apiKey": "sk-live-openai"}, "homeAssistant": {"accessToken": "ha-token"}}
+    globalFrameConfig = config
+    let state = initConnectionsState()
+    for exposeSecrets in [false, true]:
+      let payload = frameApiPayload(state, exposeSecrets = exposeSecrets)
+      check not payload.hasKey("settings")
+      let serialized = $payload
+      check "sk-live-openai" notin serialized
+      check "sk-stored-openai" notin serialized
+      check "immich-echoed" notin serialized
+      check "ha-token" notin serialized

--- a/frameos/src/frameos/server/tests/test_frame_api_routes_behavior.nim
+++ b/frameos/src/frameos/server/tests/test_frame_api_routes_behavior.nim
@@ -145,7 +145,7 @@ suite "frame api route behavior":
     # this frame is linked to (or the default one). Unreachable → nothing,
     # the SPA falls back to the bundled repositories above.
     resetCloudStoreCacheForTest()
-    setCloudStoreFetchHookForTest(proc(url: string): tuple[body: string, status: int] {.gcsafe, nimcall.} =
+    setCloudStoreFetchHookForTest(proc(url: string, maxBytes: int): tuple[body: string, status: int] {.gcsafe, nimcall.} =
       (body: "connection refused", status: 0))
     let customRepositories = httpRequest(server.port, "GET", "/api/repositories", headers = [("Cookie", adminCookie)])
     check customRepositories.status == 200
@@ -155,7 +155,7 @@ suite "frame api route behavior":
     # shape, "./" assets resolved against the index, scenes routed through
     # this frame so the browser never talks to the provider directly.
     resetCloudStoreCacheForTest()
-    setCloudStoreFetchHookForTest(proc(url: string): tuple[body: string, status: int] {.gcsafe, nimcall.} =
+    setCloudStoreFetchHookForTest(proc(url: string, maxBytes: int): tuple[body: string, status: int] {.gcsafe, nimcall.} =
       if url.endsWith("/repository.json"):
         return (body: $(%*{
           "name": "FrameOS Cloud store",

--- a/frameos/src/frameos/server/tests/test_repository_api_routes.nim
+++ b/frameos/src/frameos/server/tests/test_repository_api_routes.nim
@@ -1,0 +1,115 @@
+import std/[json, locks, os, strutils, unittest]
+
+import ../../channels
+import ../routes/repository_api_routes
+
+# The hook is nimcall + gcsafe, so the counters live in globals behind a
+# lock and are reached through a gcsafe cast.
+var hookLock: Lock
+initLock(hookLock)
+var hookCalls = 0
+var hookMaxBytes = 0
+var hookDelayMs = 0
+var hookStatus = 200
+
+proc countingHook(url: string, maxBytes: int): tuple[body: string, status: int] {.gcsafe, nimcall.} =
+  {.cast(gcsafe).}:
+    var delay = 0
+    var status = 200
+    withLock hookLock:
+      inc hookCalls
+      hookMaxBytes = maxBytes
+      delay = hookDelayMs
+      status = hookStatus
+    if delay > 0:
+      sleep(delay)
+    if status != 200:
+      return (body: "connection refused", status: status)
+    (body: $(%*{
+      "name": "FrameOS Cloud store",
+      "templates": [
+        {"name": "Weather", "sceneId": "8a5f1f2e-1111-4222-8333-444455556666",
+         "image": "./scenes/8a5f1f2e-1111-4222-8333-444455556666/image?v=3"},
+      ],
+    }), status: 200)
+
+proc drainLogChannel() =
+  while true:
+    let (ok, _) = logChannel.tryRecv()
+    if not ok:
+      break
+
+proc resetHook(delayMs = 0, status = 200) =
+  withLock hookLock:
+    hookCalls = 0
+    hookMaxBytes = 0
+    hookDelayMs = delayMs
+    hookStatus = status
+  resetCloudStoreCacheForTest()
+  setCloudStoreFetchHookForTest(countingHook)
+  drainLogChannel()
+
+proc calls(): int =
+  withLock hookLock:
+    result = hookCalls
+
+proc maxBytesSeen(): int =
+  withLock hookLock:
+    result = hookMaxBytes
+
+var threadSawEntry: array[4, bool]
+
+proc fetchFromThread(index: int) {.thread.} =
+  let payload = cloudStoreRepositoryPayload()
+  {.cast(gcsafe).}:
+    threadSawEntry[index] = payload != nil and payload{"id"}.getStr("") == CloudStoreRepositoryId
+
+suite "cloud store repository cache":
+  teardown:
+    setCloudStoreFetchHookForTest(nil)
+    resetCloudStoreCacheForTest()
+
+  test "concurrent requests past a cold cache share one fetch":
+    resetHook(delayMs = 300)
+    var threads: array[4, Thread[int]]
+    for index, t in threads.mpairs:
+      createThread(t, fetchFromThread, index)
+    for t in threads.mitems:
+      joinThread(t)
+    check calls() == 1
+    for saw in threadSawEntry:
+      check saw
+
+  test "a fresh entry is served without another fetch, and the index fetch is bounded":
+    resetHook()
+    let first = cloudStoreRepositoryPayload()
+    check first != nil
+    check first["templates"][0]["scenesUrl"].getStr() ==
+      "/api/repositories/cloud-store/scenes/8a5f1f2e-1111-4222-8333-444455556666/scenes.json"
+    check maxBytesSeen() == CloudStoreIndexMaxBytes
+    check CloudStoreIndexMaxBytes > 0
+    check CloudStoreScenesMaxBytes >= CloudStoreIndexMaxBytes
+    discard cloudStoreRepositoryPayload()
+    discard cloudStoreRepositoryEntry()
+    check calls() == 1
+
+  test "every caller gets its own node, the cached entry is a string":
+    resetHook()
+    var first = cloudStoreRepositoryPayload()
+    first["name"] = %"mutated by one worker"
+    first["templates"].add(%*{"name": "injected"})
+    let second = cloudStoreRepositoryPayload()
+    check second["name"].getStr() == "FrameOS Cloud store"
+    check second["templates"].len == 1
+    check calls() == 1
+
+  test "an unreachable provider is not asked again on the next request":
+    resetHook(status = 0)
+    check cloudStoreRepositoryPayload() == nil
+    check cloudStoreRepositoryEntry() == ""
+    check cloudStoreRepositoryPayload() == nil
+    check calls() == 1
+    # Resetting the cache ends the failure window.
+    resetCloudStoreCacheForTest()
+    check cloudStoreRepositoryPayload() == nil
+    check calls() == 2

--- a/frameos/src/frameos/tests/test_metrics.nim
+++ b/frameos/src/frameos/tests/test_metrics.nim
@@ -161,26 +161,68 @@ suite "metrics loop":
     check runtime["nodeType"].getStr() == "app"
     check runtime["keyword"].getStr() == "data/demo"
 
-  test "sample exceptions are logged as error state":
+  test "one failing probe nulls its field and keeps the rest of the sample":
+    # A ValueError from one probe (a thermal zone reading "N/A", a loadavg
+    # with an unexpected shape, a hook that raises) used to replace the whole
+    # sample with an error line. Every other field must still be reported.
     setMetricsHooksForTest(
       readFileHook = proc(path: string): string {.gcsafe, nimcall.} =
         if path == "/proc/loadavg":
           "0.10 0.20 0.30 1/123 456\n"
         elif path == "/sys/class/thermal/thermal_zone0/temp":
-          "42000\n"
+          "N/A\n"
         else:
           raise newException(IOError, "unexpected path"),
       cpuUsageHook = proc(interval: float): float {.gcsafe, nimcall.} =
         raise newException(ValueError, "cpu probe failed"),
-      sleepHook = proc(ms: int) {.gcsafe, nimcall.} = discard
+      sleepHook = proc(ms: int) {.gcsafe, nimcall.} = discard,
+      memoryUsageHook = proc(): tuple[total, used: int64, percentage: float] {.gcsafe, nimcall.} =
+        (1234'i64, 778'i64, 63.0),
+      diskUsageHook = proc(): JsonNode {.gcsafe, nimcall.} = %*{"total": 16000'i64},
+      openFileDescriptorsHook = proc(): int {.gcsafe, nimcall.} = 7
     )
 
     runMetricsLoopForTest(FrameConfig(metricsInterval: 1), iterations = 1)
 
-    let (okError, errorPayload) = logChannel.tryRecv()
-    check okError
-    check errorPayload.event == "metrics"
-    let errorJson = logJson(errorPayload)
-    check errorJson["event"].getStr() == "metrics"
-    check errorJson["state"].getStr() == "error"
-    check "cpu probe failed" in errorJson["error"].getStr()
+    let (okSample, samplePayload) = logChannel.tryRecv()
+    check okSample
+    check samplePayload.event == "metrics"
+    let sampleJson = logJson(samplePayload)
+    check not sampleJson.hasKey("state")
+    check sampleJson["load"].len == 3
+    check sampleJson["load"][2].getFloat() == 0.3
+    check sampleJson["cpuTemperature"].kind == JNull
+    check sampleJson["cpuUsage"].kind == JNull
+    check sampleJson["memoryUsage"]["used"].getInt() == 778
+    check sampleJson["diskUsage"]["total"].getInt() == 16000
+    check sampleJson["openFileDescriptors"].getInt() == 7
+    check sampleJson["runtime"].kind == JObject
+    check "cpu probe failed" in sampleJson["errors"]["cpuUsage"].getStr()
+    check sampleJson["errors"].hasKey("cpuTemperature")
+    let (hasNext, _) = logChannel.tryRecv()
+    check not hasNext
+
+  test "the loop keeps sampling after a probe fails":
+    setMetricsHooksForTest(
+      readFileHook = proc(path: string): string {.gcsafe, nimcall.} =
+        raise newException(ValueError, "no proc here"),
+      cpuUsageHook = proc(interval: float): float {.gcsafe, nimcall.} = 1.0,
+      sleepHook = proc(ms: int) {.gcsafe, nimcall.} = discard,
+      memoryUsageHook = proc(): tuple[total, used: int64, percentage: float] {.gcsafe, nimcall.} =
+        (10'i64, 5'i64, 50.0),
+      diskUsageHook = proc(): JsonNode {.gcsafe, nimcall.} = newJObject(),
+      openFileDescriptorsHook = proc(): int {.gcsafe, nimcall.} = 1
+    )
+
+    runMetricsLoopForTest(FrameConfig(metricsInterval: 1), iterations = 3)
+
+    var samples = 0
+    while true:
+      let (ok, payload) = logChannel.tryRecv()
+      if not ok:
+        break
+      let sampleJson = logJson(payload)
+      check sampleJson["load"].kind == JNull
+      check sampleJson["cpuUsage"].getFloat() == 1.0
+      inc samples
+    check samples == 3

--- a/frameos/src/frameos/tests/test_portal.nim
+++ b/frameos/src/frameos/tests/test_portal.nim
@@ -912,3 +912,12 @@ suite "portal boot-screen ticks":
     waitBetweenNetworkAttempts(120)
     check slices == @[50, 50, 20]
     resetPortalHooksForTest()
+
+suite "threadpool hand-off":
+  test "a runtime handle reads back the same FrameOS without a counted ref":
+    # spawn copies its arguments; the portal hands the pool the runtime's
+    # address (a plain pointer) and a value form, never a ref.
+    let frameOS = FrameOS(frameConfig: FrameConfig(), network: Network())
+    let handle = runtimeHandle(frameOS)
+    check cast[pointer](frameOS) == pointer(handle)
+    check sizeof(RuntimeHandle) == sizeof(pointer)

--- a/frameos/src/frameos/utils/process.nim
+++ b/frameos/src/frameos/utils/process.nim
@@ -3,6 +3,14 @@ import std/[locks, monotimes, os, osproc, posix, streams, strutils, times]
 const
   DefaultProcessTerminateTimeoutMs* = 1500
   DefaultProcessKillTimeoutMs* = 500
+  ## Every helper below bounds its child unless the caller says otherwise.
+  ## A minute covers the slowest routine child (a driver's Python setup, a
+  ## gzip of a day's log); apt, chromium and the setup scripts pass their own.
+  ## `timeoutMs = -1` still means "wait forever" but has to be asked for.
+  DefaultProcessTimeoutMs* = 60_000
+  ## Captured stdout is capped too: a chatty child used to be able to grow
+  ## the runtime's heap without limit on a 512 MB frame.
+  DefaultProcessMaxOutputBytes* = 4 * 1024 * 1024
   DefaultProcessPollMs = 100
   ProcessExitPollMs = 20
   ProcessPipeChunkSize = 8192
@@ -88,7 +96,7 @@ proc waitBounded(p: Process; timeoutMs: int): ExternalProcessResult =
 
 proc runProcessWithParentStreams*(command: string;
                                   args: seq[string] = @[];
-                                  timeoutMs = -1): ExternalProcessResult =
+                                  timeoutMs = DefaultProcessTimeoutMs): ExternalProcessResult =
   ## Use this for child processes whose output is not consumed by FrameOS.
   ## It avoids deadlocks from full stdout/stderr pipes.
   var p = startProcessSerialized(command, args = args, options = {poUsePath, poParentStreams})
@@ -97,7 +105,8 @@ proc runProcessWithParentStreams*(command: string;
   finally:
     p.close()
 
-proc runShellWithParentStreams*(command: string; timeoutMs = -1): ExternalProcessResult =
+proc runShellWithParentStreams*(command: string;
+                                timeoutMs = DefaultProcessTimeoutMs): ExternalProcessResult =
   ## Bounded replacement for osproc.execCmd/execShellCmd: runs `command`
   ## through /bin/sh -c with the parent's stdout/stderr, kills it after
   ## timeoutMs and gives up waiting if it cannot be killed.
@@ -180,11 +189,14 @@ proc waitForPipedExit(p: Process): int =
 proc runProcessPiped*(command: string;
                       args: seq[string] = @[];
                       input = "";
-                      timeoutMs = -1;
-                      maxOutputBytes = 0;
+                      timeoutMs = DefaultProcessTimeoutMs;
+                      maxOutputBytes = DefaultProcessMaxOutputBytes;
                       maxErrorBytes = 4096): PipedProcessResult =
   ## Runs a child process without blocking on stdin/stdout/stderr pipe ordering.
-  ## stdout is captured and bounded; stderr is drained and lightly captured.
+  ## stdout is captured and bounded (`maxOutputBytes <= 0` lifts the cap);
+  ## stderr is drained and lightly captured. Deadlines are monotonic: setup
+  ## steps the wall clock (NTP after the hotspot, the timezone link) while
+  ## children are running, and an epoch-based deadline jumped with it.
   var p = startProcessSerialized(command, args = args, options = {poUsePath})
   var inputClosed = false
   try:
@@ -195,13 +207,13 @@ proc runProcessPiped*(command: string;
     var inputOffset = 0
     var stdoutEof = false
     var stderrEof = false
-    let startedAt = epochTime()
+    let deadline = getMonoTime() + initDuration(milliseconds = max(0, timeoutMs))
 
     if input.len == 0:
       p.closeInput(inputClosed)
 
     while true:
-      if timeoutMs >= 0 and epochTime() > startedAt + (timeoutMs.float / 1000.0):
+      if timeoutMs >= 0 and getMonoTime() > deadline:
         p.stopProcess()
         result.timedOut = true
         result.exitCode = -1
@@ -271,8 +283,8 @@ proc runProcessPiped*(command: string;
 
 proc runShellCapture*(command: string;
                       input = "";
-                      timeoutMs = -1;
-                      maxOutputBytes = 4 * 1024 * 1024): tuple[output: string, exitCode: int] =
+                      timeoutMs = DefaultProcessTimeoutMs;
+                      maxOutputBytes = DefaultProcessMaxOutputBytes): tuple[output: string, exitCode: int] =
   ## Bounded replacement for osproc.execCmdEx: runs `command` through
   ## /bin/sh -c and captures stdout with stderr appended after it.
   let res = runProcessPiped("/bin/sh", @["-c", command], input = input,
@@ -321,7 +333,7 @@ proc readAvailableLines*(reader: var ProcessOutputReader): seq[string] =
 proc writeInputDrainingOutput*(p: Process;
                                input: openArray[uint8];
                                reader: var ProcessOutputReader;
-                               timeoutMs = -1): tuple[timedOut: bool, inputWritten: bool] =
+                               timeoutMs = DefaultProcessTimeoutMs): tuple[timedOut: bool, inputWritten: bool] =
   ## Streams `input` into p's stdin while draining p's stdout into `reader`,
   ## so neither side can block forever on a full pipe. Closes stdin when the
   ## input has been written or the child stops accepting it. Intended for
@@ -329,10 +341,10 @@ proc writeInputDrainingOutput*(p: Process;
   var inputClosed = false
   p.inputHandle().setNonBlocking()
   var inputOffset = 0
-  let startedAt = epochTime()
+  let deadline = getMonoTime() + initDuration(milliseconds = max(0, timeoutMs))
   try:
     while inputOffset < input.len:
-      if timeoutMs >= 0 and epochTime() > startedAt + (timeoutMs.float / 1000.0):
+      if timeoutMs >= 0 and getMonoTime() > deadline:
         result.timedOut = true
         return
 

--- a/frameos/src/frameos/utils/tests/test_process.nim
+++ b/frameos/src/frameos/utils/tests/test_process.nim
@@ -55,6 +55,24 @@ sys.stdout.flush()
     check result.exitCode == -1
     check result.outputExceeded
 
+  test "the defaults bound time and output without being asked":
+    # "Wait forever, buffer unbounded" is no longer what a caller gets by
+    # leaving the arguments off: the runtime hosts render and event loops on
+    # the thread that spawns most children.
+    check DefaultProcessTimeoutMs > 0
+    check DefaultProcessTimeoutMs <= 5 * 60_000
+    check DefaultProcessMaxOutputBytes > 0
+    let flood = runProcessPiped(
+      "python3",
+      @["-c", "import sys; sys.stdout.write('x' * (" & $DefaultProcessMaxOutputBytes & " + 4096)); sys.stdout.flush()"]
+    )
+    check flood.outputExceeded
+    check flood.exitCode == -1
+    check flood.output.len <= DefaultProcessMaxOutputBytes
+    let (captured, _) = runShellCapture("python3 -c \"import sys; sys.stdout.write('y' * (" &
+      $DefaultProcessMaxOutputBytes & " + 4096))\"")
+    check captured.len <= DefaultProcessMaxOutputBytes + 65536
+
   test "runShellCapture captures stdout and appends stderr":
     let (output, exitCode) = runShellCapture("echo out; echo err 1>&2; exit 3", timeoutMs = 5000)
     check exitCode == 3


### PR DESCRIPTION
Fifth cut item 2 from `docs/review-todo.md` (§12 Mediums).

## One `ValueError` no longer discards the metrics sample
- `metrics.nim` builds the sample probe by probe through a `probe` template: a `CatchableError` in one probe nulls that field and records it under `errors`; every other field still goes out. `getLoadAverage` / `getCPUTemperature` used to swallow only `IOError`, so a `parseFloat` failure killed the whole sample.
- Tests: "one failing probe nulls its field and keeps the rest of the sample", "the loop keeps sampling after a probe fails" (replacing the test that pinned the old behaviour). The frontend already treats missing/null metrics as absent.

## Cloud store fetch bounded, parsed once, single-flight
- `repository_api_routes.nim`: fetch on `boundedRequestWithHeaders` (10 s / 15 s max, 2 redirects, 2 MB index cap, 8 MB scenes.json cap). The index is fetched and shaped once per 5-minute TTL and cached as the serialized entry **string** (never a JsonNode shared across mummy workers, see the 2026-09-06 auth-cache incident); `/api/repositories` serves it without a parse per request, and `cloudStoreRepositoryPayload()` hands each caller its own node. Single-flight behind `cloudStoreFetchLock` (queued callers re-check the cache), 30 s negative cache for an unreachable provider.
- Bonus: `data{"description"}.kind` on a missing key segfaulted (`{}` returns nil) in both the cloud-store and bundled-repository shapers; nil-guarded. Found by the new `test_repository_api_routes.nim` (4 threads share one fetch, fresh entry served without refetch, per-caller nodes, failure window).

## `settings` never rides the masked frame payload
- The review item was real and worse than described: `frameApiPayload` deleted `settings`, then the trailing "last saved payload wins" echo loop copied `storedFrameApi.settings` back — for the masked reader precisely because the delete had made the key absent. The delete now runs last in both branches, and `frontendFramePayloadToRuntimeConfig` no longer stores `settings` in the `frameApi` echo at all (no second copy of service keys in `frame.json`).
- Test: live + stored + echoed service keys never appear in the serialized payload for `exposeSecrets` false or true.

## Process wrapper defaults and deadlines
- `DefaultProcessTimeoutMs = 60_000` and `DefaultProcessMaxOutputBytes = 4 MB` replace `-1` / `0` on every public wait (`-1` still opts in to "wait forever"). Every existing caller already passes explicit values, so nothing changes in the field. `epochTime()` deadlines replaced with `getMonoTime()`.

## Threadpool `spawn` refs
- The portal's two `spawn`s (`hotspotAutoTimeoutLoop`, the POST /setup wifi connect) no longer carry a `FrameOS` ref across threads: a `RuntimeHandle` (distinct pointer) is read back through a `{.cursor.}`, and `PortalSetupOptions` crosses as an object of strings. `createThread(..., frameConfig)` sites (metrics, logger) are unchanged; the item named `spawn`.

## Verified
```
test_metrics 6 OK · test_process 10 OK · test_portal 50 OK · test_api 12 OK
test_frame_api_routes_behavior 11 OK · test_repository_api_routes 4 OK
test_scenes_persistence 8 OK · test_web_routes_behavior 15 OK
nim c -d:ssl src/frameos.nim  links
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrbChngvqARbcdbkrYF7sb