### PR TITLE
Upgrade card: show the host OS, not the release slug, on Buildroot frames

### DIFF
--- a/cloud/apps/auth-web/src/test/shared-spa/frame-upgrade-card-labels.test.ts
+++ b/cloud/apps/auth-web/src/test/shared-spa/frame-upgrade-card-labels.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  upgradeBuildLabel,
+  upgradeHostLabel,
+} from '../../../../../../frontend/src/scenes/frame/panels/FrameSettings/frameSettingsHelpers'
+
+// The "FrameOS upgrade" card on a frame's settings page. `target` is the
+// release tarball slug the device downloads; on a Buildroot image that reads
+// `debian-bookworm-<arch>` even though the device runs no Debian and has no
+// apt. The card therefore leads with the host OS the runtime reports and
+// shows only the arch as the build, keeping the slug in a hint.
+describe('frame upgrade card labels', () => {
+  it('shows a Buildroot image as FrameOS with only the arch, and keeps the slug as a hint', () => {
+    const status = {
+      target: 'debian-bookworm-arm64',
+      host: { id: 'buildroot', name: 'FrameOS system image (Buildroot)', version: '2025.02.13', arch: 'arm64' },
+    }
+    expect(upgradeHostLabel(status)).toBe('FrameOS system image (Buildroot) 2025.02.13')
+    const build = upgradeBuildLabel(status)
+    expect(build.label).toBe('arm64')
+    expect(build.hint).toContain('debian-bookworm-arm64')
+    expect(build.hint).toContain('no package manager')
+  })
+
+  it('keeps the distro release on Debian and Ubuntu hosts, where it picks the binary', () => {
+    const status = {
+      target: 'debian-trixie-armhf',
+      host: { id: 'debian', name: 'Debian GNU/Linux 13 (trixie)', version: '13', arch: 'armhf' },
+    }
+    expect(upgradeHostLabel(status)).toBe('Debian GNU/Linux 13 (trixie)')
+    expect(upgradeBuildLabel(status)).toEqual({ label: 'debian-trixie-armhf' })
+  })
+
+  it('falls back to the arch in the slug when the runtime reports no arch', () => {
+    expect(upgradeBuildLabel({ target: 'debian-bookworm-armv6', host: { id: 'buildroot' } }).label).toBe('armv6')
+  })
+
+  it('reads as unknown without a target and hides the OS row on releases without a host field', () => {
+    expect(upgradeBuildLabel(null)).toEqual({ label: 'Unknown' })
+    expect(upgradeBuildLabel({ target_error: 'Cannot read /etc/os-release' })).toEqual({ label: 'Unknown' })
+    expect(upgradeHostLabel({ target: 'debian-bookworm-arm64' })).toBeUndefined()
+    expect(upgradeHostLabel({ host: { id: 'debian', name: '  ' } })).toBeUndefined()
+  })
+})

--- a/cloud/apps/auth-web/tsconfig.json
+++ b/cloud/apps/auth-web/tsconfig.json
@@ -121,6 +121,11 @@
     // reach the legacy workspace components. Vitest still runs them; only
     // tsc leaves them out.
     "src/test/shared-spa/shell-less-deploy-dialog.test.tsx",
-    "src/test/shared-spa/long-running-task-toast.test.tsx"
+    "src/test/shared-spa/long-running-task-toast.test.tsx",
+    // Imports frameSettingsHelpers.tsx from the legacy workspace, which
+    // types its React returns with the bare `JSX` namespace that this
+    // package's React types no longer provide. Vitest still runs it; only
+    // tsc leaves it out.
+    "src/test/shared-spa/frame-upgrade-card-labels.test.ts"
   ]
 }

--- a/cloud/eslint.config.mjs
+++ b/cloud/eslint.config.mjs
@@ -93,6 +93,9 @@ export default tseslint.config(
       "**/src/test/shared-spa/store-scene-errors.test.ts",
       "**/src/test/shared-spa/shell-less-deploy-dialog.test.tsx",
       "**/src/test/shared-spa/long-running-task-toast.test.tsx",
+      // Imports frameSettingsHelpers.tsx, which types React returns with the
+      // bare `JSX` namespace; out of the tsconfig for the same reason.
+      "**/src/test/shared-spa/frame-upgrade-card-labels.test.ts",
     ],
   },
   js.configs.recommended,

--- a/frameos/src/frameos/tests/test_upgrade.nim
+++ b/frameos/src/frameos/tests/test_upgrade.nim
@@ -27,6 +27,30 @@ suite "FrameOS upgrade helpers":
       "VERSION_CODENAME": "noble",
     }.toTable) == (distro: "ubuntu", release: "24.04")
 
+  test "the host identity names a Buildroot image as FrameOS, not Debian":
+    let buildroot = hostOsPayload({
+      "ID": "buildroot",
+      "NAME": "Buildroot",
+      "PRETTY_NAME": "Buildroot 2025.02.13",
+      "VERSION_ID": "2025.02.13",
+    }.toTable, "arm64")
+    check buildroot{"id"}.getStr() == "buildroot"
+    check buildroot{"name"}.getStr() == "FrameOS system image (Buildroot)"
+    check buildroot{"version"}.getStr() == "2025.02.13"
+    check buildroot{"arch"}.getStr() == "arm64"
+
+    let raspios = hostOsPayload({
+      "ID": "debian",
+      "PRETTY_NAME": "Debian GNU/Linux 12 (bookworm)",
+      "VERSION_ID": "12",
+    }.toTable, "armhf")
+    check raspios{"name"}.getStr() == "Debian GNU/Linux 12 (bookworm)"
+    check raspios{"arch"}.getStr() == "armhf"
+
+    let unknown = hostOsPayload(initTable[string, string](), "")
+    check unknown{"id"}.getStr() == ""
+    check unknown{"name"}.getStr() == ""
+
   test "uname arch mapping keeps armv6 separate from armhf":
     check archForUname("aarch64") == "arm64"
     check archForUname("armv7l") == "armhf"

--- a/frameos/src/frameos/upgrade.nim
+++ b/frameos/src/frameos/upgrade.nim
@@ -305,6 +305,28 @@ proc normalizeDistroRelease*(values: Table[string, string]): tuple[distro, relea
       elif result.release.startsWith("26.04"):
         result.release = "26.04"
 
+proc hostOsPayload*(values: Table[string, string], arch: string): JsonNode =
+  ## What the device actually runs, as opposed to the release slug it
+  ## downloads. On a Buildroot image the slug reads `debian-bookworm-<arch>`
+  ## because that is the tarball the image installs, so the admin panel shows
+  ## this host identity as the headline and the slug only as a hint.
+  let id = values.getOrDefault("ID", "").strip().toLowerAscii()
+  let name = values.getOrDefault("PRETTY_NAME", values.getOrDefault("NAME", "")).strip()
+  let version = values.getOrDefault("VERSION_ID", "").strip()
+  result = %*{"id": id, "name": name, "version": version, "arch": arch}
+  if id == "buildroot":
+    # Buildroot's PRETTY_NAME is "Buildroot 2025.02", which reads as a distro
+    # a person could apt into. It is a FrameOS system image.
+    result["name"] = %"FrameOS system image (Buildroot)"
+
+proc detectHostOs*(): JsonNode =
+  let arch =
+    try:
+      detectArch()
+    except CatchableError:
+      ""
+  hostOsPayload(parseOsRelease(), arch)
+
 proc detectUpgradeTarget*(): string =
   let overrideTarget = getEnv("FRAMEOS_TARGET").strip()
   if overrideTarget.len > 0:
@@ -486,6 +508,7 @@ proc frameOSUpgradeStatusPayload*(checkLatest = false): JsonNode =
   result["current_version"] = %installedFrameOSVersion()
   result["compiled_version"] = %compiledFrameOSVersion()
   result["target"] = %target
+  result["host"] = detectHostOs()
   if targetError.len > 0:
     result["target_error"] = %targetError
   if checkLatest and target.len > 0:

--- a/frontend/src/scenes/frame/panels/FrameSettings/frameAdminUpgradeLogic.ts
+++ b/frontend/src/scenes/frame/panels/FrameSettings/frameAdminUpgradeLogic.ts
@@ -23,6 +23,17 @@ export interface FrameOSUpgradeRelease {
   html_url?: string
 }
 
+/** The OS the device runs, from /etc/os-release plus `uname -m`. Distinct
+ * from `target`, which names the release tarball the device installs: a
+ * Buildroot image downloads the Debian bookworm build, so its target reads
+ * `debian-bookworm-<arch>` while the host is not Debian at all. */
+export interface FrameOSUpgradeHost {
+  id?: string
+  name?: string
+  version?: string
+  arch?: string
+}
+
 export interface FrameOSUpgradeStatus {
   status?: FrameOSUpgradeStatusValue | string
   message?: string
@@ -30,6 +41,7 @@ export interface FrameOSUpgradeStatus {
   compiled_version?: string
   target?: string
   target_error?: string
+  host?: FrameOSUpgradeHost
   latest_version?: string
   latest_error?: string
   latest_release?: FrameOSUpgradeRelease

--- a/frontend/src/scenes/frame/panels/FrameSettings/frameSettingsHelpers.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/frameSettingsHelpers.tsx
@@ -142,6 +142,41 @@ export function latestUpgradeVersion(status: FrameOSUpgradeStatus | null): strin
   return status?.latest_version || status?.latest_release?.version
 }
 
+/** The "Release build" row of the upgrade card. Debian and Ubuntu hosts see
+ * the distro release because it decides which precompiled binary they get
+ * (bookworm vs trixie, and bullseye gets none). A Buildroot image is not
+ * Debian and has no apt, so it sees only the architecture; the slug it
+ * downloads moves into the hint so it stops reading as the OS. */
+export function upgradeBuildLabel(status: FrameOSUpgradeStatus | null): { label: string; hint?: string } {
+  const target = status?.target?.trim()
+  if (!target) {
+    return { label: 'Unknown' }
+  }
+  const host = status?.host
+  if (host?.id === 'buildroot') {
+    const arch = host.arch?.trim() || target.split('-').pop() || target
+    return {
+      label: arch,
+      hint: `This FrameOS system image installs the ${target} release build. It is not a Debian system and has no package manager.`,
+    }
+  }
+  return { label: target }
+}
+
+/** The "Operating system" row: PRETTY_NAME from the device's os-release, or
+ * nothing on releases that predate the `host` field. */
+export function upgradeHostLabel(status: FrameOSUpgradeStatus | null): string | undefined {
+  const host = status?.host
+  if (!host) {
+    return undefined
+  }
+  const name = host.name?.trim()
+  if (!name) {
+    return undefined
+  }
+  return host.id === 'buildroot' && host.version?.trim() ? `${name} ${host.version.trim()}` : name
+}
+
 export function upgradeStatusColor(status: string | undefined) {
   return status === 'failed'
     ? 'red'

--- a/frontend/src/scenes/frame/panels/FrameSettings/sections/accountSections.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/sections/accountSections.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import equal from 'fast-deep-equal'
-import { ArrowDownTrayIcon, ArrowPathIcon } from '@heroicons/react/24/outline'
+import { ArrowDownTrayIcon, ArrowPathIcon, InformationCircleIcon } from '@heroicons/react/24/outline'
 import { Button } from '../../../../../components/Button'
 import { Field } from '../../../../../components/Field'
 import { H6 } from '../../../../../components/H6'
@@ -11,6 +11,7 @@ import { Spinner } from '../../../../../components/Spinner'
 import { Switch } from '../../../../../components/Switch'
 import { Tag } from '../../../../../components/Tag'
 import { TextInput } from '../../../../../components/TextInput'
+import { Tooltip } from '../../../../../components/Tooltip'
 import { appsModel } from '../../../../../models/appsModel'
 import { framesModel } from '../../../../../models/framesModel'
 import { settingsLogic } from '../../../../settings/settingsLogic'
@@ -29,6 +30,8 @@ import {
   hasSettingsFieldValue,
   latestUpgradeVersion,
   settingsInputValue,
+  upgradeBuildLabel,
+  upgradeHostLabel,
   upgradeStatusColor,
   upgradeStatusLabel,
 } from '../frameSettingsHelpers'
@@ -457,6 +460,8 @@ export function FrameAdminUpgradeSection(): JSX.Element {
   const checkingOrPolling = upgradeStatusLoading || isUpgradePolling || upgradeStatusIsActive
   const upgradeDisabled = checkingOrPolling || !updateAvailable
   const releaseUrl = upgradeStatus?.latest_release?.html_url
+  const build = upgradeBuildLabel(upgradeStatus)
+  const hostLabel = upgradeHostLabel(upgradeStatus)
 
   return (
     <>
@@ -470,9 +475,22 @@ export function FrameAdminUpgradeSection(): JSX.Element {
               <div className="frameos-muted">Running version</div>
               <div className="frameos-strong font-semibold">{displayVersion(upgradeStatus?.current_version)}</div>
             </div>
+            {hostLabel ? (
+              <div className="flex items-center justify-between gap-3">
+                <div className="frameos-muted">Operating system</div>
+                <div className="frameos-strong text-right">{hostLabel}</div>
+              </div>
+            ) : null}
             <div className="flex items-center justify-between gap-3">
-              <div className="frameos-muted">Release target</div>
-              <div className="frameos-strong font-mono text-xs">{upgradeStatus?.target || 'Unknown'}</div>
+              <div className="frameos-muted">Release build</div>
+              <div className="frameos-strong font-mono text-xs inline-flex items-center gap-1">
+                {build.label}
+                {build.hint ? (
+                  <Tooltip title={build.hint} label="About this release build">
+                    <InformationCircleIcon className="w-4 h-4" aria-hidden="true" />
+                  </Tooltip>
+                ) : null}
+              </div>
             </div>
             <div className="flex items-center justify-between gap-3">
               <div className="frameos-muted">Latest release</div>


### PR DESCRIPTION
## Summary

The "Release target" row on a frame's settings page printed the release tarball slug verbatim, so a Buildroot image read as `debian-bookworm-arm64` and looked like a Debian system with apt. It is not; the slug only names the precompiled build the image installs.

- **Runtime** (`frameos/src/frameos/upgrade.nim`): the upgrade status payload now carries a `host` object (`id`, `name`, `version` from os-release, `arch` from uname) next to the unchanged `target`. On Buildroot the name is "FrameOS system image (Buildroot)" rather than os-release's "Buildroot 2025.02.13". `target` stays as is because asset selection and the deploy planner key off it.
- **Card**: a new "Operating system" row shows the host name (hidden on runtimes that predate the field). "Release target" is renamed "Release build". On Buildroot it shows only the arch, with the slug and a "no package manager" note in a tooltip. Debian and Ubuntu frames keep the full slug, since there bookworm vs trixie decides which binary they get.

## Test plan

- [x] `test_upgrade.nim`: new case for the host payload (Buildroot, Raspberry Pi OS, empty os-release); suite green
- [x] `frame-upgrade-card-labels.test.ts` (shared-spa, auth-web vitest): Buildroot, Debian, missing arch, and pre-field runtimes
- [x] frontend `tsc --noEmit` clean, eslint clean
- [ ] On a Buildroot frame after upgrade: card reads "Operating system: FrameOS system image (Buildroot) 2025.02.13", "Release build: arm64 ⓘ"
- [ ] On a Raspberry Pi OS frame: "Operating system: Debian GNU/Linux 12 (bookworm)", "Release build: debian-bookworm-arm64"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEdTvhhZaJU8Des11UCLcA