### PR TITLE
Frame admin: say whether the cloud actually drives the frame, and make both cloud features switches

### DIFF
--- a/docs/cloud-link.md
+++ b/docs/cloud-link.md
@@ -547,6 +547,29 @@ GET  /api/cloud/store/drive       # "Private cloud scenes" listing (proxied, ima
 GET  /api/cloud/store/drive/image/{sceneId}   # preview image proxy (attaches the link token)
 ```
 
+The frame's own admin server adds two switches that a backend has no use for
+(admin-session-gated, `frameos/src/frameos/server/routes/cloud_api_routes.nim`):
+
+```http
+POST /api/cloud/managed      # {"enabled": bool} — hand this frame to cloud management, or take it back
+POST /api/cloud/cloud-login  # {"enabled": bool} — offer "Sign in with FrameOS Cloud" on this frame's login page
+```
+
+Both act on grants the link already carries and never ask the provider for
+more: `/managed` refuses with 409 unless the link holds `frame:managed` (and
+no self-hosted backend owns the frame), `/cloud-login` unless it holds
+`auth:login`. Turning `/managed` on runs flow B of docs/cloud-frames.md over
+the existing link token; the provider keys the frame on the linked client, so
+switching off and on again re-registers the SAME frame rather than making a
+second one. Turning it off is purely local: the frame stops answering the
+management socket and the account keeps the (now offline) frame.
+
+`/cloud-login` is local in both directions — the `auth:login` grant stays on
+the link either way. Off means `GET /api/cloud/login/options` stops offering
+the button AND `POST /api/cloud/login/start` refuses with 403, and the admin
+password comes back (see `local_fallback_enabled` below), so the two login
+switches can never both end up closed.
+
 `GET /api/cloud/status` shape (mirrored by `CloudStatus` in
 `frontend/src/types.tsx`):
 
@@ -563,6 +586,14 @@ GET  /api/cloud/store/drive/image/{sceneId}   # preview image proxy (attaches th
   "local_fallback_enabled": true
 }
 ```
+
+A frame's own admin server adds, for the two switches above: `mode`
+(`"managed"` once enrolled, absent while merely linked), `backend_managed`,
+`managed_available`, `managed_enroll_error`, `cloud_login_available` (the
+`auth:login` grant) and `cloud_login_enabled` (the switch). The settings box
+reads the first pair to say, in words, whether the cloud can drive this frame
+— a link that is live but not managed used to render as nothing but
+"Connected".
 
 `connection` is set only while `connecting`; `link` only while `connected`.
 The access token itself is never included.

--- a/e2e/frontend-visual/tests/frame-admin.spec.ts
+++ b/e2e/frontend-visual/tests/frame-admin.spec.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'fs'
 import { extname, join, normalize } from 'path'
 import { expect, test, type Page } from '@playwright/test'
-import { attachFrontendErrorCollector, connectedCloudStatus } from './visual-helpers'
+import { attachFrontendErrorCollector, connectedCloudStatus, connectedFrameCloudStatus } from './visual-helpers'
 
 /**
  * Browser tests for the ON-FRAME admin UI — the web app the frame device
@@ -58,6 +58,7 @@ const frameFixture = {
   scaling_mode: 'contain',
   rotate: 0,
   debug: false,
+  frame_admin_auth: { enabled: true },
   scenes: [
     {
       id: 'scene-dashboard',
@@ -258,6 +259,54 @@ test.describe('on-frame admin UI @e2e', () => {
     await expect(page.getByRole('button', { name: /^Show backups$/ })).toHaveCount(0)
     await expect(page.getByRole('button', { name: /^Restore$/ })).toHaveCount(0)
     await expect(page.getByText('Enabled features')).toHaveCount(0)
+
+    expectNoFrameAdminErrors(readErrors)
+  })
+
+  test('a linked frame says it is not cloud-managed, and offers both switches', async ({ page }) => {
+    const readErrors = attachFrontendErrorCollector(page)
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    await serveFrameAdmin(page, { cloudStatus: connectedFrameCloudStatus() })
+
+    await page.goto(`${FRAME_ORIGIN}/admin?tool=settings`, { waitUntil: 'domcontentloaded' })
+
+    // The question the box used to leave unanswered: the link is live, but
+    // nothing on the cloud drives this frame yet.
+    await expect(page.getByText('Linked, not managed')).toBeVisible()
+    await expect(page.getByText(/Nothing on cloud\.frameos\.net can change what this frame shows/)).toBeVisible()
+
+    // Both features are switches, so neither can turn itself on unannounced.
+    await expect(page.getByRole('switch', { name: 'Manage this frame from FrameOS Cloud' })).toBeVisible()
+    await expect(page.getByRole('switch', { name: 'Sign in here with FrameOS Cloud' })).toBeVisible()
+    // The password switch belongs under cloud sign-in, not on its own.
+    await expect(page.getByRole('switch', { name: 'Keep the admin password working' })).toBeVisible()
+    await expect(page.getByText('Local password login')).toHaveCount(0)
+
+    expectNoFrameAdminErrors(readErrors)
+  })
+
+  test('an enrolled frame says the cloud drives it', async ({ page }) => {
+    const readErrors = attachFrontendErrorCollector(page)
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    await serveFrameAdmin(page, { cloudStatus: connectedFrameCloudStatus({ managed: true }) })
+
+    await page.goto(`${FRAME_ORIGIN}/admin?tool=settings`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('Managed from the cloud')).toBeVisible()
+    await expect(page.getByText(/This frame answers to cloud\.frameos\.net/)).toBeVisible()
+
+    expectNoFrameAdminErrors(readErrors)
+  })
+
+  test('the settings page carries log out and the frame menu at the top right', async ({ page }) => {
+    const readErrors = attachFrontendErrorCollector(page)
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    await serveFrameAdmin(page, { cloudStatus: connectedFrameCloudStatus() })
+
+    await page.goto(`${FRAME_ORIGIN}/admin?tool=settings`, { waitUntil: 'domcontentloaded' })
+    // Next to the first heading the panel draws, not buried in Frame info.
+    const heading = page.locator('.frame-settings-panel').getByText('FrameOS Cloud').first()
+    await expect(heading).toBeVisible()
+    await expect(page.getByRole('button', { name: /^Log out$/ })).toBeVisible()
 
     expectNoFrameAdminErrors(readErrors)
   })

--- a/e2e/frontend-visual/tests/visual-helpers.ts
+++ b/e2e/frontend-visual/tests/visual-helpers.ts
@@ -350,6 +350,42 @@ export function connectedCloudStatus({
   }
 }
 
+/** A frame's OWN link to FrameOS Cloud, as the on-device /api/cloud/status
+ * answers it: linked to the account, and (unless `managed`) not yet driven by
+ * it. Frame links carry frame:* scopes, never the backend ones above. */
+export function connectedFrameCloudStatus({
+  managed = false,
+  cloudLoginEnabled = true,
+  localFallbackEnabled = true,
+}: { managed?: boolean; cloudLoginEnabled?: boolean; localFallbackEnabled?: boolean } = {}): Record<string, unknown> {
+  return {
+    enabled: true,
+    provider_url: 'https://cloud.frameos.net',
+    default_provider_url: 'https://cloud.frameos.net',
+    status: 'connected',
+    can_edit_provider: false,
+    poll_error: null,
+    local_fallback_enabled: localFallbackEnabled,
+    cloud_login_available: true,
+    cloud_login_enabled: cloudLoginEnabled,
+    managed_available: true,
+    managed_enroll_error: null,
+    backend_managed: false,
+    connection: null,
+    identity: null,
+    ...(managed ? { mode: 'managed' } : {}),
+    link: {
+      linked_client_id: 'lc-visual-frame-1',
+      scopes: ['frame:link', 'frame:managed', 'auth:login'],
+      account_id: 'acc-visual-1',
+      account_email: 'visual@example.com',
+      connected_at: '2026-05-20T09:00:00Z',
+      last_inventory_sync_at: '2026-05-23T11:45:00Z',
+      ...(managed ? { frame_id: 'frm-visual-1' } : {}),
+    },
+  }
+}
+
 export const cloudBackupFixtures = [
   {
     id: 'backup-frame-1',

--- a/frameos/src/frameos/cloud/link_state.nim
+++ b/frameos/src/frameos/cloud/link_state.nim
@@ -114,8 +114,9 @@ proc resetLinkState*(state: JsonNode, pollError: string = "") =
               "poll_error", "local_origin",
               "connected_at", "last_inventory_sync_at", "login_states",
               # Local password login is only ever off while cloud login can
-              # take over, so unlinking restores it.
-              "local_fallback_enabled",
+              # take over, so unlinking restores it — as does dropping the
+              # cloud-login switch itself.
+              "local_fallback_enabled", "cloud_login_enabled",
               # Cloud-managed mode (docs/cloud-frames.md): leaving managed mode
               # or resetting the link always clears these too.
               "mode", "frame_id", "ws_path", "scenes_checksum", "managed_enroll_error"]:
@@ -137,11 +138,24 @@ proc expireIfNeeded*(state: JsonNode): bool =
 proc linkHasScope*(state: JsonNode, scope: string): bool =
   scope in state{"scope"}.getStr("").splitWhitespace()
 
-proc cloudLoginPossible*(state: JsonNode): bool =
-  ## Whether the browser could sign in through the provider right now — a
-  ## connected link that carries `auth:login`. The caller still has to check
-  ## that the admin panel has auth at all; that lives outside this module.
+proc cloudLoginGranted*(state: JsonNode): bool =
+  ## Whether the provider granted this link the right to sign users in — a
+  ## connected link carrying `auth:login`. The local switch below can still be
+  ## off; this is what says the switch may be offered at all.
   state{"status"}.getStr("") == "connected" and linkHasScope(state, "auth:login")
+
+proc cloudLoginPossible*(state: JsonNode): bool =
+  ## Whether the browser could sign in through the provider right now: the
+  ## grant above AND the local "sign in here with FrameOS Cloud" switch. The
+  ## caller still has to check that the admin panel has auth at all; that
+  ## lives outside this module.
+  ##
+  ## The switch defaults to on, because a link is only ever made from the
+  ## admin page or the setup portal, both of which ask for `auth:login`
+  ## deliberately. Turning it off leaves the grant in place and simply stops
+  ## this frame from offering the cloud button — and, through
+  ## `localAdminLoginEnabled`, brings the admin password straight back.
+  cloudLoginGranted(state) and state{"cloud_login_enabled"}.getBool(true)
 
 proc localAdminLoginEnabled*(state: JsonNode): bool =
   ## The effective answer to "may someone still sign in with the admin
@@ -230,3 +244,15 @@ proc isManagedLink*(state: JsonNode): bool =
   state{"mode"}.getStr("") == "managed" and
     state{"status"}.getStr("") == "connected" and
     state{"access_token"}.getStr("") != ""
+
+proc clearManagedMode*(state: JsonNode): bool =
+  ## Demote a cloud-managed frame back to a plain link, leaving the link token
+  ## and the account's frame untouched: the device just stops answering the
+  ## management socket (the hub thread notices the generation bump and idles).
+  ## Re-enrolling later re-registers the SAME frame — the provider keys it on
+  ## the linked client — so this switch is reversible in both directions.
+  ## Returns true when anything was removed, i.e. when the caller must save.
+  for key in ["mode", "frame_id", "ws_path", "scenes_checksum", "managed_enroll_error"]:
+    if state.hasKey(key):
+      state.delete(key)
+      result = true

--- a/frameos/src/frameos/cloud/tests/test_link_state.nim
+++ b/frameos/src/frameos/cloud/tests/test_link_state.nim
@@ -45,6 +45,53 @@ suite "link scope helpers":
     check not state.hasKey("scope")
     check not managedEnrollmentRequested(state)
 
+suite "the local cloud-login switch":
+  let granted = %*{"status": "connected", "scope": "frame:link auth:login"}
+
+  test "the switch defaults to on and only ever narrows the grant":
+    check cloudLoginGranted(granted)
+    check cloudLoginPossible(granted)
+    # Off: the grant is untouched, the frame simply stops offering it.
+    let off = %*{"status": "connected", "scope": "frame:link auth:login",
+                 "cloud_login_enabled": false}
+    check cloudLoginGranted(off)
+    check not cloudLoginPossible(off)
+    # And a switch left on cannot conjure a grant that was never made.
+    check not cloudLoginPossible(%*{"status": "connected", "scope": "frame:link",
+                                    "cloud_login_enabled": true})
+
+  test "switching cloud login off puts the admin password back":
+    # The password is only ever off while the cloud can take over, so the two
+    # switches can never both end up closed.
+    let both = %*{"status": "connected", "scope": "frame:link auth:login",
+                  "local_fallback_enabled": false, "cloud_login_enabled": false}
+    check localAdminLoginEnabled(both)
+
+  test "resetting a link restores both login switches":
+    let state = %*{"status": "connected", "scope": "frame:link auth:login",
+                   "cloud_login_enabled": false, "local_fallback_enabled": false}
+    resetLinkState(state)
+    check not state.hasKey("cloud_login_enabled")
+    check localAdminLoginEnabled(state)
+
+suite "leaving cloud-managed mode":
+  test "demoting keeps the link and drops only the managed fields":
+    let state = %*{"status": "connected", "provider_url": "https://cloud.example.com",
+                   "access_token": "tok", "scope": "frame:link frame:managed",
+                   "mode": "managed", "frame_id": "frm_1", "ws_path": "/api/frames/ws",
+                   "scenes_checksum": "abc", "managed_enroll_error": "boom"}
+    check clearManagedMode(state)
+    check not isManagedLink(state)
+    check state{"status"}.getStr("") == "connected"
+    check state{"access_token"}.getStr("") == "tok"
+    # The grant stays, so the switch can be turned back on without a new
+    # approval on the provider.
+    check "frame:managed" in state{"scope"}.getStr("")
+    for key in ["mode", "frame_id", "ws_path", "scenes_checksum", "managed_enroll_error"]:
+      check not state.hasKey(key)
+    # Idempotent: a second call has nothing to remove.
+    check not clearManagedMode(state)
+
 suite "exporting link state":
   test "redaction strips every secret-bearing key and nothing else":
     let state = %*{"provider_url": "https://cloud.frameos.net",

--- a/frameos/src/frameos/server/routes/cloud_api_routes.nim
+++ b/frameos/src/frameos/server/routes/cloud_api_routes.nim
@@ -49,6 +49,15 @@ proc cloudStatusPayload(state: JsonNode): JsonNode =
     # Effective, not stored: see localAdminLoginEnabled. The panel should show
     # what actually happens at the login screen.
     "local_fallback_enabled": localAdminLoginEnabled(state),
+    # The two switches the admin panel offers once a link is live, each split
+    # into "may this be offered" and "is it on". Both are local: the grants
+    # behind them were approved when the link was made, and turning one off
+    # never needs the provider's permission.
+    "cloud_login_available": cloudLoginGranted(state),
+    "cloud_login_enabled": cloudLoginPossible(state),
+    "managed_available": status == "connected" and
+      linkHasScope(state, "frame:managed") and not backendManaged,
+    "managed_enroll_error": jsonOrNull(state{"managed_enroll_error"}),
   }
   if status == "connecting":
     result["connection"] = %*{
@@ -395,9 +404,15 @@ proc addCloudApiRoutes*(router: var Router) =
         if state{"status"}.getStr("") != "connected" or state{"access_token"}.getStr("") == "":
           jsonResponse(request, Http409, %*{"detail": "This frame is not linked to FrameOS Cloud"})
           return
-        if not linkHasScope(state, "auth:login"):
+        # The grant AND the local switch: "Sign in here with FrameOS Cloud"
+        # being off has to mean the handoff cannot be started at all, not
+        # merely that the login page stops drawing the button.
+        if not cloudLoginPossible(state):
           jsonResponse(request, Http403,
-            %*{"detail": "The cloud link is missing the auth:login permission; reconnect with it enabled"})
+            %*{"detail": (if linkHasScope(state, "auth:login"):
+                            "Signing in with FrameOS Cloud is switched off on this frame"
+                          else:
+                            "The cloud link is missing the auth:login permission; reconnect with it enabled")})
           return
         providerUrl = providerUrlFromState(state)
         accessToken = state{"access_token"}.getStr("")
@@ -553,6 +568,120 @@ proc addCloudApiRoutes*(router: var Router) =
       headers["Set-Cookie"] = adminSessionCookieHeader(request, sessionToken)
       headers["Location"] = "/admin"
       request.respond(303, headers, "")
+  )
+
+  router.post("/api/cloud/managed", proc(request: Request) {.gcsafe.} =
+    ## The "Manage this frame from FrameOS Cloud" switch on the admin page.
+    ##
+    ## On: register this frame with the provider over the link it already has
+    ## (flow B of docs/cloud-frames.md) and start the management socket. The
+    ## `frame:managed` grant is checked here, never asked for — a link that
+    ## was never approved for it cannot escalate itself from this route.
+    ## Off: the frame stops answering the hub and the account keeps the frame;
+    ## switching back on re-registers the same one.
+    if not hasAdminAccess(request):
+      jsonResponse(request, Http401, %*{"detail": "Unauthorized"})
+      return
+    {.gcsafe.}:
+      let payload = try:
+          parseJson(if request.body.strip().len == 0: "{}" else: request.body)
+        except CatchableError:
+          jsonResponse(request, Http400, %*{"detail": "Invalid JSON"})
+          return
+      if payload{"enabled"} == nil or payload{"enabled"}.kind != JBool:
+        jsonResponse(request, Http400, %*{"detail": "Send {\"enabled\": true|false}"})
+        return
+      let enabled = payload{"enabled"}.getBool()
+
+      if not enabled:
+        withLock cloudLinkLock:
+          let state = loadCloudLinkState()
+          if clearManagedMode(state):
+            saveCloudLinkState(state)
+          jsonResponse(request, Http200, cloudStatusPayload(state))
+        # The private-network deny only applies to a managed frame.
+        refreshLocalNetworkPolicy(globalFrameConfig)
+        return
+
+      var providerUrl = ""
+      var accessToken = ""
+      withLock cloudLinkLock:
+        let state = loadCloudLinkState()
+        if state{"status"}.getStr("") != "connected":
+          jsonResponse(request, Http409,
+            %*{"detail": "Connect this frame to FrameOS Cloud first"})
+          return
+        if isManagedLink(state):
+          jsonResponse(request, Http200, cloudStatusPayload(state))
+          return
+        if not linkHasScope(state, "frame:managed"):
+          jsonResponse(request, Http409,
+            %*{"detail": "This cloud link was not approved for managing the frame. " &
+                         "Disconnect and connect again to ask for it."})
+          return
+        providerUrl = providerUrlFromState(state)
+        accessToken = state{"access_token"}.getStr("")
+      if otherControlPlaneActive(globalFrameConfig):
+        jsonResponse(request, Http409,
+          %*{"detail": "This frame is managed by a self-hosted backend. " &
+                       "Remove serverHost from frame.json before letting FrameOS Cloud manage it."})
+        return
+      if accessToken.len == 0:
+        jsonResponse(request, Http409, %*{"detail": "This frame is not linked to FrameOS Cloud"})
+        return
+
+      # Another provider round trip, so no lock is held across it.
+      let outcome = enrollManagedFrame(providerUrl, "", accessToken, "", globalFrameConfig)
+      if not outcome.ok:
+        withLock cloudLinkLock:
+          let state = loadCloudLinkState()
+          state["managed_enroll_error"] = %outcome.error
+          saveCloudLinkState(state)
+        log(%*{"event": "cloud:enroll:error", "flow": "admin_toggle",
+               "status": outcome.status, "error": outcome.error})
+        jsonResponse(request, (if outcome.status == 409: Http409 else: Http502),
+          %*{"detail": "Could not hand this frame to FrameOS Cloud: " & outcome.error,
+             "error": outcome.error})
+        return
+      startCloudHubClient(globalFrameConfig)
+      refreshLocalNetworkPolicy(globalFrameConfig)
+      withLock cloudLinkLock:
+        jsonResponse(request, Http200, cloudStatusPayload(loadCloudLinkState()))
+  )
+
+  router.post("/api/cloud/cloud-login", proc(request: Request) {.gcsafe.} =
+    ## The "Sign in here with your FrameOS Cloud account" switch.
+    ##
+    ## Purely local: the `auth:login` grant stays on the link either way, and
+    ## this only decides whether this frame's login page offers the cloud
+    ## button. Turning it off also puts the admin password back, so the switch
+    ## can never be the last door closing behind the user.
+    if not hasAdminAccess(request):
+      jsonResponse(request, Http401, %*{"detail": "Unauthorized"})
+      return
+    {.gcsafe.}:
+      let payload = try:
+          parseJson(if request.body.strip().len == 0: "{}" else: request.body)
+        except CatchableError:
+          jsonResponse(request, Http400, %*{"detail": "Invalid JSON"})
+          return
+      if payload{"enabled"} == nil or payload{"enabled"}.kind != JBool:
+        jsonResponse(request, Http400, %*{"detail": "Send {\"enabled\": true|false}"})
+        return
+      let enabled = payload{"enabled"}.getBool()
+      withLock cloudLinkLock:
+        let state = loadCloudLinkState()
+        if enabled and not cloudLoginGranted(state):
+          jsonResponse(request, Http409,
+            %*{"detail": "Connect this frame to FrameOS Cloud with the auth:login permission first"})
+          return
+        state["cloud_login_enabled"] = %enabled
+        if not enabled:
+          # Without cloud login there is only the password left, so store the
+          # flag that says so rather than relying on the effective answer.
+          state["local_fallback_enabled"] = %true
+        saveCloudLinkState(state)
+        jsonResponse(request, Http200, cloudStatusPayload(state))
   )
 
   router.post("/api/cloud/local-fallback", proc(request: Request) {.gcsafe.} =

--- a/frameos/src/frameos/server/tests/helpers/http_harness.nim
+++ b/frameos/src/frameos/server/tests/helpers/http_harness.nim
@@ -140,6 +140,56 @@ proc stopServer*(testServer: var TestServer) =
   testServer.server.close()
   joinThread(testServer.thread)
 
+type ProbeOutcome* = enum
+  ## What one TCP probe against a loopback port actually learned.
+  probeConnected   ## the port accepted the connection
+  probeRefused     ## the port actively refused it (nothing is listening)
+  probeTimedOut    ## no answer inside the deadline — not an answer either way
+
+proc probePort*(port: int, timeoutMs = 1000): ProbeOutcome =
+  ## One connect to 127.0.0.1, with every outcome named instead of thrown.
+  ##
+  ## `std/net` raises `TimeoutError` when the deadline passes, and that is a
+  ## plain `CatchableError`, NOT an `OSError` — so the obvious `except OSError`
+  ## around a timed `connect` does not catch it, and a single probe that misses
+  ## its deadline takes the whole test binary down with an unhandled exception.
+  ## That is exactly what a loaded CI runner did to the hotspot-listener suite
+  ## (net.nim(2136) connect / TimeoutError) on 2026-09-13. A timed-out probe is
+  ## not evidence of anything; callers poll again.
+  ##
+  ## The socket is closed on every path. `connect` leaves it open when it times
+  ## out, and these helpers probe up to a hundred times.
+  let probe = newSocket()
+  try:
+    probe.connect("127.0.0.1", Port(port), timeout = timeoutMs)
+    result = probeConnected
+  except TimeoutError:
+    result = probeTimedOut
+  except OSError:
+    result = probeRefused
+  finally:
+    probe.close()
+
+proc waitForPortOpen*(port: int, attempts = 100, timeoutMs = 500): bool =
+  ## Polls until something accepts on `port`.
+  for _ in 0 ..< attempts:
+    if probePort(port, timeoutMs) == probeConnected:
+      return true
+    sleep(20)
+  false
+
+proc waitForPortRefused*(port: int, attempts = 100, timeoutMs = 1000): bool =
+  ## Polls until `port` actively refuses, i.e. a listener really is gone.
+  ## A probe that times out counts as "not yet" and is retried, never as a
+  ## refusal: a socket whose accept loop has not unwound yet can swallow the
+  ## SYN, and calling that "closed" would make the assertion pass for the
+  ## wrong reason.
+  for _ in 0 ..< attempts:
+    if probePort(port, timeoutMs) == probeRefused:
+      return true
+    sleep(20)
+  false
+
 proc header*(response: TestResponse, name: string): string =
   response.headers.getOrDefault(name.toLowerAscii(), "")
 

--- a/frameos/src/frameos/server/tests/test_cloud_api_routes_behavior.nim
+++ b/frameos/src/frameos/server/tests/test_cloud_api_routes_behavior.nim
@@ -7,6 +7,7 @@
 import std/[json, os, strutils, times, unittest]
 
 import ../../channels
+import ../rate_limit
 import ./helpers/http_harness
 
 let workDir = getTempDir() / ("frameos-test-cloud-routes-" & $(epochTime().int64) & "-" & $getCurrentProcessId())
@@ -210,6 +211,128 @@ suite "local password login can be handed to the cloud":
     check httpRequest(server.port, "POST", "/api/cloud/local-fallback",
       headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
       body = $(%*{})).status == 400
+
+# One session for the whole suite: /api/admin/login is rate limited (ten
+# attempts per window), and a suite that signs in per test would spend the
+# budget the earlier suites left.
+var switchesCookie = ""
+proc switchAdminCookie(): string =
+  if switchesCookie.len == 0:
+    writeLinkState(connectedLoginLink(true))
+    switchesCookie = loginAsAdmin()
+  switchesCookie
+
+suite "the two cloud switches on the admin page":
+  setup:
+    drainEventChannel()
+    configureServerState(adminConfig(""))
+    # /api/admin/login is throttled, and the suites above spend most of the
+    # window's budget before this one starts.
+    resetRateLimits()
+
+  test "status names what each switch may do and whether it is on":
+    var state = connectedLoginLink(true)
+    state["scope"] = %"frame:link frame:managed auth:login"
+    writeLinkState(state)
+    let cookie = switchAdminCookie()
+    writeLinkState(state)
+    let payload = parseJson(httpRequest(server.port, "GET", "/api/cloud/status",
+      headers = [("Cookie", cookie)]).body)
+    check payload{"managed_available"}.getBool(false)
+    check payload{"cloud_login_available"}.getBool(false)
+    check payload{"cloud_login_enabled"}.getBool(false)
+    # Linked but not managed: the panel must be able to say so.
+    check payload{"mode"}.getStr("") == ""
+
+  test "cloud login is a local switch, and turning it off brings the password back":
+    # Sign in while the password still works, then put the frame in the state
+    # the switch is meant to rescue: passwords off, everything resting on the
+    # cloud button.
+    let cookie = switchAdminCookie()
+    writeLinkState(connectedLoginLink(false))
+    check parseJson(httpRequest(server.port, "GET", "/api/cloud/login/options").body){
+      "available"}.getBool(false)
+
+    let off = httpRequest(server.port, "POST", "/api/cloud/cloud-login",
+      headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
+      body = $(%*{"enabled": false}))
+    check off.status == 200
+    let offPayload = parseJson(off.body)
+    check not offPayload{"cloud_login_enabled"}.getBool(true)
+    check offPayload{"local_fallback_enabled"}.getBool(false)
+    # The grant is untouched; only this frame stopped offering the button.
+    check offPayload{"cloud_login_available"}.getBool(false)
+    let options = parseJson(httpRequest(server.port, "GET", "/api/cloud/login/options").body)
+    check not options{"available"}.getBool(true)
+    check options{"local_login_enabled"}.getBool(false)
+    check loginAsAdmin().len > 0
+    # Off means the handoff cannot be started either, not just that the
+    # button stops being drawn.
+    let start = httpRequest(server.port, "POST", "/api/cloud/login/start",
+      headers = [("Host", "kitchen.local:8787")])
+    check start.status == 403
+    check start.body.contains("switched off")
+
+    let on = httpRequest(server.port, "POST", "/api/cloud/cloud-login",
+      headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
+      body = $(%*{"enabled": true}))
+    check on.status == 200
+    check parseJson(on.body){"cloud_login_enabled"}.getBool(false)
+
+  test "cloud login cannot be switched on without the grant":
+    var state = connectedLoginLink(true)
+    let cookie = switchAdminCookie()
+    state["scope"] = %"frame:link"
+    writeLinkState(state)
+    let refused = httpRequest(server.port, "POST", "/api/cloud/cloud-login",
+      headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
+      body = $(%*{"enabled": true}))
+    check refused.status == 409
+    check refused.body.contains("auth:login")
+
+  test "managed mode switches off locally and keeps the link":
+    var state = connectedLoginLink(true)
+    state["scope"] = %"frame:link frame:managed auth:login"
+    state["mode"] = %"managed"
+    state["frame_id"] = %"frm-1"
+    state["ws_path"] = %"/api/frames/ws"
+    let cookie = switchAdminCookie()
+    writeLinkState(state)
+    let off = httpRequest(server.port, "POST", "/api/cloud/managed",
+      headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
+      body = $(%*{"enabled": false}))
+    check off.status == 200
+    let payload = parseJson(off.body)
+    check payload{"mode"}.getStr("") == ""
+    check payload{"status"}.getStr("") == "connected"
+    # Still offered, because the grant is still on the link.
+    check payload{"managed_available"}.getBool(false)
+    let stored = parseJson(readFile(workDir / "state" / "cloud_link.json"))
+    check stored{"frame_id"}.getStr("") == ""
+    check stored{"access_token"}.getStr("") == "cloud-token"
+
+  test "managed mode cannot be switched on without the grant":
+    var state = connectedLoginLink(true)
+    let cookie = switchAdminCookie()
+    state["scope"] = %"frame:link auth:login"
+    writeLinkState(state)
+    let refused = httpRequest(server.port, "POST", "/api/cloud/managed",
+      headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
+      body = $(%*{"enabled": true}))
+    check refused.status == 409
+    check refused.body.contains("connect again")
+
+  test "both switches are admin-only and validate their body":
+    let cookie = switchAdminCookie()
+    writeLinkState(%*{"status": "disconnected"})
+    for path in ["/api/cloud/managed", "/api/cloud/cloud-login"]:
+      check httpRequest(server.port, "POST", path,
+        headers = [("Content-Type", "application/json")],
+        body = $(%*{"enabled": true})).status == 401
+    for path in ["/api/cloud/managed", "/api/cloud/cloud-login"]:
+      check httpRequest(server.port, "POST", path,
+        headers = [("Content-Type", "application/json"), ("Cookie", cookie)],
+        body = $(%*{})).status == 400
 
 # No stopServer/removeDir teardown: like the other behavior tests, the mummy
 # worker threads are torn down by process exit (an explicit close from the

--- a/frameos/src/frameos/server/tests/test_hotspot_listener.nim
+++ b/frameos/src/frameos/server/tests/test_hotspot_listener.nim
@@ -1,4 +1,4 @@
-import std/[net, os, unittest]
+import std/[os, unittest]
 
 import ./helpers/http_harness
 import ../hotspot_listener
@@ -10,15 +10,6 @@ var server = startRouterServer(19338)
 proc exposeOnlyConfig(): FrameConfig =
   result = defaultFrameConfig()
   result.httpsProxy = HttpsProxyConfig(enable: true, port: 8443, exposeOnlyPort: true)
-
-proc connectionRefused(port: int): bool =
-  let probe = newSocket()
-  try:
-    probe.connect("127.0.0.1", Port(port), timeout = 1000)
-    probe.close()
-    false
-  except OSError:
-    true
 
 suite "hotspot listener":
   setup:
@@ -68,13 +59,7 @@ suite "hotspot listener":
     stopHotspotListener(server.server)
     check hotspotListenerPort() == 0
     check hotspotSetupPort(config) == 8787
-    var refused = false
-    for attempt in 0 ..< 100:
-      if connectionRefused(second):
-        refused = true
-        break
-      sleep(20)
-    check refused
+    check waitForPortRefused(second)
 
   test "a nil server is tolerated":
     let (port, _) = startHotspotListener(nil, exposeOnlyConfig())

--- a/frameos/src/frameos/server/tests/test_settings_apply_routes.nim
+++ b/frameos/src/frameos/server/tests/test_settings_apply_routes.nim
@@ -94,30 +94,6 @@ proc clearCaptured() =
     {.cast(gcsafe).}:
       capturedJobs = @[]
 
-proc waitForPort(port: int): bool =
-  for attempt in 0 ..< 100:
-    let probe = newSocket()
-    try:
-      probe.connect("127.0.0.1", Port(port), timeout = 500)
-      probe.close()
-      return true
-    except OSError:
-      probe.close()
-      sleep(20)
-  false
-
-proc portRefused(port: int): bool =
-  for attempt in 0 ..< 100:
-    let probe = newSocket()
-    try:
-      probe.connect("127.0.0.1", Port(port), timeout = 500)
-      probe.close()
-      sleep(20)
-    except OSError:
-      probe.close()
-      return true
-  false
-
 proc httpsRequest(port: int, path: string, headers: openArray[(string, string)] = []): TestResponse =
   var socket = newSocket()
   let ctx = newContext(verifyMode = CVerifyNone)
@@ -290,16 +266,16 @@ suite "settings save applies on the device":
     check apply["listeners_changed"].getBool()
     check apply["listeners"] == %*[{"address": "127.0.0.1", "port": movedPort, "tls": false}]
     check storedConfig()["framePort"].getInt() == movedPort
-    check waitForPort(movedPort)
+    check waitForPortOpen(movedPort)
     # The session cookie is host-scoped: the same login works on the new port.
     let moved = httpRequest(movedPort, "GET", "/api/frames/1", headers = [("Cookie", cookie)])
     check moved.status == 200
-    check portRefused(plainPort)
+    check waitForPortRefused(plainPort)
     # Back to where the rest of the suite expects the server.
     let back = save(movedPort, cookie, %*{"frame_port": plainPort})
     check back.status == 200
-    check waitForPort(plainPort)
-    check portRefused(movedPort)
+    check waitForPortOpen(plainPort)
+    check waitForPortRefused(movedPort)
     check activeListenerSpecs() == @[ListenerSpec(address: "127.0.0.1", port: plainPort, tls: false)]
 
   test "a port the frame cannot bind refuses the save and keeps the config":
@@ -341,7 +317,7 @@ suite "settings save applies on the device":
     apply = parseJson(response.body)["apply"]
     check apply["listeners_changed"].getBool()
     check apply["listeners"] == %*[{"address": "127.0.0.1", "port": plainPort, "tls": false}]
-    check portRefused(tlsPort)
+    check waitForPortRefused(tlsPort)
 
   test "replacing the certificate rebinds the same port":
     let cookie = resetFrame()
@@ -371,7 +347,7 @@ suite "settings save applies on the device":
     check response.status == 200
     check not parseJson(response.body)["apply"]["listeners_changed"].getBool()
     check save(server.port, cookie, %*{"https_proxy": {"enable": false}}).status == 200
-    check portRefused(tlsPort)
+    check waitForPortRefused(tlsPort)
 
   test "a certificate the runtime cannot load refuses the save":
     let cookie = resetFrame()
@@ -381,7 +357,7 @@ suite "settings save applies on the device":
     check response.status == 409
     check parseJson(response.body)["detail"].getStr().contains("HTTPS on 127.0.0.1:" & $tlsPort)
     check not storedConfig()["httpsProxy"]["enable"].getBool()
-    check portRefused(tlsPort)
+    check waitForPortRefused(tlsPort)
 
   test "HTTPS enabled without a certificate stays plain, as at start-up":
     let cookie = resetFrame()

--- a/frameos/src/frameos/server/tests/test_tls_listener.nim
+++ b/frameos/src/frameos/server/tests/test_tls_listener.nim
@@ -151,17 +151,7 @@ suite "HTTPS listener":
 
   test "the listener can be removed while serving":
     server.server.removeListener(tlsListener)
-    var refused = false
-    for attempt in 0 ..< 100:
-      let probe = newSocket()
-      try:
-        probe.connect("127.0.0.1", Port(tlsPort), timeout = 1000)
-        probe.close()
-        sleep(20)
-      except OSError:
-        refused = true
-        break
-    check refused
+    check waitForPortRefused(tlsPort)
     check httpRequest(server.port, "GET", "/setup/status").status == 200
 
 stopServer(server)

--- a/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/FrameSettings.tsx
@@ -7,6 +7,7 @@ import { CloudSettingsSection } from '../../../settings/CloudSettings'
 import { FrameSettingsProvider, useFrameSettings, type FrameSettingsProps } from './frameSettingsContext'
 import { GpioButtonsSection } from './fields/sharedFields'
 import { FrameSettingsSection } from './sections/FrameSettingsSection'
+import { SettingsHeaderActions } from './SettingsHeaderActions'
 import {
   CloudServiceSettingsSection,
   CloudTelemetrySection,
@@ -95,7 +96,7 @@ function FrameSettingsPanel(): JSX.Element {
     >
       {/* Contains its own <form>, so it must stay outside the frameForm <Form> below. */}
       <FrameSettingsSection sectionKey="cloud-account">
-        <CloudSettingsSection headingId="frame-settings-cloud" />
+        <CloudSettingsSection headingId="frame-settings-cloud" action={<SettingsHeaderActions slot="cloud" />} />
       </FrameSettingsSection>
       <Form
         formKey="frameForm"

--- a/frontend/src/scenes/frame/panels/FrameSettings/SettingsHeaderActions.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/SettingsHeaderActions.tsx
@@ -1,0 +1,67 @@
+import { ArrowRightStartOnRectangleIcon } from '@heroicons/react/24/outline'
+import { useValues } from 'kea'
+
+import { Button } from '../../../../components/Button'
+import { isInFrameAdminMode } from '../../../../utils/frameAdmin'
+import { cloudLogic } from '../../../settings/cloudLogic'
+import { FrameActionsMenu } from './FrameActionsMenu'
+import { useFrameSettings } from './frameSettingsContext'
+
+/**
+ * The actions at the top right of the Settings panel.
+ *
+ * On a backend that owns the frame this is just the "…" frame menu, next to
+ * the first heading as before. On the frame's own admin panel the page is the
+ * whole app, so it also carries "Log out" — and the first heading there is
+ * "FrameOS Cloud", not "Frame info".
+ *
+ * Both places therefore render this with the slot they are, and exactly one of
+ * them draws anything: `cloud` when the cloud section has a heading to hang
+ * them on, `fallback` when it does not (FRAMEOS_CLOUD_URL=disabled).
+ */
+export function SettingsHeaderActions({ slot }: { slot: 'cloud' | 'fallback' }): JSX.Element | null {
+  // Not a hook: the mode is fixed for the life of the page, so the branch
+  // below never flips between renders. Keeping it out of the frame-admin
+  // component is what stops a backend's Settings panel from mounting
+  // cloudLogic (and polling /api/cloud/status) for a section it never draws.
+  if (!isInFrameAdminMode()) {
+    return slot === 'fallback' ? <FrameActionsMenu /> : null
+  }
+  return <FrameAdminHeaderActions slot={slot} />
+}
+
+function FrameAdminHeaderActions({ slot }: { slot: 'cloud' | 'fallback' }): JSX.Element | null {
+  const { frame } = useFrameSettings()
+  const { cloudStatus } = useValues(cloudLogic)
+  // Unknown yet (the status is still loading) counts as visible: the cloud
+  // heading is the usual home, and claiming the fallback first would move the
+  // buttons across the page a moment later.
+  const cloudHeadingVisible = cloudStatus?.enabled !== false
+  if (slot === 'cloud' ? !cloudHeadingVisible : cloudHeadingVisible) {
+    return null
+  }
+  return (
+    <div className="flex items-center gap-2">
+      {frame.frame_admin_auth?.enabled ? <FrameAdminLogoutButton /> : null}
+      <FrameActionsMenu />
+    </div>
+  )
+}
+
+/** GET /logout clears the admin session cookie and lands on /login. It ends a
+ * cloud sign-in the same way it ends a password one. */
+function FrameAdminLogoutButton(): JSX.Element {
+  return (
+    <Button
+      size="small"
+      color="secondary"
+      onClick={() => {
+        window.location.href = '/logout'
+      }}
+      className="inline-flex items-center gap-1.5"
+    >
+      <ArrowRightStartOnRectangleIcon className="h-4 w-4" />
+      Log out
+    </Button>
+  )
+}

--- a/frontend/src/scenes/frame/panels/FrameSettings/sections/deviceSections.tsx
+++ b/frontend/src/scenes/frame/panels/FrameSettings/sections/deviceSections.tsx
@@ -26,7 +26,7 @@ import {
   normalizeFrameCompilationModeOption,
 } from '../../../../../utils/frameBuildOptions'
 import type { FrameType } from '../../../../../types'
-import { FrameActionsMenu } from '../FrameActionsMenu'
+import { SettingsHeaderActions } from '../SettingsHeaderActions'
 import { useFrameSettings } from '../frameSettingsContext'
 import { CertificateTriangle, scrollToFrameHttpApiSection, VirtualFrameUrlRow } from '../frameSettingsHelpers'
 import {
@@ -66,7 +66,7 @@ export function FrameInfoSection(): JSX.Element | null {
   }
   return (
     <>
-      <SectionHeading id="frame-settings-info" action={<FrameActionsMenu />}>
+      <SectionHeading id="frame-settings-info" action={<SettingsHeaderActions slot="fallback" />}>
         Frame info
       </SectionHeading>
       <SectionBody>
@@ -142,7 +142,7 @@ export function DeviceSettingsSection(): JSX.Element {
           Device settings
         </SectionHeading>
       ) : (
-        <SectionHeading id="frame-settings-device" action={<FrameActionsMenu />}>
+        <SectionHeading id="frame-settings-device" action={<SettingsHeaderActions slot="fallback" />}>
           Device settings
         </SectionHeading>
       )}

--- a/frontend/src/scenes/settings/CloudSettings.tsx
+++ b/frontend/src/scenes/settings/CloudSettings.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { PencilSquareIcon } from '@heroicons/react/24/solid'
+import type { ReactNode } from 'react'
 
 import { Box } from '../../components/Box'
 import { Button } from '../../components/Button'
@@ -10,11 +11,13 @@ import { Field } from '../../components/Field'
 import { H6 } from '../../components/H6'
 import { Label } from '../../components/Label'
 import { Spinner } from '../../components/Spinner'
+import { Switch } from '../../components/Switch'
 import { Tag } from '../../components/Tag'
 import { TextInput } from '../../components/TextInput'
 import { isInFrameAdminMode } from '../../utils/frameAdmin'
 import { inHassioIngress } from '../../utils/inHassioIngress'
 import { availableCloudFeatures, cloudLogic } from './cloudLogic'
+import type { CloudStatus } from '../../types'
 
 function pollErrorMessage(pollError: string): string {
   switch (pollError) {
@@ -54,10 +57,101 @@ function expiresInLabel(expiresAt: string | null): string | null {
   return `expires in ${Math.ceil(secondsLeft / 60)} min`
 }
 
+/**
+ * What the link actually means, in a sentence, on the frame's own admin page.
+ *
+ * A frame can be linked to a cloud account without being driven by it, and the
+ * box used to say only "Connected" — so approving a link on the phone and then
+ * finding the frame unchanged on cloud.frameos.net looked like a failure. This
+ * row names the two states apart and says what each one gives you.
+ */
+function FrameCloudStatusRow({
+  cloudStatus,
+  providerHost,
+}: {
+  cloudStatus: CloudStatus | null
+  providerHost: string
+}): JSX.Element {
+  const managed = cloudStatus?.mode === 'managed'
+  return (
+    <div className="space-y-1 @md:flex @md:items-start @md:gap-2">
+      <div className="@md:w-1/3 @md:shrink-0">
+        <Label>Cloud status</Label>
+      </div>
+      <div className="w-full space-y-1 text-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <Tag color={managed ? 'teal' : 'gray'}>{managed ? 'Managed from the cloud' : 'Linked, not managed'}</Tag>
+        </div>
+        <div className="frameos-muted">
+          {managed
+            ? `This frame answers to ${providerHost}: scenes, settings and reboots can come from there, and your cloud scene library is available on this page.`
+            : `Nothing on ${providerHost} can change what this frame shows. The link signs you in and gives this page your cloud scene library; the frame is still driven from here.`}
+        </div>
+        {cloudStatus?.managed_enroll_error ? (
+          <div className="text-red-500">
+            The last attempt to hand this frame to FrameOS Cloud failed: {cloudStatus.managed_enroll_error}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One on/off feature of a live link, with the sentence that says what it does.
+ *
+ * `unavailableReason` replaces the description when the grant behind the
+ * switch is missing: the switch is shown disabled rather than hidden, because
+ * "where did cloud login go" is the question the old box kept raising.
+ */
+function CloudFeatureSwitch({
+  label,
+  description,
+  value,
+  onChange,
+  disabled,
+  busy,
+  nested,
+  unavailableReason,
+  children,
+}: {
+  label: string
+  description: string
+  value: boolean
+  onChange: (value: boolean) => void
+  disabled?: boolean
+  busy?: boolean
+  nested?: boolean
+  unavailableReason?: string
+  children?: ReactNode
+}): JSX.Element {
+  return (
+    <div className={clsx('space-y-1', nested && 'border-l border-slate-500/20 pl-3')}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Switch value={value} onChange={onChange} disabled={disabled || !!unavailableReason} label={label} />
+        {busy ? <Spinner /> : null}
+      </div>
+      <div className={clsx('frameos-muted', unavailableReason && 'text-amber-600 dark:text-amber-400')}>
+        {unavailableReason ?? description}
+      </div>
+      {children && value && !unavailableReason ? <div className="pt-2">{children}</div> : null}
+    </div>
+  )
+}
+
 /** "FrameOS Cloud" settings section. Shared between the backend's global
  * settings page and the on-device frame admin — both servers implement the
  * same /api/cloud/* endpoints (see docs/cloud-link.md). */
-export function CloudSettingsSection({ headingId = 'settings-cloud' }: { headingId?: string }): JSX.Element | null {
+export function CloudSettingsSection({
+  headingId = 'settings-cloud',
+  action,
+}: {
+  headingId?: string
+  /** Rendered at the right of the "FrameOS Cloud" heading. The frame's own
+   * admin panel puts its page actions (log out, the frame menu) there, since
+   * this is the first heading it draws. */
+  action?: ReactNode
+}): JSX.Element | null {
   const {
     cloudStatus,
     cloudStatusLoading,
@@ -80,6 +174,7 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
     backupKeyVisible,
     hasBackupScope,
     anyBackupEnabled,
+    pendingCloudSwitch,
   } = useValues(cloudLogic)
   const {
     connectCloud,
@@ -92,6 +187,8 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
     linkCloudIdentity,
     unlinkCloudIdentity,
     setLocalFallback,
+    setCloudManaged,
+    setCloudLoginEnabled,
     setBackupFeature,
     loadCloudBackups,
     backupAllToCloud,
@@ -121,9 +218,12 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2 pt-4">
-        <H6 id={headingId}>FrameOS Cloud</H6>
-        {status === 'connected' ? <Tag color="teal">Connected</Tag> : null}
+      <div className="flex flex-wrap items-center gap-3 pt-4">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <H6 id={headingId}>FrameOS Cloud</H6>
+          {status === 'connected' ? <Tag color="teal">Connected</Tag> : null}
+        </div>
+        {action ? <div className="ml-auto flex shrink-0 items-center gap-2">{action}</div> : null}
       </div>
       <Box className="settings-account-card space-y-4">
         {cloudStatusLoading && !cloudStatus ? (
@@ -143,9 +243,11 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
                   onClick={() => {
                     void confirmDialog({
                       title: 'Disconnect from FrameOS Cloud?',
-                      message:
-                        `This backend stops talking to ${providerHost}: cloud backups pause, cloud-managed frames are no longer reachable from your account, and signing in through the cloud stops working. ` +
-                        'Nothing on the frames themselves changes.\n\nYou can connect again at any time.',
+                      message: frameAdminMode
+                        ? `This frame stops talking to ${providerHost}: it drops out of cloud management, your cloud scene library is no longer available here, and signing in with your cloud account stops working. ` +
+                          'The admin password comes back, and the scenes already on the frame keep running.\n\nYou can connect again at any time.'
+                        : `This backend stops talking to ${providerHost}: cloud backups pause, cloud-managed frames are no longer reachable from your account, and signing in through the cloud stops working. ` +
+                          'Nothing on the frames themselves changes.\n\nYou can connect again at any time.',
                       confirmLabel: 'Disconnect',
                       danger: true,
                     }).then((confirmed) => {
@@ -311,7 +413,58 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
                 </div>
               </div>
             ) : null}
-            {(frameAdminMode || (!inHassioIngress() && cloudStatus?.identity)) && link.scopes.includes('auth:login') ? (
+            {frameAdminMode ? <FrameCloudStatusRow cloudStatus={cloudStatus} providerHost={providerHost} /> : null}
+            {frameAdminMode ? (
+              <div className="space-y-1 @md:flex @md:items-start @md:gap-2">
+                <div className="@md:w-1/3 @md:shrink-0">
+                  <Label>Cloud features</Label>
+                </div>
+                <div className="w-full space-y-4 text-sm">
+                  <CloudFeatureSwitch
+                    label="Manage this frame from FrameOS Cloud"
+                    value={cloudStatus?.mode === 'managed'}
+                    onChange={setCloudManaged}
+                    busy={pendingCloudSwitch === 'managed'}
+                    disabled={pendingCloudSwitch !== null || !cloudStatus?.managed_available}
+                    description={
+                      cloudStatus?.mode === 'managed'
+                        ? `Scenes, settings and reboots can be driven from ${providerHost}, wherever you are. Turn this off and the frame keeps its place in your account but stops taking orders.`
+                        : `Let ${providerHost} set this frame's scenes and settings from anywhere. Without it the frame is yours to drive from this page only.`
+                    }
+                    unavailableReason={
+                      cloudStatus?.managed_available
+                        ? undefined
+                        : cloudStatus?.backend_managed
+                        ? 'A self-hosted FrameOS backend already manages this frame. Clear serverHost in frame.json first.'
+                        : 'This link was never approved for it. Disconnect and connect again to ask for the permission.'
+                    }
+                  />
+                  <CloudFeatureSwitch
+                    label="Sign in here with FrameOS Cloud"
+                    value={cloudStatus?.cloud_login_enabled !== false}
+                    onChange={setCloudLoginEnabled}
+                    busy={pendingCloudSwitch === 'login'}
+                    disabled={pendingCloudSwitch !== null || !cloudStatus?.cloud_login_available}
+                    description={`Put a "Sign in with FrameOS Cloud" button on this frame's login page, for the account that owns the link.`}
+                    unavailableReason={
+                      cloudStatus?.cloud_login_available
+                        ? undefined
+                        : 'This link was never approved for it. Disconnect and connect again to ask for the permission.'
+                    }
+                  >
+                    <CloudFeatureSwitch
+                      nested
+                      label="Keep the admin password working"
+                      value={cloudStatus?.local_fallback_enabled !== false}
+                      onChange={setLocalFallback}
+                      disabled={pendingCloudSwitch !== null}
+                      description="Off means the cloud button is the only way in. The password comes back by itself if the link ever goes away, so this cannot lock you out."
+                    />
+                  </CloudFeatureSwitch>
+                </div>
+              </div>
+            ) : null}
+            {!frameAdminMode && !inHassioIngress() && cloudStatus?.identity && link.scopes.includes('auth:login') ? (
               <div className="space-y-1 @md:flex @md:items-center @md:gap-2">
                 <div className="@md:w-1/3 @md:shrink-0">
                   <Label>Local password login</Label>
@@ -331,9 +484,7 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
                         Disable local passwords
                       </Button>
                       <span className="frameos-muted">
-                        {frameAdminMode
-                          ? 'The cloud link is checked first, and the password comes back by itself if the link ever goes away.'
-                          : 'Requires a verified cloud login by the account that owns this install.'}
+                        Requires a verified cloud login by the account that owns this install.
                       </span>
                     </>
                   )}
@@ -607,8 +758,9 @@ export function CloudSettingsSection({ headingId = 'settings-cloud' }: { heading
               <div className="text-sm text-red-500">{pollErrorMessage(cloudStatus.poll_error)}</div>
             ) : null}
             <div className="frameos-muted text-sm">
-              Connect this backend to a cloud account to optionally enable a few extra features: cloud login, offsite
-              backups of your frames and scenes, etc. Soon also remote access and more.
+              {frameAdminMode
+                ? 'Approving the link hands this frame to your cloud account: it can then be driven from the cloud, and you can sign in here with your cloud account instead of the admin password. Both become switches on this page, so you can turn either one off again without disconnecting.'
+                : 'Connect this backend to a cloud account to optionally enable a few extra features: cloud login, offsite backups of your frames and scenes, etc. Soon also remote access and more.'}
             </div>
           </>
         )}

--- a/frontend/src/scenes/settings/cloudLogic.tsx
+++ b/frontend/src/scenes/settings/cloudLogic.tsx
@@ -111,6 +111,7 @@ export interface cloudLogicValues {
   isFeatureChangeSubmitting: boolean
   isProviderUrlSubmitting: boolean
   isProviderUrlValid: boolean
+  pendingCloudSwitch: 'login' | 'managed' | null
   providerEditorOpen: boolean
   providerUrl: CloudProviderForm
   providerUrlAllErrors: Record<string, any>
@@ -214,6 +215,12 @@ export interface cloudLogicActions {
   }
   setCloudError: (error: string | null) => {
     error: string | null
+  }
+  setCloudLoginEnabled: (enabled: boolean) => {
+    enabled: boolean
+  }
+  setCloudManaged: (enabled: boolean) => {
+    enabled: boolean
   }
   setFeatureDraft: (draft: string[] | null) => {
     draft: string[] | null
@@ -319,6 +326,8 @@ export const cloudLogic = kea<cloudLogicType>([
     linkCloudIdentity: true,
     unlinkCloudIdentity: true,
     setLocalFallback: (enabled: boolean) => ({ enabled }),
+    setCloudManaged: (enabled: boolean) => ({ enabled }),
+    setCloudLoginEnabled: (enabled: boolean) => ({ enabled }),
     setBackupFeature: (key: 'scenes' | 'frames' | 'all', enabled: boolean) => ({ key, enabled }),
     loadCloudBackups: true,
     backupAllToCloud: true,
@@ -466,6 +475,19 @@ export const cloudLogic = kea<cloudLogicType>([
         showBackupKeySuccess: () => true,
         hideBackupKey: () => false,
         disconnectCloud: () => false,
+      },
+    ],
+    // Which of the frame-admin switches is waiting on the device. Both write
+    // through /api/cloud/* and answer with a fresh status, so one marker for
+    // the whole pair is enough to disable them and show a spinner.
+    pendingCloudSwitch: [
+      null as 'login' | 'managed' | null,
+      {
+        setCloudManaged: () => 'managed',
+        setCloudLoginEnabled: () => 'login',
+        loadCloudStatusSuccess: () => null,
+        loadCloudStatusFailure: () => null,
+        setCloudError: () => null,
       },
     ],
   }),
@@ -662,6 +684,40 @@ export const cloudLogic = kea<cloudLogicType>([
       })
       if (!response.ok) {
         actions.setCloudError(await cloudErrorMessage(response, 'Could not change local password login'))
+        return
+      }
+      actions.loadCloudStatusSuccess((await response.json()) as CloudStatus)
+    },
+    setCloudManaged: async ({ enabled }) => {
+      // Handing the frame to (or taking it back from) FrameOS Cloud. The
+      // `frame:managed` grant was approved when the link was made; the device
+      // checks it and refuses rather than asking for more.
+      const response = await apiFetch('/api/cloud/managed', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      })
+      if (!response.ok) {
+        actions.setCloudError(
+          await cloudErrorMessage(
+            response,
+            enabled ? 'Could not hand this frame to FrameOS Cloud' : 'Could not take this frame back from FrameOS Cloud'
+          )
+        )
+        actions.loadCloudStatus()
+        return
+      }
+      actions.loadCloudStatusSuccess((await response.json()) as CloudStatus)
+    },
+    setCloudLoginEnabled: async ({ enabled }) => {
+      const response = await apiFetch('/api/cloud/cloud-login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      })
+      if (!response.ok) {
+        actions.setCloudError(await cloudErrorMessage(response, 'Could not change cloud sign-in'))
+        actions.loadCloudStatus()
         return
       }
       actions.loadCloudStatusSuccess((await response.json()) as CloudStatus)

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -1207,6 +1207,17 @@ export interface CloudStatus {
   /** Frame admin only: a self-hosted backend controls this frame, so
    * cloud-managed enrollment is unavailable until serverHost is cleared. */
   backend_managed?: boolean
+  /** Frame admin only: the link carries `frame:managed` and no self-hosted
+   * backend is in the way, so the "manage from the cloud" switch can be used. */
+  managed_available?: boolean
+  /** Frame admin only: why the last hand-over to cloud management failed. */
+  managed_enroll_error?: string | null
+  /** Frame admin only: the link carries `auth:login`, so the cloud sign-in
+   * switch can be used. */
+  cloud_login_available?: boolean
+  /** Frame admin only: whether this frame's login page offers the cloud
+   * button right now. Purely local — the grant stays either way. */
+  cloud_login_enabled?: boolean
 }
 
 /** Mirrors GET /api/cloud/login/options (open endpoint for the login/setup screens) */


### PR DESCRIPTION
Connecting a standalone frame to FrameOS Cloud used to leave you staring at this:

> **FrameOS Cloud** · Connected
> Connected to cloud.frameos.net as you@example.com [Disconnect]
> Local password login · Enabled · [Disable local passwords]
> *The cloud link is checked first, and the password comes back by itself if the link ever goes away.*

Two questions went unanswered, and they are the only two that matter after approving a link: **can the cloud drive this frame now**, and **what did approving switch on?** Meanwhile a row about local passwords appeared out of nowhere, about a feature nobody had been told was enabled.

## Cloud status, in words

A new row says which of the two states the link is in:

- **Linked, not managed** — "Nothing on cloud.frameos.net can change what this frame shows. The link signs you in and gives this page your cloud scene library; the frame is still driven from here."
- **Managed from the cloud** — "This frame answers to cloud.frameos.net: scenes, settings and reboots can come from there…"

It also surfaces `managed_enroll_error`. The device has been writing that key to `cloud_link.json` since flow B landed and no surface ever read it, so a hand-over to cloud management that failed looked exactly like a link that was never meant to manage anything.

## Two switches, and the password underneath the right one

"Manage this frame from FrameOS Cloud" and "Sign in here with FrameOS Cloud", each with a sentence saying what it does. The admin password is nested under cloud sign-in, because that is what it is — a sub-choice of "may I sign in with the cloud instead", not a peer of it.

Both act only on grants the link already carries and refuse with a 409 rather than ask the provider for more, so a switch can never escalate a link behind the admin's back. A link that was never approved for a feature shows the switch disabled with the reason, instead of hiding it — "where did cloud login go" is the question the old box kept raising.

## Device side

Two admin-only routes, documented in `docs/cloud-link.md`:

- `POST /api/cloud/managed` — on runs flow B enrollment over the link token the frame already holds. The provider keys frames on the linked client, so off-then-on re-registers the **same** frame rather than making a second one. Off is purely local: the managed fields go, the hub thread idles on the generation bump, and the account keeps the (now offline) frame.
- `POST /api/cloud/cloud-login` — a local `cloud_login_enabled` flag folded into `cloudLoginPossible`, so off hides the button, refuses `/login/start` with 403, **and** brings the admin password back. The two login switches can therefore never both end up closed, which is the lockout rule `local_fallback_enabled` already follows.

`GET /api/cloud/status` grows `managed_available`, `managed_enroll_error`, `cloud_login_available` and `cloud_login_enabled` alongside the `mode` it already reported.

## Log out

The on-device admin had no way to end a session. "Log out" and the "…" frame menu now sit at the top right of the settings page, next to the first heading the panel draws — FrameOS Cloud, falling back to Frame info when `FRAMEOS_CLOUD_URL=disabled`. On a backend the slot renders just the "…" menu, exactly as before.

The connect screen and the disconnect confirmation now say what they do to a *frame* instead of what they do to a backend.

## Tests

| | |
|---|---|
| Nim (routes + link state) | 12 new cases, all pass |
| Frame-admin Playwright suite | 4 new, 7 pass |
| `pnpm verify` from `cloud/` | 28 tasks green |

The settings visual snapshots drift a few pixels in both directions locally on pages this branch does not touch (the known macOS font difference); no "unexpected frontend errors" in any case, and CI regenerates the PNGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtpUGKnK81AtqePd3BGb1E
