### PR TITLE
Review todo: Nim device runtime core lows

### DIFF
--- a/frameos/src/frameos/hal/files.nim
+++ b/frameos/src/frameos/hal/files.nim
@@ -16,6 +16,7 @@ when defined(frameosEmbedded):
   proc appendTextLine*(path, line: string) = raise noFs(path)
   proc storedFileExists*(path: string): bool = false
   proc storedFileAgeSeconds*(path: string): float = -1.0
+  proc storedFileSize*(path: string): int64 = 0
   proc removeStoredFile*(path: string) = raise noFs(path)
   proc ensureDir*(path: string) = discard
   proc ensureParentDir*(path: string) = discard
@@ -52,6 +53,13 @@ else:
       (epochTime() - getLastModificationTime(path).toUnixFloat())
     except OSError:
       -1.0
+
+  proc storedFileSize*(path: string): int64 =
+    ## Size of `path` in bytes, 0 when it is missing or cannot be stat'ed.
+    try:
+      if fileExists(path): getFileSize(path) else: 0
+    except OSError:
+      0
 
   proc removeStoredFile*(path: string) {.inline.} =
     removeFile(path)

--- a/frameos/src/frameos/logger.nim
+++ b/frameos/src/frameos/logger.nim
@@ -1,4 +1,4 @@
-import zippy, json, os, times, strutils, net
+import zippy, json, os, times, strutils, net, algorithm, locks
 import std/atomics
 
 import frameos/channels
@@ -10,26 +10,94 @@ from frameos/hal/net_client import setSocketSendRecvTimeouts
 const GzipLogTimeoutMs = 10 * 60 * 1000
 
 type
+  LoggerSettings* = object
+    ## Everything the logger thread needs from the frame config, as plain
+    ## values. The thread never holds the FrameConfig ref: that object is
+    ## rewritten in place by the runner on every reload (config.nim
+    ## updateFrameConfigFrom) while four mummy workers read it, and a string
+    ## field replaced under this thread would be a use-after-free (the
+    ## auth-cache incident, server/auth.nim). A reload hands over a fresh
+    ## copy through applyLoggerSettings instead.
+    serverHost*: string
+    serverPort*: int
+    useTls*: bool
+    serverApiKey*: string
+    serverSendLogs*: bool
+    logToFile*: string
+
+  LogFileState* = object
+    ## The log file currently being appended to and how big it is: tracked
+    ## here so the size cap costs no stat per line.
+    path*: string
+    bytes*: int64
+
   LoggerThread = ref object
-    frameConfig: FrameConfig
-    host: string
-    port: int
-    useTls: bool
+    settings: LoggerSettings
+    settingsGeneration: int
     sslContext: SslContext
     logs: seq[SerializedLog]
     lastSendAt: float
     retryBackoff: float
     nextSendAllowedAt: float
-    lastLogFilePath: string
+    logFile: LogFileState
 
 const LOG_FLUSH_SECONDS = 1.0
 const MaxBufferedLogs = 1000
+# Channel entries taken per pass of the logger loop. The channel holds 5000;
+# taking one per wakeup (with a sleep between wakeups) could never catch up
+# with a burst, so the channel overflowed and dropped while the drain idled.
+const MaxDrainPerPass = MaxBufferedLogs
 const LogSendConnectTimeoutMs = 5000
 const LogSendIoTimeoutMs = 10_000
 const LogSendMaxBackoffSeconds = 60.0
 
+# A log path without `{date}` never rotates by date, so it rotates by size:
+# at this many bytes the file is gzipped in place and a fresh one started,
+# keeping the newest LogFileMaxArchives archives.
+const LogFileMaxBytes* = 8 * 1024 * 1024
+const LogFileMaxArchives* = 3
+
 var threadInitDone = false
-var thread: Thread[FrameConfig]
+var thread: Thread[LoggerSettings]
+
+# The settings the thread should be running with. Written by whichever
+# thread saves the config (runner on reload, main at start), read by the
+# logger thread; the generation counter lets the thread skip the lock on
+# every pass where nothing changed.
+var loggerSettingsLock: Lock
+initLock(loggerSettingsLock)
+var pendingLoggerSettings: LoggerSettings
+var loggerSettingsGeneration: Atomic[int]
+
+proc loggerSettingsFrom*(frameConfig: FrameConfig): LoggerSettings =
+  if frameConfig == nil:
+    return LoggerSettings()
+  LoggerSettings(
+    serverHost: frameConfig.serverHost,
+    serverPort: frameConfig.serverPort,
+    useTls: normalizeServerScheme(frameConfig.serverScheme, frameConfig.serverPort) == "https",
+    serverApiKey: frameConfig.serverApiKey,
+    serverSendLogs: frameConfig.serverSendLogs,
+    logToFile: frameConfig.logToFile,
+  )
+
+proc applyLoggerSettings*(frameConfig: FrameConfig) {.gcsafe.} =
+  ## Publish the current config to the logger thread. Called at start and
+  ## after every config reload; the thread picks the copy up on its next pass.
+  let settings = loggerSettingsFrom(frameConfig)
+  {.gcsafe.}:
+    withLock loggerSettingsLock:
+      pendingLoggerSettings = settings
+    atomicInc(loggerSettingsGeneration)
+
+proc refreshSettings(self: LoggerThread) =
+  let generation = loggerSettingsGeneration.load(moAcquire)
+  if generation == self.settingsGeneration:
+    return
+  {.gcsafe.}:
+    withLock loggerSettingsLock:
+      self.settings = pendingLoggerSettings
+  self.settingsGeneration = generation
 
 proc gzipLogFile(path: string) =
   if path.len == 0 or path.endsWith(".gz") or not storedFileExists(path):
@@ -86,21 +154,62 @@ proc cleanupOldRotatedLogs*(filenameTemplate: string, today: DateTime) =
   except CatchableError as e:
     echo "Error cleaning up old log files: " & e.msg
 
-proc logToFile(filename: string, logLine: string, lastLogFilePath: var string, timestamp: float) =
+proc pruneLogArchives*(path: string, keep = LogFileMaxArchives) =
+  ## Keep only the newest `keep` gzip archives of a size-rotated log file
+  ## (`path.gz`, `path.1.gz`, `path.2.gz`, ... as gzipLogFile names them).
+  let dir = parentDir(path)
+  let base = lastPathPart(path)
+  var archives: seq[(float, string)] = @[]
+  try:
+    for kind, candidate in walkDir(if dir.len > 0: dir else: "."):
+      if kind != pcFile:
+        continue
+      let name = lastPathPart(candidate)
+      if not (name.startsWith(base & ".") and name.endsWith(".gz")):
+        continue
+      # What follows "<base>." is either "gz" or "<digits>.gz".
+      let rest = name[base.len + 1 .. ^1]
+      if rest != "gz":
+        let digits = rest[0 ..< rest.len - 3]
+        if digits.len == 0 or not allCharsInSet(digits, {'0' .. '9'}):
+          continue
+      archives.add((getLastModificationTime(candidate).toUnixFloat(), candidate))
+    if archives.len <= keep:
+      return
+    archives.sort(proc(a, b: (float, string)): int = cmp(b[0], a[0]))
+    for index in keep ..< archives.len:
+      removeStoredFile(archives[index][1])
+  except CatchableError as e:
+    echo "Error pruning log archives: " & e.msg
+
+proc logToFile*(filename: string, logLine: string, state: var LogFileState, timestamp: float,
+                maxBytes = LogFileMaxBytes) =
+  ## Append one line to the configured log file. `{date}` paths rotate by
+  ## day (and expire after LogRetentionDays); a path without `{date}` rotates
+  ## by size instead, so neither can grow without bound on SD-backed storage.
   try:
     if filename.len > 0:
       let loggedAt = fromUnix(timestamp.int64).local
-      let file = if "{date}" in filename:
+      let dated = "{date}" in filename
+      let file = if dated:
         filename.replace("{date}", loggedAt.format("yyyyMMdd"))
       else:
         filename
-      if lastLogFilePath.len > 0 and lastLogFilePath != file:
-        gzipLogFile(lastLogFilePath)
-      if lastLogFilePath != file:
+      if state.path.len > 0 and state.path != file:
+        gzipLogFile(state.path)
+      if state.path != file:
         ensureParentDir(file)
-        cleanupOldRotatedLogs(filename, loggedAt)
-      lastLogFilePath = file
-      appendTextLine(file, loggedAt.format("[yyyy-MM-dd'T'HH:mm:ss]") & " " & logLine)
+        if dated:
+          cleanupOldRotatedLogs(filename, loggedAt)
+        state.path = file
+        state.bytes = storedFileSize(file)
+      let line = loggedAt.format("[yyyy-MM-dd'T'HH:mm:ss]") & " " & logLine
+      if not dated and state.bytes > 0 and state.bytes + line.len + 1 > maxBytes:
+        gzipLogFile(file)
+        pruneLogArchives(file)
+        state.bytes = 0
+      appendTextLine(file, line)
+      state.bytes += line.len + 1
   except Exception as e:
     echo "Error writing to log file: " & $e.msg
 
@@ -132,13 +241,13 @@ proc postLogs(self: LoggerThread, body: string): int =
   ## (DNS resolution inside connect() remains bounded only by the resolver.)
   var socket = newSocket()
   try:
-    socket.connect(self.host, Port(self.port), timeout = LogSendConnectTimeoutMs)
+    socket.connect(self.settings.serverHost, Port(self.settings.serverPort), timeout = LogSendConnectTimeoutMs)
     socket.setSocketSendRecvTimeouts(LogSendIoTimeoutMs)
-    if self.useTls:
-      self.getSslContext().wrapConnectedSocket(socket, handshakeAsClient, self.host)
+    if self.settings.useTls:
+      self.getSslContext().wrapConnectedSocket(socket, handshakeAsClient, self.settings.serverHost)
     let request = "POST /api/log HTTP/1.1\r\n" &
-      "Host: " & self.host & ":" & $self.port & "\r\n" &
-      "Authorization: Bearer " & self.frameConfig.serverApiKey & "\r\n" &
+      "Host: " & self.settings.serverHost & ":" & $self.settings.serverPort & "\r\n" &
+      "Authorization: Bearer " & self.settings.serverApiKey & "\r\n" &
       "Content-Type: application/json\r\n" &
       "Content-Encoding: gzip\r\n" &
       "Content-Length: " & $body.len & "\r\n" &
@@ -168,18 +277,21 @@ proc processQueue(self: LoggerThread): int =
   if logCount < MaxBufferedLogs and self.lastSendAt + LOG_FLUSH_SECONDS >= now:
     return 0
 
-  # make a copy, just in case some thread from somewhere adds new entries
-  var newLogs = self.logs
+  var newLogs = move(self.logs)
   self.logs = @[]
 
-  if not self.frameConfig.serverSendLogs:
-    return newLogs.len
-
+  # Report and reset the drop counter whether or not logs leave the device:
+  # with remote logging off the counter used to grow forever, and the one
+  # place the drops were visible (the journal, the log file) never heard.
   let dropped = logsDroppedCounter.exchange(0)
   if dropped > 0:
     let droppedLine = $(%*{"event": "logger:dropped", "count": dropped})
     echo droppedLine
+    logToFile(self.settings.logToFile, droppedLine, self.logFile, now)
     newLogs.add(SerializedLog(timestamp: now, event: "logger:dropped", line: droppedLine))
+
+  if not self.settings.serverSendLogs:
+    return newLogs.len
 
   self.lastSendAt = now
   try:
@@ -197,47 +309,51 @@ proc processQueue(self: LoggerThread): int =
   return newLogs.len
 
 
-proc run(self: LoggerThread) =
-  var run = 2
-  while true:
-    let processedLogs = self.processQueue()
-    if processedLogs == 0:
-      sleep(run)
-      if run < 250:
-        run += 2
+proc drainChannel(self: LoggerThread): int =
+  ## Take everything queued (up to MaxDrainPerPass) in one go: print it,
+  ## file it, and buffer it for the next send.
+  while result < MaxDrainPerPass:
     let (success, payload) = logChannel.tryRecv()
-    if success:
-      echo "(" & $payload.timestamp & ", " & payload.line & ")" # print to stdout / journal
-      self.logs.add(payload)
-      logToFile(self.frameConfig.logToFile, payload.line, self.lastLogFilePath, payload.timestamp)
-      run = 2
-    else:
-      sleep(run)
-      if run < 250:
-        run += 2
+    if not success:
+      break
+    inc result
+    echo "(" & $payload.timestamp & ", " & payload.line & ")" # print to stdout / journal
+    self.logs.add(payload)
+    logToFile(self.settings.logToFile, payload.line, self.logFile, payload.timestamp)
 
-proc createThreadRunner(frameConfig: FrameConfig) {.thread.} =
+proc run(self: LoggerThread) =
+  var idleSleepMs = 2
+  while true:
+    self.refreshSettings()
+    let received = self.drainChannel()
+    let processedLogs = self.processQueue()
+    if received == 0 and processedLogs == 0:
+      sleep(idleSleepMs)
+      if idleSleepMs < 250:
+        idleSleepMs += 2
+    else:
+      idleSleepMs = 2
+
+proc createThreadRunner(settings: LoggerSettings) {.thread.} =
   var loggerThread = LoggerThread(
-    frameConfig: frameConfig,
-    host: frameConfig.serverHost,
-    port: frameConfig.serverPort,
-    useTls: normalizeServerScheme(frameConfig.serverScheme, frameConfig.serverPort) == "https",
+    settings: settings,
     logs: @[],
     lastSendAt: 0.0,
-    lastLogFilePath: "",
   )
-  var errorLogFilePath = ""
+  var errorLogFile = LogFileState()
   while true:
     try:
       run(loggerThread)
     except Exception as e:
       echo "Error in logger thread: " & $e.msg
-      logToFile(frameConfig.logToFile, $(%*{"error": "Error in logger thread", "message": $e.msg}), errorLogFilePath, epochTime())
+      logToFile(loggerThread.settings.logToFile, $(%*{"error": "Error in logger thread", "message": $e.msg}),
+                errorLogFile, epochTime())
       sleep(1000)
 
 proc newLogger*(frameConfig: FrameConfig): Logger =
+  applyLoggerSettings(frameConfig)
   if not threadInitDone:
-    createThread(thread, createThreadRunner, frameConfig)
+    createThread(thread, createThreadRunner, loggerSettingsFrom(frameConfig))
     threadInitDone = true
   var logger = Logger(
     frameConfig: frameConfig,

--- a/frameos/src/frameos/metrics.nim
+++ b/frameos/src/frameos/metrics.nim
@@ -1,12 +1,15 @@
 import json, os, strutils, sequtils, posix, sets
+import std/atomics
 import frameos/types
 import frameos/channels
 import frameos/runtime_diagnostics
 import frameos/utils/system
 
 type
+  # Holds no FrameConfig: the sampler thread must not read a ref the runner
+  # rewrites in place on every reload (config.nim updateFrameConfigFrom). The
+  # one setting it needs travels through the atomic below instead.
   MetricsLoggerThread = ref object
-    frameConfig: FrameConfig
 
   ReadFileHook = proc(path: string): string {.gcsafe, nimcall.}
   CpuUsageHook = proc(interval: float): float {.gcsafe, nimcall.}
@@ -24,7 +27,15 @@ const noisyDiskFsTypes = [
 ]
 const systemDiskMounts = ["/boot", "/boot/efi", "/boot/firmware", "/efi", "/recovery"]
 
-var thread: Thread[FrameConfig]
+var thread: Thread[void]
+
+# `metricsInterval` in milliseconds, published by applyMetricsSettings at
+# start and on every config reload; 0 means disabled.
+var metricsIntervalMillis: Atomic[int]
+
+proc applyMetricsSettings*(frameConfig: FrameConfig) {.gcsafe.} =
+  let ms = if frameConfig == nil: 0 else: (frameConfig.metricsInterval * 1000).int
+  metricsIntervalMillis.store(max(0, ms), moRelaxed)
 var metricsReadFileHook: ReadFileHook = proc(path: string): string = readFile(path)
 var metricsSleepHook: SleepHook = proc(ms: int) = sleep(ms)
 var metricsOpenFileDescriptorsHook: OpenFileDescriptorsHook = proc(): int =
@@ -299,14 +310,15 @@ proc logMetricsSample(self: MetricsLoggerThread) =
       "error": e.msg,
     })
 
-proc logMetricsNow*(frameConfig: FrameConfig) {.gcsafe.} =
-  MetricsLoggerThread(frameConfig: frameConfig).logMetricsSample()
+proc logMetricsNow*() {.gcsafe.} =
+  MetricsLoggerThread().logMetricsSample()
 
 # How long a disabled sampler dozes between looks at its interval. The
 # interval is re-read every pass (not once at start) so a settings save —
 # local admin or cloud `set_settings` — that turns metrics on, off, or slower
-# takes effect without a runtime restart. `metricsInterval == 0` is the
-# documented "disabled" value; setConfigDefaults leaves it alone on purpose.
+# takes effect without a runtime restart: the runner's reload handler calls
+# applyMetricsSettings. `metricsInterval == 0` is the documented "disabled"
+# value; setConfigDefaults leaves it alone on purpose.
 const MetricsDisabledPollMs = 60_000
 
 proc runMetricsLoop(self: MetricsLoggerThread, maxIterations = -1) {.gcsafe.} =
@@ -316,7 +328,7 @@ proc runMetricsLoop(self: MetricsLoggerThread, maxIterations = -1) {.gcsafe.} =
     if maxIterations >= 0 and iterations >= maxIterations:
       break
     inc iterations
-    let ms = (self.frameConfig.metricsInterval * 1000).int
+    let ms = metricsIntervalMillis.load(moRelaxed)
     if ms <= 0:
       if not announcedDisabled:
         log(%*{"event": "metrics", "state": "disabled"})
@@ -330,14 +342,13 @@ proc runMetricsLoop(self: MetricsLoggerThread, maxIterations = -1) {.gcsafe.} =
 proc start(self: MetricsLoggerThread) {.gcsafe.} =
   self.runMetricsLoop()
 
-proc createThreadRunner(frameConfig: FrameConfig) {.thread.} =
-  var metricsLoggerThread = MetricsLoggerThread(
-    frameConfig: frameConfig,
-  )
+proc createThreadRunner() {.thread.} =
+  var metricsLoggerThread = MetricsLoggerThread()
   metricsLoggerThread.start()
 
 proc newMetricsLogger*(frameConfig: FrameConfig): MetricsLogger =
-  createThread(thread, createThreadRunner, frameConfig)
+  applyMetricsSettings(frameConfig)
+  createThread(thread, createThreadRunner)
   result = MetricsLogger(
     frameConfig: frameConfig,
   )
@@ -371,5 +382,6 @@ proc resetMetricsHooksForTest*() =
     fdCount
 
 proc runMetricsLoopForTest*(frameConfig: FrameConfig, iterations: int) =
-  var metricsLoggerThread = MetricsLoggerThread(frameConfig: frameConfig)
+  applyMetricsSettings(frameConfig)
+  var metricsLoggerThread = MetricsLoggerThread()
   metricsLoggerThread.runMetricsLoop(maxIterations = iterations)

--- a/frameos/src/frameos/portal.nim
+++ b/frameos/src/frameos/portal.nim
@@ -264,7 +264,11 @@ proc door(verb: PrivilegedVerb, args: JsonNode = nil,
   let res = requestPrivileged(verb, args, timeoutMs)
   pLog("portal:privileged", %*{"verb": $verb, "ok": res.ok, "rc": res.exitCode,
                                "error": res.error, "output": res.output.strip()})
-  (res.output, if res.ok: 0 else: max(res.exitCode, 1))
+  if res.ok or res.error.len == 0:
+    return (res.output, if res.ok: 0 else: max(res.exitCode, 1))
+  # A refused or timed-out request has its reason in `error`, not in the
+  # (usually empty) output; callers that surface the failure need it.
+  (res.error & (if res.output.strip().len > 0: "\n" & res.output else: ""), max(res.exitCode, 1))
 
 proc run(cmd: string, loggedCmd: string = ""): (string, int) {.gcsafe.} =
   ## Execute a shell command (through /bin/sh -c) and log the result.
@@ -945,13 +949,24 @@ proc parseSetupOptions*(params: Table[string, string], frameConfig: FrameConfig)
     if result.partialMaxRefreshesBeforeFull <= 0:
       result.partialMaxRefreshesBeforeFull = defaults.refreshes
 
-proc writeHostnameBestEffort(hostname: string) =
+proc writeHostname(hostname: string): bool =
+  ## Applies the hostname the owner typed. Through the privileged door the
+  ## answer is authoritative, so a refusal fails the setup (and names why)
+  ## instead of leaving a frame that reports success but is not reachable
+  ## under the name it just promised. The legacy sudo path has no such
+  ## answer (passwordless sudo is not a given there) and stays best-effort.
   let base = sanitizeHostnameBase(hostname)
   if base.len == 0:
-    return
+    return true
   if privilegedDoorAvailable():
-    discard door(pvSetHostname, %*{"hostname": base})
-    return
+    let (output, rc) = door(pvSetHostname, %*{"hostname": base})
+    if rc != 0:
+      let message = output.strip()
+      rememberError("Could not set the hostname" & (if message.len > 0: ": " & message else: "."))
+      pLog("portal:setup:hostnameError", %*{"hostname": base, "rc": rc})
+      return false
+    return true
+  result = true
   try:
     writeFile("/etc/hostname", base & "\n")
   except CatchableError:
@@ -1087,7 +1102,8 @@ proc persistPortalSetup*(frameOS: FrameOS, options: PortalSetupOptions): bool =
     # must leave the old frame.json, not a truncated one the frame cannot
     # boot from — and the file must never sit at 0644.
     writePrivateFile(filename, pretty(data, indent = 4) & "\n")
-    writeHostnameBestEffort(hostnameBase)
+    if not writeHostname(hostnameBase):
+      return false
 
     if not options.controlModeExplicit:
       discard

--- a/frameos/src/frameos/runner.nim
+++ b/frameos/src/frameos/runner.nim
@@ -649,7 +649,7 @@ proc startMessageLoop*(self: RunnerThread, maxIterations = -1): Future[void] {.a
           of "turnOff":
             drivers.turnOff()
           of "metrics":
-            logMetricsNow(self.frameConfig)
+            logMetricsNow()
             continue # don't dispatch this event to the scene
           of "mouseMove":
             if self.frameConfig.width > 0 and self.frameConfig.height > 0:
@@ -689,6 +689,9 @@ proc startMessageLoop*(self: RunnerThread, maxIterations = -1): Future[void] {.a
             self.logger.log(%*{"event": "reload", "message": "Reloading config and interpreted scenes"})
             try:
               updateFrameConfigFrom(self.frameConfig, loadConfig())
+              # The logger and metrics threads run on copies, not on this ref.
+              applyLoggerSettings(self.frameConfig)
+              applyMetricsSettings(self.frameConfig)
             except Exception as e:
               self.logger.log(%*{"event": "reload:config:error", "error": e.msg, "stacktrace": e.getStackTrace()})
             reloadInterpretedScenes(self.logger)

--- a/frameos/src/frameos/samba_mounts.nim
+++ b/frameos/src/frameos/samba_mounts.nim
@@ -63,20 +63,43 @@ proc mountpointNeedsCredentials*(mountpoint: MountpointConfig): bool =
 proc credentialFilePath*(credentialsDir: string, index: int): string =
   credentialsDir / ("mount-" & $(index + 1) & ".credentials")
 
+# Where a share may appear on the frame. The mountpoint config is
+# backend-owned, but a typo (or a provider that should not be trusted with
+# it) must still not be able to mount a share over /etc, /srv/frameos, the
+# root, or anything else the runtime reads as its own.
+const sambaMountTargetRoots* = ["/mnt", "/media", "/srv/assets"]
+
+proc sambaMountTargetError*(target: string): string =
+  ## "" when `target` is an acceptable mount path, otherwise the reason it is
+  ## not (without the "Samba mountpoint #n" prefix validateMountpoint adds).
+  let stripped = target.strip()
+  if stripped.len == 0:
+    return "is missing a mount path"
+  if not stripped.startsWith("/"):
+    return "mount path must be absolute"
+  if containsLineBreak(stripped):
+    return "mount path cannot contain line breaks"
+  for segment in stripped.split('/'):
+    if segment == "." or segment == "..":
+      return "mount path cannot contain . or .. segments"
+  let normalized = normalizedPath(stripped)
+  for root in sambaMountTargetRoots:
+    if normalized.startsWith(root & "/") and normalized.len > root.len + 1:
+      return ""
+  "mount path must be a directory under " & sambaMountTargetRoots.join(", ")
+
 proc validateMountpoint(mountpoint: MountpointConfig, index: int) =
   let label = "mountpoint #" & $(index + 1)
   let source = mountpoint.source.strip()
-  let target = mountpoint.target.strip()
   if source.len == 0:
     raise newException(ValueError, "Samba " & label & " is missing a source")
   if not source.startsWith("//"):
     raise newException(ValueError, "Samba " & label & " source must start with //")
-  if target.len == 0:
-    raise newException(ValueError, "Samba " & label & " is missing a mount path")
-  if not target.startsWith("/"):
-    raise newException(ValueError, "Samba " & label & " mount path must be absolute")
-  if containsLineBreak(source) or containsLineBreak(target):
-    raise newException(ValueError, "Samba " & label & " source and mount path cannot contain line breaks")
+  if containsLineBreak(source):
+    raise newException(ValueError, "Samba " & label & " source cannot contain line breaks")
+  let targetError = sambaMountTargetError(mountpoint.target)
+  if targetError.len > 0:
+    raise newException(ValueError, "Samba " & label & " " & targetError)
   if containsLineBreak(mountpoint.username) or containsLineBreak(mountpoint.password) or containsLineBreak(mountpoint.domain):
     raise newException(ValueError, "Samba " & label & " credentials cannot contain line breaks")
 
@@ -217,6 +240,8 @@ proc setupSambaMounts*(mountpoints: MountpointsConfig): SetupResult =
     deleteCredentialFiles(sambaCredentialsDir)
     return setupOk()
 
+  # Validates every mountpoint (raising before anything below touches the
+  # system) and renders the fstab block.
   let fstabBlock = frameosFstabBlock(mountpoints)
   addSetupResult(result, setupAptPackages(@["cifs-utils"]))
 

--- a/frameos/src/frameos/server/routes/admin_api_assets_routes.nim
+++ b/frameos/src/frameos/server/routes/admin_api_assets_routes.nim
@@ -12,6 +12,7 @@ import ../auth
 import ../api
 import ../state
 import ./common
+import frameos/channels
 
 # mummy buffers whole responses in RAM, and assets can include multi-hundred
 # MB videos: serving one of those would blow straight through MemoryMax and
@@ -50,6 +51,20 @@ proc configuredAssetsPath*(): string =
 
 proc uploadChunkTempRoot(): string =
   normalizedPath(getTempDir() / "frameos-upload-chunks")
+
+# Bounds on the unfinished-upload parts (local chunked uploads and the
+# cloud's offset-addressed ones alike) that sit under uploadChunkTempRoot.
+const
+  # Parts left behind by an upload that never completed (the browser tab was
+  # closed, the provider gave up, the link died mid-file) are swept once older
+  # than this: on every hub session start, and whenever a new upload begins.
+  # Long enough for a slow link to finish a big file; short enough that a dead
+  # upload does not hold disk for a day.
+  CloudUploadPartMaxAgeSeconds* = 6 * 60 * 60
+  UploadPartMaxAgeSeconds* = CloudUploadPartMaxAgeSeconds
+  # All parts together may not exceed this; the temp root is often tmpfs, so
+  # "the disk" is the frame's RAM. Big enough for a video asset in flight.
+  MaxUploadPartsTotalBytes* = 1024 * 1024 * 1024
 
 proc withinBasePath*(path, basePath: string): bool =
   let normalizedTargetPath = normalizedPath(path)
@@ -241,10 +256,59 @@ proc saveUploadedImagePayload*(filename: string, data: string): JsonNode =
 proc createAssetDirectory*(path: string) =
   createDir(resolveAssetPath(path))
 
-proc appendUploadChunk*(uploadId: string, chunkIndex: int, data: string) =
+proc isUploadPartName(fileName: string): bool =
+  fileName.endsWith(".part")
+
+proc cleanupStaleAssetUploadChunks*(maxAgeSeconds = UploadPartMaxAgeSeconds) =
+  ## Delete upload parts nobody has touched for `maxAgeSeconds` — local
+  ## `<id>.part` and cloud `cloud-<id>.part` alike (the sweep used to match
+  ## only the cloud's, so a local upload abandoned mid-way stayed forever).
+  let root = uploadChunkTempRoot()
+  if not dirExists(root):
+    return
+  let cutoff = getTime() - initDuration(seconds = maxAgeSeconds)
+  for kind, filePath in walkDir(root):
+    if kind != pcFile or not isUploadPartName(extractFilename(filePath)):
+      continue
+    try:
+      if getFileInfo(filePath).lastWriteTime < cutoff:
+        removeFile(filePath)
+    except CatchableError:
+      discard
+
+proc uploadPartsTotalBytes(root: string, excluding: string): BiggestInt =
+  ## Bytes held by every part other than `excluding` (whose own size the
+  ## caller accounts for separately: it is about to be rewritten or grown).
+  if not dirExists(root):
+    return 0
+  for kind, filePath in walkDir(root):
+    if kind != pcFile or not isUploadPartName(extractFilename(filePath)):
+      continue
+    if normalizedPath(filePath) == excluding:
+      continue
+    try:
+      result += getFileSize(filePath)
+    except CatchableError:
+      discard
+
+proc reserveUploadPartBytes(partPath: string, partBytesAfterWrite: BiggestInt,
+                            maxTotalBytes = MaxUploadPartsTotalBytes) =
+  ## Refuse a chunk that would push the unfinished uploads past the
+  ## cumulative cap. Sweeps first, so parts a dead upload left behind do not
+  ## count against a live one.
+  cleanupStaleAssetUploadChunks()
+  let others = uploadPartsTotalBytes(parentDir(partPath), partPath)
+  if others + partBytesAfterWrite > maxTotalBytes:
+    raise newException(ValueError, "Upload storage is full: too many unfinished uploads")
+
+proc appendUploadChunk*(uploadId: string, chunkIndex: int, data: string,
+                        maxTotalBytes = MaxUploadPartsTotalBytes) =
   let tempPath = uploadChunkTempPath(uploadId)
   createDir(parentDir(tempPath))
-  var fileHandle = open(tempPath, if chunkIndex <= 0: fmWrite else: fmAppend)
+  let restart = chunkIndex <= 0
+  let existing = if restart or not fileExists(tempPath): 0.BiggestInt else: getFileSize(tempPath)
+  reserveUploadPartBytes(tempPath, existing + data.len.BiggestInt, maxTotalBytes)
+  var fileHandle = open(tempPath, if restart: fmWrite else: fmAppend)
   try:
     fileHandle.write(data)
   finally:
@@ -267,13 +331,6 @@ proc discardUploadChunk*(uploadId: string) =
 # overwrites itself. Same idea as the ESP32's fos_assets_chunk_begin.
 # ---------------------------------------------------------------------------
 
-const
-  # Parts left behind by an upload that never completed (the provider gave up,
-  # the link died mid-file) are swept on the next session start once older
-  # than this. Long enough for a slow link to finish a big file; short enough
-  # that a dead upload does not hold disk for a day.
-  CloudUploadPartMaxAgeSeconds* = 6 * 60 * 60
-
 proc cloudUploadPartPath(uploadId: string): string =
   normalizedPath(uploadChunkTempRoot() / ("cloud-" & sanitizeUploadId(uploadId) & ".part"))
 
@@ -285,10 +342,12 @@ proc writeAssetUploadChunk*(uploadId: string, offset: BiggestInt, data: string):
   createDir(parentDir(partPath))
   if offset <= 0:
     # First (or restarted) chunk: whatever was there is a previous attempt.
+    reserveUploadPartBytes(partPath, data.len.BiggestInt)
     writeFile(partPath, data)
     return data.len.BiggestInt
   if not fileExists(partPath) or getFileSize(partPath) < offset:
     raise newException(ValueError, "chunk_gap")
+  reserveUploadPartBytes(partPath, max(getFileSize(partPath), offset + data.len.BiggestInt))
   var fileHandle = open(partPath, fmReadWriteExisting)
   try:
     fileHandle.setFilePos(offset)
@@ -296,6 +355,28 @@ proc writeAssetUploadChunk*(uploadId: string, offset: BiggestInt, data: string):
   finally:
     fileHandle.close()
   getFileSize(partPath)
+
+proc movePartIntoAssets(partPath: string, subdir: string, filename: string): JsonNode =
+  ## Move a finished part to its place inside the assets directory,
+  ## sanitizing the filename exactly like a single-shot upload. A part whose
+  ## destination is refused is deleted: it can never be finished, so leaving
+  ## it would only wait for the sweep.
+  try:
+    let targetPath = resolveAssetUploadPath(subdir, filename)
+    createDir(parentDir(targetPath))
+    if dirExists(targetPath):
+      raise newException(ValueError, "Invalid asset path")
+    if fileExists(targetPath):
+      removeFile(targetPath)
+    moveFile(partPath, targetPath)
+    assetPayloadForPath(targetPath)
+  except CatchableError:
+    try:
+      if fileExists(partPath):
+        removeFile(partPath)
+    except CatchableError:
+      discard
+    raise
 
 proc finishAssetUploadChunks*(uploadId: string, path: string): JsonNode =
   ## Move the finished part to `path` inside the assets directory, sanitizing
@@ -305,50 +386,18 @@ proc finishAssetUploadChunks*(uploadId: string, path: string): JsonNode =
   if not fileExists(partPath):
     raise newException(OSError, "Upload not found")
   let (dir, name, ext) = splitFile(path)
-  let targetPath = resolveAssetUploadPath(dir, name & ext)
-  createDir(parentDir(targetPath))
-  if dirExists(targetPath):
-    raise newException(ValueError, "Invalid asset path")
-  if fileExists(targetPath):
-    removeFile(targetPath)
-  moveFile(partPath, targetPath)
-  assetPayloadForPath(targetPath)
+  movePartIntoAssets(partPath, dir, name & ext)
 
 proc discardAssetUploadChunks*(uploadId: string) =
   let partPath = cloudUploadPartPath(uploadId)
   if fileExists(partPath):
     removeFile(partPath)
 
-proc cleanupStaleAssetUploadChunks*(maxAgeSeconds = CloudUploadPartMaxAgeSeconds) =
-  ## Delete cloud upload parts nobody has touched for `maxAgeSeconds`.
-  let root = uploadChunkTempRoot()
-  if not dirExists(root):
-    return
-  let cutoff = getTime() - initDuration(seconds = maxAgeSeconds)
-  for kind, filePath in walkDir(root):
-    if kind != pcFile:
-      continue
-    let fileName = extractFilename(filePath)
-    if not (fileName.startsWith("cloud-") and fileName.endsWith(".part")):
-      continue
-    try:
-      if getFileInfo(filePath).lastWriteTime < cutoff:
-        removeFile(filePath)
-    except CatchableError:
-      discard
-
 proc finishChunkedAssetUpload*(uploadId: string, subdir: string, filename: string): JsonNode =
   let tempPath = uploadChunkTempPath(uploadId)
   if not fileExists(tempPath):
     raise newException(OSError, "Upload not found")
-  let targetPath = resolveAssetUploadPath(subdir, filename)
-  createDir(parentDir(targetPath))
-  if dirExists(targetPath):
-    raise newException(ValueError, "Invalid asset path")
-  if fileExists(targetPath):
-    removeFile(targetPath)
-  moveFile(tempPath, targetPath)
-  assetPayloadForPath(targetPath)
+  movePartIntoAssets(tempPath, subdir, filename)
 
 proc finishChunkedImageUpload*(uploadId: string, filename: string): JsonNode =
   let tempPath = uploadChunkTempPath(uploadId)
@@ -467,9 +516,18 @@ proc getAssetPayload*(path: string, thumb: bool): tuple[status: httpcore.HttpCod
     setInertAssetHeaders(headers, contentTypeForFilePath(fullPath), fullPath)
     return (Http200, headers, readFile(fullPath))
 
-  let fullMd5 = getMD5(fullPath)
+  # Cache key: the path names the entry, the size and mtime say which
+  # contents it was rendered from. Keyed on the path alone, a replaced image
+  # (same name, new file) served the old thumbnail forever.
+  let pathKey = getMD5(fullPath)
+  let stamp =
+    try:
+      let info = getFileInfo(fullPath)
+      $info.size & "-" & $info.lastWriteTime.toUnix()
+    except CatchableError:
+      "0-0"
   let thumbRoot = assetsPath / ".thumbs"
-  let thumbPath = normalizedPath(thumbRoot / (fullMd5 & ThumbnailFileSuffix))
+  let thumbPath = normalizedPath(thumbRoot / (pathKey & "-" & stamp & ThumbnailFileSuffix))
   if not withinBasePath(thumbPath, thumbRoot):
     var headers: mummy.HttpHeaders
     headers["Content-Type"] = "application/json"
@@ -478,18 +536,29 @@ proc getAssetPayload*(path: string, thumb: bool): tuple[status: httpcore.HttpCod
   try:
     if not fileExists(thumbPath):
       createDir(parentDir(thumbPath))
+      # Thumbnails of earlier contents of this path are dead: evict them so
+      # the cache holds one entry per asset, not one per replacement.
+      for kind, cached in walkDir(thumbRoot):
+        let name = extractFilename(cached)
+        if kind == pcFile and name.startsWith(pathKey & "-") and name.endsWith(ThumbnailFileSuffix):
+          try:
+            removeFile(cached)
+          except CatchableError:
+            discard
       writeThumbnail(fullPath, thumbPath)
     var headers: mummy.HttpHeaders
     setInertAssetHeaders(headers, ThumbnailContentType, thumbPath)
     return (Http200, headers, readFile(thumbPath))
   except PixieError as e:
+    # Pixie's messages describe the image format, never the filesystem.
     var headers: mummy.HttpHeaders
     headers["Content-Type"] = "application/json"
     return (Http500, headers, $(%*{"detail": "Failed to generate thumbnail", "error": e.msg}))
   except CatchableError as e:
+    log(%*{"event": "assets:thumbnail:error", "path": relPath, "error": e.msg})
     var headers: mummy.HttpHeaders
     headers["Content-Type"] = "application/json"
-    return (Http500, headers, $(%*{"detail": "Failed to fetch asset", "error": e.msg}))
+    return (Http500, headers, $(%*{"detail": "Failed to fetch asset"}))
 
 proc handleAssetsUpload*(request: Request) {.gcsafe.} =
   if not hasAdminAccess(request):
@@ -534,7 +603,7 @@ proc handleAssetsUpload*(request: Request) {.gcsafe.} =
       except OSError:
         jsonResponse(request, Http404, %*{"detail": "Upload not found"})
       except CatchableError as e:
-        jsonResponse(request, Http500, %*{"detail": e.msg})
+        respondInternalError(request, "assets:upload:error", e, "Failed to store the upload")
 
 proc handleAssetsMkdir*(request: Request) {.gcsafe.} =
   if not hasAdminAccess(request):
@@ -551,7 +620,7 @@ proc handleAssetsMkdir*(request: Request) {.gcsafe.} =
       except ValueError as e:
         jsonResponse(request, Http400, %*{"detail": e.msg})
       except CatchableError as e:
-        jsonResponse(request, Http500, %*{"detail": e.msg})
+        respondInternalError(request, "assets:mkdir:error", e, "Failed to create the directory")
 
 proc handleAssetsDelete*(request: Request) {.gcsafe.} =
   if not hasAdminAccess(request):
@@ -570,7 +639,7 @@ proc handleAssetsDelete*(request: Request) {.gcsafe.} =
       except OSError:
         jsonResponse(request, Http404, %*{"detail": "Asset not found"})
       except CatchableError as e:
-        jsonResponse(request, Http500, %*{"detail": e.msg})
+        respondInternalError(request, "assets:delete:error", e, "Failed to delete the asset")
 
 proc handleAssetsRename*(request: Request) {.gcsafe.} =
   if not hasAdminAccess(request):
@@ -592,7 +661,7 @@ proc handleAssetsRename*(request: Request) {.gcsafe.} =
       except OSError:
         jsonResponse(request, Http404, %*{"detail": "Asset not found"})
       except CatchableError as e:
-        jsonResponse(request, Http500, %*{"detail": e.msg})
+        respondInternalError(request, "assets:rename:error", e, "Failed to rename the asset")
 
 
 proc addAdminApiAssetRoutes*(router: var Router) =
@@ -668,7 +737,7 @@ proc addAdminApiAssetRoutes*(router: var Router) =
         except OSError:
           jsonResponse(request, Http404, %*{"detail": "Upload not found"})
         except CatchableError as e:
-          jsonResponse(request, Http500, %*{"detail": e.msg})
+          respondInternalError(request, "assets:uploadImage:error", e, "Failed to store the upload")
   )
 
   router.post("/api/admin/frames/@id/assets/mkdir", handleAssetsMkdir)

--- a/frameos/src/frameos/server/routes/common.nim
+++ b/frameos/src/frameos/server/routes/common.nim
@@ -1,7 +1,10 @@
 import strutils
+import json
 import mummy
 import httpcore
+import ../api
 import ../state
+import frameos/channels
 
 proc respond*(request: Request; statusCode: httpcore.HttpCode;
     headers: sink mummy.HttpHeaders = emptyHttpHeaders(); body: sink string = "") =
@@ -33,3 +36,14 @@ template frameWebHtml*(frameAdminMode: bool = false): string =
 
 proc requestedFrameMatches*(request: Request): bool =
   parseFrameApiId(request.pathParams["id"]) == frameApiId()
+
+proc respondInternalError*(request: Request, event: string, e: ref CatchableError,
+                           detail: string) {.gcsafe.} =
+  ## 500 with a fixed, caller-safe `detail`. The exception text goes to the
+  ## log only: OSError and IOError messages carry absolute paths and errno
+  ## strings that describe the device's filesystem to whoever asked, and
+  ## the frame API answers unauthenticated-looking callers through the
+  ## backend proxy and the cloud alike.
+  {.gcsafe.}:
+    log(%*{"event": event, "error": e.msg})
+  jsonResponse(request, Http500, %*{"detail": detail})

--- a/frameos/src/frameos/server/routes/frame_api_routes.nim
+++ b/frameos/src/frameos/server/routes/frame_api_routes.nim
@@ -69,7 +69,7 @@ proc queueRuntimeControl(request: Request, action: string, eventName: string) {.
     jsonResponse(request, Http200, %*{"status": "ok", "action": action})
   except CatchableError as e:
     log(%*{"event": action & ":error", "error": e.msg})
-    jsonResponse(request, Http500, %*{"status": "error", "error": e.msg})
+    jsonResponse(request, Http500, %*{"status": "error", "error": "Failed to queue " & action})
 
 proc addFrameApiRoutes*(router: var Router, connectionsState: ConnectionsState) =
   router.get("/api/apps", proc(request: Request) {.gcsafe.} =
@@ -302,7 +302,7 @@ proc addFrameApiRoutes*(router: var Router, connectionsState: ConnectionsState) 
           headers["Set-Cookie"] = adminSessionCookieHeader(request, createAdminSession())
         request.respond(Http200, headers, $(%*{"message": "Frame updated successfully", "frame": framePayload}))
       except CatchableError as e:
-        jsonResponse(request, Http500, %*{"detail": e.msg})
+        respondInternalError(request, "frame:update:error", e, "Failed to update the frame")
   )
 
   router.post("/api/frames/@id/reload", proc(request: Request) {.gcsafe.} =

--- a/frameos/src/frameos/server/routes/web_routes.nim
+++ b/frameos/src/frameos/server/routes/web_routes.nim
@@ -372,5 +372,5 @@ proc addWebRoutes*(router: var Router, connectionsState: ConnectionsState, admin
       jsonResponse(request, Http200, %*{"status": "ok"})
     except CatchableError as e:
       log(%*{"event": "reload:error", "error": e.msg})
-      jsonResponse(request, Http500, %*{"status": "error", "error": e.msg})
+      jsonResponse(request, Http500, %*{"status": "error", "error": "Failed to reload the configuration"})
   )

--- a/frameos/src/frameos/server/tests/test_admin_api_assets_routes.nim
+++ b/frameos/src/frameos/server/tests/test_admin_api_assets_routes.nim
@@ -136,6 +136,26 @@ suite "Server admin api asset helpers":
     let cached = getAssetPayload("wide.png", true)
     check decodeImage(cached.body).width == 4
 
+  test "a replaced image gets a new thumbnail and the stale one is evicted":
+    let tempRoot = getTempDir() / "frameos-api-asset-thumbs-replaced"
+    removeDir(tempRoot)
+    createDir(tempRoot)
+    writeFile(tempRoot / "photo.png", newImage(800, 400).encodeImage(PngFormat))
+    globalFrameConfig = baseConfig(tempRoot)
+    let first = getAssetPayload("photo.png", true)
+    check decodeImage(first.body).height == 160
+
+    # Same path, different contents (and a different size, so the key changes
+    # even when the filesystem's mtime granularity is one second).
+    writeFile(tempRoot / "photo.png", newImage(400, 800).encodeImage(PngFormat))
+    let second = getAssetPayload("photo.png", true)
+    check decodeImage(second.body).height == ThumbnailMaxEdge
+    check decodeImage(second.body).width == 160
+    var cachedFiles: seq[string] = @[]
+    for file in walkDirRec(tempRoot / ".thumbs"):
+      cachedFiles.add(file)
+    check cachedFiles.len == 1
+
   test "getAssetPayload reports why a thumbnail could not be made":
     let tempRoot = getTempDir() / "frameos-api-asset-thumb-errors"
     removeDir(tempRoot)
@@ -223,6 +243,40 @@ suite "Server admin api asset helpers":
     let uploadedImage = finishChunkedImageUpload("upload-image", "sample.png")
     check uploadedImage{"path"}.getStr().startsWith("uploads/sample.")
     check uploadedImage{"filename"}.getStr().endsWith(".png")
+
+  test "local upload parts are swept, capped in total, and dropped when they cannot finish":
+    let tempRoot = getTempDir() / "frameos-api-chunked-parts"
+    removeDir(tempRoot)
+    createDir(tempRoot)
+    globalFrameConfig = baseConfig(tempRoot)
+
+    # The sweep matches local parts too (it used to see only `cloud-*.part`).
+    appendUploadChunk("abandoned", 0, "half a file")
+    cleanupStaleAssetUploadChunks()
+    appendUploadChunk("abandoned", 1, " and more")
+    cleanupStaleAssetUploadChunks(maxAgeSeconds = -60)
+    expect OSError:
+      discard finishChunkedAssetUpload("abandoned", "", "gone.txt")
+
+    # A cumulative cap over every unfinished part, not per upload.
+    appendUploadChunk("cap-a", 0, repeat('a', 600), maxTotalBytes = 1000)
+    expect ValueError:
+      appendUploadChunk("cap-b", 0, repeat('b', 600), maxTotalBytes = 1000)
+    # Restarting the same upload replaces its bytes rather than adding to them.
+    appendUploadChunk("cap-a", 0, repeat('a', 900), maxTotalBytes = 1000)
+    expect ValueError:
+      appendUploadChunk("cap-a", 1, repeat('a', 200), maxTotalBytes = 1000)
+    discardUploadChunk("cap-a")
+    discardUploadChunk("cap-b")
+
+    # A part whose destination is refused (here: a directory already sits at
+    # the target) does not linger as a .part.
+    createDir(tempRoot / "taken.txt")
+    appendUploadChunk("bad-dest", 0, "x")
+    expect ValueError:
+      discard finishChunkedAssetUpload("bad-dest", "", "taken.txt")
+    expect OSError:
+      discard finishChunkedAssetUpload("bad-dest", "", "ok.txt")
 
   test "offset-addressed cloud upload chunks overwrite on retry and refuse holes":
     let tempRoot = getTempDir() / "frameos-api-cloud-chunked-assets"

--- a/frameos/src/frameos/tests/test_logger.nim
+++ b/frameos/src/frameos/tests/test_logger.nim
@@ -5,6 +5,7 @@ import ../config
 import ../channels
 import ../types
 import std/json
+import std/atomics
 
 proc waitFor(condition: proc(): bool {.closure.}, timeoutMs = 1200, pollMs = 20): bool =
   let deadline = epochTime() + (float(timeoutMs) / 1000.0)
@@ -170,3 +171,59 @@ suite "Logger Tests":
 
   test "cleanupOldRotatedLogs ignores paths without a date placeholder":
     cleanupOldRotatedLogs("/tmp/frameos-static.log", now())
+
+  test "the logger drains a burst in one pass instead of one line per wakeup":
+    testConfig.logToFile = ""
+    let logger = newLogger(testConfig)
+    discard logsDroppedCounter.exchange(0)
+    for i in 0 ..< 3000:
+      logger.log(%*{"event": "burst", "i": i})
+    # 3000 entries into a 5000-slot channel: nothing may be dropped, and the
+    # thread has to empty the channel well inside the old ~250 ms idle sleeps.
+    doAssert waitFor(proc(): bool = logChannel.peek() == 0, timeoutMs = 3000),
+      "Expected the logger thread to drain the burst promptly"
+    check logsDroppedCounter.load() == 0
+
+  test "drops are reported and the counter reset even with remote logging off":
+    testConfig.logToFile = "test-logger.log"
+    testConfig.serverSendLogs = false
+    let logger = newLogger(testConfig)
+    discard logsDroppedCounter.exchange(0)
+    atomicInc(logsDroppedCounter, 7)
+    logger.log(%*{"event": "after-drop"})
+    doAssert waitFor(proc(): bool =
+      fileExists("test-logger.log") and ("logger:dropped" in readFile("test-logger.log"))
+    , timeoutMs = 3000), "Expected the drop report in the log file"
+    check readFile("test-logger.log").contains("\"count\":7")
+    check logsDroppedCounter.load() == 0
+
+  test "an undated log file rotates by size and keeps a bounded archive set":
+    let dir = getTempDir() / "frameos-logger-size-cap-test"
+    if dirExists(dir):
+      removeDir(dir)
+    createDir(dir)
+    let path = dir / "frameos.log"
+    var state = LogFileState()
+    for i in 0 ..< 60:
+      logToFile(path, "line number " & $i & " " & repeat('x', 40), state, 1700000000.0 + i.float, maxBytes = 400)
+    var archives = 0
+    for kind, file in walkDir(dir):
+      if kind == pcFile and file.endsWith(".gz"):
+        inc archives
+    check fileExists(path)
+    check getFileSize(path) <= 400
+    check archives > 0
+    check archives <= LogFileMaxArchives
+    check state.bytes == getFileSize(path)
+    removeDir(dir)
+
+  test "loggerSettingsFrom copies plain values out of the config":
+    let config = FrameConfig(serverHost: "backend.local", serverPort: 443, serverScheme: "https",
+                             serverApiKey: "k", serverSendLogs: true, logToFile: "/tmp/x.log")
+    let settings = loggerSettingsFrom(config)
+    check settings.serverHost == "backend.local"
+    check settings.useTls
+    check settings.serverApiKey == "k"
+    check settings.serverSendLogs
+    check settings.logToFile == "/tmp/x.log"
+    check loggerSettingsFrom(nil) == LoggerSettings()

--- a/frameos/src/frameos/tests/test_metrics.nim
+++ b/frameos/src/frameos/tests/test_metrics.nim
@@ -116,7 +116,7 @@ suite "metrics loop":
       openFileDescriptorsHook = proc(): int {.gcsafe, nimcall.} = 12
     )
 
-    logMetricsNow(FrameConfig(metricsInterval: 0))
+    logMetricsNow()
 
     let (okSample, samplePayload) = logChannel.tryRecv()
     check okSample

--- a/frameos/src/frameos/tests/test_portal.nim
+++ b/frameos/src/frameos/tests/test_portal.nim
@@ -5,6 +5,7 @@ import ../cloud/device_flow
 import ../network/backend
 import ../network_state
 import ../portal
+import ../privileged
 import ../types
 
 type HookMode = enum
@@ -741,6 +742,31 @@ suite "portal setup control mode":
     let options = parseSetupOptions(initTable[string, string](), frame.frameConfig)
     check options.serverHost == ""
     check options.controlMode == "none"
+
+  test "a hostname the privileged door refuses fails the setup with the reason":
+    writeFile(setupDir / "frame.json", $(%*{"name": "FrameOS Setup"}))
+    let frame = makeFrameOS()
+    var seenVerbs: seq[string] = @[]
+    setPrivilegedRequestHookForTest(proc(request: PrivilegedRequest): PrivilegedResult {.gcsafe.} =
+      {.gcsafe.}:
+        seenVerbs.add($request.verb)
+      if request.verb == pvSetHostname:
+        return PrivilegedResult(ok: false, exitCode: 1, error: "hostnamectl: read-only file system")
+      PrivilegedResult(ok: true, exitCode: 0)
+    )
+    defer: resetPrivilegedRequestHookForTest()
+    let options = parseSetupOptions({"ssid": "x", "hostname": "kitchen"}.toTable, frame.frameConfig)
+    check not persistPortalSetup(frame, options)
+    check "set-hostname" in seenVerbs
+    check getLastError().contains("Could not set the hostname")
+    check getLastError().contains("read-only file system")
+    # The config itself was saved before the hostname step; a retry can pick up where it left off.
+    check parseFile(setupDir / "frame.json"){"name"}.getStr() == "kitchen"
+
+    setPrivilegedRequestHookForTest(proc(request: PrivilegedRequest): PrivilegedResult {.gcsafe.} =
+      PrivilegedResult(ok: true, exitCode: 0)
+    )
+    check persistPortalSetup(frame, options)
 
   test "the image's placeholder name gives way to the hostname":
     writeFile(setupDir / "frame.json", $(%*{"name": "FrameOS Setup", "frameHost": "frame.local"}))

--- a/frameos/src/frameos/tests/test_setup.nim
+++ b/frameos/src/frameos/tests/test_setup.nim
@@ -478,6 +478,30 @@ block test_first_boot_service_start_is_non_blocking:
     if fileExists(path):
       removeFile(path)
 
+block test_samba_mount_targets_are_constrained_to_known_roots:
+  doAssert sambaMountTargetError("/mnt/photos") == ""
+  doAssert sambaMountTargetError(" /media/nas/share ") == ""
+  doAssert sambaMountTargetError("/srv/assets/shared") == ""
+  doAssert sambaMountTargetError("/mnt//photos/") == ""
+  for bad in ["", "mnt/photos", "/mnt", "/mnt/", "/media", "/etc", "/srv/frameos", "/srv/assets",
+              "/mnt/../etc", "/mnt/./x", "/mnt/x\n/etc", "/home/pi/photos"]:
+    doAssert sambaMountTargetError(bad).len > 0, "expected rejection of " & bad
+  var raised = false
+  try:
+    discard sambaFstabEntry(MountpointConfig(enabled: true, source: "//nas/p", target: "/srv/frameos/state"), 0)
+  except ValueError as e:
+    raised = true
+    doAssert e.msg.contains("mountpoint #1")
+    doAssert e.msg.contains("/mnt, /media, /srv/assets")
+  doAssert raised
+  # Disabled entries are not validated: an old, now-disabled mountpoint with a
+  # target outside the roots must not block setup.
+  let mixed = MountpointsConfig(enabled: true, items: @[
+    MountpointConfig(enabled: false, source: "//nas/old", target: "/home/pi/old"),
+    MountpointConfig(enabled: true, source: "//nas/new", target: "/mnt/new"),
+  ])
+  doAssert frameosFstabBlock(mixed, "/tmp/frameos-samba").contains("//nas/new /mnt/new cifs")
+
 block test_samba_mounts_fstab_block_uses_credentials_and_options:
   let mountpoints = MountpointsConfig(enabled: true, items: @[
     MountpointConfig(

--- a/frameos/src/frameos/types.nim
+++ b/frameos/src/frameos/types.nim
@@ -209,9 +209,8 @@ type
     frameConfig*: FrameConfig
     lock*: Lock
     when not defined(frameosEmbedded) and not defined(frameosWasm):
-      # The logger thread + channel only exist on OS-threaded builds; the
-      # embedded and wasm builds log synchronously through a host hook.
-      thread*: Thread[FrameConfig]
+      # The logger channel only exists on OS-threaded builds; the embedded
+      # and wasm builds log synchronously through a host hook.
       channel*: Channel[SerializedLog]
     log*: proc (payload: JsonNode)
     enabled*: bool

--- a/frameos/src/frameos/utils/process.nim
+++ b/frameos/src/frameos/utils/process.nim
@@ -31,6 +31,17 @@ type
     handle: FileHandle
     buffer: string
     eof*: bool
+    maxLineBytes: int
+    # The line being assembled already overflowed maxLineBytes: its bytes are
+    # dropped up to and including the newline that ends it.
+    skippingLine: bool
+    # Lines dropped for being longer than maxLineBytes since init.
+    overlongLines*: int
+
+# A ProcessOutputReader holds at most one unterminated line: a child that
+# writes forever without a newline (a runaway print loop, a binary blob on
+# stdout) used to grow the buffer without bound on the reading thread.
+const DefaultProcessReaderMaxLineBytes* = 256 * 1024
 
 # Writing to a pipe whose reader died must surface as EPIPE, not kill the
 # whole process with SIGPIPE.
@@ -294,12 +305,18 @@ proc runShellCapture*(command: string;
   output.add(res.errorOutput)
   (output, res.exitCode)
 
-proc initProcessOutputReader*(p: Process): ProcessOutputReader =
+proc initProcessOutputReader*(p: Process;
+                              maxLineBytes = DefaultProcessReaderMaxLineBytes): ProcessOutputReader =
   ## Non-blocking line reader over a process's stdout. Combine with
   ## poStdErrToStdOut to also cover stderr; otherwise stderr must be drained
-  ## separately.
+  ## separately. A line longer than `maxLineBytes` is dropped whole (counted
+  ## in `overlongLines`) so the buffer stays bounded whatever the child emits.
   p.outputHandle().setNonBlocking()
-  ProcessOutputReader(handle: p.outputHandle())
+  ProcessOutputReader(handle: p.outputHandle(), maxLineBytes: max(1, maxLineBytes))
+
+proc bufferedBytes*(reader: ProcessOutputReader): int =
+  ## Bytes of the unterminated line currently held (test/diagnostic seam).
+  reader.buffer.len
 
 proc fill(reader: var ProcessOutputReader) =
   if reader.eof:
@@ -313,21 +330,33 @@ proc fill(reader: var ProcessOutputReader) =
 proc readAvailableLines*(reader: var ProcessOutputReader): seq[string] =
   ## Returns the complete lines available right now without blocking.
   ## After EOF the unterminated tail (if any) is returned as a final line.
+  ## The tail of an overlong line is never returned: once a line has passed
+  ## maxLineBytes the whole line is gone, not just its excess.
   reader.fill()
   var start = 0
   while true:
     let idx = reader.buffer.find('\n', start)
     if idx == -1:
       break
-    var line = reader.buffer[start ..< idx]
-    if line.len > 0 and line[^1] == '\r':
-      line.setLen(line.len - 1)
-    result.add(line)
+    if reader.skippingLine:
+      # The rest of a line whose head was already thrown away.
+      reader.skippingLine = false
+    else:
+      var line = reader.buffer[start ..< idx]
+      if line.len > 0 and line[^1] == '\r':
+        line.setLen(line.len - 1)
+      result.add(line)
     start = idx + 1
   if start > 0:
     reader.buffer = reader.buffer[start .. ^1]
+  if reader.buffer.len > reader.maxLineBytes:
+    if not reader.skippingLine:
+      inc reader.overlongLines
+    reader.skippingLine = true
+    reader.buffer = ""
   if reader.eof and reader.buffer.len > 0:
-    result.add(reader.buffer)
+    if not reader.skippingLine:
+      result.add(reader.buffer)
     reader.buffer = ""
 
 proc writeInputDrainingOutput*(p: Process;

--- a/frameos/src/frameos/utils/tests/test_process.nim
+++ b/frameos/src/frameos/utils/tests/test_process.nim
@@ -127,6 +127,32 @@ sys.stdout.flush()
     p.stopProcess()
     p.close()
 
+  test "ProcessOutputReader drops overlong lines instead of buffering them":
+    # A child that never ends its line must not grow the reader's buffer
+    # without bound; the runaway line is dropped whole, the next one survives.
+    let script = """
+import sys
+sys.stdout.write("x" * 3000000)
+sys.stdout.flush()
+sys.stdout.write("\nsecond\nthird")
+sys.stdout.flush()
+"""
+    var p = startProcessSerialized("python3", args = @["-c", script],
+                                   options = {poUsePath, poStdErrToStdOut})
+    var reader = initProcessOutputReader(p, maxLineBytes = 64 * 1024)
+    var lines: seq[string] = @[]
+    let deadline = epochTime() + 10.0
+    while epochTime() < deadline:
+      lines.add(reader.readAvailableLines())
+      check reader.bufferedBytes() <= 64 * 1024 + 65536
+      if not p.running() and reader.eof:
+        break
+      sleep(10)
+    lines.add(reader.readAvailableLines())
+    check lines == @["second", "third"]
+    check reader.overlongLines == 1
+    p.close()
+
   test "writeInputDrainingOutput times out when the child stops reading":
     var p = startProcessSerialized("python3", args = @["-c", "import time; time.sleep(10)"],
                                    options = {poUsePath, poStdErrToStdOut})

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -4109,7 +4109,11 @@ export function FrameSettings({
                               >
                                 <TextInput name="source" placeholder="//server/share" />
                               </Field>
-                              <Field name="target" label="Mount path">
+                              <Field
+                                name="target"
+                                label="Mount path"
+                                hint="A directory under /mnt, /media or /srv/assets"
+                              >
                                 <TextInput name="target" placeholder="/mnt/share" />
                               </Field>
                               <Field name="enabled" label="Enabled">


### PR DESCRIPTION
## Summary

The nine items under **Nim device runtime core** in `docs/review-todo.md`, one commit.

- **`ProcessOutputReader` line buffer capped** (`utils/process.nim`): at most one unterminated line is held (256 KB default); a longer line is dropped whole and counted in `overlongLines`. inkyPython's two readers get the default.
- **No `FrameConfig` ref across the logger/metrics threads**: the logger thread runs on a `LoggerSettings` value copy (host, port, TLS, API key, send flag, file path) refreshed via `applyLoggerSettings`; the metrics thread reads an atomic interval set by `applyMetricsSettings`. The runner's `reload` handler publishes both right after `updateFrameConfigFrom`, so live settings changes still apply. `Logger.thread: Thread[FrameConfig]` (unused) is gone.
- **Samba mount target constrained**: a target must be a directory under `/mnt`, `/media` or `/srv/assets` (normalised, no `.`/`..`, not the root itself). Validation runs before setup creates directories or writes credentials; the frontend field gets a hint. A disabled entry with an old target does not block setup.
- **Hostname door failure surfaces**: a refused `pvSetHostname` fails `persistPortalSetup` with "Could not set the hostname: <reason>" instead of being discarded. `door()` now returns the worker's `error` text on failure (callers only logged the empty output before). The legacy sudo path stays best-effort.
- **Logger drain + drop counter**: the loop empties the channel (up to 1000 entries) per pass instead of one line per wakeup; the drop counter is reported and reset whether or not remote logging is on, and the report is also written to the log file.
- **Undated log file size cap**: a `logToFile` path without `{date}` rotates at 8 MB (gzip in place, keep the newest 3 archives).
- **Chunked upload parts**: the stale sweep matches local `<id>.part` files too (not only `cloud-*.part`) and runs when an upload starts; all parts together are capped at 1 GiB; a part whose destination is refused is deleted instead of left behind.
- **Thumbnail cache key**: `md5(path)-<size>-<mtime>`; stale entries for the same path are evicted on regeneration, so a replaced image gets a fresh thumbnail and the cache holds one entry per asset.
- **No raw OS error strings to callers**: asset upload/mkdir/delete/rename, the thumbnail fallback, the frame update route, `queueRuntimeControl` and `/reload` log the exception and answer a fixed detail. 400 messages (our own validation text) are unchanged.

## Behaviour changes worth knowing

- A frame whose Samba mountpoint target sits outside `/mnt`, `/media`, `/srv/assets` will fail the "samba mounts" setup step with a message naming the allowed roots.
- Portal setup now fails (config already saved, retry works) when the privileged door cannot set the hostname.

## Test plan

- [x] `test_process` (new: overlong-line drop), `test_logger` (new: burst drain, drop report with remote logging off, size rotation, settings copy), `test_metrics`, `test_setup` (new: target roots), `test_portal` (new: refused hostname), `test_admin_api_assets_routes` (new: replaced-image thumbnail, local part sweep/cap/cleanup) — all green locally.
- [x] `test_frame_api_routes_behavior`, `test_web_routes_behavior`, `test_channels`, `test_privileged`, `test_device_setup`, `test_runner_reload`, `test_frameos_startup`, `test_common`, `test_routes` green.
- [x] `nim c src/frameos.nim` builds; `nim check` on `drivers/inkyPython`.
- [x] Frontend file passes the repo's prettier 2.8.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM4Zhq73MKQMeParE2TQT6