### PR TITLE
Review todo: fifth cut item 5, cloud store and AI

### DIFF
--- a/cloud-frontend/src/storeSceneErrors.ts
+++ b/cloud-frontend/src/storeSceneErrors.ts
@@ -1,0 +1,11 @@
+// The store's error-code wording, for the cloud's Next.js components. The
+// table itself lives with the SPA (frontend/src/utils/storeSceneErrors.ts),
+// where the editor's cloud save path reads it; this is the window-free
+// re-export auth-web imports as `@frameos/cloud-frontend/src/storeSceneErrors`
+// so the owner buttons, the upload forms and the editor say the same thing
+// for the same refusal.
+export {
+  storeSceneErrorCode,
+  storeSceneErrorMessage,
+  type StoreErrorDetail,
+} from '../../frontend/src/utils/storeSceneErrors'

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/content/route.ts
@@ -42,6 +42,7 @@ import {
 import { loadOwnedScene } from "../../../../../../src/lib/store-owner";
 import {
   alignZipCover,
+  nextSceneVersion,
   writeSceneVersion,
 } from "../../../../../../src/lib/store-version-write";
 import {
@@ -312,7 +313,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
   }
 
-  const nextVersion = scene.latestVersion + 1;
+  const nextVersion = await nextSceneVersion(db, scene.id);
   const written = await writeSceneVersion(db, {
     content,
     images,

--- a/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/versions/[version]/route.ts
+++ b/cloud/apps/auth-web/app/api/account/scenes/[sceneId]/versions/[version]/route.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../../../../../src/lib/device-flow";
 import { rateLimitResponse } from "../../../../../../../src/lib/rate-limit";
 import { readSession } from "../../../../../../../src/lib/session";
+import { syncLatestVersion } from "../../../../../../../src/lib/store-version-write";
 
 export const runtime = "nodejs";
 
@@ -96,18 +97,29 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     }
   }
 
-  const [updated] = await db
-    .update(storeSceneVersions)
-    .set({ yankedAt: body.yanked ? new Date() : null })
-    .where(
-      and(
-        eq(storeSceneVersions.sceneId, scene.id),
-        eq(storeSceneVersions.version, versionNumber),
-      ),
-    )
-    .returning({ version: storeSceneVersions.version });
+  // The flip and the `latest_version` move are one transaction: "latest"
+  // follows the newest non-yanked version, so yanking the version the store
+  // index advertised (and whose `?v=N` cover URL the edge caches immutable
+  // for a year) hands the pointer to the one the download route now serves
+  // by default, and unyanking a newer one hands it back.
+  const outcome = await db.transaction(async (tx) => {
+    const [updated] = await tx
+      .update(storeSceneVersions)
+      .set({ yankedAt: body.yanked ? new Date() : null })
+      .where(
+        and(
+          eq(storeSceneVersions.sceneId, scene.id),
+          eq(storeSceneVersions.version, versionNumber),
+        ),
+      )
+      .returning({ version: storeSceneVersions.version });
+    if (!updated) {
+      return undefined;
+    }
+    return { latestVersion: await syncLatestVersion(tx, scene.id) };
+  });
 
-  if (!updated) {
+  if (!outcome) {
     return jsonError("version_not_found", 404);
   }
 
@@ -125,6 +137,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   });
 
   return NextResponse.json({
+    latest_version: outcome.latestVersion ?? null,
     status: body.yanked ? "yanked" : "unyanked",
     version: versionNumber,
   });

--- a/cloud/apps/auth-web/app/api/ai/apps/chat/route.ts
+++ b/cloud/apps/auth-web/app/api/ai/apps/chat/route.ts
@@ -11,7 +11,9 @@ import {
   ensureChat,
   historyForModel,
 } from "../../../../../src/lib/ai/chat-store";
+import { emptyUsage } from "../../../../../src/lib/ai/openai";
 import { formatAiException } from "../../../../../src/lib/ai/scene-utils";
+import { captureAiTurn } from "../../../../../src/lib/ai/telemetry";
 import {
   inFlightSpendMicros,
   releaseTurnSpend,
@@ -167,6 +169,7 @@ export async function POST(request: NextRequest) {
   // request, so the request is the turn. Reserved against the daily cap
   // until metered (spend-reservations.ts).
   const turnId = crypto.randomUUID();
+  const startedAt = Date.now();
   reserveTurnSpend(accountId, turnId);
   try {
     const result = await runAppChat({
@@ -181,6 +184,7 @@ export async function POST(request: NextRequest) {
       sceneId,
       signal: request.signal,
       sources,
+      telemetry: { accountId, chatId: chat.id, turnId },
     });
     await meterAiUsage({
       accountId,
@@ -193,6 +197,25 @@ export async function POST(request: NextRequest) {
       usage: result.usage,
     });
     releaseTurnSpend(turnId);
+    // The turn summary the scene chat emits from its turn loop; here the
+    // request is the turn. Same surface name as the meter row above, so the
+    // reconcile can pair them.
+    captureAiTurn({
+      accountId,
+      chatId: chat.id,
+      deliveredTool: result.tool,
+      disconnects: 0,
+      durationMs: Date.now() - startedAt,
+      model: credentials.model,
+      outcome: "ok",
+      resumes: 0,
+      rounds: 1,
+      surface: "app_chat",
+      toolArgErrors: [],
+      toolCalls: result.tool === "edit_app" ? ["write_app_files"] : [],
+      turnId,
+      usage: result.usage,
+    });
     await appendChatMessage(db, chat.id, {
       content: result.reply,
       // File contents are NOT persisted: they are already in the user's
@@ -210,6 +233,23 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     releaseTurnSpend(turnId);
     const detail = `App chat failed: ${formatAiException(error)}`;
+    captureAiTurn({
+      accountId,
+      chatId: chat.id,
+      deliveredTool: "error",
+      disconnects: 0,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+      model: credentials.model,
+      outcome: request.signal.aborted ? "stopped" : "error",
+      resumes: 0,
+      rounds: 1,
+      surface: "app_chat",
+      toolArgErrors: [],
+      toolCalls: [],
+      turnId,
+      usage: emptyUsage(),
+    });
     try {
       await appendChatMessage(db, chat.id, {
         content: detail,

--- a/cloud/apps/auth-web/app/api/store/account/repository.json/route.ts
+++ b/cloud/apps/auth-web/app/api/store/account/repository.json/route.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, gt } from "drizzle-orm";
 import { accounts, storeScenes } from "@frameos-cloud/db";
 import { NextRequest, NextResponse } from "next/server";
+import { bearerToken, isApiToken } from "../../../../../src/lib/api-tokens";
 import {
   authenticateLinkedClient,
   linkedClientHasScope,
@@ -23,10 +24,15 @@ import {
 export const runtime = "nodejs";
 
 // "My cloud drive": the authenticated account's own scenes — private and
-// public — in the frameos repository format. Two callers, two credentials:
+// public — in the frameos repository format. Three callers, three
+// credentials:
 //
 //   * a linked frameos backend sends its link token (Authorization header)
 //     and needs the store scope;
+//   * a script or agent sends a personal API token (`fc_api_` /
+//     `fc_apiro_`, same header): that IS the account, so it goes through
+//     readSession() like every other JSON route — handing it to the
+//     linked-client check used to answer 401 invalid_link_token;
 //   * the /frames workspace runs ON the cloud, where the browser session IS
 //     the account — its Add-scene drawer lists these directly, no link
 //     involved.
@@ -50,7 +56,7 @@ async function handleGet(request: NextRequest) {
 
   let accountId: string | undefined;
   const authorization = request.headers.get("authorization");
-  if (authorization) {
+  if (authorization && !isApiToken(bearerToken(authorization))) {
     const linkedClient = await authenticateLinkedClient(db, authorization);
     if (!linkedClient) {
       return jsonError("invalid_link_token", 401);

--- a/cloud/apps/auth-web/app/api/store/preview-proxy/route.ts
+++ b/cloud/apps/auth-web/app/api/store/preview-proxy/route.ts
@@ -62,8 +62,14 @@ async function handlePost(request: NextRequest) {
     return jsonError("body_too_large", 413);
   }
 
-  // Forward app-supplied headers minus hop-by-hop / host-scoped ones; our own
-  // cookies never leave (the browser sends them to us, not through us).
+  // Forward app-supplied headers minus hop-by-hop / host-scoped ones, the
+  // app's `Authorization` included: it is the app's own key for the host the
+  // app named (the frameos backend's scene_preview_proxy forwards it the
+  // same way), and an app that authenticates with a bearer used to work on
+  // the frame and silently 401 in the browser preview. Our own cookies never
+  // leave (the browser sends them to us, not through us), and guardedFetch
+  // drops the credential headers before following a redirect to another
+  // origin, as the runtime's own HTTP client does.
   const headers = new Headers();
   if (body.headers && typeof body.headers === "object") {
     for (const [key, value] of Object.entries(
@@ -72,7 +78,6 @@ async function handlePost(request: NextRequest) {
       if (
         typeof value === "string" &&
         ![
-          "authorization",
           "connection",
           "content-length",
           "cookie",

--- a/cloud/apps/auth-web/src/components/NewSceneWithAi.tsx
+++ b/cloud/apps/auth-web/src/components/NewSceneWithAi.tsx
@@ -3,6 +3,7 @@
 import { Save } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { applyAiScenes, blankScene, prepareForEditor, type AiScenesEvent, type SceneJson } from "../lib/ai-scenes-apply";
+import { ownerActionErrorMessage } from "./ownerActionError";
 import {
   clearNewSceneDraft,
   draftIdFromHash,
@@ -76,17 +77,6 @@ declare global {
   }
 }
 
-const createErrors: Record<string, string> = {
-  content_rejected: "Rejected by content moderation",
-  daily_scene_limit_exceeded: "Daily new-scene limit reached",
-  invalid_scenes: "The scene is empty",
-  login_required: "Sign in to save scenes",
-  moderation_unavailable: "Moderation service unavailable — try again later",
-  scene_name_taken: "You already have a scene with this name — rename it in Scene settings",
-  scene_quota_exceeded: "Scene limit reached",
-  storage_quota_exceeded: "Cloud scene storage limit reached",
-  store_banned: "This account cannot publish scenes",
-};
 
 // A full-page editor for a brand-new scene, AI panel open: start from one
 // blank scene, describe what you want, then "Save to my scenes" creates it
@@ -412,8 +402,7 @@ export function NewSceneWithAi({
         scene?: { slug?: string };
       };
       if (!response.ok || !payload.scene?.slug) {
-        const code = payload.error ?? String(response.status);
-        setError(createErrors[code] ?? `Saving failed: ${code}`);
+        setError(ownerActionErrorMessage(payload, response.status, "Saving failed"));
         return;
       }
       // Saved: the browser copy has done its job.

--- a/cloud/apps/auth-web/src/components/ReportSceneButton.tsx
+++ b/cloud/apps/auth-web/src/components/ReportSceneButton.tsx
@@ -2,6 +2,7 @@
 
 import posthog from "posthog-js";
 import { useState } from "react";
+import { ownerActionErrorMessage } from "./ownerActionError";
 
 export function ReportSceneButton({
   sceneId,
@@ -13,6 +14,9 @@ export function ReportSceneButton({
   const [status, setStatus] = useState<
     "idle" | "busy" | "done" | "already" | "error"
   >("idle");
+  // The server's reason — a rate limit, a pulled scene — rather than a bare
+  // "Failed" the reporter can do nothing with.
+  const [error, setError] = useState<string | null>(null);
 
   async function report() {
     if (!signedIn) {
@@ -26,12 +30,15 @@ export function ReportSceneButton({
       return;
     }
     setStatus("busy");
+    setError(null);
     const response = await fetch(`/api/store/scenes/${sceneId}/report`, {
       body: JSON.stringify({ reason: reason.trim() }),
       headers: { "content-type": "application/json" },
       method: "POST",
     });
     if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      setError(ownerActionErrorMessage(detail, response.status, "Report failed"));
       setStatus("error");
       return;
     }
@@ -51,14 +58,21 @@ export function ReportSceneButton({
   }
 
   return (
-    <button
-      className="button button--subtle"
-      disabled={status === "busy"}
-      onClick={() => void report()}
-      title="Flag this scene for the moderators"
-      type="button"
-    >
-      {status === "error" ? "Failed — retry" : "Report scene"}
-    </button>
+    <>
+      <button
+        className="button button--subtle"
+        disabled={status === "busy"}
+        onClick={() => void report()}
+        title="Flag this scene for the moderators"
+        type="button"
+      >
+        {status === "error" ? "Retry report" : "Report scene"}
+      </button>
+      {error ? (
+        <span className="pill pill-warning" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </>
   );
 }

--- a/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
+++ b/cloud/apps/auth-web/src/components/SceneEditorModal.tsx
@@ -33,6 +33,7 @@ import { applyAiScenes, type AiScenesEvent, type SceneJson } from "../lib/ai-sce
 import type { AiListingChanges } from "../lib/ai-chat-client";
 import { requiredSettingsForScenes } from "../lib/preview-settings";
 import { clearSceneDraft, readSceneDraft, writeSceneDraft } from "../lib/scene-draft";
+import { ownerActionErrorMessage } from "./ownerActionError";
 import {
   defaultSceneEditorPanels,
   onlyPanel,
@@ -1867,7 +1868,7 @@ export function SceneEditorModal({
         setError(
           payload.error === "login_required"
             ? "Sign in to fork this scene."
-            : `Forking failed: ${payload.error ?? response.status}`,
+            : ownerActionErrorMessage(payload, response.status, "Forking failed"),
         );
         return;
       }
@@ -1928,19 +1929,15 @@ export function SceneEditorModal({
       const payload = await response.json().catch(() => ({}));
       if (!response.ok) {
         setError(
-          // Renaming the scene renames the store listing with it, and two of
-          // your scenes may not share a name.
-          payload.error === "scene_name_taken"
-            ? `You already have another scene called “${payload.name ?? "that"}” — rename this one to something else.`
-            : // The name and the note show on the public page, so both are
-              // moderated; the note is the usual suspect.
-              payload.error === "content_rejected"
-              ? "The scene's name, description, tags or your note was flagged by moderation — please reword it."
-              : payload.error === "invalid_tags"
-                ? "Up to 5 tags; lowercase letters, digits, dashes, max 24 characters each."
-                : payload.error === "invalid_frameos_version"
-                  ? "The minimum FrameOS version should look like 2026.7.5."
-                  : `Saving failed: ${payload.error ?? response.status}`,
+          // The name and the note show on the public page, so both are
+          // moderated; the note is the usual suspect, and a Save is where
+          // the reader needs to know WHICH field to reword.
+          payload.error === "content_rejected"
+            ? "The scene's name, description, tags or your note was flagged by moderation — please reword it."
+            : // Everything else is the shared store wording: a name clash
+              // names the other scene, the private-scene quota and a pulled
+              // scene say so — instead of the raw code this used to show.
+              ownerActionErrorMessage(payload, response.status, "Saving failed"),
         );
         return;
       }

--- a/cloud/apps/auth-web/src/components/SceneImageGallery.tsx
+++ b/cloud/apps/auth-web/src/components/SceneImageGallery.tsx
@@ -3,6 +3,7 @@
 import { ImagePlus, Trash2 } from "lucide-react";
 import { useRef, useState } from "react";
 import { ImageLightbox } from "./ImageLightbox";
+import { ownerActionErrorMessage } from "./ownerActionError";
 
 // The scene's images (the Info panel): the version's ordered image set as
 // one grid of equal thumbnails — the first is the cover — each opening the
@@ -62,17 +63,7 @@ export function SceneImageGallery({
       onChange(images.includes(sha) ? images : [...images, sha]);
       return;
     }
-    if (payload.error === "content_rejected") {
-      setError("Rejected by content moderation");
-    } else if (payload.error === "image_too_large") {
-      setError("Image too large (max 4 MB)");
-    } else if (payload.error === "unsupported_image") {
-      setError("Not a supported image (JPEG, PNG, WebP or GIF)");
-    } else if (payload.error === "storage_quota_exceeded") {
-      setError("Storage quota reached for private scenes");
-    } else {
-      setError(`Upload failed: ${payload.error ?? response.status}`);
-    }
+    setError(ownerActionErrorMessage(payload, response.status, "Upload failed"));
   }
 
   function remove(sha: string) {

--- a/cloud/apps/auth-web/src/components/SceneZipUpload.tsx
+++ b/cloud/apps/auth-web/src/components/SceneZipUpload.tsx
@@ -3,28 +3,9 @@
 import { Upload } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
+import { ownerActionErrorMessage } from "./ownerActionError";
 
 const maxZipBytes = 8 * 1024 * 1024;
-
-const uploadErrors: Record<string, string> = {
-  content_rejected: "Rejected by content moderation",
-  daily_scene_limit_exceeded: "Daily new-scene limit reached",
-  invalid_name: "The ZIP's template.json needs a scene name",
-  invalid_template_json: "template.json is not valid",
-  invalid_upload: "Choose a FrameOS scene ZIP",
-  invalid_zip: "That file is not a valid ZIP",
-  login_required: "Sign in to upload a scene",
-  missing_scenes: "The ZIP has no scenes",
-  missing_template_json: "The ZIP has no template.json",
-  moderation_unavailable: "Moderation service unavailable — try again later",
-  scene_pulled: "This scene was pulled and cannot be republished",
-  scene_quota_exceeded: "Scene limit reached",
-  scene_requires_compilation:
-    "This is a legacy compiled scene (Nim code nodes or Nim apps). Convert it to an interpreted scene at /nim-converter first.",
-  scene_too_large: "ZIP is too large (max 8 MB)",
-  storage_quota_exceeded: "Cloud scene storage limit reached",
-  store_banned: "This account cannot publish scenes",
-};
 
 export function SceneZipUpload({
   compact = false,
@@ -67,10 +48,9 @@ export function SceneZipUpload({
         scene?: { name?: string; version?: number };
       };
       if (!response.ok) {
-        const error = payload.error ?? String(response.status);
         setMessage({
           kind: "error",
-          text: uploadErrors[error] ?? `Upload failed: ${error}`,
+          text: ownerActionErrorMessage(payload, response.status, "Upload failed"),
         });
         return;
       }

--- a/cloud/apps/auth-web/src/components/YankVersionButton.tsx
+++ b/cloud/apps/auth-web/src/components/YankVersionButton.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { ownerActionErrorMessage } from "./ownerActionError";
 
 export function YankVersionButton({
   sceneId,
@@ -14,9 +15,13 @@ export function YankVersionButton({
 }) {
   const router = useRouter();
   const [status, setStatus] = useState<"idle" | "busy" | "error">("idle");
+  // The server's reason ("scene pulled", "must keep one version"), not a
+  // bare "Failed" that reads as a bug.
+  const [error, setError] = useState<string | null>(null);
 
   async function toggle() {
     setStatus("busy");
+    setError(null);
     const response = await fetch(
       `/api/account/scenes/${sceneId}/versions/${version}`,
       {
@@ -30,19 +35,34 @@ export function YankVersionButton({
       router.refresh();
       setStatus("idle");
     } else {
+      const detail = await response.json().catch(() => ({}));
+      setError(
+        ownerActionErrorMessage(
+          detail,
+          response.status,
+          yanked ? "Republishing failed" : "Unpublishing failed",
+        ),
+      );
       setStatus("error");
     }
   }
 
   return (
-    <button
-      className="button button--small"
-      disabled={status === "busy"}
-      onClick={() => void toggle()}
-      title="Unpublished versions are skipped by new installs but stay downloadable when requested explicitly"
-      type="button"
-    >
-      {status === "error" ? "Failed — retry" : yanked ? "Republish" : "Unpublish"}
-    </button>
+    <>
+      <button
+        className="button button--small"
+        disabled={status === "busy"}
+        onClick={() => void toggle()}
+        title="Unpublished versions are skipped by new installs but stay downloadable when requested explicitly"
+        type="button"
+      >
+        {status === "error" ? "Retry" : yanked ? "Republish" : "Unpublish"}
+      </button>
+      {error ? (
+        <span className="pill pill-warning" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </>
   );
 }

--- a/cloud/apps/auth-web/src/components/ownerActionError.ts
+++ b/cloud/apps/auth-web/src/components/ownerActionError.ts
@@ -1,33 +1,20 @@
+import {
+  storeSceneErrorMessage,
+  type StoreErrorDetail,
+} from "@frameos/cloud-frontend/src/storeSceneErrors";
+
 /**
  * The message an owner sees when the store refuses an action on their scene.
  * Every route answers `{error: <code>}` (plus details); collapsing that into
  * "Failed" hid the two refusals owners actually hit — the private-scene
- * quota and the pulled state — behind a word that suggested a bug.
+ * quota and the pulled state — behind a word that suggested a bug. The
+ * wording is the shared store table (frontend/src/utils/storeSceneErrors.ts),
+ * so the editor's Save, the upload forms and these buttons agree.
  */
 export function ownerActionErrorMessage(
-  detail: Record<string, unknown>,
+  detail: StoreErrorDetail,
   status: number,
+  fallback = "Failed",
 ): string {
-  switch (detail.error) {
-    case "content_rejected": {
-      const categories = Array.isArray(detail.categories)
-        ? ` (${detail.categories.join(", ")})`
-        : "";
-      return `Rejected by content moderation${categories}`;
-    }
-    case "moderation_unavailable":
-      return "Moderation service unavailable — try again later";
-    case "storage_quota_exceeded":
-      return "Over your private scene storage quota — delete a private scene or free up space first";
-    case "scene_pulled":
-      return "This scene was pulled by moderation and cannot be changed";
-    case "rate_limited":
-      return "Too many changes in a row — wait a moment and try again";
-    case "login_required":
-      return "Signed out — sign in again";
-    default:
-      return typeof detail.error === "string" && detail.error
-        ? `Failed (${detail.error})`
-        : `Failed (${status})`;
-  }
+  return storeSceneErrorMessage(detail, status, fallback);
 }

--- a/cloud/apps/auth-web/src/lib/ai/app-chat.test.ts
+++ b/cloud/apps/auth-web/src/lib/ai/app-chat.test.ts
@@ -1,5 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { maxAppFiles, readAppSources, runAppChat } from "./app-chat";
+import { captureAiGeneration } from "./telemetry";
+
+vi.mock("./telemetry", () => ({ captureAiGeneration: vi.fn() }));
 
 function sseResponse(events: unknown[]): Response {
   const body = events.map((data) => `data: ${JSON.stringify(data)}\n\n`).join("");
@@ -131,5 +134,70 @@ describe("runAppChat", () => {
     // written into an editor that received none.
     expect(result.tool).toBe("ask_about_app");
     expect(result.files).toBeUndefined();
+  });
+
+  // The surface used to be invisible to LLM telemetry: the meter saw its
+  // tokens, PostHog saw no $ai_generation, and the reconcile between the two
+  // could not tell that gap from a real leak.
+  describe("telemetry", () => {
+    const telemetry = { accountId: "acct-1", chatId: "chat-1", turnId: "turn-1" };
+
+    beforeEach(() => {
+      vi.mocked(captureAiGeneration).mockClear();
+    });
+
+    it("records the one model round under the route's turn id", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        completed([
+          {
+            arguments: JSON.stringify({ files: { "app.ts": "x" }, reply: "ok" }),
+            call_id: "call_1",
+            name: "write_app_files",
+            type: "function_call",
+          },
+        ]),
+      );
+      await runAppChat({ ...base, reasoningEffort: "low", telemetry });
+      expect(captureAiGeneration).toHaveBeenCalledTimes(1);
+      expect(captureAiGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: "acct-1",
+          chatId: "chat-1",
+          error: undefined,
+          model: "gpt-5.5",
+          reasoningEffort: "low",
+          round: 1,
+          status: "completed",
+          toolCalls: ["write_app_files"],
+          turnId: "turn-1",
+        }),
+      );
+    });
+
+    it("records a failed call with OpenAI's status, then rethrows", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ error: { message: "slow down" } }), {
+          headers: { "Content-Type": "application/json" },
+          status: 429,
+        }),
+      );
+      await expect(runAppChat({ ...base, telemetry })).rejects.toThrow();
+      expect(captureAiGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpStatus: 429,
+          status: "failed",
+          toolCalls: [],
+          turnId: "turn-1",
+        }),
+      );
+      const record = vi.mocked(captureAiGeneration).mock.calls[0]?.[0];
+      expect(record?.error).toBeTruthy();
+    });
+
+    it("stays silent without a telemetry context", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(completed([], "hi"));
+      await runAppChat(base);
+      expect(captureAiGeneration).not.toHaveBeenCalled();
+    });
   });
 });

--- a/cloud/apps/auth-web/src/lib/ai/app-chat.ts
+++ b/cloud/apps/auth-web/src/lib/ai/app-chat.ts
@@ -14,11 +14,22 @@
 // only applies what arrives through write_app_files.
 
 import {
+  OpenAiRequestError,
   streamResponse,
   type ResponsesToolDefinition,
   type ResponseUsage,
 } from "./openai";
+import { captureAiGeneration } from "./telemetry";
 import { parseToolArguments } from "./tool-args";
+
+/** Where the call's `$ai_generation` row lands. The scene chat emits one per
+ *  model round from its turn loop; this panel has one round per request, so
+ *  the request IS the turn and the route hands its metering ids down. */
+export interface AppChatTelemetry {
+  accountId: string;
+  chatId: string;
+  turnId: string;
+}
 
 export const maxAppSourceChars = 120_000;
 export const maxAppFiles = 40;
@@ -160,30 +171,78 @@ export async function runAppChat(input: {
   sources: AppChatSources;
   history: { role: "user" | "assistant"; content: string }[];
   signal?: AbortSignal | undefined;
+  telemetry?: AppChatTelemetry | undefined;
 }): Promise<AppChatResult> {
-  const result = await streamResponse({
-    apiKey: input.apiKey,
-    input: [
-      ...input.history.map((message) => ({
-        content: message.content,
-        role: message.role,
-        type: "message",
-      })),
-      {
-        content: `${appContextBlock(input)}\n\n${input.prompt}`,
-        role: "user",
-        type: "message",
-      },
-    ],
-    instructions: buildAppChatInstructions(),
-    model: input.model,
-    onTextDelta: () => {
-      // The panel's contract is a single JSON body, not a stream — it fakes
-      // typing client-side. Deltas are aggregated by streamResponse.
+  const startedAt = Date.now();
+  // The one model round this panel makes, recorded the way the scene chat
+  // records each of its rounds — without this the surface was invisible to
+  // the meter-vs-PostHog reconcile, which compares metered tokens against
+  // $ai_generation rows. Failures are rows too: a 429 or a cut-off is
+  // exactly what the reconcile is for.
+  const record = (
+    outcome: { status: string; usage?: ResponseUsage; toolCalls: string[] } & {
+      error?: string;
+      httpStatus?: number;
     },
-    ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
-    ...(input.signal ? { signal: input.signal } : {}),
-    tools: [writeAppFilesTool],
+  ) => {
+    if (!input.telemetry) {
+      return;
+    }
+    captureAiGeneration({
+      accountId: input.telemetry.accountId,
+      chatId: input.telemetry.chatId,
+      error: outcome.error,
+      httpStatus: outcome.httpStatus,
+      latencyMs: Date.now() - startedAt,
+      model: input.model,
+      reasoningEffort: input.reasoningEffort ?? "",
+      round: 1,
+      status: outcome.status,
+      toolCalls: outcome.toolCalls,
+      turnId: input.telemetry.turnId,
+      usage: outcome.usage,
+    });
+  };
+
+  let result;
+  try {
+    result = await streamResponse({
+      apiKey: input.apiKey,
+      input: [
+        ...input.history.map((message) => ({
+          content: message.content,
+          role: message.role,
+          type: "message",
+        })),
+        {
+          content: `${appContextBlock(input)}\n\n${input.prompt}`,
+          role: "user",
+          type: "message",
+        },
+      ],
+      instructions: buildAppChatInstructions(),
+      model: input.model,
+      onTextDelta: () => {
+        // The panel's contract is a single JSON body, not a stream — it fakes
+        // typing client-side. Deltas are aggregated by streamResponse.
+      },
+      ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
+      ...(input.signal ? { signal: input.signal } : {}),
+      tools: [writeAppFilesTool],
+    });
+  } catch (error) {
+    record({
+      error: error instanceof Error ? error.message : String(error),
+      ...(error instanceof OpenAiRequestError ? { httpStatus: error.status } : {}),
+      status: "failed",
+      toolCalls: [],
+    });
+    throw error;
+  }
+  record({
+    status: result.status,
+    toolCalls: result.functionCalls.map((entry) => entry.name),
+    usage: result.usage,
   });
 
   const usage = result.usage;

--- a/cloud/apps/auth-web/src/lib/preview-settings.ts
+++ b/cloud/apps/auth-web/src/lib/preview-settings.ts
@@ -3,10 +3,13 @@
 // Mirrors frameos' settings groups (frontend/src/scenes/frame/panels/
 // secretSettings.ts) and the `settings` lists in the apps' config.json files.
 // Keys TYPED into the preview stay in the browser: they go straight into the
-// wasm runtime and out with its requests, never to our server (except hosts
-// that need the CORS fallback proxy, which forwards headers verbatim). Keys
-// SAVED on the account settings page persist server-side (account_settings)
-// and seed the preview automatically.
+// wasm runtime and out with its requests, never to our server — except for
+// hosts that need the CORS fallback proxy (/api/store/preview-proxy), which
+// forwards the app's request headers, `Authorization` included, to the host
+// the app named and to nowhere else (guardedFetch drops credential headers
+// before following a redirect to another origin; our own cookies are never
+// forwarded). Keys SAVED on the account settings page persist server-side
+// (account_settings) and seed the preview automatically.
 
 export type PreviewSettingsField = {
   label: string;

--- a/cloud/apps/auth-web/src/lib/ssrf.test.ts
+++ b/cloud/apps/auth-web/src/lib/ssrf.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isIP } from "node:net";
-import { addressIsPrivate, addressIsPrivateSource } from "./ssrf";
+import { addressIsPrivate, addressIsPrivateSource, guardedFetch } from "./ssrf";
 
 describe("addressIsPrivate", () => {
   it("blocks the RFC 1918, loopback, link-local and CGNAT v4 ranges", () => {
@@ -76,6 +76,55 @@ describe("addressIsPrivateSource", () => {
       "fe80::1%eth0",
     ]) {
       expect(spliced(address), address).toBe(addressIsPrivate(address));
+    }
+  });
+});
+
+describe("guardedFetch", () => {
+  // The preview proxy forwards an app's Authorization header to the host the
+  // app named. A redirect off that origin must not carry it along: host A's
+  // key is not host B's to see.
+  it("drops credential headers when a redirect changes origin, keeps them on the same origin", async () => {
+    const calls: { url: string; headers: Headers }[] = [];
+    const fetchMock = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ headers: new Headers(init?.headers), url });
+      if (url === "https://example.com/start") {
+        return new Response(null, {
+          headers: { location: "https://example.com/same-origin" },
+          status: 302,
+        });
+      }
+      if (url === "https://example.com/same-origin") {
+        return new Response(null, {
+          headers: { location: "https://example.org/elsewhere" },
+          status: 302,
+        });
+      }
+      return new Response("done", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const response = await guardedFetch("https://example.com/start", {
+        headers: {
+          authorization: "Bearer app-key",
+          cookie: "session",
+          "x-api-key": "k",
+        },
+      });
+      expect(await response.text()).toBe("done");
+      expect(calls.map((call) => call.url)).toEqual([
+        "https://example.com/start",
+        "https://example.com/same-origin",
+        "https://example.org/elsewhere",
+      ]);
+      expect(calls[1]?.headers.get("authorization")).toBe("Bearer app-key");
+      expect(calls[2]?.headers.get("authorization")).toBeNull();
+      expect(calls[2]?.headers.get("cookie")).toBeNull();
+      // Non-credential headers still travel.
+      expect(calls[2]?.headers.get("x-api-key")).toBe("k");
+    } finally {
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/cloud/apps/auth-web/src/lib/ssrf.ts
+++ b/cloud/apps/auth-web/src/lib/ssrf.ts
@@ -76,14 +76,31 @@ export const addressIsPrivate = new Function(
   `${addressIsPrivateSource}\nreturn addressIsPrivate;`,
 )(isIP) as (address: string) => boolean;
 
+// Headers that name the caller to ONE host. A redirect that leaves the
+// origin the caller addressed must not carry them along — the same rule
+// the runtime's own HTTP client (frameos/src/frameos/utils/http_client.nim)
+// applies — or an app's API key for host A is handed to whatever host A
+// bounces to.
+const credentialHeaders = ["authorization", "cookie", "proxy-authorization"];
+
+function withoutCredentialHeaders(headers: HeadersInit | undefined): Headers {
+  const stripped = new Headers(headers);
+  for (const name of credentialHeaders) {
+    stripped.delete(name);
+  }
+  return stripped;
+}
+
 // A fetch that applies the guard before every request (redirects included:
-// each hop is checked, so a public URL cannot bounce to an internal one).
+// each hop is checked, so a public URL cannot bounce to an internal one, and
+// credential headers stay behind when a hop changes origin).
 export async function guardedFetch(
   input: string,
   init?: RequestInit,
   maxRedirects = 5,
 ): Promise<Response> {
   let url = new URL(input);
+  let headers: HeadersInit | undefined = init?.headers;
   for (let hop = 0; hop <= maxRedirects; hop += 1) {
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error("invalid_url");
@@ -91,10 +108,18 @@ export async function guardedFetch(
     if (await hostIsBlocked(url.hostname)) {
       throw new Error("host_not_allowed");
     }
-    const response = await fetch(url, { ...init, redirect: "manual" });
+    const response = await fetch(url, {
+      ...init,
+      ...(headers === undefined ? {} : { headers }),
+      redirect: "manual",
+    });
     const location = response.headers.get("location");
     if (response.status >= 300 && response.status < 400 && location) {
-      url = new URL(location, url);
+      const next = new URL(location, url);
+      if (next.origin !== url.origin) {
+        headers = withoutCredentialHeaders(headers);
+      }
+      url = next;
       continue;
     }
     return response;

--- a/cloud/apps/auth-web/src/lib/store-publish.ts
+++ b/cloud/apps/auth-web/src/lib/store-publish.ts
@@ -29,7 +29,11 @@ import {
   type StoreImage,
 } from "./store-images";
 import type { SceneListing } from "./store-listing";
-import { alignZipCover, writeSceneVersion } from "./store-version-write";
+import {
+  alignZipCover,
+  nextSceneVersion,
+  writeSceneVersion,
+} from "./store-version-write";
 import {
   accountLimits,
   privateSceneBytesForAccount,
@@ -372,7 +376,7 @@ export async function publishStoreScene(
     );
   }
 
-  const nextVersion = scene.latestVersion + 1;
+  const nextVersion = await nextSceneVersion(db, scene.id);
   const written = await writeSceneVersion(db, {
     content: aligned.content,
     images,

--- a/cloud/apps/auth-web/src/lib/store-version-write.ts
+++ b/cloud/apps/auth-web/src/lib/store-version-write.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, max, ne } from "drizzle-orm";
 import {
   type createDb,
   storeSceneVersionImages,
@@ -154,6 +154,55 @@ export async function writeSceneVersion(
     return { error: "scene_update_failed" };
   }
   return { stored, updated: result };
+}
+
+/** The number the next version of a scene gets: one past the highest ever
+ * published, yanked ones included. `latest_version` is NOT that number — it
+ * follows the newest non-yanked version (syncLatestVersion), so a scene whose
+ * latest was yanked would otherwise re-issue a number it already used and
+ * hit the (scene_id, version) unique key on the next Save. */
+export async function nextSceneVersion(
+  db: Database,
+  sceneId: string,
+): Promise<number> {
+  const [row] = await db
+    .select({ highest: max(storeSceneVersions.version) })
+    .from(storeSceneVersions)
+    .where(eq(storeSceneVersions.sceneId, sceneId));
+  return (row?.highest ?? 0) + 1;
+}
+
+/** Points `latest_version` at the newest non-yanked version and returns it.
+ * Run after a yank or an unyank, inside the same transaction: "latest" is
+ * what the store index advertises, what the cover SQL joins on and what the
+ * `?v=N` cover URL — cached immutable at the edge for a year — names, so it
+ * must not keep naming a version the download route no longer serves by
+ * default. Every version yanked (the yank route refuses that) leaves the
+ * column alone. */
+export async function syncLatestVersion(
+  db: Database,
+  sceneId: string,
+): Promise<number | undefined> {
+  const [row] = await db
+    .select({ newest: max(storeSceneVersions.version) })
+    .from(storeSceneVersions)
+    .where(
+      and(
+        eq(storeSceneVersions.sceneId, sceneId),
+        isNull(storeSceneVersions.yankedAt),
+      ),
+    );
+  const newest = row?.newest ?? undefined;
+  if (newest === undefined) {
+    return undefined;
+  }
+  await db
+    .update(storeScenes)
+    .set({ latestVersion: newest })
+    .where(
+      and(eq(storeScenes.id, sceneId), ne(storeScenes.latestVersion, newest)),
+    );
+  return newest;
 }
 
 export { sameImageSet };

--- a/cloud/apps/auth-web/src/test/integration/store-hardening.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/store-hardening.integration.test.ts
@@ -2,6 +2,7 @@ import { strToU8, zipSync } from "fflate";
 import { eq, sql } from "drizzle-orm";
 import { NextRequest } from "next/server";
 import {
+  accountApiTokens,
   accounts,
   auditEvents,
   createDb,
@@ -29,10 +30,14 @@ import { POST as reportScene } from "../../../app/api/store/scenes/[sceneId]/rep
 import { POST as authorizeDevice } from "../../../app/api/device/authorize/route";
 import { POST as pollDevice } from "../../../app/api/device/poll/route";
 import { POST as startDevice } from "../../../app/api/device/start/route";
+import { mintApiToken } from "../../lib/api-tokens";
 import { resetRateLimitForTests } from "../../lib/rate-limit";
 import { createSession, sessionCookieName } from "../../lib/session";
 
 const cookieJar = vi.hoisted(() => new Map<string, string>());
+// readSession() reads a personal API token from the request headers when
+// there is no cookie; route handlers get the same header on the NextRequest.
+const requestHeaders = vi.hoisted(() => new Map<string, string>());
 
 vi.mock("next/headers", () => ({
   cookies: async () => ({
@@ -41,6 +46,7 @@ vi.mock("next/headers", () => ({
       return value === undefined ? undefined : { name, value };
     },
   }),
+  headers: async () => new Headers(Object.fromEntries(requestHeaders)),
 }));
 
 const baseUrl = "http://localhost:3000";
@@ -55,6 +61,7 @@ afterAll(async () => {
 beforeEach(async () => {
   resetRateLimitForTests();
   cookieJar.clear();
+  requestHeaders.clear();
   const tables = await db.execute<{ tablename: string }>(
     sql`select tablename from pg_tables where schemaname = 'public'`,
   );
@@ -559,6 +566,47 @@ describe("my cloud drive", () => {
       }),
     );
     expect(drive.status).toBe(403);
+  });
+
+  // A personal API token is the account itself (readSession resolves it),
+  // not a linked client: the route used to hand every bearer to the link
+  // check and answer 401 invalid_link_token to a script's own token.
+  it("lists the drive for a personal API token, read-only included", async () => {
+    const { accessToken, accountId } = await linkClient(publishScopes);
+    const published = await publish(accessToken);
+    const scene = (await readJson(published)).scene as { id: string };
+    cookieJar.clear();
+
+    for (const access of ["full", "read_only"] as const) {
+      const minted = mintApiToken(access);
+      await db.insert(accountApiTokens).values({
+        access,
+        accountId,
+        name: access,
+        tokenHash: minted.tokenHash,
+        tokenHint: minted.hint,
+      });
+      requestHeaders.set("authorization", `Bearer ${minted.token}`);
+      const drive = await getDriveRepositoryJson(
+        request("/api/store/account/repository.json", "GET", {
+          headers: bearer(minted.token),
+        }),
+      );
+      expect(drive.status, access).toBe(200);
+      const templates = (await readJson(drive)).templates as Record<string, unknown>[];
+      expect(templates.map((template) => template.sceneId)).toEqual([scene.id]);
+    }
+
+    // A token nobody minted resolves to no session: login_required, not the
+    // linked-client error.
+    requestHeaders.set("authorization", "Bearer fc_api_not_a_real_token");
+    const unknown = await getDriveRepositoryJson(
+      request("/api/store/account/repository.json", "GET", {
+        headers: bearer("fc_api_not_a_real_token"),
+      }),
+    );
+    expect(unknown.status).toBe(401);
+    expect((await readJson(unknown)).error).toBe("login_required");
   });
 });
 

--- a/cloud/apps/auth-web/src/test/integration/store.integration.test.ts
+++ b/cloud/apps/auth-web/src/test/integration/store.integration.test.ts
@@ -1224,6 +1224,79 @@ describe("store publish and distribution", () => {
     expect(explicit.status).toBe(200);
     expect(explicit.headers.get("x-scene-version")).toBe("2");
 
+    // `latest_version` followed the yank: the store index, the cover SQL and
+    // the immutable `?v=N` cover URL all key on it, so it must name what the
+    // download route serves by default — not the version just yanked.
+    const latestVersionOf = async () =>
+      (
+        await db
+          .select({ latestVersion: storeScenes.latestVersion })
+          .from(storeScenes)
+          .where(eq(storeScenes.id, sceneId))
+      )[0]?.latestVersion;
+    expect((await readJson(yank)).latest_version).toBe(1);
+    expect(await latestVersionOf()).toBe(1);
+    const repo = await readJson(
+      await getRepositoryJson(request("/api/store/repository.json", "GET")),
+    );
+    const listed = (repo.templates as Array<Record<string, unknown>>).find(
+      (template) => template.sceneId === sceneId,
+    );
+    expect(listed?.version).toBe("1");
+
+    // Version numbers never repeat: the next publish after the yank is v3,
+    // one past the highest ever issued, not `latest_version + 1` (= 2).
+    const republished = await publish(accessToken);
+    expect(republished.status).toBe(200);
+    expect((await readJson(republished)).scene).toMatchObject({
+      latest_version: 3,
+    });
+    expect(await latestVersionOf()).toBe(3);
+
+    // Unyanking an older version does not move the pointer off a newer live
+    // one; yanking the newest hands it to the newest still live.
+    const unyank = await patchVersion(
+      request(`/api/account/scenes/${sceneId}/versions/2`, "PATCH", {
+        body: { yanked: false },
+        headers: { origin: baseUrl },
+      }),
+      { params: Promise.resolve({ sceneId, version: "2" }) },
+    );
+    expect(unyank.status).toBe(200);
+    expect((await readJson(unyank)).latest_version).toBe(3);
+    const yankNewest = await patchVersion(
+      request(`/api/account/scenes/${sceneId}/versions/3`, "PATCH", {
+        body: { yanked: true },
+        headers: { origin: baseUrl },
+      }),
+      { params: Promise.resolve({ sceneId, version: "3" }) },
+    );
+    expect(yankNewest.status).toBe(200);
+    expect(await latestVersionOf()).toBe(2);
+    // Back to the v2-yanked state the last-version check below expects.
+    await patchVersion(
+      request(`/api/account/scenes/${sceneId}/versions/3`, "PATCH", {
+        body: { yanked: false },
+        headers: { origin: baseUrl },
+      }),
+      { params: Promise.resolve({ sceneId, version: "3" }) },
+    );
+    await patchVersion(
+      request(`/api/account/scenes/${sceneId}/versions/2`, "PATCH", {
+        body: { yanked: true },
+        headers: { origin: baseUrl },
+      }),
+      { params: Promise.resolve({ sceneId, version: "2" }) },
+    );
+    await patchVersion(
+      request(`/api/account/scenes/${sceneId}/versions/3`, "PATCH", {
+        body: { yanked: true },
+        headers: { origin: baseUrl },
+      }),
+      { params: Promise.resolve({ sceneId, version: "3" }) },
+    );
+    expect(await latestVersionOf()).toBe(1);
+
     const lastYank = await patchVersion(
       request(`/api/account/scenes/${sceneId}/versions/1`, "PATCH", {
         body: { yanked: true },
@@ -1845,7 +1918,11 @@ describe("store publish and distribution", () => {
     );
     try {
       const response = await proxied({
-        headers: { "x-api-key": "k", cookie: "never-forwarded" },
+        headers: {
+          "x-api-key": "k",
+          authorization: "Bearer app-key",
+          cookie: "never-forwarded",
+        },
         url: "https://example.com/data",
       });
       expect(response.status).toBe(201);
@@ -1863,6 +1940,10 @@ describe("store publish and distribution", () => {
       const [, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
       const sentHeaders = new Headers(init.headers);
       expect(sentHeaders.get("x-api-key")).toBe("k");
+      // The app's own key for the host it named goes through, as it does on
+      // a frame and through the backend's proxy; the browser's cookie for
+      // US never does.
+      expect(sentHeaders.get("authorization")).toBe("Bearer app-key");
       expect(sentHeaders.get("cookie")).toBeNull();
     } finally {
       vi.unstubAllGlobals();

--- a/cloud/apps/auth-web/src/test/shared-spa/store-scene-errors.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/store-scene-errors.test.ts
@@ -1,0 +1,79 @@
+// The store's error-code wording (frontend/src/utils/storeSceneErrors.ts):
+// one table read by the cloud's owner buttons, upload forms and editor Save
+// (through @frameos/cloud-frontend/src/storeSceneErrors) and by the SPA's
+// cloud scene calls. Pins that the codes owners actually hit surface the
+// server's reason instead of "Failed", that an unknown code still names the
+// action, and that the two import paths are the same function.
+
+import { describe, expect, it } from "vitest";
+import { storeSceneErrorMessage as viaCloudFrontend } from "../../../../../../cloud-frontend/src/storeSceneErrors";
+import {
+  storeSceneErrorCode,
+  storeSceneErrorMessage,
+} from "../../../../../../frontend/src/utils/storeSceneErrors";
+import { ownerActionErrorMessage } from "../../components/ownerActionError";
+
+describe("storeSceneErrorMessage", () => {
+  it("is one function behind every import path", () => {
+    expect(viaCloudFrontend).toBe(storeSceneErrorMessage);
+    expect(ownerActionErrorMessage({ error: "scene_pulled" }, 410)).toBe(
+      storeSceneErrorMessage({ error: "scene_pulled" }, 410),
+    );
+  });
+
+  it("surfaces the refusals owners hit instead of a bare Failed", () => {
+    expect(storeSceneErrorMessage({ error: "storage_quota_exceeded" }, 403)).toMatch(
+      /storage quota/,
+    );
+    expect(storeSceneErrorMessage({ error: "scene_pulled" }, 410)).toMatch(/pulled/);
+    expect(storeSceneErrorMessage({ error: "rate_limited" }, 429)).toMatch(/wait a moment/);
+    expect(storeSceneErrorMessage({ error: "cannot_yank_last_version" }, 400)).toMatch(
+      /at least one published version/,
+    );
+    for (const code of ["storage_quota_exceeded", "scene_pulled", "rate_limited"]) {
+      expect(storeSceneErrorMessage({ error: code }, 400)).not.toContain(code);
+      expect(storeSceneErrorMessage({ error: code }, 400)).not.toMatch(/^Failed/);
+    }
+  });
+
+  it("folds the route's details into the text", () => {
+    expect(
+      storeSceneErrorMessage(
+        { categories: ["harassment", "violence"], error: "content_rejected" },
+        400,
+      ),
+    ).toBe("Rejected by content moderation (harassment, violence)");
+    expect(storeSceneErrorMessage({ error: "scene_name_taken", name: "Clock" }, 409)).toBe(
+      "You already have another scene called “Clock” — rename this one to something else",
+    );
+    expect(storeSceneErrorMessage({ error: "scene_name_taken" }, 409)).toContain("“that”");
+  });
+
+  it("names the action for codes it has no wording for, and the status for no code at all", () => {
+    expect(storeSceneErrorMessage({ error: "brand_new_code" }, 400, "Saving failed")).toBe(
+      "Saving failed (brand_new_code)",
+    );
+    expect(storeSceneErrorMessage({ error: "brand_new_code" }, 400)).toBe(
+      "Failed (brand_new_code)",
+    );
+    expect(storeSceneErrorMessage({}, 502, "Upload failed")).toBe("Upload failed (502)");
+    expect(storeSceneErrorMessage(null, 500)).toBe("Failed (500)");
+    expect(storeSceneErrorMessage({ error: 42 }, 500)).toBe("Failed (500)");
+  });
+
+  it("prefers a route's free-text detail over the generic fallback", () => {
+    expect(
+      storeSceneErrorMessage({ detail: "Prompt is required", error: "invalid_prompt" }, 400),
+    ).toBe("Prompt is required");
+    // …but a known code's wording wins over the detail.
+    expect(
+      storeSceneErrorMessage({ detail: "quota", error: "storage_quota_exceeded" }, 403),
+    ).toMatch(/storage quota/);
+  });
+
+  it("exposes the code for callers that branch on it", () => {
+    expect(storeSceneErrorCode({ error: "login_required" })).toBe("login_required");
+    expect(storeSceneErrorCode({ error: "" })).toBeUndefined();
+    expect(storeSceneErrorCode(undefined)).toBeUndefined();
+  });
+});

--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -103,6 +103,8 @@
     "src/test/shared-spa/app-node-logic.test.ts",
     "src/test/shared-spa/scene-json-logic.test.ts",
     "src/test/shared-spa/select-options.test.ts",
-    "src/test/shared-spa/select-missing-value.test.tsx"
+    "src/test/shared-spa/select-missing-value.test.tsx",
+    // The store error-code wording (2026-09 review §2), same reason.
+    "src/test/shared-spa/store-scene-errors.test.ts"
   ]
 }

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -81,6 +81,8 @@ export default tseslint.config(
       "**/src/test/shared-spa/scene-json-logic.test.ts",
       "**/src/test/shared-spa/select-options.test.ts",
       "**/src/test/shared-spa/select-missing-value.test.tsx",
+      // The store error-code wording (2026-09 review §2), same reason.
+      "**/src/test/shared-spa/store-scene-errors.test.ts",
     ],
   },
   js.configs.recommended,

--- a/frontend/src/utils/cloudFrameApi.ts
+++ b/frontend/src/utils/cloudFrameApi.ts
@@ -1,6 +1,7 @@
 import type { FrameSchedule, FrameScene, FrameType } from '../types'
 import { apiFetch } from './apiFetch'
 import type { CloudFrameSceneRow } from './cloudFrameScenes'
+import { storeSceneErrorMessage, type StoreErrorDetail } from './storeSceneErrors'
 import {
   allCloudFrameSettingKeys,
   cloudFrameSettingKeys,
@@ -77,8 +78,12 @@ async function assertOk(response: Response, fallback: string): Promise<void> {
   if (response.ok) {
     return
   }
-  const detail = (await response.json().catch(() => ({}))) as { error?: string }
-  throw new Error(detail.error ? `${fallback} (${detail.error})` : fallback)
+  const detail = (await response.json().catch(() => ({}))) as StoreErrorDetail
+  // The store's own wording for the refusals it has a name for (the
+  // private-scene quota, a pulled scene, a rate limit…); the action plus
+  // the raw code for anything else, so a new server code still says what
+  // did not happen.
+  throw new Error(storeSceneErrorMessage(detail, response.status, fallback))
 }
 
 export async function sendCloudFrameCommand(

--- a/frontend/src/utils/storeSceneErrors.ts
+++ b/frontend/src/utils/storeSceneErrors.ts
@@ -1,0 +1,125 @@
+/**
+ * One wording for every refusal the cloud scene store answers with.
+ *
+ * Every store and account-scene route replies `{error: <code>}` plus a few
+ * details. Three different places used to turn that into text — the owner
+ * buttons collapsed everything into "Failed", the upload and new-scene forms
+ * each kept their own partial table, and the editor's Save showed the raw
+ * code — so the two refusals owners actually hit (the private-scene quota
+ * and the pulled state) read as a bug in one place and as `storage_quota_exceeded`
+ * in another. This is the table; every reader goes through it.
+ *
+ * Window-free and dependency-free on purpose: the cloud's Next.js components
+ * import it through `@frameos/cloud-frontend/src/storeSceneErrors`, the SPA
+ * through this path, and the shared-spa suite pins the wording.
+ */
+
+export type StoreErrorDetail = {
+  error?: unknown
+  /** Free-text explanation some routes add next to the code. */
+  detail?: unknown
+  /** content_rejected: the moderation categories that fired. */
+  categories?: unknown
+  /** scene_name_taken: the name that clashed. */
+  name?: unknown
+  [key: string]: unknown
+}
+
+export function storeSceneErrorCode(detail: StoreErrorDetail | null | undefined): string | undefined {
+  const code = detail?.error
+  return typeof code === 'string' && code ? code : undefined
+}
+
+/**
+ * The message a person sees for a store refusal. `fallback` names the action
+ * that failed ("Saving failed") and prefixes the unknown-code and no-code
+ * forms, so a new server code still tells the reader what did not happen.
+ */
+export function storeSceneErrorMessage(
+  detail: StoreErrorDetail | null | undefined,
+  status: number,
+  fallback = 'Failed'
+): string {
+  const code = storeSceneErrorCode(detail)
+  switch (code) {
+    // Moderation
+    case 'content_rejected': {
+      const categories = Array.isArray(detail?.categories) ? ` (${detail.categories.join(', ')})` : ''
+      return `Rejected by content moderation${categories}`
+    }
+    case 'moderation_unavailable':
+      return 'Moderation service unavailable — try again later'
+    case 'scene_pulled':
+      return 'This scene was pulled by moderation and cannot be changed'
+    case 'store_banned':
+      return 'This account cannot publish scenes'
+
+    // Quotas and limits
+    case 'storage_quota_exceeded':
+      return 'Over your private scene storage quota — delete a private scene or free up space first'
+    case 'scene_quota_exceeded':
+      return 'Scene limit reached'
+    case 'daily_scene_limit_exceeded':
+      return 'Daily new-scene limit reached — try again tomorrow'
+    case 'rate_limited':
+      return 'Too many changes in a row — wait a moment and try again'
+
+    // Who you are
+    case 'login_required':
+      return 'Signed out — sign in again'
+    case 'insufficient_scope':
+      return 'This link or token is not allowed to do that'
+    case 'read_only_token':
+      return 'This API token is read-only'
+
+    // The scene
+    case 'scene_not_found':
+      return 'This scene no longer exists'
+    case 'version_not_found':
+      return 'This version no longer exists'
+    case 'cannot_yank_last_version':
+      return 'A scene must keep at least one published version'
+    case 'scene_name_taken':
+      return `You already have another scene called “${
+        typeof detail?.name === 'string' && detail.name ? detail.name : 'that'
+      }” — rename this one to something else`
+    case 'invalid_tags':
+      return 'Up to 5 tags; lowercase letters, digits, dashes, max 24 characters each'
+    case 'invalid_frameos_version':
+      return 'The minimum FrameOS version should look like 2026.7.5'
+    case 'invalid_scenes':
+      return 'The scene is empty'
+    case 'scene_too_large':
+      return 'The scene is too large (max 8 MB)'
+    case 'scene_requires_compilation':
+      return 'This is a legacy compiled scene (Nim code nodes or Nim apps). Convert it to an interpreted scene at /nim-converter first.'
+
+    // Zip uploads
+    case 'invalid_name':
+      return "The ZIP's template.json needs a scene name"
+    case 'invalid_template_json':
+      return 'template.json is not valid'
+    case 'invalid_upload':
+      return 'Choose a FrameOS scene ZIP'
+    case 'invalid_zip':
+      return 'That file is not a valid ZIP'
+    case 'missing_scenes':
+      return 'The ZIP has no scenes'
+    case 'missing_template_json':
+      return 'The ZIP has no template.json'
+
+    // Images
+    case 'image_too_large':
+      return 'Image too large (max 4 MB)'
+    case 'unsupported_image':
+      return 'Not a supported image (JPEG, PNG, WebP or GIF)'
+    case 'image_not_found':
+      return "An image in this scene's set no longer exists — remove it and save again"
+
+    default:
+      if (typeof detail?.detail === 'string' && detail.detail) {
+        return detail.detail
+      }
+      return `${fallback} (${code ?? status})`
+  }
+}


### PR DESCRIPTION
Fifth cut item 5 from `docs/review-todo.md` (§2 Mediums + the §3 app-chat Medium).

## `fc_api_` tokens on My cloud drive
- `store/account/repository.json`: a bearer that `isApiToken()` recognises skips the linked-client check and falls through to `readSession()`, which already resolves personal tokens (`fc_api_` full, `fc_apiro_` read-only; job tokens → `401 login_required`). Linked clients still need `store:publish`.
- Integration test: full and read-only personal tokens list the drive; an unminted `fc_api_` gets `login_required`.

## Owner actions surface the server's reason
- New `frontend/src/utils/storeSceneErrors.ts` is the one code → wording table (`storeSceneErrorMessage(detail, status, fallback)`), re-exported window-free through `cloud-frontend/src/storeSceneErrors.ts` for auth-web. A route's free-text `detail` beats the generic fallback; unknown codes read `<action> (<code>)`.
- `ownerActionError.ts`, `SceneZipUpload`, `NewSceneWithAi`, `SceneImageGallery`, `SceneEditorModal` (Save and Fork) all go through it; their private tables are deleted. `YankVersionButton` and `ReportSceneButton` replace "Failed — retry" with "Retry" plus a `role="alert"` pill carrying the reason. `cloudFrameApi.ts` `assertOk` throws the shared wording, so the SPA's cloud-scene save shows "Over your private scene storage quota…" instead of `(storage_quota_exceeded)`.
- Shared-spa test pins the wording, the detail folding, the fallbacks, and that all three import paths are one function.

## Yank moves `latest_version`
- `store-version-write.ts`: `syncLatestVersion(tx, sceneId)` points `latest_version` at the newest non-yanked version; `nextSceneVersion(db, sceneId)` = max(version)+1 over ALL versions so a publish after a yank cannot re-issue a used number. The yank route flips + syncs in one transaction and returns `latest_version`; `store-publish.ts` and `content/route.ts` use `nextSceneVersion`.
- Integration test: yank v2 → row and public `repository.json` say 1; republish → v3; unyank v2 keeps 3; yank v3 → 2.

## Preview proxy vs `authorization`
- `preview-proxy/route.ts` now forwards the app's `Authorization` (parity with the backend's `scene_preview_proxy`); cookie, host, connection, content-length and proxy-authorization are still stripped. `guardedFetch` (`ssrf.ts`) drops `authorization`/`cookie`/`proxy-authorization` when a redirect hop changes origin, the runtime client's rule. The preview-settings comment says exactly what is forwarded and where it stops.
- Tests: `authorization` reaches upstream and `cookie` does not; new redirect test in `ssrf.test.ts`.
- Judgment call worth a look: the proxy stays anonymous, and a caller-supplied `Authorization` gives them nothing `x-api-key` did not already; the cross-origin-redirect strip is the new protection. If you would rather keep stripping, the alternative is a comment fix plus a visible 401 warning in the preview.

## App chat into LLM telemetry
- `app-chat.ts` takes optional `telemetry: {accountId, chatId, turnId}` and emits one `$ai_generation` (round, status, tool calls, usage, latency; `status: "failed"` with the OpenAI HTTP status on error, then rethrows). The route passes the metering ids and emits `ai_chat_turn` with `surface: "app_chat"` on success and on error/stop. Three new tests.

## Verified
```
auth-web unit suite: 183 files, 6 pinned-wording tests updated, re-run 93/93
auth-web integration suite (Postgres, full): exit 0, 91 s
tsc --noEmit auth-web + frontend: clean · eslint touched cloud files: clean · prettier frontend/cloud-frontend: clean
```
`next build` was not run locally; the new import chain `auth-web → @frameos/cloud-frontend/src/storeSceneErrors → frontend/src/utils/storeSceneErrors` mirrors the existing `…/src/routes` import but is the one thing to watch in the build job.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrbChngvqARbcdbkrYF7sb