### PR TITLE
Review todo: fifth cut item 7, frontend frames shell

### DIFF
--- a/cloud-frontend/src/scenes/App.tsx
+++ b/cloud-frontend/src/scenes/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, LazyExoticComponent, Suspense } from 'react'
+import { lazy, type ComponentType, type LazyExoticComponent, Suspense } from 'react'
 import { useValues } from 'kea'
 
 import { AccountHeader } from '../components/AccountHeader'
@@ -33,7 +33,7 @@ const PreviewKeyConsentModal = lazy(() =>
 // scrollbar — that is what would break the drawers' sizing.
 export function App(): JSX.Element {
   const { scene, params } = useValues(sceneLogic)
-  const SceneComponent: (() => JSX.Element) | LazyExoticComponent<any> =
+  const SceneComponent: ComponentType<any> | LazyExoticComponent<any> =
     scenes[scene as keyof typeof scenes] || scenes.error404
 
   return (

--- a/cloud-frontend/src/scenes/scenes.tsx
+++ b/cloud-frontend/src/scenes/scenes.tsx
@@ -1,9 +1,10 @@
 import { lazy } from 'react'
 
 import { urls } from '../../../frontend/src/urls'
+import { NotFound } from '../../../frontend/src/scenes/NotFound'
 
 export const scenes = {
-  error404: () => <div>404</div>,
+  error404: NotFound,
   frames: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudFramesHome }))),
   frame: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudFrame }))),
   sceneWorkspace: lazy(() => import('./cloud/Cloud').then((module) => ({ default: module.CloudSceneWorkspace }))),

--- a/cloud/apps/auth-web/src/test/shared-spa/frame-delete-copy.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/frame-delete-copy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  frameDeleteCopy,
+  frameDeleteCopyByMode,
+} from "../../../../../../frontend/src/scenes/workspace/frameDeleteCopy";
+import { allowedFrameMenuActions } from "../../../../../../frontend/src/scenes/workspace/workspaceSurfaces";
+
+// The "Delete frame" confirmation used to say the same thing on every
+// control plane: "…and all of its scenes … Archive it instead". On the cloud
+// neither exists — there is no archive, the scenes live in the account's
+// store, and DELETE /api/frames/{id} revokes the device's link so it drops
+// back to standalone while still showing what it has (2026-09 review, §10).
+
+describe("frameDeleteCopy", () => {
+  it("describes the backend's delete: the frame and its scenes go, archive is the alternative", () => {
+    const copy = frameDeleteCopy("backend");
+    const question = copy.confirm("Kitchen");
+    expect(question).toContain('"Kitchen"');
+    expect(question).toContain("all of its scenes");
+    expect(question).toContain("Archive it instead");
+    expect(copy.title).toContain("all of its scenes");
+  });
+
+  it("describes the cloud's delete: the device is unlinked and keeps running, scenes stay", () => {
+    const copy = frameDeleteCopy("cloud");
+    const question = copy.confirm("Kitchen");
+    expect(question).toContain('"Kitchen"');
+    expect(question).toContain("standalone");
+    expect(question).toContain("keeps showing the scenes it has");
+    expect(question).toContain("scenes stay in your account");
+    expect(question).toContain("cannot be undone");
+    expect(question).not.toContain("all of its scenes");
+    expect(question).not.toContain("Archive");
+    expect(copy.title).not.toContain("scenes");
+  });
+
+  it("only promises an archive where the mode's menu has one", () => {
+    for (const mode of ["backend", "cloud", "frameAdmin"] as const) {
+      const mentionsArchive = frameDeleteCopyByMode[mode].confirm("x").includes("Archive");
+      // frameAdmin hides Delete altogether (its menu allows neither verb),
+      // so its copy is only required to be consistent with itself.
+      if (allowedFrameMenuActions[mode].includes("delete")) {
+        expect(mentionsArchive).toBe(allowedFrameMenuActions[mode].includes("archive"));
+      }
+    }
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/frame-tool-route.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/frame-tool-route.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  frameToolNotFoundMessage,
+  frameToolPanels,
+  isFrameToolPanel,
+  resolveFrameToolRoute,
+} from "../../../../../../frontend/src/scenes/workspace/frameToolRoute";
+import { allowedFrameToolPanels } from "../../../../../../frontend/src/scenes/workspace/workspaceSurfaces";
+
+// The tool segment of a frame URL (/frames/<id>/<tool>) used to be checked
+// against EVERY panel and then fell back to the overview, so
+// /frames/<id>/terminal on the cloud — which has no shell — quietly rendered
+// the scenes page (2026-09 review, §10). The resolver now answers against
+// the mode's allow-list: a foreign or unknown tool is a 404, a tool the
+// device profile cannot serve is an explanation, and only a tool the control
+// plane implements for this frame is a panel.
+
+describe("resolveFrameToolRoute", () => {
+  it("treats the bare frame URL as the overview", () => {
+    expect(resolveFrameToolRoute(null, "cloud")).toEqual({ kind: "panel", panel: "overview" });
+    expect(resolveFrameToolRoute(undefined, "backend")).toEqual({ kind: "panel", panel: "overview" });
+    expect(resolveFrameToolRoute("", "frameAdmin")).toEqual({ kind: "panel", panel: "overview" });
+  });
+
+  it("is a 404, not the overview, for a tool another control plane implements", () => {
+    expect(resolveFrameToolRoute("terminal", "cloud")).toEqual({ kind: "notFound", segment: "terminal" });
+    expect(resolveFrameToolRoute("ping", "frameAdmin")).toEqual({ kind: "notFound", segment: "ping" });
+    expect(resolveFrameToolRoute("activity", "backend")).toEqual({ kind: "notFound", segment: "activity" });
+  });
+
+  it("is a 404 for a segment that is no tool at all", () => {
+    expect(resolveFrameToolRoute("nonsense", "backend")).toEqual({ kind: "notFound", segment: "nonsense" });
+    expect(resolveFrameToolRoute(42, "cloud")).toEqual({ kind: "notFound", segment: "42" });
+  });
+
+  it("renders every tool the mode lists, on every mode", () => {
+    for (const mode of ["backend", "cloud", "frameAdmin"] as const) {
+      for (const panel of allowedFrameToolPanels[mode]) {
+        expect(resolveFrameToolRoute(panel, mode)).toEqual({ kind: "panel", panel });
+      }
+      for (const panel of frameToolPanels) {
+        if (!allowedFrameToolPanels[mode].includes(panel)) {
+          expect(resolveFrameToolRoute(panel, mode)).toEqual({ kind: "notFound", segment: panel });
+        }
+      }
+    }
+  });
+
+  it("hides a tool whose concept the device lacks (terminal on a virtual frame) as a 404", () => {
+    const virtual = { embedded: { platform: "virtual" } };
+    expect(resolveFrameToolRoute("terminal", "backend", virtual)).toEqual({ kind: "notFound", segment: "terminal" });
+    expect(resolveFrameToolRoute("metrics", "backend", virtual)).toEqual({ kind: "notFound", segment: "metrics" });
+    expect(resolveFrameToolRoute("assets", "backend", virtual)).toEqual({ kind: "panel", panel: "assets" });
+  });
+
+  it("explains, rather than swaps, a tool the device profile disables", () => {
+    // The esp32 cloud profile currently gates nothing (workspaceSurfaces.ts),
+    // so the disabled branch is exercised through the resolver's own contract
+    // against the surfaces module: whatever the profile disables must come
+    // back as `disabled` with the surfaces' reason, never as another panel.
+    const esp32 = { hardware: { platform: "esp32-s3" } };
+    for (const panel of allowedFrameToolPanels.cloud) {
+      const resolution = resolveFrameToolRoute(panel, "cloud", esp32);
+      expect(resolution.kind === "panel" || resolution.kind === "disabled").toBe(true);
+      if (resolution.kind === "disabled") {
+        expect(resolution.panel).toBe(panel);
+        expect(resolution.reason.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("frameToolPanels", () => {
+  it("covers every panel any mode lists", () => {
+    for (const mode of ["backend", "cloud", "frameAdmin"] as const) {
+      for (const panel of allowedFrameToolPanels[mode]) {
+        expect(isFrameToolPanel(panel)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("frameToolNotFoundMessage", () => {
+  it("names the control plane for a real tool it does not implement", () => {
+    expect(frameToolNotFoundMessage("terminal", "cloud")).toBe(
+      'There is no "terminal" tool for this frame on FrameOS Cloud.',
+    );
+    expect(frameToolNotFoundMessage("ping", "frameAdmin")).toContain("admin panel");
+  });
+
+  it("says plainly that an unknown segment is no page", () => {
+    expect(frameToolNotFoundMessage("nonsense", "backend")).toBe('This frame has no "nonsense" page.');
+  });
+});

--- a/cloud/apps/auth-web/src/test/shared-spa/not-found-scene.test.tsx
+++ b/cloud/apps/auth-web/src/test/shared-spa/not-found-scene.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NotFound, NotFoundContent } from "../../../../../../frontend/src/scenes/NotFound";
+
+// Both scene tables (frontend/src/scenes/scenes.tsx and
+// cloud-frontend/src/scenes/scenes.tsx) used to map `error404` to a bare
+// `<div>404</div>`. The shared page names the path that failed and offers a
+// way back; under the cloud's /frames mount the way back is the SPA's own
+// frames URL.
+
+function withAppConfig<T>(config: Record<string, unknown>, run: () => T): T {
+  (window as unknown as { FRAMEOS_APP_CONFIG?: unknown }).FRAMEOS_APP_CONFIG = config;
+  try {
+    return run();
+  } finally {
+    delete (window as unknown as { FRAMEOS_APP_CONFIG?: unknown }).FRAMEOS_APP_CONFIG;
+  }
+}
+
+afterEach(() => {
+  delete (window as unknown as { FRAMEOS_APP_CONFIG?: unknown }).FRAMEOS_APP_CONFIG;
+});
+
+describe("<NotFound>", () => {
+  it("says which path failed and links back to the frames list", () => {
+    const html = renderToStaticMarkup(<NotFound path="/frames/7/nonsense" />);
+    expect(html).toContain("Page not found");
+    expect(html).toContain("/frames/7/nonsense");
+    expect(html).toContain("Back to your frames");
+    // Self-hosted, the frames list is the SPA's root.
+    expect(html).toMatch(/<a [^>]*href="\/"/);
+    expect(html).not.toBe("<div>404</div>");
+  });
+
+  it("links to the cloud's /frames mount under the cloud SPA config", () => {
+    const html = withAppConfig({ cloudMode: true, route_base_path: "/frames", ingress_path: "" }, () =>
+      renderToStaticMarkup(<NotFound path="/frames/x/terminal" />),
+    );
+    expect(html).toMatch(/<a [^>]*href="\/frames"/);
+  });
+
+  it("takes an explanation and a way out of its own for a tool the frame lacks", () => {
+    const html = renderToStaticMarkup(
+      <NotFoundContent
+        title="Terminal is not available for this frame"
+        message="This frame does not have a shell."
+        link={{ href: "/frames/7", label: "Back to the frame" }}
+      />,
+    );
+    expect(html).toContain("Terminal is not available for this frame");
+    expect(html).toContain("This frame does not have a shell.");
+    expect(html).toMatch(/<a [^>]*href="\/frames\/7"[^>]*>Back to the frame<\/a>/);
+    expect(html).not.toContain("There is nothing at");
+  });
+});

--- a/frontend/src/scenes/NotFound.tsx
+++ b/frontend/src/scenes/NotFound.tsx
@@ -1,0 +1,79 @@
+import type { ReactElement } from 'react'
+import { A } from 'kea-router'
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
+import { urls } from '../urls'
+import { workspaceMode } from './workspace/workspaceSurfaces'
+
+// The one 404 for all three shells (the self-hosted SPA, the cloud's
+// /frames mount and the on-device admin panel). Both scene tables used to
+// map `error404` to a bare `<div>404</div>`; a frame tool the control plane
+// does not implement now lands here too (FrameWorkspace), so the page has to
+// say which path failed and where to go instead.
+
+export interface NotFoundProps {
+  /** The path that did not resolve; defaults to the browser's location. */
+  path?: string | null
+  title?: string
+  /** Replaces the default explanation. */
+  message?: string | null
+  /** Where the way out leads; the frames list by default. */
+  link?: { href: string; label: string }
+}
+
+function attemptedPath(path: string | null | undefined): string | null {
+  if (typeof path === 'string') {
+    return path
+  }
+  if (typeof window === 'undefined') {
+    return null
+  }
+  return window.location.pathname + window.location.search
+}
+
+export function homeLinkLabel(): string {
+  // urls.frames() is the frame itself on the on-device admin panel: the
+  // panel manages the one frame it runs on.
+  return workspaceMode() === 'frameAdmin' ? 'Back to the frame' : 'Back to your frames'
+}
+
+/** The 404 card without a page wrapper, for rendering inside a workspace shell. */
+export function NotFoundContent({ path, title = 'Page not found', message, link }: NotFoundProps): ReactElement {
+  const attempted = attemptedPath(path)
+  const href = link?.href ?? urls.frames()
+  const label = link?.label ?? homeLinkLabel()
+  return (
+    <div className="frameos-muted text-center" data-testid="not-found">
+      <QuestionMarkCircleIcon className="mx-auto mb-3 h-10 w-10 text-slate-300" aria-hidden="true" />
+      <div className="text-base font-semibold">{title}</div>
+      <div className="mt-1 text-sm">
+        {message ??
+          (attempted ? (
+            <>
+              There is nothing at{' '}
+              <code className="break-all rounded bg-slate-100 px-1 py-0.5 font-mono text-xs dark:bg-slate-800">
+                {attempted}
+              </code>
+              .
+            </>
+          ) : (
+            'There is nothing at this address.'
+          ))}
+      </div>
+      <div className="mt-4 text-sm">
+        <A href={href} className="frameos-link underline decoration-slate-300 underline-offset-2">
+          {label}
+        </A>
+      </div>
+    </div>
+  )
+}
+
+export function NotFound(props: NotFoundProps): ReactElement {
+  return (
+    <main className="flex min-h-[60vh] items-center justify-center px-4 py-12" role="main">
+      <NotFoundContent {...props} />
+    </main>
+  )
+}
+
+export default NotFound

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -12,7 +12,14 @@ import { Form, Group } from 'kea-forms'
 import { TextInput } from '../../../../components/TextInput'
 import { SecretField } from '../../../../components/SecretField'
 import { Select, type Option } from '../../../../components/Select'
-import { frameAdminUrl, frameControlUrl, frameImageUrl, frameRootUrl, frameUrl } from '../../../../decorators/frame'
+import {
+  frameAdminUrl,
+  frameControlUrl,
+  frameHost,
+  frameImageUrl,
+  frameRootUrl,
+  frameUrl,
+} from '../../../../decorators/frame'
 import {
   DEFAULT_FRAME_ERROR_BEHAVIOR,
   DEFAULT_TIMEZONE_UPDATE_HOUR,
@@ -87,6 +94,7 @@ import { ColorInput } from '../../../../components/ColorInput'
 import { settingsLogic } from '../../../settings/settingsLogic'
 import { isInFrameAdminMode } from '../../../../utils/frameAdmin'
 import { frameSettingsSectionIsAllowed, isEsp32CloudFrame, workspaceMode } from '../../../workspace/workspaceSurfaces'
+import { frameDeleteCopy } from '../../../workspace/frameDeleteCopy'
 import { CloudSettingsSection } from '../../../settings/CloudSettings'
 import { normalizeSshKeys } from '../../../../utils/sshKeys'
 import { Label } from '../../../../components/Label'
@@ -1885,8 +1893,9 @@ export function FrameSettings({
               },
               {
                 label: 'Delete frame',
+                title: frameDeleteCopy(workspaceMode()).title,
                 onClick: () => {
-                  if (confirm('Are you sure you want to DELETE this frame?')) {
+                  if (confirm(frameDeleteCopy(workspaceMode()).confirm(frame.name || frameHost(frame)))) {
                     deleteFrame(frame.id)
                   }
                 },

--- a/frontend/src/scenes/frames/Frame.tsx
+++ b/frontend/src/scenes/frames/Frame.tsx
@@ -20,6 +20,8 @@ import { urls } from '../../urls'
 import { Tooltip } from '../../components/Tooltip'
 import { getFrameCertificateStatus } from '../../utils/certificates'
 import { CURRENT_FRAMEOS_VERSION } from '../frame/frameDeployUtils'
+import { frameMenuActionIsAllowed, workspaceMode } from '../workspace/workspaceSurfaces'
+import { frameDeleteCopy } from '../workspace/frameDeleteCopy'
 
 interface FrameProps {
   frame: FrameType
@@ -101,6 +103,11 @@ export function Frame({ frame }: FrameProps): JSX.Element {
       ? frame.last_successful_deploy.frameos_version.split('+')[0]
       : null
   const hasFrameOSUpdate = Boolean(deployedFrameOSVersion && deployedFrameOSVersion !== CURRENT_FRAMEOS_VERSION)
+  // Same allow-list and copy as the workspace menu (FrameActionsMenu): the
+  // cloud has no archive, and deleting there unlinks the device rather than
+  // erasing its scenes.
+  const mode = workspaceMode()
+  const deleteCopy = frameDeleteCopy(mode)
 
   return (
     <Box id={`frame-${frame.id}`} className="relative">
@@ -113,25 +120,32 @@ export function Frame({ frame }: FrameProps): JSX.Element {
               onClick: () => router.actions.push(urls.frame(frame.id)),
               icon: <PencilSquareIcon className="w-5 h-5" />,
             },
-            frame.archived
-              ? {
-                  label: 'Restore frame',
-                  onClick: () => setFrameArchived(frame.id, false),
-                  icon: <ArrowUturnLeftIcon className="w-5 h-5" />,
-                }
-              : {
-                  label: 'Archive frame',
-                  onClick: () => setFrameArchived(frame.id, true),
-                  icon: <ArchiveBoxIcon className="w-5 h-5" />,
-                },
-            {
-              label: 'Delete frame',
-              onClick: () =>
-                window.confirm(
-                  `Delete the frame "${frame.name}" and all of its scenes? This cannot be undone. (Archive it instead to hide it without losing anything.)`
-                ) && deleteFrame(frame.id),
-              icon: <TrashIcon className="w-5 h-5" />,
-            },
+            ...(frameMenuActionIsAllowed(mode, 'archive', frame)
+              ? [
+                  frame.archived
+                    ? {
+                        label: 'Restore frame',
+                        onClick: () => setFrameArchived(frame.id, false),
+                        icon: <ArrowUturnLeftIcon className="w-5 h-5" />,
+                      }
+                    : {
+                        label: 'Archive frame',
+                        onClick: () => setFrameArchived(frame.id, true),
+                        icon: <ArchiveBoxIcon className="w-5 h-5" />,
+                      },
+                ]
+              : []),
+            ...(frameMenuActionIsAllowed(mode, 'delete', frame)
+              ? [
+                  {
+                    label: 'Delete frame',
+                    title: deleteCopy.title,
+                    confirm: deleteCopy.confirm(frame.name || frameHost(frame)),
+                    onClick: () => deleteFrame(frame.id),
+                    icon: <TrashIcon className="w-5 h-5" />,
+                  },
+                ]
+              : []),
           ]}
         />
       </div>

--- a/frontend/src/scenes/scenes.tsx
+++ b/frontend/src/scenes/scenes.tsx
@@ -3,12 +3,13 @@ import { urls } from '../urls'
 import { getRouteBasePath } from '../utils/getBasePath'
 import { isInFrameAdminMode } from '../utils/frameAdmin'
 import { isCloudMode } from '../utils/cloudMode'
+import { NotFound } from './NotFound'
 
 export type SceneComponent = ComponentType<Record<string, any>>
 
-export function Error404(): JSX.Element {
-  return <div>404</div>
-}
+// One 404 for every shell — see NotFound.tsx. Kept under this name so the
+// scene table and App.tsx's load-failure fallback keep their imports.
+export const Error404 = NotFound
 
 const sceneLoaders = {
   frames: () => import('./frames/Frames'),
@@ -100,4 +101,4 @@ export const getRoutes = () =>
     [urls.setupUnavailable()]: 'setupUnavailable',
     [urls.frame(':id')]: 'frame',
     [urls.frame(':id', ':tool')]: 'frame',
-  }) as const
+  } as const)

--- a/frontend/src/scenes/workspace/FrameActionsMenu.tsx
+++ b/frontend/src/scenes/workspace/FrameActionsMenu.tsx
@@ -28,6 +28,7 @@ import {
   workspaceMode,
   type FrameMenuAction,
 } from './workspaceSurfaces'
+import { frameDeleteCopy } from './frameDeleteCopy'
 
 interface FrameActionsMenuProps {
   frame: FrameType
@@ -68,6 +69,11 @@ export function FrameActionsMenu({
   // hidden because there is no device — see workspaceSurfaces.ts.
   const mode = workspaceMode()
   const allows = (action: FrameMenuAction): boolean => frameMenuActionIsAllowed(mode, action, frame)
+  // "Delete" is a different act per control plane (frameDeleteCopy.ts): the
+  // backend drops the frame and its scenes, the cloud unlinks a device that
+  // keeps running. The words come from the same allow-list module as the
+  // verbs, so the copy cannot describe an Archive the mode does not have.
+  const deleteCopy = frameDeleteCopy(mode)
   const disabledReason = (action: FrameMenuAction): string | null => frameMenuActionDisabledReason(mode, action, frame)
   const renameDisabledReason = disabledReason('rename')
 
@@ -217,8 +223,8 @@ export function FrameActionsMenu({
           ? [
               {
                 label: 'Delete frame',
-                title: 'Permanently delete this frame and all of its scenes',
-                confirm: `Delete the frame "${frameName}" and all of its scenes? This cannot be undone. (Archive it instead to hide it without losing anything.)`,
+                title: deleteCopy.title,
+                confirm: deleteCopy.confirm(frameName),
                 onClick: () => deleteFrame(frame.id),
                 icon: <TrashIcon className="h-5 w-5" />,
               },

--- a/frontend/src/scenes/workspace/FrameWorkspace.tsx
+++ b/frontend/src/scenes/workspace/FrameWorkspace.tsx
@@ -2,7 +2,9 @@ import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { A, router } from 'kea-router'
 import clsx from 'clsx'
 import { useCallback, useEffect, useLayoutEffect, useRef, type DragEvent, type MouseEvent } from 'react'
-import { frameToolDefinitions, frameToolDefinitionsForMode, type FrameToolDefinition } from './frameToolDefinitions'
+import { frameToolDefinitionsForMode, type FrameToolDefinition } from './frameToolDefinitions'
+import { frameToolNotFoundMessage, resolveFrameToolRoute, type FrameToolRouteResolution } from './frameToolRoute'
+import { NotFoundContent } from '../NotFound'
 import {
   frameCheckin,
   frameCheckinDescription,
@@ -28,7 +30,7 @@ import { FrameBatteryIndicator } from './FrameBatteryIndicator'
 import { FrameActionsMenu } from './FrameActionsMenu'
 import { sceneWorkspaceLogic } from './sceneWorkspaceLogic'
 import {
-  frameToolFromPathname,
+  frameToolSegmentFromPathname,
   frameToolScrollKey,
   isMobileWorkspaceViewport,
   workspaceLogic,
@@ -227,22 +229,51 @@ function frameToolInitialScrollTop(
 }
 
 // The tool the URL asks for: /frames/<id>/<tool>, or `?tool=` on an old
-// link. Unknown or disabled tools fall back to the overview.
-function frameToolPanelFromRoute(
+// link, resolved against the control plane's allow-list and the frame's
+// device profile (frameToolRoute.ts). A tool this mode does not implement is
+// a 404 and a tool the device cannot serve is an explanation — neither is a
+// silent overview any more, which is what /frames/<id>/terminal on the cloud
+// used to render.
+function frameToolRouteFromLocation(
   pathname: string,
   searchParams: Record<string, unknown>,
   frameId: FrameId | null,
-  availableDefinitions: FrameToolDefinition[] = frameToolDefinitions
-): WorkspaceUtilityPanel | null {
-  const fromPath = frameId !== null ? frameToolFromPathname(pathname, frameId) : null
+  mode: WorkspaceMode,
+  frame?: FrameType | null
+): FrameToolRouteResolution {
+  const fromPath = frameId !== null ? frameToolSegmentFromPathname(pathname, frameId) : null
   const value = searchParams.tool
-  const tool = fromPath ?? (Array.isArray(value) ? value[0] : value)
-  if (!tool) {
-    return 'overview'
-  }
-  return typeof tool === 'string' && availableDefinitions.some((definition) => definition.panel === tool)
-    ? (tool as WorkspaceUtilityPanel)
-    : 'overview'
+  const segment = fromPath ?? (Array.isArray(value) ? value[0] : value)
+  return resolveFrameToolRoute(segment, mode, frame)
+}
+
+function FrameToolNotFound({ segment, mode }: { segment: string; mode: WorkspaceMode }): JSX.Element {
+  const { location } = useValues(router)
+  return (
+    <div className="flex min-h-[32rem] items-center justify-center">
+      <NotFoundContent path={location.pathname} message={frameToolNotFoundMessage(segment, mode)} />
+    </div>
+  )
+}
+
+function FrameToolDisabled({
+  definition,
+  frameId,
+  reason,
+}: {
+  definition: FrameToolDefinition | undefined
+  frameId: FrameId
+  reason: string
+}): JSX.Element {
+  return (
+    <div className="flex min-h-[32rem] items-center justify-center">
+      <NotFoundContent
+        title={`${definition?.label ?? 'This tool'} is not available for this frame`}
+        message={reason}
+        link={{ href: urls.frame(frameId), label: 'Back to the frame' }}
+      />
+    </div>
+  )
 }
 
 const allFrameSettingsSections = [
@@ -1372,7 +1403,8 @@ function FrameWorkspaceForFrame({ frameId }: { frameId: FrameId }): JSX.Element 
   // user inside one.
   const availableToolDefinitions = frameToolDefinitionsForMode(mode, frame)
   const enabledToolDefinitions = availableToolDefinitions.filter((definition) => !definition.disabledReason)
-  const requestedPanel = frameToolPanelFromRoute(location.pathname, searchParams, frameId, enabledToolDefinitions)
+  const toolRoute = frameToolRouteFromLocation(location.pathname, searchParams, frameId, mode, frame)
+  const requestedPanel = toolRoute.kind === 'panel' ? toolRoute.panel : null
   const fallbackPanel = enabledToolDefinitions.some((definition) => definition.panel === utilityPanel)
     ? utilityPanel
     : 'overview'
@@ -1380,13 +1412,16 @@ function FrameWorkspaceForFrame({ frameId }: { frameId: FrameId }): JSX.Element 
     enabledToolDefinitions.find((definition) => definition.panel === (requestedPanel ?? fallbackPanel)) ??
     enabledToolDefinitions[0]
   const activeToolPanel = activeTool.panel
+  // The rail highlights the tool the URL names even when the device profile
+  // has it disabled — that is the entry whose tooltip explains the page.
+  const railToolPanel = toolRoute.kind === 'disabled' ? toolRoute.panel : activeToolPanel
   const activeToolScrollKey = frameToolScrollKey(frameId, activeToolPanel)
   const frameToolScrollPositionsRef = useRef(frameToolScrollPositions)
   const lastObservedFrameToolScrollTopRef = useRef(0)
   const visibleScenes = scenes
   const frameLoaded = !!frame
   const toolUsesSearch = false
-  const toolUsesPageScroll = frameToolUsesPageScroll(activeToolPanel)
+  const toolUsesPageScroll = toolRoute.kind === 'panel' ? frameToolUsesPageScroll(activeToolPanel) : true
 
   frameToolScrollPositionsRef.current = frameToolScrollPositions
 
@@ -1492,7 +1527,7 @@ function FrameWorkspaceForFrame({ frameId }: { frameId: FrameId }): JSX.Element 
             <FrameTree
               frame={frame}
               frames={framesList}
-              activeTool={activeToolPanel}
+              activeTool={railToolPanel}
               toolDefinitions={availableToolDefinitions}
               unsavedChanges={unsavedChanges}
               undeployedChanges={undeployedChanges}
@@ -1520,13 +1555,23 @@ function FrameWorkspaceForFrame({ frameId }: { frameId: FrameId }): JSX.Element 
                   : 'overflow-y-auto'
               )}
             >
-              <FrameToolSurface
-                activeTool={activeToolPanel}
-                frame={frame}
-                scenes={visibleScenes}
-                totalScenes={scenes.length}
-                pageScroll={toolUsesPageScroll}
-              />
+              {toolRoute.kind === 'notFound' ? (
+                <FrameToolNotFound segment={toolRoute.segment} mode={mode} />
+              ) : toolRoute.kind === 'disabled' ? (
+                <FrameToolDisabled
+                  definition={availableToolDefinitions.find((definition) => definition.panel === toolRoute.panel)}
+                  frameId={frameId}
+                  reason={toolRoute.reason}
+                />
+              ) : (
+                <FrameToolSurface
+                  activeTool={activeToolPanel}
+                  frame={frame}
+                  scenes={visibleScenes}
+                  totalScenes={scenes.length}
+                  pageScroll={toolUsesPageScroll}
+                />
+              )}
             </div>
           </div>
         </FrameosShell>
@@ -1541,7 +1586,6 @@ export function FrameWorkspace({ id }: FrameWorkspaceProps): JSX.Element {
   const { selectedFrame } = useValues(workspaceLogic)
   const { activeFramesList, framesList, framesLoading } = useValues(framesModel)
   const { location, searchParams } = useValues(router)
-  const availableToolDefinitions = frameToolDefinitionsForMode()
   const routeFrameId = parseFrameId(id)
   const firstFrame =
     (routeFrameId ? framesList.find((frame) => frameIdsEqual(frame.id, routeFrameId)) : null) ??
@@ -1551,8 +1595,8 @@ export function FrameWorkspace({ id }: FrameWorkspaceProps): JSX.Element {
     null
 
   if (!firstFrame && framesLoading) {
-    const loadingTool =
-      frameToolPanelFromRoute(location.pathname, searchParams, routeFrameId, availableToolDefinitions) ?? 'overview'
+    const loadingRoute = frameToolRouteFromLocation(location.pathname, searchParams, routeFrameId, workspaceMode())
+    const loadingTool = loadingRoute.kind === 'panel' ? loadingRoute.panel : 'overview'
     const loadingToolUsesPageScroll = frameToolUsesPageScroll(loadingTool)
 
     return (

--- a/frontend/src/scenes/workspace/frameDeleteCopy.ts
+++ b/frontend/src/scenes/workspace/frameDeleteCopy.ts
@@ -1,0 +1,44 @@
+import type { WorkspaceMode } from './workspaceSurfaces'
+
+// What "Delete frame" means depends on the control plane, so the words do
+// too. On the self-hosted backend the frame row owns its scenes and there is
+// an archive to point at instead. On the cloud there is no archive, the
+// scenes live in the account's store and survive, and DELETE
+// /api/frames/{id} revokes the device's link first — the device keeps
+// showing what it has and drops back to standalone. Pinned by the cloud's
+// node suite; keep the three call sites (the frames-home menu, the frame
+// card, the settings panel) on this one module.
+
+export interface FrameDeleteCopy {
+  /** Menu entry tooltip. */
+  title: string
+  /** The confirmation question. */
+  confirm: (frameName: string) => string
+}
+
+const backendDeleteCopy: FrameDeleteCopy = {
+  title: 'Permanently delete this frame and all of its scenes',
+  confirm: (frameName) =>
+    `Delete the frame "${frameName}" and all of its scenes? This cannot be undone. ` +
+    '(Archive it instead to hide it without losing anything.)',
+}
+
+const cloudDeleteCopy: FrameDeleteCopy = {
+  title: 'Remove this frame from your account',
+  confirm: (frameName) =>
+    `Remove "${frameName}" from FrameOS Cloud? The device keeps showing the scenes it has and goes back to ` +
+    'standalone mode; its cloud logs, metrics and history are deleted. Your scenes stay in your account. ' +
+    'This cannot be undone — to manage it again, enroll it with a new claim code.',
+}
+
+export const frameDeleteCopyByMode: Record<WorkspaceMode, FrameDeleteCopy> = {
+  backend: backendDeleteCopy,
+  // The on-device admin manages the frame it runs on; its settings panel
+  // hides Delete, so this entry only keeps the mode contract complete.
+  frameAdmin: backendDeleteCopy,
+  cloud: cloudDeleteCopy,
+}
+
+export function frameDeleteCopy(mode: WorkspaceMode): FrameDeleteCopy {
+  return frameDeleteCopyByMode[mode]
+}

--- a/frontend/src/scenes/workspace/frameToolRoute.ts
+++ b/frontend/src/scenes/workspace/frameToolRoute.ts
@@ -1,0 +1,92 @@
+import {
+  frameToolPanelDisabledReason,
+  frameToolPanelIsAllowed,
+  type FrameCapabilityInput,
+  type WorkspaceMode,
+  type WorkspaceUtilityPanel,
+} from './workspaceSurfaces'
+
+// The tool segment of a frame URL (/frames/<id>/<tool>) resolved against the
+// control plane's allow-list. Kept free of React, kea and the DOM so the
+// cloud's node suite can pin it: a segment the mode does not implement used
+// to be validated against EVERY panel and then quietly fell back to the
+// overview, so /frames/<id>/terminal on the cloud rendered the scenes page
+// with nothing to say about it.
+
+/** Every panel a frame URL may name, across all modes. */
+export const frameToolPanels = [
+  'overview',
+  'preview',
+  'schedule',
+  'logs',
+  'metrics',
+  'assets',
+  'terminal',
+  'ping',
+  'debug',
+  'settings',
+  'activity',
+] as const satisfies readonly WorkspaceUtilityPanel[]
+
+export type FrameToolPanel = (typeof frameToolPanels)[number]
+
+export function isFrameToolPanel(panel: unknown): panel is FrameToolPanel {
+  return typeof panel === 'string' && (frameToolPanels as readonly string[]).includes(panel)
+}
+
+export type FrameToolRouteResolution =
+  /** A panel this control plane renders for this frame. */
+  | { kind: 'panel'; panel: FrameToolPanel }
+  /**
+   * A panel the mode lists but the frame's device profile cannot serve (a
+   * schedule on firmware without `set_schedule`): the rail shows it disabled
+   * with this reason, and a deep link lands on the same explanation instead
+   * of a different tool.
+   */
+  | { kind: 'disabled'; panel: FrameToolPanel; reason: string }
+  /**
+   * No such tool here: not a panel at all, or one another control plane
+   * implements (the terminal on the cloud, ping on the on-device admin) or
+   * one hidden for this device (a shell on a virtual frame). A 404, not the
+   * overview.
+   */
+  | { kind: 'notFound'; segment: string }
+
+/**
+ * Resolve the tool a frame route asks for. `segment` is the raw path segment
+ * (or the legacy `?tool=` value); null, undefined and '' mean the bare frame
+ * URL, which is the overview.
+ */
+export function resolveFrameToolRoute(
+  segment: unknown,
+  mode: WorkspaceMode,
+  frame?: FrameCapabilityInput | null
+): FrameToolRouteResolution {
+  if (segment === null || segment === undefined || segment === '') {
+    return { kind: 'panel', panel: 'overview' }
+  }
+  if (!isFrameToolPanel(segment)) {
+    return { kind: 'notFound', segment: typeof segment === 'string' ? segment : String(segment) }
+  }
+  if (!frameToolPanelIsAllowed(mode, segment, frame)) {
+    return { kind: 'notFound', segment }
+  }
+  const reason = frameToolPanelDisabledReason(mode, segment, frame)
+  if (reason) {
+    return { kind: 'disabled', panel: segment, reason }
+  }
+  return { kind: 'panel', panel: segment }
+}
+
+const controlPlaneNames: Record<WorkspaceMode, string> = {
+  backend: 'this FrameOS backend',
+  frameAdmin: "the frame's own admin panel",
+  cloud: 'FrameOS Cloud',
+}
+
+/** The 404 page's explanation for a tool segment this control plane does not implement. */
+export function frameToolNotFoundMessage(segment: string, mode: WorkspaceMode): string {
+  return isFrameToolPanel(segment)
+    ? `There is no "${segment}" tool for this frame on ${controlPlaneNames[mode]}.`
+    : `This frame has no "${segment}" page.`
+}

--- a/frontend/src/scenes/workspace/workspaceLogic.tsx
+++ b/frontend/src/scenes/workspace/workspaceLogic.tsx
@@ -13,28 +13,13 @@ import { controlLogic } from '../frame/panels/Scenes/controlLogic'
 import { newFrameForm } from '../frames/newFrameForm'
 
 import type { WorkspaceUtilityPanel } from './workspaceSurfaces'
+import { isFrameToolPanel } from './frameToolRoute'
 
 // Re-exported so the SPA's existing `from './workspaceLogic'` imports keep
-// working; the union itself lives with the allow-lists that gate it.
+// working; the union itself lives with the allow-lists that gate it, and the
+// list of panels a frame URL may name with the route resolver
+// (frameToolRoute.ts).
 export type { WorkspaceUtilityPanel }
-
-const frameToolPanels = [
-  'overview',
-  'preview',
-  'schedule',
-  'logs',
-  'metrics',
-  'assets',
-  'terminal',
-  'ping',
-  'debug',
-  'settings',
-  'activity',
-] as const satisfies readonly WorkspaceUtilityPanel[]
-
-function isFrameToolPanel(panel: unknown): panel is (typeof frameToolPanels)[number] {
-  return typeof panel === 'string' && (frameToolPanels as readonly string[]).includes(panel)
-}
 
 function searchValue(search: Record<string, unknown>, key: string): string | null {
   const value = Array.isArray(search[key]) ? (search[key] as unknown[])[0] : search[key]
@@ -60,14 +45,23 @@ export function frameToolFromRoute(routeTool: unknown, search: Record<string, un
   return isFrameToolPanel(tool) ? tool : 'overview'
 }
 
-// The tool segment of `pathname` when it is a frame route — null when it is
-// the bare frame path or not a frame route at all.
-export function frameToolFromPathname(pathname: string, frameId: FrameId): WorkspaceUtilityPanel | null {
+// The raw segment after the frame id in `pathname` (/frames/<id>/<segment>)
+// — null when it is the bare frame path or not a frame route at all. What
+// the segment means for this control plane is frameToolRoute.ts's business.
+export function frameToolSegmentFromPathname(pathname: string, frameId: FrameId): string | null {
   const framePath = urls.frame(frameId)
   if (!pathname.startsWith(`${framePath}/`)) {
     return null
   }
   const segment = decodeURIComponent(pathname.slice(framePath.length + 1))
+  return segment === '' ? null : segment
+}
+
+// The tool segment of `pathname` when it is a frame route naming a known
+// tool — null when it is the bare frame path, an unknown segment, or not a
+// frame route at all.
+export function frameToolFromPathname(pathname: string, frameId: FrameId): WorkspaceUtilityPanel | null {
+  const segment = frameToolSegmentFromPathname(pathname, frameId)
   return isFrameToolPanel(segment) ? segment : null
 }
 


### PR DESCRIPTION
Fifth cut item 7 from `docs/review-todo.md` (§10 Mediums, minus the `FrameSettings.tsx` split).

## Cloud delete confirmation copy
- New pure `frontend/src/scenes/workspace/frameDeleteCopy.ts`: `frameDeleteCopy(mode)` → `{title, confirm(frameName)}`. Backend keeps the existing "…and all of its scenes … Archive it instead" copy. Cloud: the device keeps showing the scenes it has and goes back to standalone; its cloud logs, metrics and history are deleted; the account's scenes stay; re-enroll with a new claim code to manage it again (matches the DELETE route's revoke-then-cascade).
- Used by `FrameActionsMenu.tsx` (Archive was already gated by `allows('archive')`), the legacy `Frame.tsx` card (Archive/Restore and Delete now behind `frameMenuActionIsAllowed`) and the bare `confirm(...)` in `FrameSettings.tsx`. Kept the existing `confirm` mechanism, which is the DropdownMenu convention.

## A real 404 scene
- New `frontend/src/scenes/NotFound.tsx`: `NotFound` scene + `NotFoundContent` card ("Page not found", the attempted path, a kea-router link back to the frames list, "Back to the frame" in frame-admin mode; `title`/`message`/`link` overrides). Styled like the FramesHome empty state.
- `frontend/src/scenes/scenes.tsx` `Error404 = NotFound`; `cloud-frontend/src/scenes/scenes.tsx` `error404: NotFound` (scene component type widened in `App.tsx` since the 404 takes props). There is no third scene table: the on-device admin runs the frontend bundle.

## Tool URL segment against the mode's allow-list
- New pure `frontend/src/scenes/workspace/frameToolRoute.ts`: `frameToolPanels` / `isFrameToolPanel` moved out of workspaceLogic, plus `resolveFrameToolRoute(segment, mode, frame)` → `{kind:'panel'}` / `{kind:'disabled', reason}` (mode lists it, device profile cannot serve it) / `{kind:'notFound'}` (unknown segment, another control plane's tool, hidden for the device such as terminal on a virtual frame). `frameToolNotFoundMessage()` names the control plane.
- `FrameWorkspace.tsx`: `frameToolPanelFromRoute` (validated against every definition, fell back to the overview) replaced by the resolver. `notFound` renders the 404 card inside the frame shell; `disabled` renders "<Tool> is not available for this frame" with the surfaces' reason and a link back, with the rail highlighting that tool. `workspaceLogic.tsx` gains `frameToolSegmentFromPathname()`; `frameToolFromPathname()` unchanged in behaviour.

## Tests (cloud shared-spa suite)
- `frame-tool-route.test.ts`: bare URL → overview; terminal on cloud / ping on frameAdmin / activity on backend → 404; every listed panel on every mode → panel, every unlisted → 404; virtual frame hides terminal/metrics; the disabled contract; the messages.
- `frame-delete-copy.test.ts`: backend mentions scenes + Archive; cloud mentions standalone and never Archive / "all of its scenes"; Archive is promised only where the mode's menu has it.
- `not-found-scene.test.tsx`: path shown, root link self-hosted, `/frames` link under the cloud config, overrides.

## Verified
```
frontend tsc --noEmit: clean · cloud-frontend tsc --noEmit: clean · auth-web tsc: clean
eslint (3 new tests): clean · prettier --check (touched frontend files): clean
npx vitest run src/test/shared-spa: 69 files, 658 tests passed
```

Not done: the `FrameSettings.tsx` split (its own task); the legacy `?tool=bogus` query link still canonicalises to the overview URL in workspaceLogic's redirect (pre-existing; the finding was about the path segment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrbChngvqARbcdbkrYF7sb