### PR TITLE
Review todo: fifth cut item 6, hub sweeps guarded and batched

### DIFF
--- a/cloud/apps/frame-hub/src/hub.ts
+++ b/cloud/apps/frame-hub/src/hub.ts
@@ -68,6 +68,7 @@ import {
   isAllowedBrowserOrigin,
 } from "./env";
 import { errorField, logError, logInfo, logWarn } from "./log";
+import { createGuardedInterval } from "./periodic";
 import {
   browserEvent,
   commandMessage,
@@ -302,13 +303,20 @@ export interface FrameHubOptions {
   sweepIntervalMs?: number;
   lifecycleAuditDebounceMs?: number;
   assetStreamIdleMs?: number;
+  // Test seam: called with the text of every statement this hub's pool
+  // sends, so a test can count what one sweep costs. Gives the hub its own
+  // (uncached) pool; production leaves it unset.
+  onQuery?: (query: string) => void;
 }
 
 export interface FrameHub {
   port: number;
   connectedFrames(): number;
-  // Runs one periodic sweep immediately; the interval keeps running too.
+  // Runs one periodic sweep immediately (after any sweep already in flight);
+  // the interval keeps running too.
   sweep(): Promise<void>;
+  // Timer ticks skipped because the previous sweep was still running.
+  skippedSweeps(): number;
   close(): Promise<void>;
 }
 
@@ -319,7 +327,9 @@ export async function startFrameHub(
   if (!databaseUrl) {
     throw new Error("DATABASE_URL is required to start the frame hub");
   }
-  const db = createDb(databaseUrl);
+  const db = options.onQuery
+    ? createDb(databaseUrl, { onQuery: options.onQuery })
+    : createDb(databaseUrl);
   const authTimeoutMs = options.authTimeoutMs ?? defaultAuthTimeoutMs;
   const heartbeatIntervalMs =
     options.heartbeatIntervalMs ?? defaultHeartbeatIntervalMs;
@@ -506,13 +516,20 @@ export async function startFrameHub(
   // this session wrote can be outstanding yet), or the write was lost on a
   // still-live connection (caught by the sweep, cutoff = now minus the grace
   // period).
-  async function redeliverSentCommands(frameId: string, cutoff: Date) {
+  //
+  // Takes a list of frames so the sweep can do this for every connected
+  // device in three statements instead of three per device; the per-frame
+  // semantics (and the per-frame log line) are unchanged.
+  async function redeliverSentCommands(frameIds: string[], cutoff: Date) {
+    if (frameIds.length === 0) {
+      return 0;
+    }
     await db
       .update(frameCommands)
       .set({ error: "delivered_once", status: "expired" })
       .where(
         and(
-          eq(frameCommands.frameId, frameId),
+          inArray(frameCommands.frameId, frameIds),
           eq(frameCommands.status, "sent"),
           lt(frameCommands.sentAt, cutoff),
           inArray(frameCommands.type, [
@@ -532,7 +549,7 @@ export async function startFrameHub(
       .set({ error: "superseded", status: "expired" })
       .where(
         and(
-          eq(frameCommands.frameId, frameId),
+          inArray(frameCommands.frameId, frameIds),
           eq(frameCommands.status, "sent"),
           lt(frameCommands.sentAt, cutoff),
           sql`exists (
@@ -549,21 +566,51 @@ export async function startFrameHub(
       .set({ sentAt: null, status: "pending" })
       .where(
         and(
-          eq(frameCommands.frameId, frameId),
+          inArray(frameCommands.frameId, frameIds),
           eq(frameCommands.status, "sent"),
           lt(frameCommands.sentAt, cutoff),
         ),
       )
-      .returning({ id: frameCommands.id });
-    if (requeued.length > 0) {
-      logWarn("command.redelivering", { count: requeued.length, frameId });
+      .returning({ frameId: frameCommands.frameId, id: frameCommands.id });
+    const perFrame = new Map<string, number>();
+    for (const row of requeued) {
+      perFrame.set(row.frameId, (perFrame.get(row.frameId) ?? 0) + 1);
+    }
+    for (const [frameId, count] of perFrame) {
+      logWarn("command.redelivering", { count, frameId });
     }
     return requeued.length;
   }
 
+  // Which of these frames have a command waiting. One statement for the
+  // whole connected set: the sweep drains only the frames that come back,
+  // and in the steady state (NOTIFY already drained everything) that is none.
+  async function framesWithPendingCommands(frameIds: string[]) {
+    if (frameIds.length === 0) {
+      return new Set<string>();
+    }
+    const rows = await db
+      .selectDistinct({ frameId: frameCommands.frameId })
+      .from(frameCommands)
+      .where(
+        and(
+          inArray(frameCommands.frameId, frameIds),
+          eq(frameCommands.status, "pending"),
+        ),
+      );
+    return new Set(rows.map((row) => row.frameId));
+  }
+
   // Drain the durable command queue to a live device socket, oldest first.
   // Serialized per session: a NOTIFY landing mid-drain queues one more pass.
-  async function drainCommands(session: DeviceSession) {
+  //
+  // `expire: false` is for the sweep, which has just expired every frame's
+  // stale commands in one statement and does not need it again on the first
+  // pass; a queued second pass (a NOTIFY landed mid-drain) expires as usual.
+  async function drainCommands(
+    session: DeviceSession,
+    { expire = true }: { expire?: boolean } = {},
+  ) {
     if (!session.ready || session.closed) {
       return;
     }
@@ -572,10 +619,14 @@ export async function startFrameHub(
       return;
     }
     session.draining = true;
+    let expireThisPass = expire;
     try {
       do {
         session.drainQueued = false;
-        await expireStaleCommands(session.frame.id);
+        if (expireThisPass) {
+          await expireStaleCommands(session.frame.id);
+        }
+        expireThisPass = true;
         const pending = await db
           .select()
           .from(frameCommands)
@@ -668,20 +719,42 @@ export async function startFrameHub(
   // device redials and hears the new grant in a fresh `ready` (neither
   // device plane takes an unsolicited scope message; both reconnect on any
   // close but 4401).
-  async function frameSessionStaleness(
+  //
+  // The read is batched (one statement for every connected frame) because the
+  // sweep asks this of the whole connected set every 30 s; the NOTIFY path
+  // asks for one frame.
+  type Staleness = "stale" | "rescoped" | undefined;
+
+  async function frameStalenessRows(frameIds: string[]) {
+    const rows =
+      frameIds.length === 0
+        ? []
+        : await db
+            .select({
+              frameId: frames.id,
+              providerClientMetadata: linkedClients.providerClientMetadata,
+              publicKey: frames.publicKey,
+              revokedAt: linkedClients.revokedAt,
+              status: frames.status,
+            })
+            .from(frames)
+            .innerJoin(
+              linkedClients,
+              eq(linkedClients.id, frames.linkedClientId),
+            )
+            .where(inArray(frames.id, frameIds));
+    return new Map(rows.map((row) => [row.frameId, row]));
+  }
+
+  type StalenessRow =
+    Awaited<ReturnType<typeof frameStalenessRows>> extends Map<string, infer Row>
+      ? Row
+      : never;
+
+  function judgeStaleness(
     session: DeviceSession,
-  ): Promise<"stale" | "rescoped" | undefined> {
-    const [row] = await db
-      .select({
-        providerClientMetadata: linkedClients.providerClientMetadata,
-        publicKey: frames.publicKey,
-        revokedAt: linkedClients.revokedAt,
-        status: frames.status,
-      })
-      .from(frames)
-      .innerJoin(linkedClients, eq(linkedClients.id, frames.linkedClientId))
-      .where(eq(frames.id, session.frame.id))
-      .limit(1);
+    row: StalenessRow | undefined,
+  ): Staleness {
     if (
       !row ||
       row.status === "revoked" ||
@@ -694,6 +767,27 @@ export async function startFrameHub(
       return "rescoped";
     }
     return undefined;
+  }
+
+  async function frameSessionStaleness(
+    session: DeviceSession,
+  ): Promise<Staleness> {
+    const rows = await frameStalenessRows([session.frame.id]);
+    return judgeStaleness(session, rows.get(session.frame.id));
+  }
+
+  // The stale / rescoped exits, shared by the NOTIFY wake and the sweep.
+  // Returns true when the session was closed and must not be drained.
+  async function closeIfStale(session: DeviceSession, staleness: Staleness) {
+    if (staleness === "stale") {
+      await kickRevokedSession(session);
+      return true;
+    }
+    if (staleness === "rescoped") {
+      await closeRescopedSession(session);
+      return true;
+    }
+    return false;
   }
 
   async function isFrameSessionStale(session: DeviceSession) {
@@ -737,18 +831,12 @@ export async function startFrameHub(
     if (!session.ready || !session.readySent || session.closed) {
       return;
     }
-    const staleness = await frameSessionStaleness(session);
-    if (staleness === "stale") {
-      await kickRevokedSession(session);
-      return;
-    }
-    if (staleness === "rescoped") {
-      await closeRescopedSession(session);
+    if (await closeIfStale(session, await frameSessionStaleness(session))) {
       return;
     }
     // Anything still unacked well past its write is treated as lost.
     await redeliverSentCommands(
-      session.frame.id,
+      [session.frame.id],
       new Date(Date.now() - redeliverAfterMs),
     );
     await drainCommands(session);
@@ -865,7 +953,7 @@ export async function startFrameHub(
     // A fresh session cannot have written anything yet, so every command
     // still in "sent" belongs to a socket that died before acking: requeue it
     // all (cutoff = now) before counting what the device is about to receive.
-    await redeliverSentCommands(frameId, now);
+    await redeliverSentCommands([frameId], now);
     const [pendingRow] = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(frameCommands)
@@ -2151,7 +2239,7 @@ export async function startFrameHub(
   });
 
   // Liveness: ping every 30s, terminate sockets that missed a pong.
-  const heartbeatTimer = setInterval(() => {
+  function runHeartbeat() {
     const now = Date.now();
     for (const session of deviceSessions.values()) {
       if (!session.alive) {
@@ -2186,7 +2274,14 @@ export async function startFrameHub(
         }
       }
     }
-  }, heartbeatIntervalMs);
+  }
+  const heartbeat = createGuardedInterval({
+    intervalMs: heartbeatIntervalMs,
+    onError: (error) =>
+      logError("heartbeat.failed", { error: errorField(error) }),
+    onSkip: () => logWarn("heartbeat.tick_skipped"),
+    run: runHeartbeat,
+  });
 
   // Browser sockets authenticate once, at upgrade; a session revoked later
   // (logout, admin revoke, expiry) has to be noticed here or the socket keeps
@@ -2218,18 +2313,61 @@ export async function startFrameHub(
   // pending/sent commands whose TTL passed while no one was draining them,
   // plus the browser-session revocation recheck.
   //
+  // The per-device work of a wake (the staleness re-read, the three
+  // redelivery statements, the pending check) is done here for the whole
+  // connected set in one statement each, so a tick costs a handful of
+  // queries however many devices are connected; only a frame that actually
+  // has a command waiting (or has to be kicked) gets its own statements.
+  // The steady state — NOTIFY drained everything, nobody revoked — is six
+  // statements per tick (expiry, staleness, the three redelivery updates,
+  // the pending check), pinned by the "sweep" integration tests.
+  //
   // One session's failure (a database error mid-drain, a socket that went
   // away between the readyState check and the write) must not skip the wake
   // of every session after it in iteration order — the sweep is the fallback
   // for a missed NOTIFY, so a frame skipped here waits a whole interval.
   async function runSweep() {
     await expireStaleCommands();
-    for (const session of deviceSessions.values()) {
-      if (!session.ready) {
+    const sessions = [...deviceSessions.values()].filter(
+      (session) => session.ready && session.readySent && !session.closed,
+    );
+    const staleness = await frameStalenessRows(
+      sessions.map((session) => session.frame.id),
+    );
+    const live: DeviceSession[] = [];
+    for (const session of sessions) {
+      try {
+        const verdict = judgeStaleness(
+          session,
+          staleness.get(session.frame.id),
+        );
+        if (!(await closeIfStale(session, verdict))) {
+          live.push(session);
+        }
+      } catch (error) {
+        logError("sweep.wake_failed", {
+          error: errorField(error),
+          frameId: session.frame.id,
+        });
+      }
+    }
+    const liveIds = live.map((session) => session.frame.id);
+    try {
+      // Anything still unacked well past its write is treated as lost.
+      await redeliverSentCommands(
+        liveIds,
+        new Date(Date.now() - redeliverAfterMs),
+      );
+    } catch (error) {
+      logError("sweep.redeliver_failed", { error: errorField(error) });
+    }
+    const withPending = await framesWithPendingCommands(liveIds);
+    for (const session of live) {
+      if (!withPending.has(session.frame.id)) {
         continue;
       }
       try {
-        await wakeSession(session);
+        await drainCommands(session, { expire: false });
       } catch (error) {
         logError("sweep.wake_failed", {
           error: errorField(error),
@@ -2240,11 +2378,16 @@ export async function startFrameHub(
     await closeRevokedBrowserSockets();
   }
 
-  const sweepTimer = setInterval(() => {
-    runSweep().catch((error: unknown) =>
-      logError("sweep.failed", { error: errorField(error) }),
-    );
-  }, sweepIntervalMs);
+  // Guarded: a tick that outlives the interval (a slow database, many frames
+  // with work) is not started again on top of itself — the next tick is
+  // skipped and logged instead.
+  const sweep = createGuardedInterval({
+    intervalMs: sweepIntervalMs,
+    onError: (error) => logError("sweep.failed", { error: errorField(error) }),
+    onSkip: () =>
+      logWarn("sweep.tick_skipped", { connected: deviceSessions.size }),
+    run: runSweep,
+  });
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -2263,8 +2406,8 @@ export async function startFrameHub(
       return;
     }
     closed = true;
-    clearInterval(heartbeatTimer);
-    clearInterval(sweepTimer);
+    heartbeat.stop();
+    sweep.stop();
     try {
       await listenClient.end({ timeout: 5 });
     } catch (error) {
@@ -2310,12 +2453,18 @@ export async function startFrameHub(
       // so shutdown cannot hang on a half-open peer.
       setTimeout(() => server.closeAllConnections(), 250).unref();
     });
+    // An observed pool is this hub's own (see FrameHubOptions.onQuery); the
+    // shared cached one belongs to whoever created it.
+    if (options.onQuery) {
+      await db.$client.end({ timeout: 5 });
+    }
   }
 
   return {
     close,
     connectedFrames: () => deviceSessions.size,
     port,
-    sweep: runSweep,
+    skippedSweeps: () => sweep.skipped(),
+    sweep: () => sweep.runNow(),
   };
 }

--- a/cloud/apps/frame-hub/src/periodic.test.ts
+++ b/cloud/apps/frame-hub/src/periodic.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGuardedInterval } from "./periodic";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+// Lets the promise callbacks queued by a resolved tick run before the next
+// assertion (vi.advanceTimersByTimeAsync drains microtasks too, but a bare
+// resolve() does not).
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe("createGuardedInterval", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips the ticks that fire while one is still running", async () => {
+    const gate = deferred();
+    const run = vi.fn(() => gate.promise);
+    const onSkip = vi.fn();
+    const onError = vi.fn();
+    const interval = createGuardedInterval({
+      intervalMs: 100,
+      onError,
+      onSkip,
+      run,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    // Two more timer firings while the first tick is still awaiting.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onSkip).toHaveBeenCalledTimes(2);
+    expect(interval.skipped()).toBe(2);
+
+    gate.resolve();
+    await flush();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+    interval.stop();
+  });
+
+  it("keeps ticking after a tick throws or rejects", async () => {
+    const run = vi
+      .fn<() => void | Promise<void>>()
+      .mockImplementationOnce(() => {
+        throw new Error("sync failure");
+      })
+      .mockImplementationOnce(() => Promise.reject(new Error("async failure")))
+      .mockImplementation(() => undefined);
+    const onError = vi.fn();
+    const interval = createGuardedInterval({
+      intervalMs: 100,
+      onError,
+      onSkip: vi.fn(),
+      run,
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledTimes(2);
+    const messages = onError.mock.calls.map((call) => (call[0] as Error).message);
+    expect(messages).toEqual(["sync failure", "async failure"]);
+    expect(interval.skipped()).toBe(0);
+    interval.stop();
+  });
+
+  it("runNow waits for the in-flight tick and then runs a full one", async () => {
+    const gate = deferred();
+    let calls = 0;
+    const run = vi.fn(() => {
+      calls += 1;
+      return calls === 1 ? gate.promise : Promise.resolve();
+    });
+    const interval = createGuardedInterval({
+      intervalMs: 100,
+      onError: vi.fn(),
+      onSkip: vi.fn(),
+      run,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    let manualDone = false;
+    const manual = interval.runNow().then(() => {
+      manualDone = true;
+    });
+    await flush();
+    // Serialized behind the slow tick: not skipped, not started on top of it.
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(manualDone).toBe(false);
+
+    gate.resolve();
+    await manual;
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(interval.skipped()).toBe(0);
+    interval.stop();
+  });
+
+  it("stop() ends the timer", async () => {
+    const run = vi.fn();
+    const interval = createGuardedInterval({
+      intervalMs: 100,
+      onError: vi.fn(),
+      onSkip: vi.fn(),
+      run,
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    interval.stop();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cloud/apps/frame-hub/src/periodic.ts
+++ b/cloud/apps/frame-hub/src/periodic.ts
@@ -1,0 +1,70 @@
+// A setInterval whose ticks cannot overlap. The hub's periodic work (the
+// heartbeat, the command sweep) talks to Postgres and to sockets; a tick that
+// takes longer than the interval — a slow database, a few hundred devices
+// with pending commands — would otherwise start again on top of itself, and
+// every overlapping tick adds to the load that made the first one slow. A
+// tick still running when the timer fires is skipped and counted; a tick that
+// throws is logged and the next one still runs.
+
+export interface GuardedIntervalOptions {
+  intervalMs: number;
+  // One tick. May be synchronous or return a promise.
+  run: () => void | Promise<void>;
+  onError: (error: unknown) => void;
+  // The timer fired while the previous tick was still running.
+  onSkip: () => void;
+}
+
+export interface GuardedInterval {
+  // Runs one tick now, after any tick already in flight has finished (the
+  // caller wants a full pass to have happened, not a skipped one).
+  runNow(): Promise<void>;
+  // Ticks the timer found still running and skipped.
+  skipped(): number;
+  stop(): void;
+}
+
+export function createGuardedInterval(
+  options: GuardedIntervalOptions,
+): GuardedInterval {
+  let inFlight: Promise<void> | undefined;
+  let skipped = 0;
+
+  async function runOnce() {
+    try {
+      await options.run();
+    } catch (error) {
+      options.onError(error);
+    }
+  }
+
+  function start(): Promise<void> {
+    const tick = runOnce().finally(() => {
+      if (inFlight === tick) {
+        inFlight = undefined;
+      }
+    });
+    inFlight = tick;
+    return tick;
+  }
+
+  const timer = setInterval(() => {
+    if (inFlight) {
+      skipped += 1;
+      options.onSkip();
+      return;
+    }
+    void start();
+  }, options.intervalMs);
+
+  return {
+    async runNow() {
+      while (inFlight) {
+        await inFlight;
+      }
+      await start();
+    },
+    skipped: () => skipped,
+    stop: () => clearInterval(timer),
+  };
+}

--- a/cloud/apps/frame-hub/src/test/integration/frame-hub.integration.test.ts
+++ b/cloud/apps/frame-hub/src/test/integration/frame-hub.integration.test.ts
@@ -2320,3 +2320,122 @@ describe("deep-sleep forecast", () => {
     device.ws.close();
   });
 });
+
+// The periodic sweep is the fallback for a missed NOTIFY and the only wake
+// for a command that was written but never acked. It does its per-device
+// reads for the whole connected set at once (hub.ts runSweep), so its cost
+// must not grow with the number of connected devices.
+describe("sweep", () => {
+  // A row written without pg_notify: only the sweep can find it.
+  async function insertPendingCommand(frameId: string) {
+    const [row] = await db
+      .insert(frameCommands)
+      .values({
+        expiresAt: new Date(Date.now() + 60_000),
+        frameId,
+        type: "render",
+      })
+      .returning();
+    if (!row) {
+      throw new Error("command insert failed");
+    }
+    return row;
+  }
+
+  async function connectDevice(
+    fixture: { privateKey: KeyObject; token: string },
+    port: number,
+  ) {
+    const device = await openDevice(fixture.token, port);
+    await handshake(device, fixture.privateKey);
+    return device;
+  }
+
+  it("delivers, redelivers and kicks across every connected device in one pass", async () => {
+    const { account, ...first } = await createFrameFixture();
+    const second = await createFrameForAccount(account.id);
+    const third = await createFrameForAccount(account.id);
+    const extra = await startExtraHub({ commandRedeliverAfterMs: 0 });
+    const firstDevice = await connectDevice(first, extra.port);
+    const secondDevice = await connectDevice(second, extra.port);
+    const thirdDevice = await connectDevice(third, extra.port);
+
+    // first: a command nobody NOTIFYed about.
+    const pendingFirst = await insertPendingCommand(first.frame.id);
+    // second: written to the socket, never acked.
+    const sentSecond = await enqueueFrameCommand(db, {
+      frameId: second.frame.id,
+      ttlMs: 60_000,
+      type: "render",
+    });
+    await secondDevice.next((msg) => msg.id === sentSecond?.id, "first delivery");
+    await waitFor(async () => {
+      const [row] = await db
+        .select()
+        .from(frameCommands)
+        .where(eq(frameCommands.id, String(sentSecond?.id)));
+      return row?.status === "sent" ? row : undefined;
+    }, "command marked sent");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // third: revoked since it connected, without the NOTIFY revokeFrame sends
+    // — the sweep's own re-read has to catch it — and holding a command that
+    // must not go out.
+    await db
+      .update(frames)
+      .set({ status: "revoked" })
+      .where(eq(frames.id, third.frame.id));
+    const pendingThird = await insertPendingCommand(third.frame.id);
+
+    await extra.sweep();
+
+    await firstDevice.next((msg) => msg.id === pendingFirst.id, "sweep delivery");
+    await secondDevice.next(
+      (msg) => msg.id === sentSecond?.id,
+      "redelivery after the sweep",
+    );
+    expect(await thirdDevice.closed).toBe(4401);
+    const [thirdRow] = await db
+      .select()
+      .from(frameCommands)
+      .where(eq(frameCommands.id, pendingThird.id));
+    expect(thirdRow?.status).toBe("pending");
+    firstDevice.ws.close();
+    secondDevice.ws.close();
+  });
+
+  it("costs the same number of statements however many devices are connected", async () => {
+    const { account, ...first } = await createFrameFixture();
+    const statements: string[] = [];
+    const extra = await startExtraHub({
+      onQuery: (query) => statements.push(query),
+    });
+    const devices = [await connectDevice(first, extra.port)];
+    // Let the connect-time tail (update_frame broadcast, audit rows) finish
+    // before counting, then count one full sweep on an idle fleet.
+    async function countIdleSweep() {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await extra.sweep();
+      statements.length = 0;
+      await extra.sweep();
+      return statements.length;
+    }
+    const withOne = await countIdleSweep();
+
+    for (let i = 0; i < 4; i += 1) {
+      devices.push(
+        await connectDevice(await createFrameForAccount(account.id), extra.port),
+      );
+    }
+    expect(extra.connectedFrames()).toBe(5);
+    const withFive = await countIdleSweep();
+
+    expect(withFive).toBe(withOne);
+    // Expiry, the staleness re-read, the three redelivery updates and the
+    // pending check — one statement each for the whole connected set.
+    expect(withOne).toBe(6);
+    expect(extra.skippedSweeps()).toBe(0);
+    for (const device of devices) {
+      device.ws.close();
+    }
+  });
+});

--- a/cloud/packages/db/src/index.ts
+++ b/cloud/packages/db/src/index.ts
@@ -37,7 +37,18 @@ const cacheHolder = globalThis as typeof globalThis & {
 const clientCache = (cacheHolder.__frameosCloudDbClients ??=
   new Map<string, Database>());
 
-export function createDb(databaseUrl = process.env.DATABASE_URL) {
+export interface CreateDbOptions {
+  // Test seam: called with the text of every statement the pool sends. A
+  // client with an observer is NOT cached — it is the caller's own pool, to
+  // be ended by the caller — so the observer never leaks into the shared
+  // client other modules get for the same URL.
+  onQuery?: (query: string) => void;
+}
+
+export function createDb(
+  databaseUrl = process.env.DATABASE_URL,
+  options: CreateDbOptions = {},
+) {
   if (!databaseUrl) {
     throw new Error(
       "DATABASE_URL is required to create the FrameOS Cloud database client",
@@ -47,7 +58,7 @@ export function createDb(databaseUrl = process.env.DATABASE_URL) {
   // postgres.js holds its pool open until `.end()` is called, so creating a new
   // client per request would leak connections until Postgres refuses new ones.
   // Cache one pooled client per connection string and reuse it.
-  const cached = clientCache.get(databaseUrl);
+  const cached = options.onQuery ? undefined : clientCache.get(databaseUrl);
   if (cached) {
     return cached;
   }
@@ -56,12 +67,18 @@ export function createDb(databaseUrl = process.env.DATABASE_URL) {
   // socket, but any deployment where Postgres is on another host must set
   // DATABASE_SSL=require (or put sslmode=require in DATABASE_URL).
   const ssl = process.env.DATABASE_SSL;
+  const { onQuery } = options;
   const client = postgres(databaseUrl, {
     max: parsePoolMax(process.env.DATABASE_POOL_MAX),
     ...(ssl === "require" || ssl === "true" ? { ssl: "require" as const } : {}),
+    ...(onQuery
+      ? { debug: (_connection: number, query: string) => onQuery(query) }
+      : {}),
   });
   const db = drizzle(client, { schema });
-  clientCache.set(databaseUrl, db);
+  if (!onQuery) {
+    clientCache.set(databaseUrl, db);
+  }
   return db;
 }
 


### PR DESCRIPTION
Fifth cut item 6 from `docs/review-todo.md` (§6 Medium: sweeps not re-entrancy guarded, ~5 queries per connected device every 30 s).

## Re-entrancy guard
- New `cloud/apps/frame-hub/src/periodic.ts` `createGuardedInterval({ intervalMs, run, onError, onSkip })`: a tick still running when the timer fires is skipped and counted, a throwing/rejecting tick is reported and the next tick still runs, `runNow()` waits for any in-flight tick and then runs a full pass, `stop()` clears the timer.
- The heartbeat and the sweep both run on it (`heartbeat.tick_skipped` / `sweep.tick_skipped` warns, `heartbeat.failed` / `sweep.failed` errors). `FrameHub` gains `skippedSweeps()`; `sweep()` is `runNow()`.
- Fake-timer unit tests: two firings during a slow tick are skipped and the tick after runs; sync throw and async reject both reported and ticking continues; `runNow()` serializes behind the in-flight tick.

## Fewer queries per connected device
- `runSweep` is batched: global `expireStaleCommands()` → one `frameStalenessRows(ids)` select (`frames ⋈ linked_clients WHERE id = ANY`) judged per session → stale/rescoped sessions closed via the shared `closeIfStale` → `redeliverSentCommands(liveIds, cutoff)` (three statements over the whole live set, per-frame `command.redelivering` log kept via `returning frame_id`) → one `framesWithPendingCommands(liveIds)` distinct select → `drainCommands(session, { expire: false })` only for frames with a pending row.
- Per-session failures are still isolated (`sweep.wake_failed`), plus `sweep.redeliver_failed` for the batch. The NOTIFY wake and reconnect paths are unchanged in behaviour and call the same helpers with one-element lists.

| idle tick, N connected devices | statements |
|---|---|
| before | 1 + 5N |
| after | 6 |

- Integration tests: three devices on one hub in one sweep (pending row without NOTIFY delivered, unacked "sent" command redelivered, frame revoked by direct row update kicked 4401 with its pending command left pending); statement count of one idle sweep with 1 device equals the count with 5, pinned at 6, `skippedSweeps() === 0`.
- `createDb(url, { onQuery })` in `packages/db` is the test seam: an observed client uses postgres.js `debug`, is not cached, and the hub ends it on close. Without an observer, unchanged.

## Verified
```
frame-hub unit: 66/66 (5 files, incl. periodic.test.ts 4/4)
frame-hub integration (Postgres): 55/55 (53 existing + 2 new)
packages/db: 4/4 · tsc --noEmit (frame-hub, db): clean · eslint --max-warnings=0: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrbChngvqARbcdbkrYF7sb